### PR TITLE
♻️ refactor: Move Pipefy client initialization to ServicesContainer

### DIFF
--- a/src/pipefy_mcp/core/container.py
+++ b/src/pipefy_mcp/core/container.py
@@ -1,5 +1,6 @@
 from typing import Self
 
+from pipefy_mcp.services.pipefy.client import PipefyClient
 from pipefy_mcp.settings import Settings
 
 
@@ -7,6 +8,7 @@ class ServicesContainer:
     """Container for all services"""
 
     _instance: Self | None = None
+    pipefy_client: PipefyClient | None = None
 
     @classmethod
     def get_instance(cls) -> Self:
@@ -20,7 +22,7 @@ class ServicesContainer:
         pass
 
     def initialize_services(self, settings: Settings) -> None:
-        pass
+        self.pipefy_client = PipefyClient()
 
     def shutdown(self) -> None:
         pass

--- a/src/pipefy_mcp/tools/pipe_tools.py
+++ b/src/pipefy_mcp/tools/pipe_tools.py
@@ -3,8 +3,8 @@ from typing import Any
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
 
+from pipefy_mcp.core.container import ServicesContainer
 from pipefy_mcp.models.form import create_form_model
-from pipefy_mcp.services.pipefy import PipefyClient
 
 
 class PipeTools:
@@ -14,7 +14,8 @@ class PipeTools:
     def register(mcp: FastMCP):
         """Register the tools in the MCP server"""
 
-        client = PipefyClient()
+        container = ServicesContainer.get_instance()
+        client = container.pipefy_client
 
         @mcp.tool()
         async def create_card(pipe_id: int, ctx: Context[ServerSession, None]) -> dict:


### PR DESCRIPTION
This PR refactors the `PipefyClient` instantiation to utilize a `ServicesContainer` for dependency management.

Previously, the `PipefyClient` was directly instantiated within `pipe_tools.py`. This approach made it challenging to manage dependencies, especially for testing and extending the application.

  Changes in this PR:
   - Introduced `ServicesContainer` in `src/pipefy_mcp/core/container.py` to manage service instances.
   - The `PipefyClient` is now initialized and stored within the `ServicesContainer`.
   - Modified `src/pipefy_mcp/tools/pipe_tools.py` to retrieve the `PipefyClient` instance from the `ServicesContainer` instead of direct instantiation.

  This change promotes:
   - Improved testability by allowing easier mocking of `PipefyClient`.
   - Better modularity and separation of concerns.
   - A more maintainable and scalable architecture.