### PR TITLE
✨ feat: enhance `create_card` tool to include card link in response

### DIFF
--- a/src/pipefy_mcp/services/pipefy/base_client.py
+++ b/src/pipefy_mcp/services/pipefy/base_client.py
@@ -49,7 +49,6 @@ class BasePipefyClient:
         if self.settings is None:
             raise ValueError("Settings must be provided to create a GraphQL client.")
 
-        print(self.settings)
         transport = HTTPXAsyncTransport(
             url=self.settings.graphql_url,
             auth=OAuth2ClientCredentials(

--- a/src/pipefy_mcp/tools/pipe_tools.py
+++ b/src/pipefy_mcp/tools/pipe_tools.py
@@ -58,7 +58,12 @@ class PipeTools:
                 except UserCancelledError:
                     return {"error": "Card creation cancelled by user."}
 
-            return await client.create_card(pipe_id, card_data)
+            result = await client.create_card(pipe_id, card_data)
+            card_id = result.get("createCard", {}).get("card", {}).get("id")
+            if card_id:
+                card_url = f"https://app.pipefy.com/open-cards/{card_id}"
+                result["card_link"] = f"[{card_url}]({card_url})"
+            return result
 
         @mcp.tool(
             annotations=ToolAnnotations(

--- a/tests/tools/test_pipe_tools.py
+++ b/tests/tools/test_pipe_tools.py
@@ -1,3 +1,4 @@
+import json
 from datetime import timedelta
 from random import randint
 from typing import Any
@@ -90,12 +91,22 @@ async def test_create_card_tool_with_elicitation(
     pipe_id,
 ):
     mock_pipefy_client.get_start_form_fields.return_value = {"start_form_fields": []}
-    mock_pipefy_client.create_card.return_value = {"card": {"id": "789"}}
+    mock_pipefy_client.create_card.return_value = {
+        "createCard": {"card": {"id": "789"}}
+    }
 
     async with client_session as session:
         result = await session.call_tool("create_card", {"pipe_id": pipe_id})
         assert result.isError is False, "Unexpected tool result"
         mock_pipefy_client.create_card.assert_called_once_with(pipe_id, {})
+        response = json.loads(result.content[0].text)
+        expected_response = {
+            "createCard": {"card": {"id": "789"}},
+            "card_link": (
+                "[https://app.pipefy.com/open-cards/789](https://app.pipefy.com/open-cards/789)"
+            ),
+        }
+        assert response == expected_response
 
 
 @pytest.mark.anyio
@@ -110,7 +121,9 @@ async def test_create_card_tool_with_elicitation_declined(
     pipe_id,
 ):
     mock_pipefy_client.get_start_form_fields.return_value = {"start_form_fields": []}
-    mock_pipefy_client.create_card.return_value = {"card": {"id": "789"}}
+    mock_pipefy_client.create_card.return_value = {
+        "createCard": {"card": {"id": "789"}}
+    }
 
     async with client_session as session:
         result = await session.call_tool("create_card", {"pipe_id": pipe_id})
@@ -128,7 +141,9 @@ async def test_create_card_tool_without_elicitation(
     mock_pipefy_client.get_start_form_fields.return_value = {
         "start_form_fields": ["field_1", "field_2"]
     }
-    mock_pipefy_client.create_card.return_value = {"card": {"id": "789"}}
+    mock_pipefy_client.create_card.return_value = {
+        "createCard": {"card": {"id": "789"}}
+    }
 
     async with client_session as session:
         result = await session.call_tool(
@@ -142,6 +157,14 @@ async def test_create_card_tool_without_elicitation(
         mock_pipefy_client.create_card.assert_called_once_with(
             pipe_id, {"field_1": "value_1", "field_2": "value_2"}
         )
+        response = json.loads(result.content[0].text)
+        expected_response = {
+            "createCard": {"card": {"id": "789"}},
+            "card_link": (
+                "[https://app.pipefy.com/open-cards/789](https://app.pipefy.com/open-cards/789)"
+            ),
+        }
+        assert response == expected_response
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
* Removed debug print statement from `BasePipefyClient`.
* Updated `create_card` method in `PipeTools` to return a card link in the response.
* Adjusted tests to validate the new card link format in the response.
* Fixed the mock for create card response in tests

<img width="479" height="629" alt="image" src="https://github.com/user-attachments/assets/d24f231c-298e-4321-b08e-016a01f8ecba" />
