### PR TITLE
feat: AI Agents and AI Automations MCP tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 - `tests/` mirrors the source layout with unit tests for tools, services, models, and the server entrypoints.
 - `README.md` documents usage, tool behavior, and local development notes.
 
-## Build, Test, and Development Commands
+## Build, Test and Development Commands
 - `uv sync` installs dependencies using `uv` (recommended in this repo).
 - `uv run pipefy-mcp-server` runs the MCP server locally via the project script.
 - `uv run pytest` runs the full test suite.
@@ -24,8 +24,8 @@
 - Keep new tests alongside existing suites in `tests/`, aligned with the module they cover.
 - Use markers `@pytest.mark.unit` or `@pytest.mark.integration` when appropriate.
 - Examples for targeted runs:
-  - Single file: `uv run pytest tests/tools/test_cards.py`
-  - Single test case: `uv run pytest tests/tools/test_cards.py -k "test_create_card"`
+  - Single file: `uv run pytest tests/tools/test_pipe_tools.py`
+  - Single test case: `uv run pytest tests/tools/test_pipe_tools.py -k "test_create_card"`
 
 ## Adding a New Tool
 When implementing a new tool, follow this checklist (TDD-first):

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <p align="center">
   <a href="https://github.com/gbrlcustodio/pipefy-mcp-server/actions"><img src="https://github.com/gbrlcustodio/pipefy-mcp-server/workflows/CI/badge.svg" alt="CI Status" /></a>
-  <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.12%2B-blue.svg" alt="Python 3.12+" /></a>
+  <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="Python 3.11+" /></a>
   <a href="https://github.com/astral-sh/uv"><img src="https://img.shields.io/badge/uv-package%20manager-blueviolet" alt="uv package manager" /></a>
   <a href="https://modelcontextprotocol.io/introduction"><img src="https://img.shields.io/badge/MCP-Server-orange" alt="MCP Server" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License" /></a>
@@ -81,11 +81,47 @@ This server exposes common Kanban actions as "tools" that LLMs (like Claude Sonn
 - **Use `update_card` with `field_updates`** when you want to update **one or more custom fields at once** by ID, replacing their values (the server converts this to `updateFieldsValues` with `REPLACE` under the hood).
 - **Use `update_card` with attribute parameters** (`title`, `assignee_ids`, `label_ids`, `due_date`) when you need to update card metadata. These can be combined with `field_updates` in a single call.
 
+### AI Automation Tools
+
+* **`create_ai_automation`**: Create a simple AI automation that generates content with a prompt and writes the result to one or more card fields. Best for straightforward field-filling use cases (e.g. summarize, classify, extract data into a field). Requires AI to be enabled for the pipe in Pipefy UI.
+    * `name` (str): Automation name.
+    * `event_id` (str): Event trigger (e.g. `card_created`, `card_moved`).
+    * `pipe_id` (str): Pipe ID where the automation runs.
+    * `prompt` (str): AI prompt text that generates the content.
+    * `field_ids` (list[str]): List of field internal IDs to write the result to.
+    * `condition` (dict, optional): Condition structure for the automation trigger.
+
+* **`update_ai_automation`**: Update an existing AI automation's name, prompt, destination fields, or active state.
+    * `automation_id` (str): ID of the automation to update.
+    * `name` (str, optional): New automation name.
+    * `active` (bool, optional): Whether the automation is active.
+    * `prompt` (str, optional): New AI prompt text.
+    * `field_ids` (list[str], optional): New list of field internal IDs.
+    * `condition` (dict, optional): New condition structure.
+
+### AI Agent Tools
+
+* **`create_ai_agent`**: Create an AI Agent (empty, no behaviors) attached to a pipe. Use `update_ai_agent` to configure 1 to 5 behaviors. `repo_uuid` is the pipe's unique identifier — not the numeric pipe ID from the URL. Resolve it via the `get_pipe` tool.
+    * `name` (str): Agent display name.
+    * `repo_uuid` (str): UUID of the pipe the agent belongs to.
+
+* **`update_ai_agent`**: Update an AI Agent with an instruction and 1 to 5 behaviors that can execute complex actions (e.g. move card, update fields conditionally). The API replaces the entire agent payload, so always send the complete list of behaviors.
+    * `uuid` (str): UUID of the agent to update.
+    * `name` (str): Agent display name.
+    * `repo_uuid` (str): UUID of the pipe the agent belongs to.
+    * `instruction` (str): Global instruction for the agent.
+    * `behaviors` (list[dict]): List of 1 to 5 behavior dicts (`name` and `event_id` required per behavior).
+    * `data_source_ids` (list[str], optional): List of data source IDs.
+
+* **`toggle_ai_agent_status`**: Enable or disable an AI Agent without resending its configuration. Agents are created inactive by default; use this after configuring behaviors to activate them.
+    * `uuid` (str): UUID of the agent to enable/disable.
+    * `active` (bool): `true` to activate, `false` to deactivate.
+
 ## Getting Started
 
 ### Prerequisites
 Installing the server requires the following on your system:
-- Python 3.12+
+- Python 3.11+
 - A **Pipefy Service Account Token** (Generate in Admin Panel > Service Accounts).
 - Rembember to add the Service account to the pipe you want the AI to use.
 

--- a/src/pipefy_mcp/core/container.py
+++ b/src/pipefy_mcp/core/container.py
@@ -1,28 +1,65 @@
 from typing import Self
 
+from httpx_auth import OAuth2ClientCredentials
+
 from pipefy_mcp.services.pipefy import PipefyClient
+from pipefy_mcp.services.pipefy.ai_agent_service import AiAgentService
+from pipefy_mcp.services.pipefy.ai_automation_service import AiAutomationService
+from pipefy_mcp.services.pipefy.internal_api_client import InternalApiClient
 from pipefy_mcp.settings import Settings
 
 
 class ServicesContainer:
-    """Container for all services"""
+    """Container for all services."""
 
     _instance: Self | None = None
     pipefy_client: PipefyClient | None = None
+    internal_api_client: InternalApiClient | None = None
+    ai_automation_service: AiAutomationService | None = None
+    ai_agent_service: AiAgentService | None = None
 
     @classmethod
     def get_instance(cls) -> Self:
-        """Get the singleton instance of the container"""
+        """Get the singleton instance of the container."""
         if cls._instance is None:
             cls._instance = cls()
         return cls._instance
 
     def __init__(self):
-        """Initialize the container"""
+        """Initialize the container."""
         pass
 
     def initialize_services(self, settings: Settings) -> None:
+        """Create and wire all services.
+
+        Args:
+            settings: Application settings with Pipefy credentials.
+        """
         self.pipefy_client = PipefyClient(settings=settings.pipefy)
+
+        oauth_url = settings.pipefy.oauth_url
+        oauth_client = settings.pipefy.oauth_client
+        oauth_secret = settings.pipefy.oauth_secret
+
+        if oauth_url and oauth_client and oauth_secret:
+            self.internal_api_client = InternalApiClient(
+                url=settings.pipefy.internal_api_url,
+                oauth_url=oauth_url,
+                oauth_client=oauth_client,
+                oauth_secret=oauth_secret,
+            )
+            self.ai_automation_service = AiAutomationService(
+                client=self.internal_api_client
+            )
+            auth = OAuth2ClientCredentials(
+                token_url=oauth_url,
+                client_id=oauth_client,
+                client_secret=oauth_secret,
+            )
+            self.ai_agent_service = AiAgentService(
+                settings=settings.pipefy,
+                auth=auth,
+            )
 
     def shutdown(self) -> None:
         pass

--- a/src/pipefy_mcp/models/ai_agent.py
+++ b/src/pipefy_mcp/models/ai_agent.py
@@ -1,0 +1,71 @@
+"""Pydantic models for AI Agent input validation."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from pipefy_mcp.models.validators import NonBlankStr
+
+ACTION_ID_AI_BEHAVIOR = "ai_behavior"
+MAX_BEHAVIORS = 5
+
+
+class CreateAiAgentInput(BaseModel):
+    """Validated input for creating an AI Agent.
+
+    Attributes:
+        name: Agent name (non-empty, stripped).
+        repo_uuid: Repository UUID (non-empty, stripped).
+    """
+
+    name: NonBlankStr
+    repo_uuid: NonBlankStr
+
+
+class BehaviorInput(BaseModel):
+    """Validated input for an AI Agent behavior.
+
+    Accepts both snake_case and camelCase field names (e.g. event_id or eventId).
+    Serializes to camelCase for the GraphQL API when using model_dump(by_alias=True).
+
+    Attributes:
+        name: Behavior name (non-empty, stripped).
+        event_id: Event trigger ID (eventId in GraphQL).
+        action_id: Action ID; defaults to ai_behavior (actionId in GraphQL).
+        active: Whether the behavior is active; defaults to True.
+        condition: Optional condition structure.
+        action_params: Optional action parameters (actionParams in GraphQL).
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    name: NonBlankStr
+    event_id: NonBlankStr = Field(alias="eventId")
+    action_id: str = Field(default=ACTION_ID_AI_BEHAVIOR, alias="actionId")
+    active: bool = True
+    condition: dict | None = None
+    action_params: dict | None = Field(default=None, alias="actionParams")
+
+
+class UpdateAiAgentInput(BaseModel):
+    """Validated input for updating an AI Agent.
+
+    Attributes:
+        uuid: Agent UUID (non-empty, stripped).
+        name: Agent name (non-empty, stripped).
+        repo_uuid: Repository UUID (non-empty, stripped).
+        behaviors: List of behaviors (1 to MAX_BEHAVIORS).
+        instruction: Optional instruction text.
+        data_source_ids: Optional list of data source IDs.
+    """
+
+    uuid: NonBlankStr
+    name: NonBlankStr
+    repo_uuid: NonBlankStr
+    behaviors: list[BehaviorInput] = Field(
+        min_length=1,
+        max_length=MAX_BEHAVIORS,
+        description="List of behaviors (1 to MAX_BEHAVIORS)",
+    )
+    instruction: str | None = None
+    data_source_ids: list[str] = Field(default_factory=list)

--- a/src/pipefy_mcp/models/ai_automation.py
+++ b/src/pipefy_mcp/models/ai_automation.py
@@ -1,0 +1,76 @@
+"""Pydantic models for AI Automation input validation."""
+
+from __future__ import annotations
+
+import copy
+from typing import Annotated
+
+from pydantic import BaseModel, BeforeValidator, Field
+
+from pipefy_mcp.models.validators import NonBlankStr
+
+EVENT_ID_BLACKLIST = frozenset({"scheduler"})
+
+DEFAULT_CONDITION = {
+    "expressions": [
+        {"structure_id": 0, "field_address": "", "operation": "", "value": ""}
+    ],
+    "expressions_structure": [[0]],
+}
+
+
+def _reject_blacklisted_event_id(v: str) -> str:
+    stripped = v.strip()
+    if stripped.lower() in EVENT_ID_BLACKLIST:
+        raise ValueError(f"event_id '{stripped}' is not allowed for generate_with_ai")
+    return stripped
+
+
+_EventId = Annotated[
+    str,
+    BeforeValidator(_reject_blacklisted_event_id),
+    Field(description="Event ID (e.g. card_created); 'scheduler' is blacklisted"),
+]
+
+
+class CreateAiAutomationInput(BaseModel):
+    """Validated input for creating an AI Automation (generate_with_ai).
+
+    Attributes:
+        name: Automation name (non-empty, stripped).
+        event_id: Event trigger (e.g. card_created); scheduler is blacklisted.
+        pipe_id: Pipe ID (event_repo_id / action_repo_id).
+        prompt: AI prompt text (non-empty, stripped).
+        field_ids: Non-empty list of field internal IDs as strings.
+        condition: Optional condition structure; defaults to placeholder.
+    """
+
+    name: NonBlankStr
+    event_id: _EventId
+    pipe_id: NonBlankStr
+    prompt: NonBlankStr
+    field_ids: list[str] = Field(
+        min_length=1,
+        description="Non-empty list of field internal IDs as strings",
+    )
+    condition: dict = Field(default_factory=lambda: copy.deepcopy(DEFAULT_CONDITION))
+
+
+class UpdateAiAutomationInput(BaseModel):
+    """Validated input for updating an AI Automation.
+
+    Attributes:
+        automation_id: ID of the automation to update.
+        name: Optional new name.
+        active: Optional active state.
+        prompt: Optional new prompt.
+        field_ids: Optional new field IDs.
+        condition: Optional new condition.
+    """
+
+    automation_id: str = Field(description="Automation ID to update")
+    name: NonBlankStr | None = None
+    active: bool | None = None
+    prompt: NonBlankStr | None = None
+    field_ids: list[str] | None = Field(default=None, min_length=1)
+    condition: dict | None = None

--- a/src/pipefy_mcp/models/validators.py
+++ b/src/pipefy_mcp/models/validators.py
@@ -1,0 +1,13 @@
+"""Shared Pydantic validators and annotated types."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from pydantic import BeforeValidator, Field
+
+NonBlankStr = Annotated[
+    str,
+    BeforeValidator(str.strip),
+    Field(min_length=1, description="Non-empty string after stripping whitespace"),
+]

--- a/src/pipefy_mcp/services/pipefy/__init__.py
+++ b/src/pipefy_mcp/services/pipefy/__init__.py
@@ -1,6 +1,17 @@
+from .ai_agent_service import AiAgentService
+from .ai_automation_service import AiAutomationService
 from .base_client import BasePipefyClient
 from .card_service import CardService
 from .client import PipefyClient
+from .internal_api_client import InternalApiClient
 from .pipe_service import PipeService
 
-__all__ = ["PipefyClient", "PipeService", "CardService", "BasePipefyClient"]
+__all__ = [
+    "AiAgentService",
+    "AiAutomationService",
+    "BasePipefyClient",
+    "CardService",
+    "InternalApiClient",
+    "PipefyClient",
+    "PipeService",
+]

--- a/src/pipefy_mcp/services/pipefy/ai_agent_service.py
+++ b/src/pipefy_mcp/services/pipefy/ai_agent_service.py
@@ -1,0 +1,180 @@
+"""Service for AI Agent create and update operations."""
+
+from __future__ import annotations
+
+import copy
+import uuid
+
+from httpx_auth import OAuth2ClientCredentials
+
+from pipefy_mcp.models.ai_agent import CreateAiAgentInput, UpdateAiAgentInput
+from pipefy_mcp.services.pipefy.base_client import BasePipefyClient
+from pipefy_mcp.services.pipefy.queries.ai_agent_queries import (
+    CREATE_AI_AGENT_MUTATION,
+    TOGGLE_AI_AGENT_STATUS_MUTATION,
+    UPDATE_AI_AGENT_MUTATION,
+)
+from pipefy_mcp.services.pipefy.types import AgentServiceResult, ToggleAgentStatusResult
+from pipefy_mcp.settings import PipefySettings
+
+
+def inject_reference_ids(behaviors: list[dict]) -> list[dict]:
+    """Generate and inject referenceIds into behavior actions.
+
+    For each behavior, generates a UUID v4 per action in actionsAttributes,
+    sets it as the action's referenceId, and appends a %{action:<uuid>}
+    placeholder to the behavior's instruction.
+
+    Args:
+        behaviors: List of behavior dicts with actionParams.aiBehaviorParams.
+
+    Returns:
+        New list of behaviors (deep copy) with referenceIds injected.
+        Original input is never mutated.
+    """
+    result = [copy.deepcopy(b) for b in behaviors]
+
+    for behavior in result:
+        ai_params = (behavior.get("actionParams") or {}).get("aiBehaviorParams")
+        if not ai_params:
+            continue
+
+        actions = ai_params.get("actionsAttributes")
+        if not actions:
+            continue
+
+        placeholders: list[str] = []
+        for action in actions:
+            ref_id = str(uuid.uuid4())
+            action["referenceId"] = ref_id
+            placeholders.append(f"%{{action:{ref_id}}}")
+
+        instruction = ai_params.get("instruction") or ""
+        separator = "\n" if instruction else ""
+        ai_params["instruction"] = instruction + separator + "\n".join(placeholders)
+
+    return result
+
+
+class AiAgentService(BasePipefyClient):
+    """Service for creating and updating AI Agents via GraphQL."""
+
+    def __init__(
+        self,
+        settings: PipefySettings,
+        auth: OAuth2ClientCredentials | None = None,
+    ) -> None:
+        """Create the service.
+
+        Args:
+            settings: Pipefy settings (graphql_url, OAuth credentials).
+            auth: Optional pre-built OAuth2 auth to share token cache.
+        """
+        super().__init__(settings=settings, auth=auth)
+
+    async def create_agent(self, agent_input: CreateAiAgentInput) -> AgentServiceResult:
+        """Create an AI Agent (empty, no behaviors).
+
+        Args:
+            agent_input: Validated create input with name and repo_uuid.
+
+        Returns:
+            Dict with agent_uuid and message.
+
+        Raises:
+            ValueError: When API response is missing agent.uuid.
+        """
+        variables = {
+            "agent": {
+                "name": agent_input.name,
+                "repoUuid": agent_input.repo_uuid,
+            }
+        }
+
+        response = await self.execute_query(CREATE_AI_AGENT_MUTATION, variables)
+
+        agent = response.get("createAiAgent", {}).get("agent")
+        if not agent or "uuid" not in agent:
+            raise ValueError(
+                "Unexpected API payload: agent.uuid missing from createAiAgent response"
+            )
+
+        agent_uuid = str(agent["uuid"])
+        return {
+            "agent_uuid": agent_uuid,
+            "message": f"AI Agent created successfully. UUID: {agent_uuid}",
+        }
+
+    async def update_agent(self, agent_input: UpdateAiAgentInput) -> AgentServiceResult:
+        """Update an AI Agent with instruction and behaviors.
+
+        Calls inject_reference_ids on behaviors before building the payload
+        so each action gets a fresh UUID v4 referenceId.
+
+        Args:
+            agent_input: Validated update input with uuid, name, repo_uuid, behaviors.
+
+        Returns:
+            Dict with agent_uuid and message.
+
+        Raises:
+            ValueError: When API response is missing agent.uuid.
+        """
+        behaviors_raw = [
+            b.model_dump(by_alias=True, exclude_none=True)
+            for b in agent_input.behaviors
+        ]
+        behaviors_with_refs = inject_reference_ids(behaviors_raw)
+
+        variables = {
+            "uuid": agent_input.uuid,
+            "agent": {
+                "name": agent_input.name,
+                "repoUuid": agent_input.repo_uuid,
+                "instruction": agent_input.instruction or "",
+                "dataSourceIds": agent_input.data_source_ids,
+                "behaviors": behaviors_with_refs,
+            },
+        }
+
+        response = await self.execute_query(UPDATE_AI_AGENT_MUTATION, variables)
+
+        agent = response.get("updateAiAgent", {}).get("agent")
+        if not agent or "uuid" not in agent:
+            raise ValueError(
+                "Unexpected API payload: agent.uuid missing from updateAiAgent response"
+            )
+
+        agent_uuid = str(agent["uuid"])
+        return {
+            "agent_uuid": agent_uuid,
+            "message": f"AI Agent updated successfully. UUID: {agent_uuid}",
+        }
+
+    async def toggle_agent_status(
+        self, agent_uuid: str, active: bool
+    ) -> ToggleAgentStatusResult:
+        """Enable or disable an AI Agent.
+
+        Args:
+            agent_uuid: Agent UUID.
+            active: True to activate, False to deactivate.
+
+        Returns:
+            Dict with success flag and message.
+
+        Raises:
+            ValueError: When the API reports failure.
+        """
+        variables = {"uuid": agent_uuid, "active": active}
+        response = await self.execute_query(TOGGLE_AI_AGENT_STATUS_MUTATION, variables)
+
+        result = response.get("updateAiAgentStatus", {})
+        if not result.get("success"):
+            raise ValueError("Toggle agent status failed: API returned success=false")
+
+        action = "activated" if active else "deactivated"
+        return {
+            "success": True,
+            "message": f"AI Agent {action} successfully.",
+        }

--- a/src/pipefy_mcp/services/pipefy/ai_automation_service.py
+++ b/src/pipefy_mcp/services/pipefy/ai_automation_service.py
@@ -1,0 +1,134 @@
+"""Service for AI Automation create and update operations."""
+
+from __future__ import annotations
+
+from pipefy_mcp.models.ai_automation import (
+    CreateAiAutomationInput,
+    UpdateAiAutomationInput,
+)
+from pipefy_mcp.services.pipefy.internal_api_client import InternalApiClient
+from pipefy_mcp.services.pipefy.queries.ai_automation_queries import (
+    CREATE_AUTOMATION_MUTATION,
+    UPDATE_AUTOMATION_MUTATION,
+)
+from pipefy_mcp.services.pipefy.types import AutomationServiceResult
+
+ACTION_ID_GENERATE_WITH_AI = "generate_with_ai"
+
+
+class AiAutomationService:
+    """Service for creating and updating AI Automations via the internal API."""
+
+    def __init__(self, client: InternalApiClient) -> None:
+        """Create the service.
+
+        Args:
+            client: InternalApiClient for the internal_api endpoint.
+        """
+        self._client = client
+
+    async def create_automation(
+        self, automation_input: CreateAiAutomationInput
+    ) -> AutomationServiceResult:
+        """Create an AI Automation (generate_with_ai action).
+
+        Args:
+            automation_input: Validated create input.
+
+        Returns:
+            Dict with automation_id and message.
+
+        Raises:
+            ValueError: When API response is missing automation.id.
+        """
+        variables = {
+            "name": automation_input.name,
+            "action_id": ACTION_ID_GENERATE_WITH_AI,
+            "event_id": automation_input.event_id,
+            "event_repo_id": automation_input.pipe_id,
+            "action_repo_id": automation_input.pipe_id,
+            "action_params": {
+                "aiParams": {
+                    "value": automation_input.prompt,
+                    "fieldIds": automation_input.field_ids,
+                }
+            },
+            "condition": automation_input.condition,
+        }
+
+        response = await self._client.execute_query(
+            CREATE_AUTOMATION_MUTATION, variables
+        )
+
+        create_result = response.get("data", {}).get("createAutomation", {})
+        error_details = create_result.get("error_details")
+        if error_details:
+            messages = error_details.get("messages", [])
+            raise ValueError(f"API error: {'; '.join(messages)}")
+
+        automation = create_result.get("automation")
+        if not automation or "id" not in automation:
+            raise ValueError(
+                "Unexpected API payload: automation.id missing from createAutomation response"
+            )
+
+        automation_id = str(automation["id"])
+        return {
+            "automation_id": automation_id,
+            "message": f"AI Automation created successfully. ID: {automation_id}",
+        }
+
+    async def update_automation(
+        self, automation_input: UpdateAiAutomationInput
+    ) -> AutomationServiceResult:
+        """Update an existing AI Automation.
+
+        Args:
+            automation_input: Validated update input.
+
+        Returns:
+            Dict with automation_id and message.
+
+        Raises:
+            ValueError: When API response is missing automation.id.
+        """
+        input_dict: dict = {"id": automation_input.automation_id}
+        if automation_input.name is not None:
+            input_dict["name"] = automation_input.name
+        if automation_input.active is not None:
+            input_dict["active"] = automation_input.active
+
+        ai_params: dict = {}
+        if automation_input.prompt is not None:
+            ai_params["value"] = automation_input.prompt
+        if automation_input.field_ids is not None:
+            ai_params["fieldIds"] = automation_input.field_ids
+        if ai_params:
+            input_dict["action_params"] = {"aiParams": ai_params}
+
+        if automation_input.condition is not None:
+            input_dict["condition"] = automation_input.condition
+
+        variables = {"input": input_dict}
+
+        response = await self._client.execute_query(
+            UPDATE_AUTOMATION_MUTATION, variables
+        )
+
+        update_result = response.get("data", {}).get("updateAutomation", {})
+        error_details = update_result.get("error_details")
+        if error_details:
+            messages = error_details.get("messages", [])
+            raise ValueError(f"API error: {'; '.join(messages)}")
+
+        automation = update_result.get("automation")
+        if not automation or "id" not in automation:
+            raise ValueError(
+                "Unexpected API payload: automation.id missing from updateAutomation response"
+            )
+
+        automation_id = str(automation["id"])
+        return {
+            "automation_id": automation_id,
+            "message": f"AI Automation updated successfully. ID: {automation_id}",
+        }

--- a/src/pipefy_mcp/services/pipefy/base_client.py
+++ b/src/pipefy_mcp/services/pipefy/base_client.py
@@ -13,74 +13,48 @@ from pipefy_mcp.settings import PipefySettings
 class BasePipefyClient:
     """Base infrastructure for Pipefy GraphQL operations.
 
-    This class centralizes GraphQL client creation so services can reuse a single
-    underlying `gql.Client` instance via constructor injection.
+    Creates a fresh transport per execute_query() call so parallel requests
+    never share mutable transport state (avoids TransportAlreadyConnected).
+    The OAuth2 auth instance is shared across calls to reuse the token cache.
+    Pass a pre-built auth instance to share it across multiple service instances
+    (e.g. from PipefyClient) so only one token cache exists for the whole client.
     """
 
     GRAPHQL_REQUEST_TIMEOUT_SECONDS: ClassVar[int] = 30
 
     def __init__(
         self,
-        settings: PipefySettings | None = None,
-        schema: str | None = None,
-        client: Client | None = None,
+        settings: PipefySettings,
+        auth: OAuth2ClientCredentials | None = None,
     ) -> None:
-        """Create a base client.
-
-        Args:
-            schema: Optional schema string to pass to `gql.Client`.
-            client: Optional pre-built `gql.Client` to reuse (preferred for shared wiring).
-
-        Raises:
-            ValueError: If both schema and client are provided, as schema would be ignored.
-        """
-        if schema is not None and client is not None:
-            raise ValueError(
-                "Cannot specify both 'schema' and 'client'. "
-                "When reusing an existing client, its schema is already configured."
-            )
-
-        self.settings = settings
-        self.client: Client = client or self._create_client(schema)
-
-    def _create_client(self, schema: str | None) -> Client:
-        """Create and configure a `gql.Client` using project settings.
-
-        Note: This preserves the current behavior from `PipefyClient._create_client`.
-        """
-
-        if self.settings is None:
-            raise ValueError("Settings must be provided to create a GraphQL client.")
-
-        if self.settings.graphql_url is None:
+        if settings.graphql_url is None:
             raise ValueError("GraphQL URL must be provided in settings.")
-        if self.settings.oauth_url is None:
+        if settings.oauth_url is None:
             raise ValueError("OAuth URL must be provided in settings.")
-        if self.settings.oauth_client is None:
+        if settings.oauth_client is None:
             raise ValueError("OAuth client ID must be provided in settings.")
-        if self.settings.oauth_secret is None:
+        if settings.oauth_secret is None:
             raise ValueError("OAuth client secret must be provided in settings.")
 
-        transport = HTTPXAsyncTransport(
-            url=self.settings.graphql_url,
-            auth=OAuth2ClientCredentials(
-                token_url=self.settings.oauth_url,
-                client_id=self.settings.oauth_client,
-                client_secret=self.settings.oauth_secret,
-            ),
-            timeout=Timeout(timeout=self.GRAPHQL_REQUEST_TIMEOUT_SECONDS),
+        self.settings = settings
+        self._auth = auth or OAuth2ClientCredentials(
+            token_url=settings.oauth_url,
+            client_id=settings.oauth_client,
+            client_secret=settings.oauth_secret,
         )
-
-        if schema:
-            return Client(transport=transport, schema=schema)
-        return Client(transport=transport, fetch_schema_from_transport=True)
 
     async def execute_query(self, query: Any, variables: dict[str, Any]) -> dict:
         """Execute a GraphQL query/mutation with variables.
 
-        This method standardizes session usage and preserves current behavior by
-        passing `variable_values` through without transformation.
+        A fresh HTTPXAsyncTransport is created per call so concurrent invocations
+        each get their own isolated connection state.
         """
-
-        async with self.client as session:
+        transport = HTTPXAsyncTransport(
+            url=self.settings.graphql_url,
+            auth=self._auth,
+            timeout=Timeout(timeout=self.GRAPHQL_REQUEST_TIMEOUT_SECONDS),
+        )
+        async with Client(
+            transport=transport, fetch_schema_from_transport=True
+        ) as session:
             return await session.execute(query, variable_values=variables)

--- a/src/pipefy_mcp/services/pipefy/card_service.py
+++ b/src/pipefy_mcp/services/pipefy/card_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from gql import Client
+from httpx_auth import OAuth2ClientCredentials
 
 from pipefy_mcp.services.pipefy.base_client import BasePipefyClient
 from pipefy_mcp.services.pipefy.queries.card_queries import (
@@ -24,13 +24,18 @@ from pipefy_mcp.services.pipefy.utils.formatters import (
     convert_fields_to_array,
     convert_values_to_camel_case,
 )
+from pipefy_mcp.settings import PipefySettings
 
 
 class CardService(BasePipefyClient):
     """Service for Card-related operations."""
 
-    def __init__(self, client: Client) -> None:
-        super().__init__(client=client)
+    def __init__(
+        self,
+        settings: PipefySettings,
+        auth: OAuth2ClientCredentials | None = None,
+    ) -> None:
+        super().__init__(settings=settings, auth=auth)
 
     async def create_card(
         self, pipe_id: int, fields: dict[str, Any] | list[dict[str, Any]]

--- a/src/pipefy_mcp/services/pipefy/client.py
+++ b/src/pipefy_mcp/services/pipefy/client.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from gql import Client
+from httpx_auth import OAuth2ClientCredentials
 
-from pipefy_mcp.services.pipefy.base_client import BasePipefyClient
 from pipefy_mcp.services.pipefy.card_service import CardService
 from pipefy_mcp.services.pipefy.pipe_service import PipeService
 from pipefy_mcp.services.pipefy.types import CardSearch
@@ -14,15 +13,14 @@ from pipefy_mcp.settings import PipefySettings
 class PipefyClient:
     """Facade client for Pipefy API operations (pure delegation)."""
 
-    def __init__(self, settings: PipefySettings, schema: str | None = None):
-        graphql = BasePipefyClient(settings=settings, schema=schema)
-
-        # Keep `client` as a public attribute for backward compatibility.
-        self.client: Client = graphql.client
-
-        # Service layer (domain logic lives here).
-        self._pipe_service = PipeService(self.client)
-        self._card_service = CardService(self.client)
+    def __init__(self, settings: PipefySettings):
+        auth = OAuth2ClientCredentials(
+            token_url=settings.oauth_url,
+            client_id=settings.oauth_client,
+            client_secret=settings.oauth_secret,
+        )
+        self._pipe_service = PipeService(settings=settings, auth=auth)
+        self._card_service = CardService(settings=settings, auth=auth)
 
     async def get_pipe(self, pipe_id: int) -> dict:
         """Get a pipe by ID, including phases, labels, and start form fields."""

--- a/src/pipefy_mcp/services/pipefy/internal_api_client.py
+++ b/src/pipefy_mcp/services/pipefy/internal_api_client.py
@@ -1,0 +1,72 @@
+"""HTTP client for Pipefy's internal_api endpoint."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+from httpx import Timeout
+from httpx_auth import OAuth2ClientCredentials
+
+REQUEST_TIMEOUT_SECONDS = 30
+
+
+class InternalApiClient:
+    """HTTP client for Pipefy internal API (AI Automation mutations).
+
+    Uses OAuth2 client credentials for token authentication. Sends GraphQL
+    requests as JSON POST to the configured internal_api URL.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        oauth_url: str,
+        oauth_client: str,
+        oauth_secret: str,
+    ) -> None:
+        """Create an internal API client.
+
+        Args:
+            url: URL of the internal_api endpoint (e.g. https://app.pipefy.com/internal_api).
+            oauth_url: OAuth token URL.
+            oauth_client: OAuth client ID.
+            oauth_secret: OAuth client secret.
+        """
+        self._url = url
+        self._auth = OAuth2ClientCredentials(
+            token_url=oauth_url,
+            client_id=oauth_client,
+            client_secret=oauth_secret,
+        )
+
+    async def execute_query(self, query: str, variables: dict[str, Any]) -> dict:
+        """Execute a GraphQL query/mutation via POST.
+
+        Args:
+            query: GraphQL query string.
+            variables: Variables for the query.
+
+        Returns:
+            Parsed JSON response from the API.
+
+        Raises:
+            httpx.HTTPStatusError: When response status is not 2xx.
+            httpx.TimeoutException: When the request times out.
+            ValueError: When response contains GraphQL errors (HTTP 200 but {"errors": [...]}).
+        """
+        async with httpx.AsyncClient(
+            auth=self._auth,
+            timeout=Timeout(timeout=REQUEST_TIMEOUT_SECONDS),
+        ) as client:
+            response = await client.post(
+                self._url,
+                json={"query": query, "variables": variables},
+                headers={"Content-Type": "application/json"},
+            )
+            response.raise_for_status()
+
+            data = response.json()
+            if "errors" in data and data["errors"]:
+                raise ValueError(f"GraphQL error response: {data['errors']}")
+            return data

--- a/src/pipefy_mcp/services/pipefy/pipe_service.py
+++ b/src/pipefy_mcp/services/pipefy/pipe_service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from gql import Client
+from httpx_auth import OAuth2ClientCredentials
 from rapidfuzz import fuzz
 
 from pipefy_mcp.services.pipefy.base_client import BasePipefyClient
@@ -11,13 +11,18 @@ from pipefy_mcp.services.pipefy.queries.pipe_queries import (
     GET_START_FORM_FIELDS_QUERY,
     SEARCH_PIPES_QUERY,
 )
+from pipefy_mcp.settings import PipefySettings
 
 
 class PipeService(BasePipefyClient):
     """Service for Pipe-related operations."""
 
-    def __init__(self, client: Client) -> None:
-        super().__init__(client=client)
+    def __init__(
+        self,
+        settings: PipefySettings,
+        auth: OAuth2ClientCredentials | None = None,
+    ) -> None:
+        super().__init__(settings=settings, auth=auth)
 
     async def get_pipe(self, pipe_id: int) -> dict:
         """Get a pipe by its ID, including phases, labels, and start form fields."""

--- a/src/pipefy_mcp/services/pipefy/queries/ai_agent_queries.py
+++ b/src/pipefy_mcp/services/pipefy/queries/ai_agent_queries.py
@@ -1,0 +1,87 @@
+"""GraphQL mutations for AI Agent operations."""
+
+from gql import gql
+
+# NOTE: Keep this module free of runtime logic. Only GraphQL operation constants.
+
+CREATE_AI_AGENT_MUTATION = gql(
+    """
+    mutation createAiAgent($agent: AiAgentInput!) {
+        createAiAgent(input: { agent: $agent }) {
+            agent {
+                uuid
+                name
+                repoUuid
+                instruction
+                dataSourceIds
+            }
+        }
+    }
+    """
+)
+
+TOGGLE_AI_AGENT_STATUS_MUTATION = gql(
+    """
+    mutation updateAiAgentStatus($uuid: ID!, $active: Boolean!) {
+        updateAiAgentStatus(input: { uuid: $uuid, active: $active }) {
+            success
+        }
+    }
+    """
+)
+
+UPDATE_AI_AGENT_MUTATION = gql(
+    """
+    mutation updateAiAgent($agent: AiAgentInput!, $uuid: ID!) {
+        updateAiAgent(input: { agent: $agent, uuid: $uuid }) {
+            agent {
+                uuid
+                name
+                repoUuid
+                instruction
+                dataSourceIds
+                behaviors {
+                    id
+                    name
+                    active
+                    eventId: event_id
+                    actionId: action_id
+                    condition {
+                        expressions_structure
+                        expressions {
+                            id
+                            field_address
+                            operation
+                            value
+                            structure_id
+                        }
+                    }
+                    actionParams: action_params {
+                        aiBehaviorParams {
+                            instruction
+                            dataSourceIds
+                            referencedFieldIds
+                            actionsAttributes {
+                                id
+                                name
+                                actionType
+                                referenceId
+                                metadata {
+                                    destinationPhaseId
+                                    pipeId
+                                    tableId
+                                    fieldsAttributes {
+                                        fieldId
+                                        inputMode
+                                        value
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """
+)

--- a/src/pipefy_mcp/services/pipefy/queries/ai_automation_queries.py
+++ b/src/pipefy_mcp/services/pipefy/queries/ai_automation_queries.py
@@ -1,0 +1,50 @@
+"""GraphQL mutation strings for AI Automation (internal_api endpoint).
+
+Plain strings (not gql()) since internal_api does not support schema validation.
+"""
+
+CREATE_AUTOMATION_MUTATION = """
+mutation createAutomation(
+  $name: String!,
+  $action_id: ID!,
+  $event_id: ID!,
+  $action_repo_id: ID,
+  $event_repo_id: ID,
+  $action_params: AutomationActionParamsInput,
+  $condition: ConditionInput
+) {
+  createAutomation(input: {
+    name: $name,
+    action_id: $action_id,
+    event_id: $event_id,
+    action_repo_id: $action_repo_id,
+    event_repo_id: $event_repo_id,
+    action_params: $action_params,
+    condition: $condition
+  }) {
+    automation {
+      id
+    }
+    error_details {
+      object_name
+      object_key
+      messages
+    }
+  }
+}
+"""
+
+UPDATE_AUTOMATION_MUTATION = """
+mutation updateAutomation($input: UpdateAutomationInput!) {
+  updateAutomation(input: $input) {
+    automation {
+      id
+    }
+    error_details {
+      object_name
+      object_key
+      messages
+    }
+  }
+}
+"""

--- a/src/pipefy_mcp/services/pipefy/queries/pipe_queries.py
+++ b/src/pipefy_mcp/services/pipefy/queries/pipe_queries.py
@@ -7,6 +7,7 @@ GET_PIPE_QUERY = gql(
     query ($pipe_id: ID!) {
         pipe(id: $pipe_id) {
             id
+            uuid
             name
             phases {
                 id

--- a/src/pipefy_mcp/services/pipefy/types.py
+++ b/src/pipefy_mcp/services/pipefy/types.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Literal
+
 from typing_extensions import TypedDict
 
 
@@ -12,3 +14,18 @@ class CardSearch(TypedDict, total=False):
     title: str
     inbox_emails_read: bool
     include_done: bool
+
+
+class AgentServiceResult(TypedDict):
+    agent_uuid: str
+    message: str
+
+
+class AutomationServiceResult(TypedDict):
+    automation_id: str
+    message: str
+
+
+class ToggleAgentStatusResult(TypedDict):
+    success: Literal[True]
+    message: str

--- a/src/pipefy_mcp/settings.py
+++ b/src/pipefy_mcp/settings.py
@@ -8,6 +8,11 @@ class PipefySettings(BaseModel):
         description="GraphQL URL for Pipefy",
     )
 
+    internal_api_url: str = Field(
+        default="https://app.pipefy.com/internal_api",
+        description="Internal API URL for AI Automation endpoints",
+    )
+
     oauth_url: str | None = Field(
         default=None,
         description="OAuth URL for Pipefy",

--- a/src/pipefy_mcp/tools/ai_agent_tools.py
+++ b/src/pipefy_mcp/tools/ai_agent_tools.py
@@ -1,0 +1,137 @@
+"""MCP tools for AI Agent operations (create + update)."""
+
+from __future__ import annotations
+
+from mcp.server.fastmcp import Context, FastMCP
+from mcp.types import ToolAnnotations
+from pydantic import ValidationError
+
+from pipefy_mcp.models.ai_agent import CreateAiAgentInput, UpdateAiAgentInput
+from pipefy_mcp.services.pipefy.ai_agent_service import AiAgentService
+from pipefy_mcp.tools.ai_tool_helpers import (
+    build_ai_tool_error,
+    build_create_agent_success,
+    build_toggle_agent_status_success,
+    build_update_agent_success,
+)
+
+
+class AiAgentTools:
+    """Declares MCP tools for AI Agent create and update."""
+
+    @staticmethod
+    def register(mcp: FastMCP, service: AiAgentService) -> None:
+        """Register AI Agent tools on the MCP server."""
+
+        @mcp.tool(
+            annotations=ToolAnnotations(readOnlyHint=False),
+        )
+        async def create_ai_agent(
+            ctx: Context,
+            name: str,
+            repo_uuid: str,
+        ) -> dict:
+            """Create an AI Agent (empty, no behaviors) attached to a pipe.
+
+            Use update_ai_agent to configure 1 to 5 behaviors.
+            repo_uuid is the pipe's unique identifier — not the numeric pipe ID from the URL.
+            Resolve it via pipe query.
+
+            Args:
+                name: Agent display name.
+                repo_uuid: UUID of the pipe the agent belongs to.
+            """
+            ctx.debug(f"create_ai_agent: name={name}, repo_uuid={repo_uuid}")
+            try:
+                validated = CreateAiAgentInput(name=name, repo_uuid=repo_uuid)
+            except ValidationError as exc:
+                return build_ai_tool_error(str(exc))
+
+            try:
+                result = await service.create_agent(validated)
+            except Exception as exc:  # noqa: BLE001
+                return build_ai_tool_error(str(exc))
+
+            return build_create_agent_success(
+                agent_uuid=result["agent_uuid"],
+                message=result["message"],
+            )
+
+        @mcp.tool(
+            annotations=ToolAnnotations(readOnlyHint=False),
+        )
+        async def update_ai_agent(
+            ctx: Context,
+            uuid: str,
+            name: str,
+            repo_uuid: str,
+            instruction: str,
+            behaviors: list[dict],
+            data_source_ids: list[str] | None = None,
+        ) -> dict:
+            """Update an AI Agent with an instruction and 1 to 5 behaviors that can execute complex actions (e.g. move card, update fields conditionally).
+
+            The API replaces the entire agent payload, so always send the complete list of behaviors.
+            Other agents (e.g. OpenClaw) can use this tool to configure Pipefy AI Agents programmatically.
+
+            Args:
+                uuid: UUID of the agent to update.
+                name: Agent display name.
+                repo_uuid: UUID of the pipe the agent belongs to.
+                instruction: Global instruction for the agent.
+                behaviors: List of 1 to 5 behavior dicts (name, event_id required per behavior).
+                data_source_ids: Optional list of data source IDs.
+            """
+            ctx.debug(f"update_ai_agent: uuid={uuid}, behaviors_count={len(behaviors)}")
+            try:
+                validated = UpdateAiAgentInput(
+                    uuid=uuid,
+                    name=name,
+                    repo_uuid=repo_uuid,
+                    instruction=instruction,
+                    behaviors=behaviors,
+                    data_source_ids=data_source_ids or [],
+                )
+            except ValidationError as exc:
+                return build_ai_tool_error(str(exc))
+
+            try:
+                result = await service.update_agent(validated)
+            except Exception as exc:  # noqa: BLE001
+                return build_ai_tool_error(str(exc))
+
+            return build_update_agent_success(
+                agent_uuid=result["agent_uuid"],
+                message=result["message"],
+            )
+
+        @mcp.tool(
+            annotations=ToolAnnotations(readOnlyHint=False),
+        )
+        async def toggle_ai_agent_status(
+            ctx: Context,
+            uuid: str,
+            active: bool,
+        ) -> dict:
+            """Enable or disable an AI Agent.
+
+            Set active=true to activate or active=false to deactivate.
+            Does not require resending the agent configuration.
+
+            Args:
+                uuid: UUID of the agent to enable/disable.
+                active: True to activate, False to deactivate.
+            """
+            ctx.debug(f"toggle_ai_agent_status: uuid={uuid}, active={active}")
+            agent_uuid = uuid.strip()
+            if not agent_uuid:
+                return build_ai_tool_error("uuid must not be blank")
+
+            try:
+                result = await service.toggle_agent_status(
+                    agent_uuid=agent_uuid, active=active
+                )
+            except Exception as exc:  # noqa: BLE001
+                return build_ai_tool_error(str(exc))
+
+            return build_toggle_agent_status_success(message=result["message"])

--- a/src/pipefy_mcp/tools/ai_automation_tools.py
+++ b/src/pipefy_mcp/tools/ai_automation_tools.py
@@ -1,0 +1,121 @@
+"""MCP tools for AI Automation operations (create + update)."""
+
+from __future__ import annotations
+
+from mcp.server.fastmcp import Context, FastMCP
+from mcp.types import ToolAnnotations
+from pydantic import ValidationError
+
+from pipefy_mcp.models.ai_automation import (
+    CreateAiAutomationInput,
+    UpdateAiAutomationInput,
+)
+from pipefy_mcp.services.pipefy.ai_automation_service import AiAutomationService
+from pipefy_mcp.tools.ai_tool_helpers import (
+    build_ai_tool_error,
+    build_create_automation_success,
+    build_update_automation_success,
+)
+
+
+class AiAutomationTools:
+    """Declares MCP tools for AI Automation create and update."""
+
+    @staticmethod
+    def register(mcp: FastMCP, service: AiAutomationService) -> None:
+        """Register AI Automation tools on the MCP server."""
+
+        @mcp.tool(
+            annotations=ToolAnnotations(readOnlyHint=False),
+        )
+        async def create_ai_automation(
+            ctx: Context,
+            name: str,
+            event_id: str,
+            pipe_id: str,
+            prompt: str,
+            field_ids: list[str],
+            condition: dict | None = None,
+        ) -> dict:
+            """Create a simple AI automation that generates content with a prompt and writes the result to one or more card fields.
+
+            Best for straightforward field-filling use cases (e.g. summarize, classify, extract data into a field).
+            Requires AI to be enabled for the pipe in Pipefy UI.
+
+            Args:
+                name: Automation name.
+                event_id: Event trigger (e.g. card_created, card_moved).
+                pipe_id: Pipe ID where the automation runs.
+                prompt: AI prompt text that generates the content.
+                field_ids: List of field internal IDs to write the result to.
+                condition: Optional condition structure for the automation trigger.
+            """
+            ctx.debug(
+                f"create_ai_automation: name={name}, event_id={event_id}, pipe_id={pipe_id}"
+            )
+            try:
+                validated = CreateAiAutomationInput(
+                    name=name,
+                    event_id=event_id,
+                    pipe_id=pipe_id,
+                    prompt=prompt,
+                    field_ids=field_ids,
+                    **({"condition": condition} if condition is not None else {}),
+                )
+            except ValidationError as exc:
+                return build_ai_tool_error(str(exc))
+
+            try:
+                result = await service.create_automation(validated)
+            except Exception as exc:  # noqa: BLE001
+                return build_ai_tool_error(str(exc))
+
+            return build_create_automation_success(
+                automation_id=result["automation_id"],
+                message=result["message"],
+            )
+
+        @mcp.tool(
+            annotations=ToolAnnotations(readOnlyHint=False),
+        )
+        async def update_ai_automation(
+            ctx: Context,
+            automation_id: str,
+            name: str | None = None,
+            active: bool | None = None,
+            prompt: str | None = None,
+            field_ids: list[str] | None = None,
+            condition: dict | None = None,
+        ) -> dict:
+            """Update an existing AI automation's name, prompt, destination fields, or active state.
+
+            Args:
+                automation_id: ID of the automation to update.
+                name: New automation name (optional).
+                active: Whether the automation is active (optional).
+                prompt: New AI prompt text (optional).
+                field_ids: New list of field internal IDs (optional).
+                condition: New condition structure (optional).
+            """
+            ctx.debug(f"update_ai_automation: automation_id={automation_id}")
+            try:
+                validated = UpdateAiAutomationInput(
+                    automation_id=automation_id,
+                    name=name,
+                    active=active,
+                    prompt=prompt,
+                    field_ids=field_ids,
+                    condition=condition,
+                )
+            except ValidationError as exc:
+                return build_ai_tool_error(str(exc))
+
+            try:
+                result = await service.update_automation(validated)
+            except Exception as exc:  # noqa: BLE001
+                return build_ai_tool_error(str(exc))
+
+            return build_update_automation_success(
+                automation_id=result["automation_id"],
+                message=result["message"],
+            )

--- a/src/pipefy_mcp/tools/ai_tool_helpers.py
+++ b/src/pipefy_mcp/tools/ai_tool_helpers.py
@@ -1,0 +1,81 @@
+"""Typed response payloads and builder functions for AI tools."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from typing_extensions import TypedDict
+
+
+class CreateAiAutomationSuccessPayload(TypedDict):
+    success: Literal[True]
+    automation_id: str
+    message: str
+
+
+class UpdateAiAutomationSuccessPayload(TypedDict):
+    success: Literal[True]
+    automation_id: str
+    message: str
+
+
+class CreateAiAgentSuccessPayload(TypedDict):
+    success: Literal[True]
+    agent_uuid: str
+    message: str
+
+
+class UpdateAiAgentSuccessPayload(TypedDict):
+    success: Literal[True]
+    agent_uuid: str
+    message: str
+
+
+class ToggleAiAgentStatusSuccessPayload(TypedDict):
+    success: Literal[True]
+    message: str
+
+
+class AiToolErrorPayload(TypedDict):
+    success: Literal[False]
+    error: str
+
+
+def build_create_automation_success(
+    *, automation_id: str, message: str
+) -> CreateAiAutomationSuccessPayload:
+    """Build success payload for create_ai_automation."""
+    return {"success": True, "automation_id": automation_id, "message": message}
+
+
+def build_update_automation_success(
+    *, automation_id: str, message: str
+) -> UpdateAiAutomationSuccessPayload:
+    """Build success payload for update_ai_automation."""
+    return {"success": True, "automation_id": automation_id, "message": message}
+
+
+def build_create_agent_success(
+    *, agent_uuid: str, message: str
+) -> CreateAiAgentSuccessPayload:
+    """Build success payload for create_ai_agent."""
+    return {"success": True, "agent_uuid": agent_uuid, "message": message}
+
+
+def build_update_agent_success(
+    *, agent_uuid: str, message: str
+) -> UpdateAiAgentSuccessPayload:
+    """Build success payload for update_ai_agent."""
+    return {"success": True, "agent_uuid": agent_uuid, "message": message}
+
+
+def build_toggle_agent_status_success(
+    *, message: str
+) -> ToggleAiAgentStatusSuccessPayload:
+    """Build success payload for toggle_ai_agent_status."""
+    return {"success": True, "message": message}
+
+
+def build_ai_tool_error(message: str) -> AiToolErrorPayload:
+    """Build error payload for any AI tool."""
+    return {"success": False, "error": message}

--- a/src/pipefy_mcp/tools/registry.py
+++ b/src/pipefy_mcp/tools/registry.py
@@ -1,24 +1,31 @@
 from mcp.server.fastmcp import FastMCP
 
 from pipefy_mcp.core.container import ServicesContainer
+from pipefy_mcp.tools.ai_agent_tools import AiAgentTools
+from pipefy_mcp.tools.ai_automation_tools import AiAutomationTools
 from pipefy_mcp.tools.pipe_tools import PipeTools
 
 
 class ToolRegistry:
-    """Responsible for registering tools with the MCP server"""
+    """Responsible for registering tools with the MCP server."""
 
     def __init__(self, mcp: FastMCP, services_container: ServicesContainer):
         self.mcp = mcp
         self.services_container = services_container
 
     def register_tools(self) -> FastMCP:
-        """Register tools with the MCP server"""
-
+        """Register tools with the MCP server."""
         if self.services_container.pipefy_client is None:
             raise ValueError("Pipefy client is not initialized in services container")
 
         PipeTools.register(self.mcp, self.services_container.pipefy_client)
 
-        mcp = self.mcp
+        if self.services_container.ai_automation_service is not None:
+            AiAutomationTools.register(
+                self.mcp, self.services_container.ai_automation_service
+            )
 
-        return mcp
+        if self.services_container.ai_agent_service is not None:
+            AiAgentTools.register(self.mcp, self.services_container.ai_agent_service)
+
+        return self.mcp

--- a/tests/core/test_container.py
+++ b/tests/core/test_container.py
@@ -41,10 +41,20 @@ class TestServicesContainer:
 
         assert container.pipefy_client is None
 
+    @patch("pipefy_mcp.core.container.AiAgentService")
+    @patch("pipefy_mcp.core.container.AiAutomationService")
+    @patch("pipefy_mcp.core.container.InternalApiClient")
     @patch("pipefy_mcp.core.container.PipefyClient")
-    def test_initialize_services_creates_pipefy_client(self, mock_pipefy_client_class):
+    def test_initialize_services_creates_pipefy_client(
+        self,
+        mock_pipefy_client_class,
+        mock_internal_api_client_class,
+        mock_ai_automation_service_class,
+        mock_ai_agent_service_class,
+    ):
         """Test that initialize_services creates and assigns PipefyClient"""
         mock_client = Mock(spec=PipefyClient)
+        mock_client.client = Mock()
         mock_pipefy_client_class.return_value = mock_client
 
         settings = Settings(
@@ -68,3 +78,33 @@ class TestServicesContainer:
 
         # Should not raise any exception
         container.shutdown()
+
+    @patch("pipefy_mcp.core.container.InternalApiClient")
+    @patch("pipefy_mcp.core.container.AiAutomationService")
+    @patch("pipefy_mcp.core.container.AiAgentService")
+    @patch("pipefy_mcp.core.container.PipefyClient")
+    def test_initialize_services_creates_ai_services(
+        self,
+        mock_pipefy_client_class,
+        mock_ai_agent_service_class,
+        mock_ai_automation_service_class,
+        mock_internal_api_client_class,
+    ):
+        settings = Settings(
+            pipefy=PipefySettings(
+                graphql_url="https://api.pipefy.com/graphql",
+                oauth_url="https://auth.pipefy.com/oauth/token",
+                oauth_client="client_id",
+                oauth_secret="client_secret",
+            )
+        )
+
+        container = ServicesContainer()
+        container.initialize_services(settings)
+
+        assert container.internal_api_client is not None
+        assert container.ai_automation_service is not None
+        assert container.ai_agent_service is not None
+        mock_internal_api_client_class.assert_called_once()
+        mock_ai_automation_service_class.assert_called_once()
+        mock_ai_agent_service_class.assert_called_once()

--- a/tests/models/test_ai_agent.py
+++ b/tests/models/test_ai_agent.py
@@ -1,0 +1,226 @@
+"""Tests for AI Agent Pydantic input validation models."""
+
+import pytest
+from pydantic import ValidationError
+
+from pipefy_mcp.models.ai_agent import (
+    ACTION_ID_AI_BEHAVIOR,
+    MAX_BEHAVIORS,
+    BehaviorInput,
+    CreateAiAgentInput,
+    UpdateAiAgentInput,
+)
+
+
+def _make_behavior(name="Test Behavior", event_id="card_created"):
+    return {"name": name, "event_id": event_id}
+
+
+@pytest.mark.unit
+def test_create_ai_agent_input_requires_name_and_repo_uuid():
+    inp = CreateAiAgentInput(name="My Agent", repo_uuid="repo-123")
+    assert inp.name == "My Agent"
+    assert inp.repo_uuid == "repo-123"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("name", ["", "   ", "\n\t  "])
+def test_create_ai_agent_input_rejects_blank_name(name):
+    with pytest.raises(ValidationError):
+        CreateAiAgentInput(name=name, repo_uuid="repo-123")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("repo_uuid", ["", "   "])
+def test_create_ai_agent_input_rejects_blank_repo_uuid(repo_uuid):
+    with pytest.raises(ValidationError):
+        CreateAiAgentInput(name="My Agent", repo_uuid=repo_uuid)
+
+
+@pytest.mark.unit
+def test_create_ai_agent_input_strips_name():
+    inp = CreateAiAgentInput(name="  My Agent  ", repo_uuid="repo-123")
+    assert inp.name == "My Agent"
+
+
+@pytest.mark.unit
+def test_behavior_input_requires_name_and_event_id():
+    inp = BehaviorInput(name="Test Behavior", event_id="card_created")
+    assert inp.name == "Test Behavior"
+    assert inp.event_id == "card_created"
+    assert inp.action_id == ACTION_ID_AI_BEHAVIOR
+    assert inp.active is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("name", ["", "   ", "\n\t  "])
+def test_behavior_input_rejects_blank_name(name):
+    with pytest.raises(ValidationError):
+        BehaviorInput(name=name, event_id="card_created")
+
+
+@pytest.mark.unit
+def test_behavior_input_optional_fields():
+    inp = BehaviorInput(name="Test", event_id="card_created")
+    assert inp.condition is None
+    assert inp.action_params is None
+
+
+@pytest.mark.unit
+def test_behavior_input_accepts_condition_and_action_params():
+    condition = {"expressions": []}
+    action_params = {"key": "value"}
+    inp = BehaviorInput(
+        name="Test",
+        event_id="card_created",
+        condition=condition,
+        action_params=action_params,
+    )
+    assert inp.condition == condition
+    assert inp.action_params == action_params
+
+
+@pytest.mark.unit
+def test_update_ai_agent_input_requires_uuid_name_repo_uuid_behaviors():
+    inp = UpdateAiAgentInput(
+        uuid="agent-123",
+        name="My Agent",
+        repo_uuid="repo-456",
+        behaviors=[_make_behavior()],
+    )
+    assert inp.uuid == "agent-123"
+    assert inp.name == "My Agent"
+    assert inp.repo_uuid == "repo-456"
+    assert len(inp.behaviors) == 1
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("uuid_val", ["", "   ", "\n\t  "])
+def test_update_ai_agent_input_rejects_blank_uuid(uuid_val):
+    with pytest.raises(ValidationError):
+        UpdateAiAgentInput(
+            uuid=uuid_val,
+            name="My Agent",
+            repo_uuid="repo-456",
+            behaviors=[_make_behavior()],
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("name", ["", "   ", "\n\t  "])
+def test_update_ai_agent_input_rejects_blank_name(name):
+    with pytest.raises(ValidationError):
+        UpdateAiAgentInput(
+            uuid="agent-123",
+            name=name,
+            repo_uuid="repo-456",
+            behaviors=[_make_behavior()],
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("repo_uuid", ["", "   ", "\n\t  "])
+def test_update_ai_agent_input_rejects_blank_repo_uuid(repo_uuid):
+    with pytest.raises(ValidationError):
+        UpdateAiAgentInput(
+            uuid="agent-123",
+            name="My Agent",
+            repo_uuid=repo_uuid,
+            behaviors=[_make_behavior()],
+        )
+
+
+@pytest.mark.unit
+def test_update_ai_agent_input_rejects_empty_behaviors():
+    with pytest.raises(ValidationError):
+        UpdateAiAgentInput(
+            uuid="agent-123",
+            name="My Agent",
+            repo_uuid="repo-456",
+            behaviors=[],
+        )
+
+
+@pytest.mark.unit
+def test_update_ai_agent_input_rejects_more_than_five_behaviors():
+    behaviors = [_make_behavior(name=f"Behavior {i}") for i in range(MAX_BEHAVIORS + 1)]
+    with pytest.raises(ValidationError):
+        UpdateAiAgentInput(
+            uuid="agent-123",
+            name="My Agent",
+            repo_uuid="repo-456",
+            behaviors=behaviors,
+        )
+
+
+@pytest.mark.unit
+def test_update_ai_agent_input_accepts_one_behavior():
+    inp = UpdateAiAgentInput(
+        uuid="agent-123",
+        name="My Agent",
+        repo_uuid="repo-456",
+        behaviors=[_make_behavior()],
+    )
+    assert len(inp.behaviors) == 1
+
+
+@pytest.mark.unit
+def test_update_ai_agent_input_accepts_three_behaviors():
+    inp = UpdateAiAgentInput(
+        uuid="agent-123",
+        name="My Agent",
+        repo_uuid="repo-456",
+        behaviors=[
+            _make_behavior(name="B1"),
+            _make_behavior(name="B2"),
+            _make_behavior(name="B3"),
+        ],
+    )
+    assert len(inp.behaviors) == 3
+
+
+@pytest.mark.unit
+def test_update_ai_agent_input_accepts_five_behaviors():
+    inp = UpdateAiAgentInput(
+        uuid="agent-123",
+        name="My Agent",
+        repo_uuid="repo-456",
+        behaviors=[_make_behavior(name=f"B{i}") for i in range(MAX_BEHAVIORS)],
+    )
+    assert len(inp.behaviors) == MAX_BEHAVIORS
+
+
+@pytest.mark.unit
+def test_update_ai_agent_input_optional_instruction_defaults_none():
+    inp = UpdateAiAgentInput(
+        uuid="agent-123",
+        name="My Agent",
+        repo_uuid="repo-456",
+        behaviors=[_make_behavior()],
+    )
+    assert inp.instruction is None
+
+
+@pytest.mark.unit
+def test_update_ai_agent_input_optional_data_source_ids_defaults_empty():
+    inp = UpdateAiAgentInput(
+        uuid="agent-123",
+        name="My Agent",
+        repo_uuid="repo-456",
+        behaviors=[_make_behavior()],
+    )
+    assert inp.data_source_ids == []
+
+
+@pytest.mark.unit
+def test_update_ai_agent_input_accepts_instruction_and_data_source_ids():
+    inp = UpdateAiAgentInput(
+        uuid="agent-123",
+        name="My Agent",
+        repo_uuid="repo-456",
+        behaviors=[_make_behavior()],
+        instruction="Do something",
+        data_source_ids=["ds1", "ds2"],
+    )
+    assert inp.instruction == "Do something"
+    assert inp.data_source_ids == ["ds1", "ds2"]

--- a/tests/models/test_ai_automation.py
+++ b/tests/models/test_ai_automation.py
@@ -1,0 +1,171 @@
+"""Tests for CreateAiAutomationInput and UpdateAiAutomationInput Pydantic models."""
+
+import pytest
+from pydantic import ValidationError
+
+from pipefy_mcp.models.ai_automation import (
+    CreateAiAutomationInput,
+    UpdateAiAutomationInput,
+)
+
+DEFAULT_CONDITION = {
+    "expressions": [
+        {"structure_id": 0, "field_address": "", "operation": "", "value": ""}
+    ],
+    "expressions_structure": [[0]],
+}
+
+
+@pytest.mark.unit
+def test_create_ai_automation_input_requires_name_event_id_pipe_id_prompt_field_ids():
+    """CreateAiAutomationInput requires name, event_id, pipe_id, prompt, field_ids."""
+    inp = CreateAiAutomationInput(
+        name="My Automation",
+        event_id="card_created",
+        pipe_id="123",
+        prompt="Summarize the card",
+        field_ids=["133"],
+    )
+    assert inp.name == "My Automation"
+    assert inp.event_id == "card_created"
+    assert inp.pipe_id == "123"
+    assert inp.prompt == "Summarize the card"
+    assert inp.field_ids == ["133"]
+
+
+@pytest.mark.unit
+def test_create_ai_automation_input_condition_defaults_to_placeholder():
+    """CreateAiAutomationInput condition defaults to placeholder structure."""
+    inp = CreateAiAutomationInput(
+        name="My Automation",
+        event_id="card_created",
+        pipe_id="123",
+        prompt="Summarize",
+        field_ids=["133"],
+    )
+    assert inp.condition == DEFAULT_CONDITION
+
+
+@pytest.mark.unit
+def test_create_ai_automation_input_field_ids_rejects_empty_list():
+    """CreateAiAutomationInput rejects empty field_ids."""
+    with pytest.raises(ValidationError):
+        CreateAiAutomationInput(
+            name="My Automation",
+            event_id="card_created",
+            pipe_id="123",
+            prompt="Summarize",
+            field_ids=[],
+        )
+
+
+@pytest.mark.unit
+def test_create_ai_automation_input_field_ids_values_must_be_strings():
+    """CreateAiAutomationInput field_ids values must be strings."""
+    with pytest.raises(ValidationError):
+        CreateAiAutomationInput(
+            name="My Automation",
+            event_id="card_created",
+            pipe_id="123",
+            prompt="Summarize",
+            field_ids=[133],
+        )
+
+
+@pytest.mark.unit
+def test_create_ai_automation_input_field_ids_accepts_strings():
+    """CreateAiAutomationInput accepts string field_ids."""
+    inp = CreateAiAutomationInput(
+        name="My Automation",
+        event_id="card_created",
+        pipe_id="123",
+        prompt="Summarize",
+        field_ids=["133", "456"],
+    )
+    assert inp.field_ids == ["133", "456"]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("name", ["", "   ", "\n\t  "])
+def test_create_ai_automation_input_rejects_blank_or_whitespace_name(name):
+    """CreateAiAutomationInput rejects empty or whitespace-only name."""
+    with pytest.raises(ValidationError):
+        CreateAiAutomationInput(
+            name=name,
+            event_id="card_created",
+            pipe_id="123",
+            prompt="Summarize",
+            field_ids=["133"],
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("prompt", ["", "   ", "\n\t  "])
+def test_create_ai_automation_input_rejects_blank_or_whitespace_prompt(prompt):
+    """CreateAiAutomationInput rejects empty or whitespace-only prompt."""
+    with pytest.raises(ValidationError):
+        CreateAiAutomationInput(
+            name="My Automation",
+            event_id="card_created",
+            pipe_id="123",
+            prompt=prompt,
+            field_ids=["133"],
+        )
+
+
+@pytest.mark.unit
+def test_create_ai_automation_input_rejects_scheduler_event_id():
+    """CreateAiAutomationInput rejects event_id 'scheduler' (blacklisted)."""
+    with pytest.raises(ValidationError):
+        CreateAiAutomationInput(
+            name="My Automation",
+            event_id="scheduler",
+            pipe_id="123",
+            prompt="Summarize",
+            field_ids=["133"],
+        )
+
+
+@pytest.mark.unit
+def test_update_ai_automation_input_requires_automation_id():
+    """UpdateAiAutomationInput requires automation_id."""
+    inp = UpdateAiAutomationInput(automation_id="456")
+    assert inp.automation_id == "456"
+
+
+@pytest.mark.unit
+def test_update_ai_automation_input_accepts_optional_fields():
+    """UpdateAiAutomationInput accepts optional name, active, prompt, field_ids, condition."""
+    inp = UpdateAiAutomationInput(
+        automation_id="456",
+        name="Updated Name",
+        active=False,
+        prompt="New prompt",
+        field_ids=["133", "789"],
+        condition={"expressions": [], "expressions_structure": []},
+    )
+    assert inp.automation_id == "456"
+    assert inp.name == "Updated Name"
+    assert inp.active is False
+    assert inp.prompt == "New prompt"
+    assert inp.field_ids == ["133", "789"]
+    assert inp.condition == {"expressions": [], "expressions_structure": []}
+
+
+@pytest.mark.unit
+def test_update_ai_automation_input_minimal():
+    """UpdateAiAutomationInput accepts only automation_id."""
+    inp = UpdateAiAutomationInput(automation_id="456")
+    assert inp.automation_id == "456"
+    assert inp.name is None
+    assert inp.active is None
+    assert inp.prompt is None
+    assert inp.field_ids is None
+    assert inp.condition is None
+
+
+@pytest.mark.unit
+def test_update_ai_automation_input_field_ids_rejects_empty_list():
+    """UpdateAiAutomationInput rejects empty field_ids when provided."""
+    with pytest.raises(ValidationError):
+        UpdateAiAutomationInput(automation_id="456", field_ids=[])

--- a/tests/services/test_ai_agent_service.py
+++ b/tests/services/test_ai_agent_service.py
@@ -1,0 +1,412 @@
+"""Unit tests for AiAgentService."""
+
+import copy
+import re
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from pipefy_mcp.models.ai_agent import CreateAiAgentInput, UpdateAiAgentInput
+from pipefy_mcp.services.pipefy.ai_agent_service import (
+    AiAgentService,
+    inject_reference_ids,
+)
+from pipefy_mcp.settings import PipefySettings
+
+UUID_PATTERN = re.compile(r"%\{action:([a-f0-9-]{36})\}")
+
+
+def _make_behavior_dict(instruction="", actions=None):
+    result = {
+        "name": "Test Behavior",
+        "actionId": "ai_behavior",
+        "active": True,
+        "eventId": "card_created",
+        "actionParams": {
+            "aiBehaviorParams": {
+                "instruction": instruction,
+                "actionsAttributes": actions or [],
+                "referencedFieldIds": [],
+                "dataSourceIds": [],
+            }
+        },
+    }
+    return result
+
+
+def _make_action_dict(name="Move card", action_type="move_card"):
+    return {"name": name, "actionType": action_type, "metadata": {}}
+
+
+_MOCK_SETTINGS = PipefySettings(
+    graphql_url="https://api.pipefy.com/graphql",
+    oauth_url="https://auth.pipefy.com/oauth/token",
+    oauth_client="test-client",
+    oauth_secret="test-secret",
+)
+
+
+def _create_mock_service(execute_return=None):
+    """Create an AiAgentService with mocked execute_query."""
+    service = AiAgentService(settings=_MOCK_SETTINGS)
+    service.execute_query = AsyncMock(
+        return_value=execute_return or {"createAiAgent": {"agent": {"uuid": "abc-123"}}}
+    )
+    return service
+
+
+@pytest.mark.unit
+def test_inject_reference_ids_single_behavior_single_action():
+    """1 behavior with 1 action: output has exactly 1 UUID in referenceId and 1 %{action:...} in instruction."""
+    action = _make_action_dict()
+    behavior = _make_behavior_dict(instruction="Do something", actions=[action])
+    behaviors = [behavior]
+
+    result = inject_reference_ids(behaviors)
+
+    assert len(result) == 1
+    out_behavior = result[0]
+    out_actions = out_behavior["actionParams"]["aiBehaviorParams"]["actionsAttributes"]
+    assert len(out_actions) == 1
+    ref_id = out_actions[0]["referenceId"]
+    assert ref_id is not None
+    instruction = out_behavior["actionParams"]["aiBehaviorParams"]["instruction"]
+    placeholders = UUID_PATTERN.findall(instruction)
+    assert len(placeholders) == 1
+    assert placeholders[0] == ref_id
+
+
+@pytest.mark.unit
+def test_inject_reference_ids_two_behaviors_two_actions_each():
+    """2 behaviors with 2 actions each: output has 4 unique UUIDs total."""
+    action1 = _make_action_dict(name="Move", action_type="move_card")
+    action2 = _make_action_dict(name="Comment", action_type="add_comment")
+    behavior1 = _make_behavior_dict(instruction="First", actions=[action1, action2])
+    behavior2 = _make_behavior_dict(instruction="Second", actions=[action1, action2])
+    behaviors = [behavior1, behavior2]
+
+    result = inject_reference_ids(behaviors)
+
+    all_ref_ids = []
+    for b in result:
+        for a in b["actionParams"]["aiBehaviorParams"]["actionsAttributes"]:
+            all_ref_ids.append(a["referenceId"])
+        placeholders = UUID_PATTERN.findall(
+            b["actionParams"]["aiBehaviorParams"]["instruction"]
+        )
+        all_ref_ids.extend(placeholders)
+    assert len(set(all_ref_ids)) == 4
+    for b in result:
+        ref_ids = [
+            a["referenceId"]
+            for a in b["actionParams"]["aiBehaviorParams"]["actionsAttributes"]
+        ]
+        instruction = b["actionParams"]["aiBehaviorParams"]["instruction"]
+        placeholders = UUID_PATTERN.findall(instruction)
+        for rid in ref_ids:
+            assert rid in placeholders
+
+
+@pytest.mark.unit
+def test_inject_reference_ids_generates_valid_uuid_v4():
+    """Generated referenceId is a valid UUID v4 string."""
+    action = _make_action_dict()
+    behavior = _make_behavior_dict(actions=[action])
+
+    result = inject_reference_ids([behavior])
+
+    ref_id = result[0]["actionParams"]["aiBehaviorParams"]["actionsAttributes"][0][
+        "referenceId"
+    ]
+    uuid.UUID(ref_id, version=4)
+
+
+@pytest.mark.unit
+def test_inject_reference_ids_preserves_existing_instruction():
+    """Output instruction contains original text plus %{action:...} placeholder(s)."""
+    action = _make_action_dict()
+    behavior = _make_behavior_dict(
+        instruction="Do something important", actions=[action]
+    )
+
+    result = inject_reference_ids([behavior])
+
+    instruction = result[0]["actionParams"]["aiBehaviorParams"]["instruction"]
+    assert "Do something important" in instruction
+    assert UUID_PATTERN.search(instruction) is not None
+
+
+@pytest.mark.unit
+def test_inject_reference_ids_does_not_mutate_input():
+    """Original input list is unchanged; returned list is a deep copy."""
+    action = _make_action_dict()
+    behavior = _make_behavior_dict(instruction="Test", actions=[action])
+    input_list = [behavior]
+    input_copy = copy.deepcopy(input_list)
+
+    result = inject_reference_ids(input_list)
+
+    assert input_list == input_copy
+    assert result is not input_list
+
+
+@pytest.mark.unit
+def test_inject_reference_ids_no_actions_returns_behavior_unchanged():
+    """Behavior with actionsAttributes: [] or missing returns unchanged."""
+    behavior_empty = _make_behavior_dict(instruction="Empty", actions=[])
+    behavior_missing = {
+        "name": "Test",
+        "actionId": "ai_behavior",
+        "active": True,
+        "eventId": "card_created",
+        "actionParams": {
+            "aiBehaviorParams": {
+                "instruction": "No actions",
+                "referencedFieldIds": [],
+                "dataSourceIds": [],
+            }
+        },
+    }
+
+    result_empty = inject_reference_ids([behavior_empty])
+    result_missing = inject_reference_ids([behavior_missing])
+
+    assert (
+        result_empty[0]["actionParams"]["aiBehaviorParams"]["actionsAttributes"] == []
+    )
+    assert result_empty[0]["actionParams"]["aiBehaviorParams"]["instruction"] == "Empty"
+    assert (
+        "actionsAttributes" not in behavior_missing["actionParams"]["aiBehaviorParams"]
+    )
+    assert (
+        result_missing[0]["actionParams"]["aiBehaviorParams"]["instruction"]
+        == "No actions"
+    )
+
+
+@pytest.mark.unit
+def test_inject_reference_ids_no_ai_behavior_params_returns_behavior_unchanged():
+    """Behavior with action_params but no aiBehaviorParams passes through unchanged."""
+    behavior = {
+        "name": "Test",
+        "actionId": "ai_behavior",
+        "active": True,
+        "eventId": "card_created",
+        "actionParams": {},
+    }
+
+    result = inject_reference_ids([behavior])
+
+    assert result[0]["actionParams"] == {}
+    assert "aiBehaviorParams" not in result[0]["actionParams"]
+
+
+@pytest.mark.unit
+def test_inject_reference_ids_instruction_with_existing_placeholders():
+    """Instruction with existing %{action:old-uuid} still gets new placeholders for current actions."""
+    action = _make_action_dict()
+    behavior = _make_behavior_dict(
+        instruction="Old %{action:00000000-0000-4000-8000-000000000001}",
+        actions=[action],
+    )
+
+    result = inject_reference_ids([behavior])
+
+    instruction = result[0]["actionParams"]["aiBehaviorParams"]["instruction"]
+    ref_id = result[0]["actionParams"]["aiBehaviorParams"]["actionsAttributes"][0][
+        "referenceId"
+    ]
+    assert ref_id != "00000000-0000-4000-8000-000000000001"
+    assert f"%{{action:{ref_id}}}" in instruction
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_agent_calls_execute_query_with_correct_variables():
+    """create_agent calls execute_query with createAiAgent mutation and correct variables."""
+    service = _create_mock_service(
+        {"createAiAgent": {"agent": {"uuid": "new-uuid-123"}}}
+    )
+    inp = CreateAiAgentInput(name="My Agent", repo_uuid="repo-456")
+
+    result = await service.create_agent(inp)
+
+    service.execute_query.assert_called_once()
+    call_args = service.execute_query.call_args
+    variables = call_args[0][1]
+
+    assert variables["agent"]["name"] == "My Agent"
+    assert variables["agent"]["repoUuid"] == "repo-456"
+    assert result["agent_uuid"] == "new-uuid-123"
+    assert "AI Agent created successfully" in result["message"]
+    assert "new-uuid-123" in result["message"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_agent_returns_success_format():
+    """create_agent returns agent_uuid and message in success format."""
+    service = _create_mock_service({"createAiAgent": {"agent": {"uuid": "xyz-789"}}})
+    inp = CreateAiAgentInput(name="Test", repo_uuid="repo-1")
+
+    result = await service.create_agent(inp)
+
+    assert result == {
+        "agent_uuid": "xyz-789",
+        "message": "AI Agent created successfully. UUID: xyz-789",
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_update_agent_calls_execute_query_with_correct_variables():
+    """update_agent calls execute_query with updateAiAgent mutation and correct variables."""
+    service = _create_mock_service({"updateAiAgent": {"agent": {"uuid": "agent-uuid"}}})
+    inp = UpdateAiAgentInput(
+        uuid="agent-uuid",
+        name="Updated Agent",
+        repo_uuid="repo-456",
+        instruction="Do things",
+        data_source_ids=["ds1"],
+        behaviors=[{"name": "B1", "event_id": "card_created"}],
+    )
+
+    result = await service.update_agent(inp)
+
+    service.execute_query.assert_called_once()
+    call_args = service.execute_query.call_args
+    variables = call_args[0][1]
+
+    assert variables["uuid"] == "agent-uuid"
+    assert variables["agent"]["name"] == "Updated Agent"
+    assert variables["agent"]["repoUuid"] == "repo-456"
+    assert variables["agent"]["instruction"] == "Do things"
+    assert variables["agent"]["dataSourceIds"] == ["ds1"]
+    assert len(variables["agent"]["behaviors"]) == 1
+    assert result["agent_uuid"] == "agent-uuid"
+    assert "AI Agent updated successfully" in result["message"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_update_agent_calls_inject_reference_ids():
+    """update_agent calls inject_reference_ids before building the payload."""
+    service = _create_mock_service({"updateAiAgent": {"agent": {"uuid": "agent-uuid"}}})
+    inp = UpdateAiAgentInput(
+        uuid="agent-uuid",
+        name="Agent",
+        repo_uuid="repo-1",
+        behaviors=[{"name": "B1", "event_id": "card_created"}],
+    )
+
+    with patch(
+        "pipefy_mcp.services.pipefy.ai_agent_service.inject_reference_ids",
+        wraps=inject_reference_ids,
+    ) as mock_inject:
+        await service.update_agent(inp)
+        mock_inject.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_agent_propagates_execute_query_error():
+    """create_agent propagates errors when execute_query raises."""
+    service = _create_mock_service()
+    service.execute_query = AsyncMock(side_effect=ValueError("GraphQL error"))
+    inp = CreateAiAgentInput(name="Test", repo_uuid="repo-1")
+
+    with pytest.raises(ValueError, match="GraphQL error"):
+        await service.create_agent(inp)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_update_agent_propagates_execute_query_error():
+    """update_agent propagates errors when execute_query raises."""
+    service = _create_mock_service()
+    service.execute_query = AsyncMock(side_effect=RuntimeError("Network error"))
+    inp = UpdateAiAgentInput(
+        uuid="agent-uuid",
+        name="Agent",
+        repo_uuid="repo-1",
+        behaviors=[{"name": "B1", "event_id": "card_created"}],
+    )
+
+    with pytest.raises(RuntimeError, match="Network error"):
+        await service.update_agent(inp)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_agent_missing_uuid_returns_clear_error():
+    """create_agent returns clear error when API response missing agent.uuid."""
+    service = _create_mock_service({"createAiAgent": {}})
+    inp = CreateAiAgentInput(name="Test", repo_uuid="repo-1")
+
+    with pytest.raises(ValueError, match="agent.*uuid|unexpected.*payload"):
+        await service.create_agent(inp)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_update_agent_missing_uuid_returns_clear_error():
+    """update_agent returns clear error when API response missing agent.uuid."""
+    service = _create_mock_service({"updateAiAgent": {"agent": {}}})
+    inp = UpdateAiAgentInput(
+        uuid="agent-uuid",
+        name="Agent",
+        repo_uuid="repo-1",
+        behaviors=[{"name": "B1", "event_id": "card_created"}],
+    )
+
+    with pytest.raises(ValueError, match="agent.*uuid|unexpected.*payload"):
+        await service.update_agent(inp)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_toggle_agent_status_enable_calls_execute_query():
+    """toggle_agent_status(active=True) calls execute_query with correct variables and returns activation message."""
+    service = _create_mock_service({"updateAiAgentStatus": {"success": True}})
+
+    result = await service.toggle_agent_status("agent-uuid", True)
+
+    service.execute_query.assert_called_once()
+    call_args = service.execute_query.call_args
+    variables = call_args[0][1]
+    assert variables["uuid"] == "agent-uuid"
+    assert variables["active"] is True
+    assert result == {"success": True, "message": "AI Agent activated successfully."}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_toggle_agent_status_disable_returns_correct_message():
+    """toggle_agent_status(active=False) returns deactivation message."""
+    service = _create_mock_service({"updateAiAgentStatus": {"success": True}})
+
+    result = await service.toggle_agent_status("agent-uuid", False)
+
+    assert result == {"success": True, "message": "AI Agent deactivated successfully."}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_toggle_agent_status_propagates_error():
+    """toggle_agent_status propagates errors when execute_query raises."""
+    service = _create_mock_service()
+    service.execute_query = AsyncMock(side_effect=RuntimeError("Network error"))
+
+    with pytest.raises(RuntimeError, match="Network error"):
+        await service.toggle_agent_status("agent-uuid", True)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_toggle_agent_status_api_returns_failure():
+    """toggle_agent_status raises ValueError when API returns success=False."""
+    service = _create_mock_service({"updateAiAgentStatus": {"success": False}})
+
+    with pytest.raises(ValueError, match="failed|unexpected"):
+        await service.toggle_agent_status("agent-uuid", True)

--- a/tests/services/test_ai_automation_service.py
+++ b/tests/services/test_ai_automation_service.py
@@ -1,0 +1,256 @@
+"""Unit tests for AiAutomationService."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pipefy_mcp.models.ai_automation import (
+    CreateAiAutomationInput,
+    UpdateAiAutomationInput,
+)
+from pipefy_mcp.services.pipefy.ai_automation_service import AiAutomationService
+from pipefy_mcp.services.pipefy.internal_api_client import InternalApiClient
+
+
+def _create_mock_internal_api_client(execute_return: dict | None = None) -> MagicMock:
+    """Create a mock InternalApiClient with async execute_query."""
+    mock = MagicMock(spec=InternalApiClient)
+    mock.execute_query = AsyncMock(
+        return_value=execute_return
+        or {"data": {"createAutomation": {"automation": {"id": "123"}}}}
+    )
+    return mock
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_automation_calls_execute_query_with_correct_variables():
+    """create_automation calls execute_query with createAutomation mutation and correct variables."""
+    mock_client = _create_mock_internal_api_client(
+        {"data": {"createAutomation": {"automation": {"id": "456"}}}}
+    )
+    service = AiAutomationService(client=mock_client)
+
+    inp = CreateAiAutomationInput(
+        name="My Automation",
+        event_id="card_created",
+        pipe_id="303",
+        prompt="Summarize the card",
+        field_ids=["133", "789"],
+    )
+    result = await service.create_automation(inp)
+
+    mock_client.execute_query.assert_called_once()
+    call_args = mock_client.execute_query.call_args
+    query_str = call_args[0][0]
+    variables = call_args[0][1]
+
+    assert "createAutomation" in query_str or "create_automation" in query_str
+    assert variables["action_id"] == "generate_with_ai"
+    assert variables["event_id"] == "card_created"
+    assert variables["event_repo_id"] == "303"
+    assert variables["action_repo_id"] == "303"
+    assert variables["action_params"]["aiParams"]["value"] == "Summarize the card"
+    assert variables["action_params"]["aiParams"]["fieldIds"] == ["133", "789"]
+    assert result["automation_id"] == "456"
+    assert "AI Automation created successfully" in result["message"]
+    assert "456" in result["message"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_automation_returns_success_format():
+    """create_automation returns automation_id and message in success format."""
+    mock_client = _create_mock_internal_api_client(
+        {"data": {"createAutomation": {"automation": {"id": "999"}}}}
+    )
+    service = AiAutomationService(client=mock_client)
+
+    inp = CreateAiAutomationInput(
+        name="Test",
+        event_id="card_created",
+        pipe_id="1",
+        prompt="Do something",
+        field_ids=["1"],
+    )
+    result = await service.create_automation(inp)
+
+    assert result == {
+        "automation_id": "999",
+        "message": "AI Automation created successfully. ID: 999",
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_update_automation_calls_execute_query_with_correct_variables():
+    """update_automation calls execute_query with updateAutomation mutation and correct variables."""
+    mock_client = _create_mock_internal_api_client(
+        {"data": {"updateAutomation": {"automation": {"id": "789"}}}}
+    )
+    service = AiAutomationService(client=mock_client)
+
+    inp = UpdateAiAutomationInput(
+        automation_id="789",
+        name="Updated Name",
+        active=False,
+        prompt="New prompt",
+        field_ids=["133"],
+    )
+    result = await service.update_automation(inp)
+
+    mock_client.execute_query.assert_called_once()
+    call_args = mock_client.execute_query.call_args
+    query_str = call_args[0][0]
+    variables = call_args[0][1]
+
+    assert "updateAutomation" in query_str or "update_automation" in query_str
+    assert variables["input"]["id"] == "789"
+    assert variables["input"]["name"] == "Updated Name"
+    assert variables["input"]["active"] is False
+    assert variables["input"]["action_params"]["aiParams"]["value"] == "New prompt"
+    assert variables["input"]["action_params"]["aiParams"]["fieldIds"] == ["133"]
+    assert result["automation_id"] == "789"
+    assert "AI Automation updated successfully" in result["message"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_update_automation_returns_success_format():
+    """update_automation returns automation_id and message in success format."""
+    mock_client = _create_mock_internal_api_client(
+        {"data": {"updateAutomation": {"automation": {"id": "111"}}}}
+    )
+    service = AiAutomationService(client=mock_client)
+
+    inp = UpdateAiAutomationInput(automation_id="111")
+    result = await service.update_automation(inp)
+
+    assert result == {
+        "automation_id": "111",
+        "message": "AI Automation updated successfully. ID: 111",
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_automation_propagates_execute_query_error():
+    """create_automation propagates errors when execute_query raises."""
+    mock_client = _create_mock_internal_api_client()
+    mock_client.execute_query = AsyncMock(side_effect=ValueError("GraphQL error"))
+    service = AiAutomationService(client=mock_client)
+
+    inp = CreateAiAutomationInput(
+        name="Test",
+        event_id="card_created",
+        pipe_id="1",
+        prompt="Do something",
+        field_ids=["1"],
+    )
+
+    with pytest.raises(ValueError, match="GraphQL error"):
+        await service.create_automation(inp)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_update_automation_propagates_execute_query_error():
+    """update_automation propagates errors when execute_query raises."""
+    mock_client = _create_mock_internal_api_client()
+    mock_client.execute_query = AsyncMock(side_effect=RuntimeError("Network error"))
+    service = AiAutomationService(client=mock_client)
+
+    inp = UpdateAiAutomationInput(automation_id="123")
+
+    with pytest.raises(RuntimeError, match="Network error"):
+        await service.update_automation(inp)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_automation_missing_automation_id_returns_clear_error():
+    """create_automation returns clear error when API response missing automation.id."""
+    mock_client = _create_mock_internal_api_client({"data": {}})
+    service = AiAutomationService(client=mock_client)
+
+    inp = CreateAiAutomationInput(
+        name="Test",
+        event_id="card_created",
+        pipe_id="1",
+        prompt="Do something",
+        field_ids=["1"],
+    )
+
+    with pytest.raises(ValueError, match="automation.*id|unexpected.*payload"):
+        await service.create_automation(inp)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_update_automation_missing_automation_id_returns_clear_error():
+    """update_automation returns clear error when API response missing automation.id."""
+    mock_client = _create_mock_internal_api_client(
+        {"data": {"updateAutomation": {"automation": {}}}}
+    )
+    service = AiAutomationService(client=mock_client)
+
+    inp = UpdateAiAutomationInput(automation_id="123")
+
+    with pytest.raises(ValueError, match="automation.*id|unexpected.*payload"):
+        await service.update_automation(inp)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_automation_raises_on_error_details():
+    """create_automation raises ValueError when API returns error_details."""
+    mock_client = _create_mock_internal_api_client(
+        {
+            "data": {
+                "createAutomation": {
+                    "automation": None,
+                    "error_details": {
+                        "object_name": "Automation",
+                        "object_key": "base",
+                        "messages": ["Pipe not found", "AI not enabled"],
+                    },
+                }
+            }
+        }
+    )
+    service = AiAutomationService(client=mock_client)
+    inp = CreateAiAutomationInput(
+        name="Test",
+        event_id="card_created",
+        pipe_id="1",
+        prompt="Do something",
+        field_ids=["1"],
+    )
+
+    with pytest.raises(ValueError, match="API error.*Pipe not found.*AI not enabled"):
+        await service.create_automation(inp)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_update_automation_raises_on_error_details():
+    """update_automation raises ValueError when API returns error_details."""
+    mock_client = _create_mock_internal_api_client(
+        {
+            "data": {
+                "updateAutomation": {
+                    "automation": None,
+                    "error_details": {
+                        "object_name": "Automation",
+                        "object_key": "base",
+                        "messages": ["Invalid field"],
+                    },
+                }
+            }
+        }
+    )
+    service = AiAutomationService(client=mock_client)
+    inp = UpdateAiAutomationInput(automation_id="123")
+
+    with pytest.raises(ValueError, match="API error.*Invalid field"):
+        await service.update_automation(inp)

--- a/tests/services/test_card_service.py
+++ b/tests/services/test_card_service.py
@@ -3,43 +3,45 @@
 Tests validate the card-related operations without requiring real API credentials.
 """
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
-from gql import Client
 
 from pipefy_mcp.services.pipefy.card_service import CardService
 from pipefy_mcp.services.pipefy.queries.card_queries import (
     FIND_CARDS_QUERY,
     GET_CARDS_QUERY,
 )
+from pipefy_mcp.settings import PipefySettings
 
 
-def _create_mock_gql_client(mock_session: AsyncMock) -> MagicMock:
-    """Create a mock gql.Client with async context manager support."""
-    mock_client = MagicMock(spec=Client)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
-    return mock_client
+@pytest.fixture
+def mock_settings() -> PipefySettings:
+    return PipefySettings(
+        graphql_url="https://api.pipefy.com/graphql",
+        oauth_url="https://auth.pipefy.com/oauth/token",
+        oauth_client="client_id",
+        oauth_secret="client_secret",
+    )
+
+
+def _make_service(mock_settings: PipefySettings, return_value: dict) -> CardService:
+    service = CardService(settings=mock_settings)
+    service.execute_query = AsyncMock(return_value=return_value)
+    return service
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_create_card_converts_fields_and_sets_generated_by_ai():
+async def test_create_card_converts_fields_and_sets_generated_by_ai(mock_settings):
     """Test create_card converts dict fields to array format with generated_by_ai."""
     pipe_id = 303181849
     fields = {"title": "Teste-MCP"}
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(
-        return_value={"createCard": {"card": {"id": "12345"}}}
-    )
-    mock_client = _create_mock_gql_client(mock_session)
-
-    service = CardService(client=mock_client)
+    service = _make_service(mock_settings, {"createCard": {"card": {"id": "12345"}}})
     result = await service.create_card(pipe_id, fields)
 
-    variables = mock_session.execute.call_args[1]["variable_values"]
+    variables = service.execute_query.call_args[0][1]
     assert variables["pipe_id"] == pipe_id, "Expected pipe_id in variables"
     assert variables["fields"] == [
         {"field_id": "title", "field_value": "Teste-MCP", "generated_by_ai": True}
@@ -51,21 +53,15 @@ async def test_create_card_converts_fields_and_sets_generated_by_ai():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_create_card_with_empty_dict_sends_empty_list():
+async def test_create_card_with_empty_dict_sends_empty_list(mock_settings):
     """Test that create_card with empty dict sends fields as empty list to GraphQL."""
     pipe_id = 303181849
     fields = {}
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(
-        return_value={"createCard": {"card": {"id": "12345"}}}
-    )
-    mock_client = _create_mock_gql_client(mock_session)
-
-    service = CardService(client=mock_client)
+    service = _make_service(mock_settings, {"createCard": {"card": {"id": "12345"}}})
     result = await service.create_card(pipe_id, fields)
 
-    variables = mock_session.execute.call_args[1]["variable_values"]
+    variables = service.execute_query.call_args[0][1]
     assert variables["pipe_id"] == pipe_id, "Expected pipe_id in variables"
     assert variables["fields"] == [], "Empty dict should result in empty list"
     assert result == {"createCard": {"card": {"id": "12345"}}}, (
@@ -75,18 +71,14 @@ async def test_create_card_with_empty_dict_sends_empty_list():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_get_cards_with_none_search_sends_empty_search():
+async def test_get_cards_with_none_search_sends_empty_search(mock_settings):
     """Test get_cards sends empty search object when search is None."""
     pipe_id = 303181849
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(return_value={"cards": {"edges": []}})
-    mock_client = _create_mock_gql_client(mock_session)
-
-    service = CardService(client=mock_client)
+    service = _make_service(mock_settings, {"cards": {"edges": []}})
     result = await service.get_cards(pipe_id, None)
 
-    variables = mock_session.execute.call_args[1]["variable_values"]
+    variables = service.execute_query.call_args[0][1]
     assert variables == {
         "pipe_id": pipe_id,
         "search": {},
@@ -97,59 +89,51 @@ async def test_get_cards_with_none_search_sends_empty_search():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_get_cards_with_include_fields_true_passes_includeFields_variable():
+async def test_get_cards_with_include_fields_true_passes_includeFields_variable(
+    mock_settings,
+):
     """Test get_cards uses GET_CARDS_QUERY with includeFields=True when include_fields=True."""
     pipe_id = 303181849
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(return_value={"cards": {"edges": []}})
-    mock_client = _create_mock_gql_client(mock_session)
-
-    service = CardService(client=mock_client)
+    service = _make_service(mock_settings, {"cards": {"edges": []}})
     await service.get_cards(pipe_id, search=None, include_fields=True)
 
-    query_used = mock_session.execute.call_args[0][0]
-    variables = mock_session.execute.call_args[1]["variable_values"]
+    query_used = service.execute_query.call_args[0][0]
+    variables = service.execute_query.call_args[0][1]
     assert query_used is GET_CARDS_QUERY
     assert variables["includeFields"] is True
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_get_cards_with_include_fields_false_passes_includeFields_variable():
+async def test_get_cards_with_include_fields_false_passes_includeFields_variable(
+    mock_settings,
+):
     """Test get_cards uses GET_CARDS_QUERY with includeFields=False when include_fields=False."""
     pipe_id = 303181849
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(return_value={"cards": {"edges": []}})
-    mock_client = _create_mock_gql_client(mock_session)
-
-    service = CardService(client=mock_client)
+    service = _make_service(mock_settings, {"cards": {"edges": []}})
     await service.get_cards(pipe_id, search=None, include_fields=False)
 
-    query_used = mock_session.execute.call_args[0][0]
-    variables = mock_session.execute.call_args[1]["variable_values"]
+    query_used = service.execute_query.call_args[0][0]
+    variables = service.execute_query.call_args[0][1]
     assert query_used is GET_CARDS_QUERY
     assert variables["includeFields"] is False
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_find_cards_sends_pipeId_search_and_includeFields():
+async def test_find_cards_sends_pipeId_search_and_includeFields(mock_settings):
     """Test find_cards uses FIND_CARDS_QUERY with pipeId, search.fieldId, search.fieldValue, includeFields."""
     pipe_id = 303181849
     field_id = "status"
     field_value = "In Progress"
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(return_value={"findCards": {"edges": []}})
-    mock_client = _create_mock_gql_client(mock_session)
-
-    service = CardService(client=mock_client)
+    service = _make_service(mock_settings, {"findCards": {"edges": []}})
     await service.find_cards(pipe_id, field_id, field_value, include_fields=True)
 
-    query_used = mock_session.execute.call_args[0][0]
-    variables = mock_session.execute.call_args[1]["variable_values"]
+    query_used = service.execute_query.call_args[0][0]
+    variables = service.execute_query.call_args[0][1]
     assert query_used is FIND_CARDS_QUERY
     assert variables["pipeId"] == pipe_id
     assert variables["search"] == {"fieldId": field_id, "fieldValue": field_value}
@@ -158,18 +142,14 @@ async def test_find_cards_sends_pipeId_search_and_includeFields():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_find_cards_returns_raw_findCards_response():
+async def test_find_cards_returns_raw_findCards_response(mock_settings):
     """Test find_cards returns the raw findCards GraphQL response."""
     pipe_id = 1
     field_id = "field_1"
     field_value = "Value 1"
     expected = {"findCards": {"edges": [{"node": {"id": "1", "title": "Card"}}]}}
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(return_value=expected)
-    mock_client = _create_mock_gql_client(mock_session)
-
-    service = CardService(client=mock_client)
+    service = _make_service(mock_settings, expected)
     result = await service.find_cards(
         pipe_id, field_id, field_value, include_fields=False
     )
@@ -179,65 +159,54 @@ async def test_find_cards_returns_raw_findCards_response():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_get_card_passes_card_id_and_includeFields():
+async def test_get_card_passes_card_id_and_includeFields(mock_settings):
     """Test get_card passes card_id and includeFields in variable_values."""
     card_id = 12345
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(
-        return_value={"card": {"id": str(card_id), "title": "Test"}}
+    service = _make_service(
+        mock_settings, {"card": {"id": str(card_id), "title": "Test"}}
     )
-    mock_client = _create_mock_gql_client(mock_session)
-
-    service = CardService(client=mock_client)
     await service.get_card(card_id, include_fields=False)
 
-    variables = mock_session.execute.call_args[1]["variable_values"]
+    variables = service.execute_query.call_args[0][1]
     assert variables == {"card_id": card_id, "includeFields": False}
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_get_card_with_include_fields_true_passes_includeFields():
+async def test_get_card_with_include_fields_true_passes_includeFields(mock_settings):
     """Test get_card with include_fields=True passes includeFields=True to query."""
     card_id = 12345
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(
-        return_value={
+    service = _make_service(
+        mock_settings,
+        {
             "card": {
                 "id": str(card_id),
                 "title": "Test",
                 "fields": [{"name": "Field", "value": "x"}],
             }
-        }
+        },
     )
-    mock_client = _create_mock_gql_client(mock_session)
-
-    service = CardService(client=mock_client)
     await service.get_card(card_id, include_fields=True)
 
-    variables = mock_session.execute.call_args[1]["variable_values"]
+    variables = service.execute_query.call_args[0][1]
     assert variables == {"card_id": card_id, "includeFields": True}
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_move_card_to_phase_variable_shape():
+async def test_move_card_to_phase_variable_shape(mock_settings):
     """Test move_card_to_phase sends correct input shape."""
     card_id = 12345
     destination_phase_id = 678
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(
-        return_value={"moveCardToPhase": {"clientMutationId": None}}
+    service = _make_service(
+        mock_settings, {"moveCardToPhase": {"clientMutationId": None}}
     )
-    mock_client = _create_mock_gql_client(mock_session)
-
-    service = CardService(client=mock_client)
     result = await service.move_card_to_phase(card_id, destination_phase_id)
 
-    variables = mock_session.execute.call_args[1]["variable_values"]
+    variables = service.execute_query.call_args[0][1]
     expected_input = {"card_id": card_id, "destination_phase_id": destination_phase_id}
     assert variables == {"input": expected_input}, "Expected correct input shape"
     assert result == {"moveCardToPhase": {"clientMutationId": None}}, (
@@ -247,21 +216,15 @@ async def test_move_card_to_phase_variable_shape():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_update_card_attribute_mode_uses_update_card_shape():
+async def test_update_card_attribute_mode_uses_update_card_shape(mock_settings):
     """Test update_card uses updateCard mutation when title is provided."""
     card_id = 12345
     new_title = "Updated Card Title"
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(
-        return_value={"updateCard": {"card": {"id": "12345"}}}
-    )
-    mock_client = _create_mock_gql_client(mock_session)
-
-    service = CardService(client=mock_client)
+    service = _make_service(mock_settings, {"updateCard": {"card": {"id": "12345"}}})
     result = await service.update_card(card_id, title=new_title)
 
-    variables = mock_session.execute.call_args[1]["variable_values"]
+    variables = service.execute_query.call_args[0][1]
     assert variables == {"input": {"id": card_id, "title": new_title}}, (
         "Expected updateCard input"
     )
@@ -272,21 +235,15 @@ async def test_update_card_attribute_mode_uses_update_card_shape():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_update_card_with_due_date_includes_due_date_in_input():
+async def test_update_card_with_due_date_includes_due_date_in_input(mock_settings):
     """Test that update_card with due_date correctly passes it to GraphQL input."""
     card_id = 12345
     due_date = "2025-12-31"
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(
-        return_value={"updateCard": {"card": {"id": "12345"}}}
-    )
-    mock_client = _create_mock_gql_client(mock_session)
-
-    service = CardService(client=mock_client)
+    service = _make_service(mock_settings, {"updateCard": {"card": {"id": "12345"}}})
     result = await service.update_card(card_id, due_date=due_date)
 
-    variables = mock_session.execute.call_args[1]["variable_values"]
+    variables = service.execute_query.call_args[0][1]
     expected_input = {"id": card_id, "due_date": due_date}
     assert variables == {"input": expected_input}, "Expected due_date in input"
     assert result == {"updateCard": {"card": {"id": "12345"}}}, (
@@ -296,21 +253,15 @@ async def test_update_card_with_due_date_includes_due_date_in_input():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_update_card_field_mode_uses_update_fields_values_shape():
+async def test_update_card_field_mode_uses_update_fields_values_shape(mock_settings):
     """Test update_card uses updateFieldsValues mutation when field_updates is provided."""
     card_id = 12345
     field_updates = [{"field_id": "field_1", "value": "Value 1"}]
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(
-        return_value={"updateFieldsValues": {"success": True}}
-    )
-    mock_client = _create_mock_gql_client(mock_session)
-
-    service = CardService(client=mock_client)
+    service = _make_service(mock_settings, {"updateFieldsValues": {"success": True}})
     result = await service.update_card(card_id, field_updates=field_updates)
 
-    variables = mock_session.execute.call_args[1]["variable_values"]
+    variables = service.execute_query.call_args[0][1]
     assert variables["input"]["nodeId"] == card_id, "Expected nodeId in input"
     expected_values = [
         {
@@ -330,21 +281,17 @@ async def test_update_card_field_mode_uses_update_fields_values_shape():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_create_comment_variable_shape_and_return_passthrough():
+async def test_create_comment_variable_shape_and_return_passthrough(mock_settings):
     """Test create_comment sends correct input shape and returns response unchanged."""
     card_id = 12345
     text = "This is a comment"
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(
-        return_value={"createComment": {"comment": {"id": "c_987"}}}
+    service = _make_service(
+        mock_settings, {"createComment": {"comment": {"id": "c_987"}}}
     )
-    mock_client = _create_mock_gql_client(mock_session)
-
-    service = CardService(client=mock_client)
     result = await service.create_comment(card_id=card_id, text=text)
 
-    variables = mock_session.execute.call_args[1]["variable_values"]
+    variables = service.execute_query.call_args[0][1]
     assert variables == {"input": {"card_id": card_id, "text": text}}, (
         "Expected correct input shape"
     )
@@ -355,21 +302,17 @@ async def test_create_comment_variable_shape_and_return_passthrough():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_update_comment_variable_shape_and_return_structure():
+async def test_update_comment_variable_shape_and_return_structure(mock_settings):
     """Test update_comment sends correct input shape and returns response with comment id."""
     comment_id = 12345
     text = "Updated comment text"
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(
-        return_value={"updateComment": {"comment": {"id": "c_999"}}}
+    service = _make_service(
+        mock_settings, {"updateComment": {"comment": {"id": "c_999"}}}
     )
-    mock_client = _create_mock_gql_client(mock_session)
-
-    service = CardService(client=mock_client)
     result = await service.update_comment(comment_id, text)
 
-    variables = mock_session.execute.call_args[1]["variable_values"]
+    variables = service.execute_query.call_args[0][1]
     assert variables == {"input": {"id": comment_id, "text": text}}, (
         "Expected correct input shape"
     )
@@ -380,18 +323,14 @@ async def test_update_comment_variable_shape_and_return_structure():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_delete_comment_variable_shape_and_success_return():
+async def test_delete_comment_variable_shape_and_success_return(mock_settings):
     """Test delete_comment sends correct input shape and returns success."""
     comment_id = 12345
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(return_value={"deleteComment": {"success": True}})
-    mock_client = _create_mock_gql_client(mock_session)
-
-    service = CardService(client=mock_client)
+    service = _make_service(mock_settings, {"deleteComment": {"success": True}})
     result = await service.delete_comment(comment_id)
 
-    variables = mock_session.execute.call_args[1]["variable_values"]
+    variables = service.execute_query.call_args[0][1]
     assert variables == {"input": {"id": comment_id}}, "Expected correct input shape"
     assert result == {"deleteComment": {"success": True}}, (
         "Expected deleteComment success response"
@@ -400,37 +339,28 @@ async def test_delete_comment_variable_shape_and_success_return():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_delete_card_success_scenario():
+async def test_delete_card_success_scenario(mock_settings):
     """Test delete_card sends correct input and returns success response."""
     card_id = 12345
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(return_value={"deleteCard": {"success": True}})
-    mock_client = _create_mock_gql_client(mock_session)
-
-    service = CardService(client=mock_client)
+    service = _make_service(mock_settings, {"deleteCard": {"success": True}})
     result = await service.delete_card(card_id)
 
-    variables = mock_session.execute.call_args[1]["variable_values"]
+    variables = service.execute_query.call_args[0][1]
     assert variables == {"input": {"id": card_id}}, "Expected correct input shape"
     assert result == {"deleteCard": {"success": True}}, "Expected deleteCard response"
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_delete_card_resource_not_found_error():
+async def test_delete_card_resource_not_found_error(mock_settings):
     """Test delete_card returns error response for RESOURCE_NOT_FOUND."""
     card_id = 99999
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(
-        return_value={
-            "deleteCard": {"success": False, "errors": ["RESOURCE_NOT_FOUND"]}
-        }
+    service = _make_service(
+        mock_settings,
+        {"deleteCard": {"success": False, "errors": ["RESOURCE_NOT_FOUND"]}},
     )
-    mock_client = _create_mock_gql_client(mock_session)
-
-    service = CardService(client=mock_client)
     result = await service.delete_card(card_id)
 
     assert result == {
@@ -440,17 +370,14 @@ async def test_delete_card_resource_not_found_error():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_delete_card_permission_denied_error():
+async def test_delete_card_permission_denied_error(mock_settings):
     """Test delete_card returns error response for PERMISSION_DENIED."""
     card_id = 12345
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(
-        return_value={"deleteCard": {"success": False, "errors": ["PERMISSION_DENIED"]}}
+    service = _make_service(
+        mock_settings,
+        {"deleteCard": {"success": False, "errors": ["PERMISSION_DENIED"]}},
     )
-    mock_client = _create_mock_gql_client(mock_session)
-
-    service = CardService(client=mock_client)
     result = await service.delete_card(card_id)
 
     assert result == {

--- a/tests/services/test_internal_api_client.py
+++ b/tests/services/test_internal_api_client.py
@@ -1,0 +1,182 @@
+"""Unit tests for InternalApiClient and PipefySettings.internal_api_url.
+
+Tests validate the internal API client behavior without real network calls.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+import respx
+
+from pipefy_mcp.services.pipefy.internal_api_client import InternalApiClient
+from pipefy_mcp.settings import PipefySettings, Settings
+
+DEFAULT_INTERNAL_API_URL = "https://app.pipefy.com/internal_api"
+
+
+@pytest.mark.unit
+def test_pipefy_settings_internal_api_url_default():
+    """Test that PipefySettings.internal_api_url defaults to the expected URL."""
+    settings = PipefySettings()
+    assert settings.internal_api_url == DEFAULT_INTERNAL_API_URL
+
+
+@pytest.mark.unit
+def test_internal_api_url_overridden_via_env(monkeypatch):
+    """Test that internal_api_url can be overridden via PIPEFY_INTERNAL_API_URL."""
+    custom_url = "https://custom.pipefy.com/internal_api"
+    monkeypatch.setenv("PIPEFY_INTERNAL_API_URL", custom_url)
+    settings = Settings()
+    assert settings.pipefy.internal_api_url == custom_url
+
+
+OAUTH_TOKEN_URL = "https://auth.pipefy.com/oauth/token"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@respx.mock(assert_all_mocked=False, assert_all_called=False)
+async def test_execute_query_sends_post_with_correct_headers_and_body(respx_mock):
+    """Test execute_query sends POST with Authorization, Content-Type, and JSON body."""
+    query_string = "mutation { test }"
+    variables = {"key": "value"}
+    expected_json = {"data": {"automation": {"id": "123"}}}
+
+    respx_mock.post(OAUTH_TOKEN_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "access_token": "test-bearer-token",
+                "token_type": "bearer",
+                "expires_in": 3600,
+            },
+        )
+    )
+    route = respx_mock.post(DEFAULT_INTERNAL_API_URL).mock(
+        return_value=httpx.Response(200, json=expected_json)
+    )
+
+    client = InternalApiClient(
+        url=DEFAULT_INTERNAL_API_URL,
+        oauth_url=OAUTH_TOKEN_URL,
+        oauth_client="client_id",
+        oauth_secret="client_secret",
+    )
+    result = await client.execute_query(query_string, variables)
+
+    assert route.called
+    request = route.calls.last.request
+    assert request.content
+    body = json.loads(request.content)
+    assert body == {"query": query_string, "variables": variables}
+    assert "authorization" in (h.lower() for h in request.headers.keys())
+    assert "content-type" in (h.lower() for h in request.headers.keys())
+    assert result == expected_json
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@respx.mock(assert_all_mocked=False, assert_all_called=False)
+async def test_execute_query_returns_parsed_json_response(respx_mock):
+    """Test execute_query returns the parsed JSON response from the API."""
+    expected = {"data": {"automation": {"id": "456"}}}
+    respx_mock.post(OAUTH_TOKEN_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={"access_token": "tok", "token_type": "bearer", "expires_in": 3600},
+        )
+    )
+    respx_mock.post(DEFAULT_INTERNAL_API_URL).mock(
+        return_value=httpx.Response(200, json=expected)
+    )
+
+    client = InternalApiClient(
+        url=DEFAULT_INTERNAL_API_URL,
+        oauth_url=OAUTH_TOKEN_URL,
+        oauth_client="client_id",
+        oauth_secret="client_secret",
+    )
+    result = await client.execute_query("query { x }", {})
+
+    assert result == expected
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@respx.mock(assert_all_mocked=False, assert_all_called=False)
+async def test_execute_query_raises_on_non_2xx_response(respx_mock):
+    """Test execute_query raises when HTTP response is not 2xx."""
+    respx_mock.post(OAUTH_TOKEN_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={"access_token": "tok", "token_type": "bearer", "expires_in": 3600},
+        )
+    )
+    respx_mock.post(DEFAULT_INTERNAL_API_URL).mock(
+        return_value=httpx.Response(500, json={"error": "Internal Server Error"})
+    )
+
+    client = InternalApiClient(
+        url=DEFAULT_INTERNAL_API_URL,
+        oauth_url=OAUTH_TOKEN_URL,
+        oauth_client="client_id",
+        oauth_secret="client_secret",
+    )
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await client.execute_query("query { x }", {})
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@respx.mock(assert_all_mocked=False, assert_all_called=False)
+async def test_execute_query_raises_on_graphql_errors_in_body(respx_mock):
+    """Test execute_query detects GraphQL errors (HTTP 200 but errors in JSON) and raises."""
+    graphql_error_response = {"errors": [{"message": "Something went wrong"}]}
+    respx_mock.post(OAUTH_TOKEN_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={"access_token": "tok", "token_type": "bearer", "expires_in": 3600},
+        )
+    )
+    respx_mock.post(DEFAULT_INTERNAL_API_URL).mock(
+        return_value=httpx.Response(200, json=graphql_error_response)
+    )
+
+    client = InternalApiClient(
+        url=DEFAULT_INTERNAL_API_URL,
+        oauth_url=OAUTH_TOKEN_URL,
+        oauth_client="client_id",
+        oauth_secret="client_secret",
+    )
+
+    with pytest.raises(ValueError, match="GraphQL.*error"):
+        await client.execute_query("query { x }", {})
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execute_query_raises_on_timeout():
+    """Test execute_query raises appropriate error when HTTP request times out."""
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(
+        side_effect=httpx.TimeoutException("Request timed out")
+    )
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch(
+        "pipefy_mcp.services.pipefy.internal_api_client.httpx.AsyncClient",
+        return_value=mock_client,
+    ):
+        client = InternalApiClient(
+            url=DEFAULT_INTERNAL_API_URL,
+            oauth_url=OAUTH_TOKEN_URL,
+            oauth_client="client_id",
+            oauth_secret="client_secret",
+        )
+
+        with pytest.raises(httpx.TimeoutException):
+            await client.execute_query("query { x }", {})

--- a/tests/services/test_pipe_service.py
+++ b/tests/services/test_pipe_service.py
@@ -3,44 +3,48 @@
 Tests validate the pipe-related operations without requiring real API credentials.
 """
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
-from gql import Client
 
 from pipefy_mcp.services.pipefy.pipe_service import PipeService
+from pipefy_mcp.settings import PipefySettings
 
 
-def _create_mock_gql_client(mock_session: AsyncMock) -> MagicMock:
-    """Create a mock gql.Client with async context manager support."""
-    mock_client = MagicMock(spec=Client)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
-    return mock_client
+@pytest.fixture
+def mock_settings() -> PipefySettings:
+    return PipefySettings(
+        graphql_url="https://api.pipefy.com/graphql",
+        oauth_url="https://auth.pipefy.com/oauth/token",
+        oauth_client="client_id",
+        oauth_secret="client_secret",
+    )
+
+
+def _make_service(mock_settings: PipefySettings, return_value: dict) -> PipeService:
+    service = PipeService(settings=mock_settings)
+    service.execute_query = AsyncMock(return_value=return_value)
+    return service
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_get_pipe_passes_pipe_id_variable():
+async def test_get_pipe_passes_pipe_id_variable(mock_settings):
     """Test get_pipe sends pipe_id in GraphQL variables."""
     pipe_id = 303181849
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(return_value={"pipe": {"id": str(pipe_id)}})
-    mock_client = _create_mock_gql_client(mock_session)
-
-    service = PipeService(client=mock_client)
+    service = _make_service(mock_settings, {"pipe": {"id": str(pipe_id)}})
     result = await service.get_pipe(pipe_id)
 
-    mock_session.execute.assert_called_once()
-    variables = mock_session.execute.call_args[1]["variable_values"]
+    service.execute_query.assert_called_once()
+    variables = service.execute_query.call_args[0][1]
     assert variables == {"pipe_id": pipe_id}, "Expected pipe_id in variables"
     assert result == {"pipe": {"id": str(pipe_id)}}, "Expected pipe response"
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_get_pipe_members_returns_members():
+async def test_get_pipe_members_returns_members(mock_settings):
     """Test get_pipe_members returns the list of members for a pipe."""
     pipe_id = 123
     mock_members = [
@@ -58,15 +62,11 @@ async def test_get_pipe_members_returns_members():
         },
     ]
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(return_value={"pipe": {"members": mock_members}})
-    mock_client = _create_mock_gql_client(mock_session)
-
-    service = PipeService(client=mock_client)
+    service = _make_service(mock_settings, {"pipe": {"members": mock_members}})
     result = await service.get_pipe_members(pipe_id)
 
-    mock_session.execute.assert_called_once()
-    variables = mock_session.execute.call_args[1]["variable_values"]
+    service.execute_query.assert_called_once()
+    variables = service.execute_query.call_args[0][1]
     assert variables == {"pipeId": pipe_id}, "Expected pipeId in variables"
     assert result == {"pipe": {"members": mock_members}}, (
         "Expected pipe members response"
@@ -75,15 +75,11 @@ async def test_get_pipe_members_returns_members():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_get_start_form_fields_empty_returns_message():
+async def test_get_start_form_fields_empty_returns_message(mock_settings):
     """Test get_start_form_fields returns user-friendly message when no fields configured."""
     pipe_id = 303181849
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(return_value={"pipe": {"start_form_fields": []}})
-    mock_client = _create_mock_gql_client(mock_session)
-
-    service = PipeService(client=mock_client)
+    service = _make_service(mock_settings, {"pipe": {"start_form_fields": []}})
     result = await service.get_start_form_fields(pipe_id)
 
     assert result == {
@@ -94,7 +90,9 @@ async def test_get_start_form_fields_empty_returns_message():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_get_start_form_fields_required_only_filters_and_returns_message_when_none():
+async def test_get_start_form_fields_required_only_filters_and_returns_message_when_none(
+    mock_settings,
+):
     """Test get_start_form_fields with required_only=True returns message when all optional."""
     pipe_id = 303181849
     mock_fields = [
@@ -102,13 +100,7 @@ async def test_get_start_form_fields_required_only_filters_and_returns_message_w
         {"id": "notes", "required": False},
     ]
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(
-        return_value={"pipe": {"start_form_fields": mock_fields}}
-    )
-    mock_client = _create_mock_gql_client(mock_session)
-
-    service = PipeService(client=mock_client)
+    service = _make_service(mock_settings, {"pipe": {"start_form_fields": mock_fields}})
     result = await service.get_start_form_fields(pipe_id, required_only=True)
 
     assert result == {
@@ -119,7 +111,7 @@ async def test_get_start_form_fields_required_only_filters_and_returns_message_w
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_get_start_form_fields_required_only_returns_only_required():
+async def test_get_start_form_fields_required_only_returns_only_required(mock_settings):
     """Test get_start_form_fields with required_only=True filters correctly."""
     pipe_id = 303181849
     mock_fields = [
@@ -128,13 +120,7 @@ async def test_get_start_form_fields_required_only_returns_only_required():
         {"id": "due_date", "required": True},
     ]
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(
-        return_value={"pipe": {"start_form_fields": mock_fields}}
-    )
-    mock_client = _create_mock_gql_client(mock_session)
-
-    service = PipeService(client=mock_client)
+    service = _make_service(mock_settings, {"pipe": {"start_form_fields": mock_fields}})
     result = await service.get_start_form_fields(pipe_id, required_only=True)
 
     expected_fields = [
@@ -183,13 +169,11 @@ def mock_organizations() -> list[dict]:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_search_pipes_without_name_returns_all(mock_organizations: list[dict]):
+async def test_search_pipes_without_name_returns_all(
+    mock_settings, mock_organizations: list[dict]
+):
     """Test search_pipes returns all organizations and pipes when no name filter provided."""
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(return_value={"organizations": mock_organizations})
-    mock_client = _create_mock_gql_client(mock_session)
-
-    service = PipeService(client=mock_client)
+    service = _make_service(mock_settings, {"organizations": mock_organizations})
     result = await service.search_pipes()
 
     assert result == {"organizations": mock_organizations}, (
@@ -296,6 +280,7 @@ async def test_search_pipes_without_name_returns_all(mock_organizations: list[di
     ],
 )
 async def test_search_pipes_fuzzy_matching(
+    mock_settings,
     mock_organizations: list[dict],
     search_term: str,
     expected_org_ids: list[str],
@@ -303,11 +288,7 @@ async def test_search_pipes_fuzzy_matching(
     expected_pipe_scores: list[list[float]],
 ):
     """Test search_pipes fuzzy matching filters and sorts correctly."""
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(return_value={"organizations": mock_organizations})
-    mock_client = _create_mock_gql_client(mock_session)
-
-    service = PipeService(client=mock_client)
+    service = _make_service(mock_settings, {"organizations": mock_organizations})
     result = await service.search_pipes(pipe_name=search_term)
 
     assert len(result["organizations"]) == len(expected_org_ids)
@@ -323,13 +304,11 @@ async def test_search_pipes_fuzzy_matching(
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_search_pipes_no_matches_returns_empty(mock_organizations: list[dict]):
+async def test_search_pipes_no_matches_returns_empty(
+    mock_settings, mock_organizations: list[dict]
+):
     """Test search_pipes returns empty list when no pipes match the search term."""
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(return_value={"organizations": mock_organizations})
-    mock_client = _create_mock_gql_client(mock_session)
-
-    service = PipeService(client=mock_client)
+    service = _make_service(mock_settings, {"organizations": mock_organizations})
     result = await service.search_pipes(pipe_name="XyzNonExistent123")
 
     assert result == {"organizations": []}, (
@@ -339,7 +318,7 @@ async def test_search_pipes_no_matches_returns_empty(mock_organizations: list[di
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_search_pipes_empty_organizations():
+async def test_search_pipes_empty_organizations(mock_settings):
     """Test search_pipes handles organizations with no pipes."""
     mock_orgs = [
         {
@@ -353,11 +332,9 @@ async def test_search_pipes_empty_organizations():
             "pipes": [{"id": "201", "name": "Test Pipe"}],
         },
     ]
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(return_value={"organizations": mock_orgs})
-    mock_client = _create_mock_gql_client(mock_session)
 
-    service = PipeService(client=mock_client)
+    service = PipeService(settings=mock_settings)
+    service.execute_query = AsyncMock(return_value={"organizations": mock_orgs})
 
     result = await service.search_pipes()
     assert len(result["organizations"]) == 2
@@ -369,13 +346,10 @@ async def test_search_pipes_empty_organizations():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_search_pipes_all_organizations_empty():
+async def test_search_pipes_all_organizations_empty(mock_settings):
     """Test search_pipes handles API response with no organizations."""
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(return_value={"organizations": []})
-    mock_client = _create_mock_gql_client(mock_session)
-
-    service = PipeService(client=mock_client)
+    service = PipeService(settings=mock_settings)
+    service.execute_query = AsyncMock(return_value={"organizations": []})
 
     result = await service.search_pipes()
     assert result == {"organizations": []}
@@ -392,14 +366,13 @@ class TestGetPhaseFields:
     PHASE_ID = 12345
 
     @pytest.fixture
-    def mock_phase_service(self):
+    def mock_phase_service(self, mock_settings):
         """Factory fixture to create a PipeService with mocked phase response."""
 
         def _create(phase_response: dict):
-            mock_session = AsyncMock()
-            mock_session.execute = AsyncMock(return_value={"phase": phase_response})
-            mock_client = _create_mock_gql_client(mock_session)
-            return PipeService(client=mock_client), mock_session
+            service = PipeService(settings=mock_settings)
+            service.execute_query = AsyncMock(return_value={"phase": phase_response})
+            return service, service.execute_query
 
         return _create
 
@@ -409,14 +382,14 @@ class TestGetPhaseFields:
             {"id": "status", "label": "Status", "type": "select", "required": True},
             {"id": "notes", "label": "Notes", "type": "long_text", "required": False},
         ]
-        service, session = mock_phase_service(
+        service, mock_eq = mock_phase_service(
             {"id": str(self.PHASE_ID), "name": "In Progress", "fields": mock_fields}
         )
 
         result = await service.get_phase_fields(self.PHASE_ID)
 
-        session.execute.assert_called_once()
-        variables = session.execute.call_args[1]["variable_values"]
+        mock_eq.assert_called_once()
+        variables = mock_eq.call_args[0][1]
         assert variables == {"phase_id": self.PHASE_ID}, (
             "Expected phase_id in variables"
         )

--- a/tests/services/test_pipefy_base_client.py
+++ b/tests/services/test_pipefy_base_client.py
@@ -1,28 +1,37 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
-from gql import Client
 
 from pipefy_mcp.services.pipefy.base_client import BasePipefyClient
 from pipefy_mcp.settings import PipefySettings
 
 
+@pytest.fixture
+def valid_settings() -> PipefySettings:
+    return PipefySettings(
+        graphql_url="https://api.pipefy.com/graphql",
+        oauth_url="https://auth.pipefy.com/oauth/token",
+        oauth_client="client_id",
+        oauth_secret="client_secret",
+    )
+
+
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_execute_query_uses_injected_client_and_passthrough_variables():
-    """Test execute_query uses the injected client and passes variable_values unchanged."""
+async def test_execute_query_passes_variables_to_session(valid_settings):
+    """Test execute_query creates a session and passes variable_values unchanged."""
     query = object()
     variables = {"a": 1, "nested": {"b": 2}}
 
     mock_session = AsyncMock()
     mock_session.execute = AsyncMock(return_value={"ok": True})
 
-    mock_client = MagicMock(spec=Client)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
+    with patch("pipefy_mcp.services.pipefy.base_client.Client") as mock_client_cls:
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=None)
 
-    base = BasePipefyClient(client=mock_client)
-    result = await base.execute_query(query, variables)
+        base = BasePipefyClient(settings=valid_settings)
+        result = await base.execute_query(query, variables)
 
     mock_session.execute.assert_called_once_with(query, variable_values=variables)
     assert result == {"ok": True}
@@ -30,7 +39,7 @@ async def test_execute_query_uses_injected_client_and_passthrough_variables():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_execute_query_bubbles_up_execute_errors_unchanged():
+async def test_execute_query_bubbles_up_execute_errors_unchanged(valid_settings):
     """Test execute_query does not wrap exceptions raised by the GraphQL session."""
     query = object()
     variables = {"x": 1}
@@ -39,36 +48,16 @@ async def test_execute_query_bubbles_up_execute_errors_unchanged():
     mock_session = AsyncMock()
     mock_session.execute = AsyncMock(side_effect=expected_error)
 
-    mock_client = MagicMock(spec=Client)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
+    with patch("pipefy_mcp.services.pipefy.base_client.Client") as mock_client_cls:
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=None)
 
-    base = BasePipefyClient(client=mock_client)
+        base = BasePipefyClient(settings=valid_settings)
 
-    with pytest.raises(RuntimeError) as exc:
-        await base.execute_query(query, variables)
+        with pytest.raises(RuntimeError) as exc:
+            await base.execute_query(query, variables)
 
     assert exc.value is expected_error
-
-
-@pytest.mark.unit
-def test_base_pipefy_client_raises_when_both_schema_and_client_provided():
-    """Test that providing both schema and client raises ValueError."""
-    mock_client = MagicMock(spec=Client)
-
-    with pytest.raises(ValueError) as exc:
-        BasePipefyClient(schema="some_schema", client=mock_client)
-
-    assert "Cannot specify both 'schema' and 'client'" in str(exc.value)
-
-
-@pytest.mark.unit
-def test_init_raises_when_settings_is_none_and_no_client_provided():
-    """Test that __init__ raises ValueError when settings is None and no client provided."""
-    with pytest.raises(ValueError) as exc:
-        BasePipefyClient(settings=None, client=None)
-
-    assert "Settings must be provided to create a GraphQL client" in str(exc.value)
 
 
 @pytest.mark.unit

--- a/tests/services/test_pipefy_client.py
+++ b/tests/services/test_pipefy_client.py
@@ -1,21 +1,37 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from gql import Client
 
 from pipefy_mcp.services.pipefy.card_service import CardService
 from pipefy_mcp.services.pipefy.client import PipefyClient
 from pipefy_mcp.services.pipefy.pipe_service import PipeService
+from pipefy_mcp.settings import PipefySettings
 
 
-def _make_facade_client(mock_client):
+def _mock_settings() -> PipefySettings:
+    return PipefySettings(
+        graphql_url="https://api.pipefy.com/graphql",
+        oauth_url="https://auth.pipefy.com/oauth/token",
+        oauth_client="client_id",
+        oauth_secret="client_secret",
+    )
+
+
+def _make_facade_client(execute_return_value: dict):
+    """Create a PipefyClient with execute_query mocked on both services.
+
+    Returns (client, mock_execute_query) so tests can inspect call args.
+    """
+    settings = _mock_settings()
     client = PipefyClient.__new__(PipefyClient)
-    # Keep public attr for backward compatibility
-    client.client = mock_client
-    # Real services with injected client (so behavior stays identical)
-    client._pipe_service = PipeService(mock_client)
-    client._card_service = CardService(mock_client)
-    return client
+    client._pipe_service = PipeService(settings=settings)
+    client._card_service = CardService(settings=settings)
+
+    mock_execute = AsyncMock(return_value=execute_return_value)
+    client._pipe_service.execute_query = mock_execute
+    client._card_service.execute_query = mock_execute
+
+    return client, mock_execute
 
 
 @pytest.mark.unit
@@ -25,26 +41,13 @@ async def test_create_card_with_dict_fields():
     pipe_id = 303181849
     fields_dict = {"title": "Teste-MCP", "description": "Test description"}
 
-    # Mock the GraphQL client and session
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(
-        return_value={"createCard": {"card": {"id": "12345"}}}
+    client, mock_execute = _make_facade_client(
+        {"createCard": {"card": {"id": "12345"}}}
     )
-
-    mock_client = MagicMock(spec=Client)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
-
-    client = _make_facade_client(mock_client)
-
     result = await client.create_card(pipe_id, fields_dict)
 
-    # Verify the session was called with correct variables
-    mock_session.execute.assert_called_once()
-    call_args = mock_session.execute.call_args
-
-    # Check that fields were converted to array format
-    variables = call_args[1]["variable_values"]
+    mock_execute.assert_called_once()
+    variables = mock_execute.call_args[0][1]
     assert variables["pipe_id"] == pipe_id
     assert isinstance(variables["fields"], list)
     assert len(variables["fields"]) == 2
@@ -58,8 +61,6 @@ async def test_create_card_with_dict_fields():
         "field_value": "Test description",
         "generated_by_ai": True,
     }
-
-    # Verify result
     assert result == {"createCard": {"card": {"id": "12345"}}}
 
 
@@ -73,26 +74,13 @@ async def test_create_card_with_array_fields():
         {"field_id": "description", "field_value": "Test description"},
     ]
 
-    # Mock the GraphQL client and session
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(
-        return_value={"createCard": {"card": {"id": "12345"}}}
+    client, mock_execute = _make_facade_client(
+        {"createCard": {"card": {"id": "12345"}}}
     )
-
-    mock_client = MagicMock(spec=Client)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
-
-    client = _make_facade_client(mock_client)
-
     result = await client.create_card(pipe_id, fields_array)
 
-    # Verify the session was called with correct variables
-    mock_session.execute.assert_called_once()
-    call_args = mock_session.execute.call_args
-
-    # Check that fields array was used and generated_by_ai was added
-    variables = call_args[1]["variable_values"]
+    mock_execute.assert_called_once()
+    variables = mock_execute.call_args[0][1]
     assert variables["pipe_id"] == pipe_id
     assert len(variables["fields"]) == 2
     assert variables["fields"][0] == {
@@ -105,8 +93,6 @@ async def test_create_card_with_array_fields():
         "field_value": "Test description",
         "generated_by_ai": True,
     }
-
-    # Verify result
     assert result == {"createCard": {"card": {"id": "12345"}}}
 
 
@@ -115,31 +101,16 @@ async def test_create_card_with_array_fields():
 async def test_create_card_with_empty_dict():
     """Test create_card handles empty dict fields."""
     pipe_id = 303181849
-    fields_dict = {}
 
-    # Mock the GraphQL client and session
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(
-        return_value={"createCard": {"card": {"id": "12345"}}}
+    client, mock_execute = _make_facade_client(
+        {"createCard": {"card": {"id": "12345"}}}
     )
+    result = await client.create_card(pipe_id, {})
 
-    mock_client = MagicMock(spec=Client)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
-
-    client = _make_facade_client(mock_client)
-
-    result = await client.create_card(pipe_id, fields_dict)
-
-    # Verify the session was called with empty array
-    mock_session.execute.assert_called_once()
-    call_args = mock_session.execute.call_args
-
-    variables = call_args[1]["variable_values"]
+    mock_execute.assert_called_once()
+    variables = mock_execute.call_args[0][1]
     assert variables["pipe_id"] == pipe_id
     assert variables["fields"] == []
-
-    # Verify result
     assert result == {"createCard": {"card": {"id": "12345"}}}
 
 
@@ -150,25 +121,13 @@ async def test_create_card_with_single_field():
     pipe_id = 303181849
     fields_dict = {"title": "Teste-MCP"}
 
-    # Mock the GraphQL client and session
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(
-        return_value={"createCard": {"card": {"id": "12345"}}}
+    client, mock_execute = _make_facade_client(
+        {"createCard": {"card": {"id": "12345"}}}
     )
-
-    mock_client = MagicMock(spec=Client)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
-
-    client = _make_facade_client(mock_client)
-
     result = await client.create_card(pipe_id, fields_dict)
 
-    # Verify the session was called with correct variables
-    mock_session.execute.assert_called_once()
-    call_args = mock_session.execute.call_args
-
-    variables = call_args[1]["variable_values"]
+    mock_execute.assert_called_once()
+    variables = mock_execute.call_args[0][1]
     assert variables["pipe_id"] == pipe_id
     assert len(variables["fields"]) == 1
     assert variables["fields"][0] == {
@@ -176,8 +135,6 @@ async def test_create_card_with_single_field():
         "field_value": "Teste-MCP",
         "generated_by_ai": True,
     }
-
-    # Verify result
     assert result == {"createCard": {"card": {"id": "12345"}}}
 
 
@@ -214,27 +171,14 @@ async def test_get_start_form_fields_returns_all_fields():
         },
     ]
 
-    # Mock the GraphQL client and session
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(
-        return_value={"pipe": {"start_form_fields": mock_fields}}
+    client, mock_execute = _make_facade_client(
+        {"pipe": {"start_form_fields": mock_fields}}
     )
-
-    mock_client = MagicMock(spec=Client)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
-
-    client = _make_facade_client(mock_client)
-
     result = await client.get_start_form_fields(pipe_id)
 
-    # Verify the session was called with correct variables
-    mock_session.execute.assert_called_once()
-    call_args = mock_session.execute.call_args
-    variables = call_args[1]["variable_values"]
+    mock_execute.assert_called_once()
+    variables = mock_execute.call_args[0][1]
     assert variables["pipe_id"] == pipe_id
-
-    # Verify result contains all fields
     assert "start_form_fields" in result
     assert len(result["start_form_fields"]) == 2
     assert result["start_form_fields"][0]["id"] == "title"
@@ -279,21 +223,9 @@ async def test_get_start_form_fields_required_only_filter():
         },
     ]
 
-    # Mock the GraphQL client and session
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(
-        return_value={"pipe": {"start_form_fields": mock_fields}}
-    )
-
-    mock_client = MagicMock(spec=Client)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
-
-    client = _make_facade_client(mock_client)
-
+    client, _ = _make_facade_client({"pipe": {"start_form_fields": mock_fields}})
     result = await client.get_start_form_fields(pipe_id, required_only=True)
 
-    # Verify only required fields are returned
     assert "start_form_fields" in result
     assert len(result["start_form_fields"]) == 2
     assert all(field["required"] for field in result["start_form_fields"])
@@ -307,19 +239,9 @@ async def test_get_start_form_fields_empty_returns_friendly_message():
     """Test get_start_form_fields returns user-friendly message when no fields configured."""
     pipe_id = 303181849
 
-    # Mock the GraphQL client and session with empty fields
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(return_value={"pipe": {"start_form_fields": []}})
-
-    mock_client = MagicMock(spec=Client)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
-
-    client = _make_facade_client(mock_client)
-
+    client, _ = _make_facade_client({"pipe": {"start_form_fields": []}})
     result = await client.get_start_form_fields(pipe_id)
 
-    # Verify user-friendly message is returned
     assert "message" in result
     assert result["message"] == "This pipe has no start form fields configured."
     assert "start_form_fields" in result
@@ -354,21 +276,9 @@ async def test_get_start_form_fields_required_only_no_required_fields():
         },
     ]
 
-    # Mock the GraphQL client and session
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(
-        return_value={"pipe": {"start_form_fields": mock_fields}}
-    )
-
-    mock_client = MagicMock(spec=Client)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
-
-    client = _make_facade_client(mock_client)
-
+    client, _ = _make_facade_client({"pipe": {"start_form_fields": mock_fields}})
     result = await client.get_start_form_fields(pipe_id, required_only=True)
 
-    # Verify user-friendly message is returned for no required fields
     assert "message" in result
     assert result["message"] == "This pipe has no required fields in the start form."
     assert "start_form_fields" in result
@@ -406,21 +316,11 @@ async def test_update_card_field_success():
         }
     }
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(return_value=mock_response)
-
-    mock_client = MagicMock(spec=Client)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
-
-    client = _make_facade_client(mock_client)
-
+    client, mock_execute = _make_facade_client(mock_response)
     result = await client.update_card_field(card_id, field_id, new_value)
 
-    mock_session.execute.assert_called_once()
-    call_args = mock_session.execute.call_args
-    variables = call_args[1]["variable_values"]
-
+    mock_execute.assert_called_once()
+    variables = mock_execute.call_args[0][1]
     assert variables["input"]["card_id"] == card_id
     assert variables["input"]["field_id"] == field_id
     assert variables["input"]["new_value"] == new_value
@@ -454,21 +354,11 @@ async def test_update_card_replacement_mode_with_title():
         }
     }
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(return_value=mock_response)
-
-    mock_client = MagicMock(spec=Client)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
-
-    client = _make_facade_client(mock_client)
-
+    client, mock_execute = _make_facade_client(mock_response)
     result = await client.update_card(card_id, title=new_title)
 
-    mock_session.execute.assert_called_once()
-    call_args = mock_session.execute.call_args
-    variables = call_args[1]["variable_values"]
-
+    mock_execute.assert_called_once()
+    variables = mock_execute.call_args[0][1]
     assert variables["input"]["id"] == card_id
     assert variables["input"]["title"] == new_title
     assert result == mock_response
@@ -492,27 +382,15 @@ async def test_update_card_with_fields_dict_uses_update_fields_values():
         }
     }
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(return_value=mock_response)
-
-    mock_client = MagicMock(spec=Client)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
-
-    client = _make_facade_client(mock_client)
-
+    client, mock_execute = _make_facade_client(mock_response)
     result = await client.update_card(card_id, field_updates=field_updates)
 
-    mock_session.execute.assert_called_once()
-    call_args = mock_session.execute.call_args
-    variables = call_args[1]["variable_values"]
-
-    # Fields are converted to updateFieldsValues format
+    mock_execute.assert_called_once()
+    variables = mock_execute.call_args[0][1]
     assert variables["input"]["nodeId"] == card_id
     assert "values" in variables["input"]
     values = variables["input"]["values"]
     assert len(values) == 2
-    # Check that fields were converted to camelCase format with generatedByAi
     field_ids = [v["fieldId"] for v in values]
     assert "field_1" in field_ids
     assert "field_2" in field_ids
@@ -547,23 +425,13 @@ async def test_update_card_replacement_mode_with_assignees_and_labels():
         }
     }
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(return_value=mock_response)
-
-    mock_client = MagicMock(spec=Client)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
-
-    client = _make_facade_client(mock_client)
-
+    client, mock_execute = _make_facade_client(mock_response)
     result = await client.update_card(
         card_id, assignee_ids=assignee_ids, label_ids=label_ids
     )
 
-    mock_session.execute.assert_called_once()
-    call_args = mock_session.execute.call_args
-    variables = call_args[1]["variable_values"]
-
+    mock_execute.assert_called_once()
+    variables = mock_execute.call_args[0][1]
     assert variables["input"]["id"] == card_id
     assert variables["input"]["assignee_ids"] == assignee_ids
     assert variables["input"]["label_ids"] == label_ids
@@ -584,27 +452,16 @@ async def test_update_card_incremental_mode_with_add_operation():
             "updatedNode": {
                 "id": "12345",
                 "title": "Test Card",
-                "assignees": [{"id": "123", "name": "New User"}],
                 "updated_at": "2024-12-16T10:00:00Z",
             },
         }
     }
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(return_value=mock_response)
-
-    mock_client = MagicMock(spec=Client)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
-
-    client = _make_facade_client(mock_client)
-
+    client, mock_execute = _make_facade_client(mock_response)
     result = await client.update_card(card_id, field_updates=values)
 
-    mock_session.execute.assert_called_once()
-    call_args = mock_session.execute.call_args
-    variables = call_args[1]["variable_values"]
-
+    mock_execute.assert_called_once()
+    variables = mock_execute.call_args[0][1]
     assert variables["input"]["nodeId"] == card_id
     assert "values" in variables["input"]
     assert result == mock_response
@@ -625,21 +482,11 @@ async def test_update_card_incremental_mode_with_remove_operation():
         }
     }
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(return_value=mock_response)
-
-    mock_client = MagicMock(spec=Client)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
-
-    client = _make_facade_client(mock_client)
-
+    client, mock_execute = _make_facade_client(mock_response)
     result = await client.update_card(card_id, field_updates=values)
 
-    mock_session.execute.assert_called_once()
-    call_args = mock_session.execute.call_args
-    variables = call_args[1]["variable_values"]
-
+    mock_execute.assert_called_once()
+    variables = mock_execute.call_args[0][1]
     assert variables["input"]["nodeId"] == card_id
     assert result == mock_response
 
@@ -651,23 +498,13 @@ async def test_update_card_incremental_mode_value_format_conversion():
     card_id = 12345
     values = [{"field_id": "field_1", "value": "New Value", "operation": "ADD"}]
 
-    mock_response = {"updateFieldsValues": {"success": True, "userErrors": []}}
-
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(return_value=mock_response)
-
-    mock_client = MagicMock(spec=Client)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
-
-    client = _make_facade_client(mock_client)
-
+    client, mock_execute = _make_facade_client(
+        {"updateFieldsValues": {"success": True, "userErrors": []}}
+    )
     await client.update_card(card_id, field_updates=values)
 
-    call_args = mock_session.execute.call_args
-    variables = call_args[1]["variable_values"]
+    variables = mock_execute.call_args[0][1]
     formatted_values = variables["input"]["values"]
-
     assert len(formatted_values) == 1
     assert formatted_values[0]["fieldId"] == "field_1"
     assert formatted_values[0]["value"] == "New Value"
@@ -694,20 +531,11 @@ async def test_get_pipe_passes_pipe_id_variable():
     """Test get_pipe passes pipe_id under variable_values unchanged."""
     pipe_id = 303181849
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(return_value={"pipe": {"id": str(pipe_id)}})
-
-    mock_client = MagicMock(spec=Client)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
-
-    client = _make_facade_client(mock_client)
-
+    client, mock_execute = _make_facade_client({"pipe": {"id": str(pipe_id)}})
     result = await client.get_pipe(pipe_id)
 
-    mock_session.execute.assert_called_once()
-    call_args = mock_session.execute.call_args
-    variables = call_args[1]["variable_values"]
+    mock_execute.assert_called_once()
+    variables = mock_execute.call_args[0][1]
     assert variables == {"pipe_id": pipe_id}
     assert result == {"pipe": {"id": str(pipe_id)}}
 
@@ -719,18 +547,15 @@ async def test_get_pipe_members_calls_service():
     pipe_id = 123
     mock_members = [{"user": {"id": "1", "name": "Test User"}}]
 
-    # Mock PipeService and its get_pipe_members method
     mock_pipe_service = MagicMock(spec=PipeService)
     mock_pipe_service.get_pipe_members = AsyncMock(return_value=mock_members)
 
     client = PipefyClient.__new__(PipefyClient)
     client._pipe_service = mock_pipe_service
-    client._card_service = MagicMock(spec=CardService)  # Mock CardService as well
+    client._card_service = MagicMock(spec=CardService)
 
-    # Call the method
     result = await client.get_pipe_members(pipe_id)
 
-    # Assert that the service method was called with the correct argument
     mock_pipe_service.get_pipe_members.assert_called_once_with(pipe_id)
     assert result == mock_members
 
@@ -740,32 +565,7 @@ async def test_get_pipe_members_calls_service():
 async def test_get_card_passes_card_id_variable():
     """Test get_card passes card_id under variable_values unchanged."""
     card_id = 12345
-
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(
-        return_value={
-            "card": {
-                "id": str(card_id),
-                "title": "Test Card",
-                "current_phase": {"id": "1", "name": "Test Phase"},
-                "pipe": {"id": "123", "name": "Test Pipe"},
-            }
-        }
-    )
-
-    mock_client = MagicMock(spec=Client)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
-
-    client = _make_facade_client(mock_client)
-
-    result = await client.get_card(card_id)
-
-    mock_session.execute.assert_called_once()
-    call_args = mock_session.execute.call_args
-    variables = call_args[1]["variable_values"]
-    assert variables == {"card_id": card_id, "includeFields": False}
-    assert result == {
+    mock_response = {
         "card": {
             "id": str(card_id),
             "title": "Test Card",
@@ -774,6 +574,14 @@ async def test_get_card_passes_card_id_variable():
         }
     }
 
+    client, mock_execute = _make_facade_client(mock_response)
+    result = await client.get_card(card_id)
+
+    mock_execute.assert_called_once()
+    variables = mock_execute.call_args[0][1]
+    assert variables == {"card_id": card_id, "includeFields": False}
+    assert result == mock_response
+
 
 @pytest.mark.unit
 @pytest.mark.asyncio
@@ -781,21 +589,11 @@ async def test_get_cards_with_none_search_sends_empty_search_dict():
     """Test get_cards sends an empty search object when search is None."""
     pipe_id = 303181849
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(return_value={"cards": {"edges": []}})
-
-    mock_client = MagicMock(spec=Client)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
-
-    client = _make_facade_client(mock_client)
-
+    client, mock_execute = _make_facade_client({"cards": {"edges": []}})
     result = await client.get_cards(pipe_id, None)
 
-    mock_session.execute.assert_called_once()
-    call_args = mock_session.execute.call_args
-    variables = call_args[1]["variable_values"]
-
+    mock_execute.assert_called_once()
+    variables = mock_execute.call_args[0][1]
     assert variables["pipe_id"] == pipe_id
     assert variables["search"] == {}
     assert result == {"cards": {"edges": []}}
@@ -808,21 +606,11 @@ async def test_get_cards_with_search_dict_passes_search_as_is():
     pipe_id = 303181849
     search = {"title": "Test"}
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(return_value={"cards": {"edges": []}})
-
-    mock_client = MagicMock(spec=Client)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
-
-    client = _make_facade_client(mock_client)
-
+    client, mock_execute = _make_facade_client({"cards": {"edges": []}})
     result = await client.get_cards(pipe_id, search)
 
-    mock_session.execute.assert_called_once()
-    call_args = mock_session.execute.call_args
-    variables = call_args[1]["variable_values"]
-
+    mock_execute.assert_called_once()
+    variables = mock_execute.call_args[0][1]
     assert variables["pipe_id"] == pipe_id
     assert variables["search"] == search
     assert result == {"cards": {"edges": []}}
@@ -842,11 +630,7 @@ async def test_get_cards_with_include_fields_true_passes_include_fields_to_servi
     client._card_service = card_service
     client._pipe_service = MagicMock(spec=PipeService)
 
-    result = await client.get_cards(
-        pipe_id,
-        search=None,
-        include_fields=True,
-    )
+    result = await client.get_cards(pipe_id, search=None, include_fields=True)
 
     card_service.get_cards.assert_awaited_once_with(pipe_id, None, include_fields=True)
     assert result == expected
@@ -866,11 +650,7 @@ async def test_get_cards_with_include_fields_false_passes_include_fields_to_serv
     client._card_service = card_service
     client._pipe_service = MagicMock(spec=PipeService)
 
-    result = await client.get_cards(
-        pipe_id,
-        search=None,
-        include_fields=False,
-    )
+    result = await client.get_cards(pipe_id, search=None, include_fields=False)
 
     card_service.get_cards.assert_awaited_once_with(pipe_id, None, include_fields=False)
     assert result == expected
@@ -994,23 +774,13 @@ async def test_move_card_to_phase_variable_shape():
     card_id = 12345
     destination_phase_id = 678
 
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(
-        return_value={"moveCardToPhase": {"clientMutationId": None}}
+    client, mock_execute = _make_facade_client(
+        {"moveCardToPhase": {"clientMutationId": None}}
     )
-
-    mock_client = MagicMock(spec=Client)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
-
-    client = _make_facade_client(mock_client)
-
     result = await client.move_card_to_phase(card_id, destination_phase_id)
 
-    mock_session.execute.assert_called_once()
-    call_args = mock_session.execute.call_args
-    variables = call_args[1]["variable_values"]
-
+    mock_execute.assert_called_once()
+    variables = mock_execute.call_args[0][1]
     assert variables == {
         "input": {"card_id": card_id, "destination_phase_id": destination_phase_id}
     }

--- a/tests/services/test_pipefy_facade.py
+++ b/tests/services/test_pipefy_facade.py
@@ -2,7 +2,9 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from pipefy_mcp.services.pipefy.card_service import CardService
 from pipefy_mcp.services.pipefy.client import PipefyClient
+from pipefy_mcp.services.pipefy.pipe_service import PipeService
 from pipefy_mcp.settings import PipefySettings
 
 
@@ -77,25 +79,22 @@ async def test_pipefy_client_facade_delegates_to_services_without_modifying_args
 
 
 @pytest.mark.unit
-def test_pipefy_client_injects_same_shared_client_instance_into_services():
-    """Test PipefyClient creates one shared gql.Client and injects it into both services."""
-    from unittest.mock import MagicMock, patch
+def test_pipefy_client_creates_services_with_shared_auth():
+    """Test PipefyClient creates services that share the same OAuth auth instance."""
 
-    from gql import Client
+    settings = PipefySettings(
+        graphql_url="https://api.pipefy.com/graphql",
+        oauth_url="https://auth.pipefy.com/oauth/token",
+        oauth_client="client_id",
+        oauth_secret="client_secret",
+    )
+    client = PipefyClient(settings=settings)
 
-    # Mock the BasePipefyClient._create_client to avoid OAuth dependencies
-    mock_client_instance = MagicMock(spec=Client)
-
-    with patch(
-        "pipefy_mcp.services.pipefy.base_client.BasePipefyClient._create_client",
-        return_value=mock_client_instance,
-    ):
-        client = PipefyClient(settings=MagicMock(spec=PipefySettings))
-
-    # Verify that both services received the same client instance
-    assert client._pipe_service.client is client._card_service.client
-    # Verify that the shared client is also exposed as the public `client` attribute
-    assert client.client is client._pipe_service.client
-    assert client.client is client._card_service.client
-    # Verify it's the same mock instance we injected
-    assert client.client is mock_client_instance
+    assert isinstance(client._pipe_service, PipeService)
+    assert isinstance(client._card_service, CardService)
+    assert client._pipe_service._auth is not None, (
+        "PipeService should have an auth instance"
+    )
+    assert client._card_service._auth is not None, (
+        "CardService should have an auth instance"
+    )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -41,6 +41,9 @@ _MINIMAL_PIPEFY_SETTINGS = Settings(
 async def test_register_tools(client_session):
     expected_tool_names = [
         "add_card_comment",
+        "create_ai_agent",
+        "create_ai_automation",
+        "toggle_ai_agent_status",
         "create_card",
         "delete_card",
         "delete_comment",
@@ -54,6 +57,8 @@ async def test_register_tools(client_session):
         "get_start_form_fields",
         "move_card_to_phase",
         "search_pipes",
+        "update_ai_agent",
+        "update_ai_automation",
         "update_card",
         "update_card_field",
         "update_comment",

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -1,0 +1,33 @@
+"""Shared fixtures for tool tests."""
+
+import json
+
+import pytest
+
+
+@pytest.fixture
+def extract_payload():
+    """Extract tool payload from CallToolResult across MCP SDK versions."""
+
+    def _extract(result) -> dict:
+        structured = getattr(result, "structuredContent", None)
+        if structured is not None:
+            if isinstance(structured, dict) and "result" in structured:
+                payload = structured.get("result")
+                if isinstance(payload, dict):
+                    return payload
+            if isinstance(structured, dict):
+                return structured
+        content = getattr(result, "content", None) or []
+        for item in content:
+            if getattr(item, "type", None) == "text":
+                text = getattr(item, "text", "")
+                try:
+                    payload = json.loads(text)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(payload, dict):
+                    return payload
+        raise AssertionError("Could not extract tool payload from CallToolResult")
+
+    return _extract

--- a/tests/tools/test_ai_agent_tools.py
+++ b/tests/tools/test_ai_agent_tools.py
@@ -1,0 +1,276 @@
+"""Tests for AI Agent MCP tools."""
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+from mcp.shared.memory import (
+    create_connected_server_and_client_session as create_client_session,
+)
+
+from pipefy_mcp.tools.ai_agent_tools import AiAgentTools
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture
+def mock_ai_agent_service():
+    service = MagicMock()
+    service.create_agent = AsyncMock()
+    service.update_agent = AsyncMock()
+    service.toggle_agent_status = AsyncMock()
+    return service
+
+
+@pytest.fixture
+def mcp_server(mock_ai_agent_service):
+    mcp = FastMCP("AI Agent Tools Test")
+    AiAgentTools.register(mcp, mock_ai_agent_service)
+    return mcp
+
+
+@pytest.fixture
+def client_session(mcp_server):
+    return create_client_session(
+        mcp_server,
+        read_timeout_seconds=timedelta(seconds=10),
+        raise_exceptions=True,
+    )
+
+
+@pytest.mark.anyio
+class TestCreateAiAgent:
+    async def test_success(
+        self,
+        client_session,
+        mock_ai_agent_service,
+        extract_payload,
+    ):
+        mock_ai_agent_service.create_agent.return_value = {
+            "agent_uuid": "abc-123",
+            "message": "AI Agent created successfully. UUID: abc-123",
+        }
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_ai_agent",
+                {"name": "My Agent", "repo_uuid": "repo-456"},
+            )
+        assert result.isError is False
+        payload = extract_payload(result)
+        assert payload == {
+            "success": True,
+            "agent_uuid": "abc-123",
+            "message": "AI Agent created successfully. UUID: abc-123",
+        }
+        assert isinstance(payload["message"], str)
+        assert isinstance(payload["agent_uuid"], str)
+
+    async def test_service_error_returns_error_payload(
+        self,
+        client_session,
+        mock_ai_agent_service,
+        extract_payload,
+    ):
+        mock_ai_agent_service.create_agent.side_effect = RuntimeError("GraphQL error")
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_ai_agent",
+                {"name": "My Agent", "repo_uuid": "repo-456"},
+            )
+        assert result.isError is False
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "error" in payload
+        assert isinstance(payload["error"], str)
+
+    async def test_validation_error_returns_error_payload(
+        self,
+        client_session,
+        mock_ai_agent_service,
+        extract_payload,
+    ):
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_ai_agent",
+                {"name": "", "repo_uuid": "repo-456"},
+            )
+        assert result.isError is False
+        mock_ai_agent_service.create_agent.assert_not_called()
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "error" in payload
+
+
+@pytest.mark.anyio
+class TestUpdateAiAgent:
+    async def test_success(
+        self,
+        client_session,
+        mock_ai_agent_service,
+        extract_payload,
+    ):
+        mock_ai_agent_service.update_agent.return_value = {
+            "agent_uuid": "agent-uuid",
+            "message": "AI Agent updated successfully. UUID: agent-uuid",
+        }
+        async with client_session as session:
+            result = await session.call_tool(
+                "update_ai_agent",
+                {
+                    "uuid": "agent-uuid",
+                    "name": "Updated Agent",
+                    "repo_uuid": "repo-456",
+                    "instruction": "Do things",
+                    "behaviors": [{"name": "B1", "event_id": "card_created"}],
+                },
+            )
+        assert result.isError is False
+        payload = extract_payload(result)
+        assert payload == {
+            "success": True,
+            "agent_uuid": "agent-uuid",
+            "message": "AI Agent updated successfully. UUID: agent-uuid",
+        }
+        assert isinstance(payload["message"], str)
+        assert isinstance(payload["agent_uuid"], str)
+
+    async def test_zero_behaviors_returns_error_payload(
+        self,
+        client_session,
+        mock_ai_agent_service,
+        extract_payload,
+    ):
+        async with client_session as session:
+            result = await session.call_tool(
+                "update_ai_agent",
+                {
+                    "uuid": "agent-uuid",
+                    "name": "Updated Agent",
+                    "repo_uuid": "repo-456",
+                    "instruction": "Do things",
+                    "behaviors": [],
+                },
+            )
+        assert result.isError is False
+        mock_ai_agent_service.update_agent.assert_not_called()
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "error" in payload
+
+    async def test_six_behaviors_returns_error_payload(
+        self,
+        client_session,
+        mock_ai_agent_service,
+        extract_payload,
+    ):
+        async with client_session as session:
+            result = await session.call_tool(
+                "update_ai_agent",
+                {
+                    "uuid": "agent-uuid",
+                    "name": "Updated Agent",
+                    "repo_uuid": "repo-456",
+                    "instruction": "Do things",
+                    "behaviors": [
+                        {"name": f"B{i}", "event_id": "card_created"} for i in range(6)
+                    ],
+                },
+            )
+        assert result.isError is False
+        mock_ai_agent_service.update_agent.assert_not_called()
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "error" in payload
+
+    async def test_service_error_returns_error_payload(
+        self,
+        client_session,
+        mock_ai_agent_service,
+        extract_payload,
+    ):
+        mock_ai_agent_service.update_agent.side_effect = ValueError("Network error")
+        async with client_session as session:
+            result = await session.call_tool(
+                "update_ai_agent",
+                {
+                    "uuid": "agent-uuid",
+                    "name": "Updated Agent",
+                    "repo_uuid": "repo-456",
+                    "instruction": "Do things",
+                    "behaviors": [{"name": "B1", "event_id": "card_created"}],
+                },
+            )
+        assert result.isError is False
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "error" in payload
+
+
+@pytest.mark.anyio
+class TestToggleAiAgentStatus:
+    async def test_activate_success(
+        self,
+        client_session,
+        mock_ai_agent_service,
+        extract_payload,
+    ):
+        mock_ai_agent_service.toggle_agent_status.return_value = {
+            "success": True,
+            "message": "AI Agent activated successfully.",
+        }
+        async with client_session as session:
+            result = await session.call_tool(
+                "toggle_ai_agent_status",
+                {"uuid": "agent-uuid", "active": True},
+            )
+        assert result.isError is False
+        payload = extract_payload(result)
+        assert payload == {
+            "success": True,
+            "message": "AI Agent activated successfully.",
+        }
+        assert isinstance(payload["message"], str)
+
+    async def test_deactivate_success(
+        self,
+        client_session,
+        mock_ai_agent_service,
+        extract_payload,
+    ):
+        mock_ai_agent_service.toggle_agent_status.return_value = {
+            "success": True,
+            "message": "AI Agent deactivated successfully.",
+        }
+        async with client_session as session:
+            result = await session.call_tool(
+                "toggle_ai_agent_status",
+                {"uuid": "agent-uuid", "active": False},
+            )
+        assert result.isError is False
+        payload = extract_payload(result)
+        assert payload["success"] is True
+        assert "deactivated" in payload["message"]
+
+    async def test_service_error_returns_error_payload(
+        self,
+        client_session,
+        mock_ai_agent_service,
+        extract_payload,
+    ):
+        mock_ai_agent_service.toggle_agent_status.side_effect = RuntimeError(
+            "API error"
+        )
+        async with client_session as session:
+            result = await session.call_tool(
+                "toggle_ai_agent_status",
+                {"uuid": "agent-uuid", "active": True},
+            )
+        assert result.isError is False
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "error" in payload
+        assert isinstance(payload["error"], str)

--- a/tests/tools/test_ai_automation_tools.py
+++ b/tests/tools/test_ai_automation_tools.py
@@ -1,0 +1,171 @@
+"""Tests for AI Automation MCP tools."""
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+from mcp.shared.memory import (
+    create_connected_server_and_client_session as create_client_session,
+)
+
+from pipefy_mcp.tools.ai_automation_tools import AiAutomationTools
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture
+def mock_ai_automation_service():
+    service = MagicMock()
+    service.create_automation = AsyncMock()
+    service.update_automation = AsyncMock()
+    return service
+
+
+@pytest.fixture
+def mcp_server(mock_ai_automation_service):
+    mcp = FastMCP("AI Automation Tools Test")
+    AiAutomationTools.register(mcp, mock_ai_automation_service)
+    return mcp
+
+
+@pytest.fixture
+def client_session(mcp_server):
+    return create_client_session(
+        mcp_server,
+        read_timeout_seconds=timedelta(seconds=10),
+        raise_exceptions=True,
+    )
+
+
+@pytest.mark.anyio
+class TestCreateAiAutomation:
+    async def test_success(
+        self,
+        client_session,
+        mock_ai_automation_service,
+        extract_payload,
+    ):
+        mock_ai_automation_service.create_automation.return_value = {
+            "automation_id": "123",
+            "message": "AI Automation created successfully. ID: 123",
+        }
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_ai_automation",
+                {
+                    "name": "My Auto",
+                    "event_id": "card_created",
+                    "pipe_id": "303",
+                    "prompt": "Summarize",
+                    "field_ids": ["133"],
+                },
+            )
+        assert result.isError is False
+        payload = extract_payload(result)
+        assert payload == {
+            "success": True,
+            "automation_id": "123",
+            "message": "AI Automation created successfully. ID: 123",
+        }
+        assert isinstance(payload["message"], str)
+        assert isinstance(payload["automation_id"], str)
+
+    async def test_service_error_returns_error_payload(
+        self,
+        client_session,
+        mock_ai_automation_service,
+        extract_payload,
+    ):
+        mock_ai_automation_service.create_automation.side_effect = RuntimeError(
+            "GraphQL error"
+        )
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_ai_automation",
+                {
+                    "name": "My Auto",
+                    "event_id": "card_created",
+                    "pipe_id": "303",
+                    "prompt": "Summarize",
+                    "field_ids": ["133"],
+                },
+            )
+        assert result.isError is False
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "error" in payload
+        assert isinstance(payload["error"], str)
+
+    async def test_validation_error_returns_error_payload(
+        self,
+        client_session,
+        mock_ai_automation_service,
+        extract_payload,
+    ):
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_ai_automation",
+                {
+                    "name": "",
+                    "event_id": "card_created",
+                    "pipe_id": "303",
+                    "prompt": "Summarize",
+                    "field_ids": ["133"],
+                },
+            )
+        assert result.isError is False
+        mock_ai_automation_service.create_automation.assert_not_called()
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "error" in payload
+
+
+@pytest.mark.anyio
+class TestUpdateAiAutomation:
+    async def test_success(
+        self,
+        client_session,
+        mock_ai_automation_service,
+        extract_payload,
+    ):
+        mock_ai_automation_service.update_automation.return_value = {
+            "automation_id": "789",
+            "message": "AI Automation updated successfully. ID: 789",
+        }
+        async with client_session as session:
+            result = await session.call_tool(
+                "update_ai_automation",
+                {"automation_id": "789", "name": "Updated", "active": False},
+            )
+        assert result.isError is False
+        payload = extract_payload(result)
+        assert payload == {
+            "success": True,
+            "automation_id": "789",
+            "message": "AI Automation updated successfully. ID: 789",
+        }
+        assert isinstance(payload["message"], str)
+        assert isinstance(payload["automation_id"], str)
+
+    async def test_service_error_returns_error_payload(
+        self,
+        client_session,
+        mock_ai_automation_service,
+        extract_payload,
+    ):
+        mock_ai_automation_service.update_automation.side_effect = ValueError(
+            "Network error"
+        )
+        async with client_session as session:
+            result = await session.call_tool(
+                "update_ai_automation",
+                {"automation_id": "789", "name": "Updated", "active": False},
+            )
+        assert result.isError is False
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "error" in payload

--- a/tests/tools/test_pipe_tools.py
+++ b/tests/tools/test_pipe_tools.py
@@ -110,31 +110,6 @@ def elicitation_callback_raises(exc=None):
     return callback
 
 
-def _extract_call_tool_payload(result) -> dict:
-    """Extract tool payload from CallToolResult across MCP SDK versions."""
-    structured = getattr(result, "structuredContent", None)
-    if structured is not None:
-        if isinstance(structured, dict) and "result" in structured:
-            payload = structured.get("result")
-            if isinstance(payload, dict):
-                return payload
-        if isinstance(structured, dict):
-            return structured
-
-    content = getattr(result, "content", None) or []
-    for item in content:
-        if getattr(item, "type", None) == "text":
-            text = getattr(item, "text", "")
-            try:
-                payload = json.loads(text)
-            except json.JSONDecodeError:
-                continue
-            if isinstance(payload, dict):
-                return payload
-
-    raise AssertionError("Could not extract tool payload from CallToolResult")
-
-
 @pytest.mark.anyio
 class TestCreateCardTool:
     @pytest.mark.parametrize(
@@ -305,7 +280,7 @@ class TestDirectToolCalls:
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
     async def test_get_card_forwards_params_to_client(
-        self, client_session, mock_pipefy_client
+        self, client_session, mock_pipefy_client, extract_payload
     ):
         """get_card tool forwards card_id and include_fields to client."""
         mock_pipefy_client.get_card = AsyncMock(
@@ -317,12 +292,12 @@ class TestDirectToolCalls:
             )
         assert result.isError is False
         mock_pipefy_client.get_card.assert_called_once_with(123, include_fields=True)
-        payload = _extract_call_tool_payload(result)
+        payload = extract_payload(result)
         assert payload["card"]["id"] == "123"
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
     async def test_get_pipe_forwards_pipe_id_to_client(
-        self, client_session, mock_pipefy_client, pipe_id
+        self, client_session, mock_pipefy_client, pipe_id, extract_payload
     ):
         """get_pipe tool forwards pipe_id to client."""
         mock_pipefy_client.get_pipe = AsyncMock(
@@ -332,7 +307,7 @@ class TestDirectToolCalls:
             result = await session.call_tool("get_pipe", {"pipe_id": pipe_id})
         assert result.isError is False
         mock_pipefy_client.get_pipe.assert_called_once_with(pipe_id)
-        payload = _extract_call_tool_payload(result)
+        payload = extract_payload(result)
         assert payload["pipe"]["name"] == "My Pipe"
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
@@ -353,7 +328,7 @@ class TestDirectToolCalls:
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
     async def test_get_start_form_fields_forwards_params_to_client(
-        self, client_session, mock_pipefy_client, pipe_id
+        self, client_session, mock_pipefy_client, pipe_id, extract_payload
     ):
         """get_start_form_fields tool forwards pipe_id and required_only to client."""
         mock_pipefy_client.get_start_form_fields = AsyncMock(
@@ -366,7 +341,7 @@ class TestDirectToolCalls:
             )
         assert result.isError is False
         mock_pipefy_client.get_start_form_fields.assert_called_once_with(pipe_id, True)
-        payload = _extract_call_tool_payload(result)
+        payload = extract_payload(result)
         assert "start_form_fields" in payload
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
@@ -374,6 +349,7 @@ class TestDirectToolCalls:
         self,
         client_session,
         mock_pipefy_client,
+        extract_payload,
     ):
         """update_comment with valid input returns success payload with comment_id."""
         async with client_session as session:
@@ -383,7 +359,7 @@ class TestDirectToolCalls:
             )
         assert result.isError is False
         mock_pipefy_client.update_comment.assert_called_once_with(456, "Updated text")
-        payload = _extract_call_tool_payload(result)
+        payload = extract_payload(result)
         assert payload == {"success": True, "comment_id": "c_999"}
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
@@ -391,6 +367,7 @@ class TestDirectToolCalls:
         self,
         client_session,
         mock_pipefy_client,
+        extract_payload,
     ):
         """update_comment with comment_id <= 0 returns error payload without calling API."""
         async with client_session as session:
@@ -400,7 +377,7 @@ class TestDirectToolCalls:
             )
         assert result.isError is False
         mock_pipefy_client.update_comment.assert_not_called()
-        payload = _extract_call_tool_payload(result)
+        payload = extract_payload(result)
         assert payload["success"] is False
         assert "error" in payload
 
@@ -409,6 +386,7 @@ class TestDirectToolCalls:
         self,
         client_session,
         mock_pipefy_client,
+        extract_payload,
     ):
         """update_comment with blank text returns error payload without calling API."""
         async with client_session as session:
@@ -418,7 +396,7 @@ class TestDirectToolCalls:
             )
         assert result.isError is False
         mock_pipefy_client.update_comment.assert_not_called()
-        payload = _extract_call_tool_payload(result)
+        payload = extract_payload(result)
         assert payload["success"] is False
         assert "error" in payload
 
@@ -427,6 +405,7 @@ class TestDirectToolCalls:
         self,
         client_session,
         mock_pipefy_client,
+        extract_payload,
     ):
         """update_comment with text > 1000 chars returns error payload without calling API."""
         from pipefy_mcp.models.comment import MAX_COMMENT_TEXT_LENGTH
@@ -438,7 +417,7 @@ class TestDirectToolCalls:
             )
         assert result.isError is False
         mock_pipefy_client.update_comment.assert_not_called()
-        payload = _extract_call_tool_payload(result)
+        payload = extract_payload(result)
         assert payload["success"] is False
         assert "error" in payload
 
@@ -447,6 +426,7 @@ class TestDirectToolCalls:
         self,
         client_session,
         mock_pipefy_client,
+        extract_payload,
     ):
         """When update_comment API raises, tool returns error payload with friendly message."""
         from gql.transport.exceptions import TransportQueryError
@@ -464,7 +444,7 @@ class TestDirectToolCalls:
             )
         assert result.isError is False
         mock_pipefy_client.update_comment.assert_called_once_with(99999, "hello")
-        payload = _extract_call_tool_payload(result)
+        payload = extract_payload(result)
         assert payload["success"] is False
         assert "error" in payload
         assert "comment" in payload["error"].lower() or "comment_id" in payload["error"]
@@ -474,6 +454,7 @@ class TestDirectToolCalls:
         self,
         client_session,
         mock_pipefy_client,
+        extract_payload,
     ):
         """delete_comment with valid comment_id returns success payload."""
         async with client_session as session:
@@ -483,7 +464,7 @@ class TestDirectToolCalls:
             )
         assert result.isError is False
         mock_pipefy_client.delete_comment.assert_called_once_with(456)
-        payload = _extract_call_tool_payload(result)
+        payload = extract_payload(result)
         assert payload == {"success": True}
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
@@ -491,6 +472,7 @@ class TestDirectToolCalls:
         self,
         client_session,
         mock_pipefy_client,
+        extract_payload,
     ):
         """delete_comment with comment_id <= 0 returns error payload without calling API."""
         async with client_session as session:
@@ -500,7 +482,7 @@ class TestDirectToolCalls:
             )
         assert result.isError is False
         mock_pipefy_client.delete_comment.assert_not_called()
-        payload = _extract_call_tool_payload(result)
+        payload = extract_payload(result)
         assert payload["success"] is False
         assert "error" in payload
 
@@ -509,6 +491,7 @@ class TestDirectToolCalls:
         self,
         client_session,
         mock_pipefy_client,
+        extract_payload,
     ):
         """When delete_comment API raises, tool returns error payload with friendly message."""
         from gql.transport.exceptions import TransportQueryError
@@ -529,7 +512,7 @@ class TestDirectToolCalls:
             )
         assert result.isError is False
         mock_pipefy_client.delete_comment.assert_called_once_with(12345)
-        payload = _extract_call_tool_payload(result)
+        payload = extract_payload(result)
         assert payload["success"] is False
         assert "error" in payload
         assert "permission" in payload["error"].lower()
@@ -539,6 +522,7 @@ class TestDirectToolCalls:
         self,
         client_session,
         mock_pipefy_client,
+        extract_payload,
     ):
         """When delete_comment API returns not found, tool returns friendly error payload."""
         from gql.transport.exceptions import TransportQueryError
@@ -554,7 +538,7 @@ class TestDirectToolCalls:
             )
         assert result.isError is False
         mock_pipefy_client.delete_comment.assert_called_once_with(99999)
-        payload = _extract_call_tool_payload(result)
+        payload = extract_payload(result)
         assert payload["success"] is False
         assert "error" in payload
         assert "comment" in payload["error"].lower() or "not found" in payload["error"]
@@ -587,7 +571,7 @@ class TestGetCardsTool:
 class TestFindCardsTool:
     @pytest.mark.parametrize("client_session", [None], indirect=True)
     async def test_find_cards_forwards_params_to_client(
-        self, client_session, mock_pipefy_client, pipe_id
+        self, client_session, mock_pipefy_client, pipe_id, extract_payload
     ):
         """Integration test: find_cards tool forwards pipe_id, field_id, field_value, include_fields to client."""
         mock_pipefy_client.find_cards = AsyncMock(
@@ -615,13 +599,13 @@ class TestFindCardsTool:
         mock_pipefy_client.find_cards.assert_called_once_with(
             pipe_id, field_id, field_value, include_fields=True
         )
-        payload = _extract_call_tool_payload(result)
+        payload = extract_payload(result)
         assert FIND_CARDS_RESPONSE_KEY in payload
         assert payload[FIND_CARDS_RESPONSE_KEY]["edges"]
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
     async def test_find_cards_empty_edges_includes_message(
-        self, client_session, mock_pipefy_client, pipe_id
+        self, client_session, mock_pipefy_client, pipe_id, extract_payload
     ):
         """When findCards returns empty edges, tool response includes FIND_CARDS_EMPTY_MESSAGE."""
         mock_pipefy_client.find_cards = AsyncMock(
@@ -639,7 +623,7 @@ class TestFindCardsTool:
             )
 
         assert result.isError is False
-        payload = _extract_call_tool_payload(result)
+        payload = extract_payload(result)
         assert payload.get("message") == FIND_CARDS_EMPTY_MESSAGE
         assert payload.get(FIND_CARDS_RESPONSE_KEY, {}).get("edges") == []
 
@@ -651,6 +635,7 @@ class TestAddCardCommentTool:
         self,
         client_session,
         mock_pipefy_client,
+        extract_payload,
     ):
         async with client_session as session:
             result = await session.call_tool(
@@ -662,7 +647,7 @@ class TestAddCardCommentTool:
             mock_pipefy_client.add_card_comment.assert_called_once_with(
                 card_id=123, text="hello"
             )
-            payload = _extract_call_tool_payload(result)
+            payload = extract_payload(result)
             assert payload == {"success": True, "comment_id": "c_987"}
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
@@ -670,6 +655,7 @@ class TestAddCardCommentTool:
         self,
         client_session,
         mock_pipefy_client,
+        extract_payload,
     ):
         async with client_session as session:
             result = await session.call_tool(
@@ -679,7 +665,7 @@ class TestAddCardCommentTool:
 
             assert result.isError is False  # Tool returns error payload, not exception
             mock_pipefy_client.add_card_comment.assert_not_called()
-            payload = _extract_call_tool_payload(result)
+            payload = extract_payload(result)
             assert payload == {
                 "success": False,
                 "error": "Invalid input. Please provide a valid 'card_id' and non-empty 'text'.",
@@ -690,6 +676,7 @@ class TestAddCardCommentTool:
         self,
         client_session,
         mock_pipefy_client,
+        extract_payload,
     ):
         """When add_card_comment API raises, tool returns error payload with mapped message."""
         from gql.transport.exceptions import TransportQueryError
@@ -712,7 +699,7 @@ class TestAddCardCommentTool:
         mock_pipefy_client.add_card_comment.assert_called_once_with(
             card_id=123, text="hello"
         )
-        payload = _extract_call_tool_payload(result)
+        payload = extract_payload(result)
         assert payload["success"] is False
         assert "error" in payload
         assert "Card not found" in payload["error"] or "card_id" in payload["error"]
@@ -729,7 +716,7 @@ class TestGetPhaseFieldsTool:
         indirect=["client_session"],
     )
     async def test_returns_phase_fields(
-        self, client_session, mock_pipefy_client, required_only
+        self, client_session, mock_pipefy_client, required_only, extract_payload
     ):
         phase_id = 12345
         mock_fields = [
@@ -754,7 +741,7 @@ class TestGetPhaseFieldsTool:
             mock_pipefy_client.get_phase_fields.assert_called_once_with(
                 phase_id, required_only
             )
-            response = _extract_call_tool_payload(result)
+            response = extract_payload(result)
             assert response["phase_id"] == str(phase_id)
             assert response["phase_name"] == "In Progress"
             assert response["fields"] == mock_fields
@@ -883,6 +870,7 @@ class TestFillCardPhaseFieldsTool:
         self,
         client_session,
         mock_pipefy_client,
+        extract_payload,
     ):
         card_id = 456
         phase_id = 12345
@@ -906,7 +894,7 @@ class TestFillCardPhaseFieldsTool:
 
             assert result.isError is False
             mock_pipefy_client.update_card.assert_not_called()
-            response = _extract_call_tool_payload(result)
+            response = extract_payload(result)
             assert response == {
                 "success": False,
                 "error": "Phase field update cancelled by user.",
@@ -1006,6 +994,7 @@ class TestFillCardPhaseFieldsTool:
         self,
         client_session,
         mock_pipefy_client,
+        extract_payload,
     ):
         card_id = 456
         phase_id = 12345
@@ -1027,7 +1016,7 @@ class TestFillCardPhaseFieldsTool:
 
             assert result.isError is False
             mock_pipefy_client.update_card.assert_not_called()
-            response = _extract_call_tool_payload(result)
+            response = extract_payload(result)
             assert response.get("message") == "No fields to update."
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
@@ -1104,6 +1093,7 @@ class TestDeleteCardTool:
         self,
         client_session,
         mock_pipefy_client,
+        extract_payload,
     ) -> None:
         """Test delete_card tool when user declines confirmation via elicitation."""
         # Setup mock responses
@@ -1122,7 +1112,7 @@ class TestDeleteCardTool:
             mock_pipefy_client.get_card.assert_called_once_with(12345)
             mock_pipefy_client.delete_card.assert_not_called()
 
-            payload = _extract_call_tool_payload(result)
+            payload = extract_payload(result)
             expected_payload: DeleteCardErrorPayload = {
                 "success": False,
                 "error": "Card deletion cancelled by user.",
@@ -1134,6 +1124,7 @@ class TestDeleteCardTool:
         self,
         client_session,
         mock_pipefy_client,
+        extract_payload,
     ) -> None:
         """Test delete_card tool with invalid card_id returns error payload."""
         async with client_session as session:
@@ -1147,7 +1138,7 @@ class TestDeleteCardTool:
             mock_pipefy_client.get_card.assert_not_called()
             mock_pipefy_client.delete_card.assert_not_called()
 
-            payload = _extract_call_tool_payload(result)
+            payload = extract_payload(result)
             expected_payload: DeleteCardErrorPayload = {
                 "success": False,
                 "error": "Invalid 'card_id'. Please provide a positive integer.",
@@ -1159,6 +1150,7 @@ class TestDeleteCardTool:
         self,
         client_session,
         mock_pipefy_client,
+        extract_payload,
     ) -> None:
         """Test delete_card tool maps RESOURCE_NOT_FOUND GraphQL exception to friendly message."""
         # Simulate GraphQL exception with RESOURCE_NOT_FOUND code
@@ -1185,7 +1177,7 @@ class TestDeleteCardTool:
             mock_pipefy_client.get_card.assert_called_once_with(99999)
             mock_pipefy_client.delete_card.assert_not_called()
 
-            payload = _extract_call_tool_payload(result)
+            payload = extract_payload(result)
             expected_payload: DeleteCardErrorPayload = {
                 "success": False,
                 "error": "Card with ID 99999 not found. Verify the card exists and you have access permissions.",
@@ -1197,6 +1189,7 @@ class TestDeleteCardTool:
         self,
         client_session,
         mock_pipefy_client,
+        extract_payload,
     ) -> None:
         """Test delete_card tool maps PERMISSION_DENIED GraphQL exception to friendly message."""
         # Simulate GraphQL exception with PERMISSION_DENIED code
@@ -1230,7 +1223,7 @@ class TestDeleteCardTool:
             assert result.isError is False
             mock_pipefy_client.delete_card.assert_called_once_with(12345)
 
-            payload = _extract_call_tool_payload(result)
+            payload = extract_payload(result)
             expected_payload: DeleteCardErrorPayload = {
                 "success": False,
                 "error": "You don't have permission to delete card 12345. Please check your access permissions.",
@@ -1242,6 +1235,7 @@ class TestDeleteCardTool:
         self,
         client_session,
         mock_pipefy_client,
+        extract_payload,
     ) -> None:
         """Test delete_card tool handles API returning success=False."""
         mock_pipefy_client.get_card.return_value = {
@@ -1263,7 +1257,7 @@ class TestDeleteCardTool:
             assert result.isError is False
             mock_pipefy_client.delete_card.assert_called_once_with(12345)
 
-            payload = _extract_call_tool_payload(result)
+            payload = extract_payload(result)
             expected_payload: DeleteCardErrorPayload = {
                 "success": False,
                 "error": "Failed to delete card 'Test Card' (ID: 12345). Please try again or contact support.",
@@ -1279,6 +1273,7 @@ class TestDeleteCardTool:
         self,
         client_session,
         mock_pipefy_client,
+        extract_payload,
     ) -> None:
         """Test delete_card tool when user confirms deletion via elicitation."""
         # Setup mock responses for both get_card and delete_card
@@ -1297,7 +1292,7 @@ class TestDeleteCardTool:
             # Should execute deletion when user confirms
             mock_pipefy_client.delete_card.assert_called_once_with(12345)
 
-            payload = _extract_call_tool_payload(result)
+            payload = extract_payload(result)
             expected_payload: DeleteCardSuccessPayload = {
                 "success": True,
                 "card_id": 12345,
@@ -1316,6 +1311,7 @@ class TestDeleteCardTool:
         self,
         client_session,
         mock_pipefy_client,
+        extract_payload,
     ) -> None:
         """When elicitation for confirmation raises, tool returns error with 'Failed to request confirmation'."""
         mock_pipefy_client.get_card.return_value = {
@@ -1326,7 +1322,7 @@ class TestDeleteCardTool:
         assert result.isError is False
         mock_pipefy_client.get_card.assert_called_once_with(12345)
         mock_pipefy_client.delete_card.assert_not_called()
-        payload = _extract_call_tool_payload(result)
+        payload = extract_payload(result)
         assert payload["success"] is False
         assert "Failed to request confirmation" in payload["error"]
 
@@ -1335,6 +1331,7 @@ class TestDeleteCardTool:
         self,
         client_session,
         mock_pipefy_client,
+        extract_payload,
     ) -> None:
         """When debug=True and client raises, error message includes codes and correlation_id."""
         from gql.transport.exceptions import TransportQueryError
@@ -1357,7 +1354,7 @@ class TestDeleteCardTool:
                 "delete_card", {"card_id": 12345, "debug": True}
             )
         assert result.isError is False
-        payload = _extract_call_tool_payload(result)
+        payload = extract_payload(result)
         assert payload["success"] is False
         assert "error" in payload
         assert "codes=" in payload["error"] or "correlation_id=" in payload["error"]

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -48,3 +48,32 @@ class TestToolRegistry:
         assert "Pipefy client is not initialized in services container" in str(
             exc.value
         )
+
+    @patch("pipefy_mcp.tools.registry.AiAgentTools.register")
+    @patch("pipefy_mcp.tools.registry.AiAutomationTools.register")
+    @patch("pipefy_mcp.tools.registry.PipeTools.register")
+    def test_register_tools_calls_ai_tools_register(
+        self,
+        mock_pipe_tools_register,
+        mock_ai_automation_tools_register,
+        mock_ai_agent_tools_register,
+    ):
+        mock_mcp = Mock(spec=FastMCP)
+        mock_client = Mock()
+        mock_ai_automation_service = Mock()
+        mock_ai_agent_service = Mock()
+        mock_container = Mock(spec=ServicesContainer)
+        mock_container.pipefy_client = mock_client
+        mock_container.ai_automation_service = mock_ai_automation_service
+        mock_container.ai_agent_service = mock_ai_agent_service
+
+        registry = ToolRegistry(mcp=mock_mcp, services_container=mock_container)
+        registry.register_tools()
+
+        mock_pipe_tools_register.assert_called_once_with(mock_mcp, mock_client)
+        mock_ai_automation_tools_register.assert_called_once_with(
+            mock_mcp, mock_ai_automation_service
+        )
+        mock_ai_agent_tools_register.assert_called_once_with(
+            mock_mcp, mock_ai_agent_service
+        )


### PR DESCRIPTION
## Summary

This PR implements **AI Agents** and **AI Automations** MCP capabilities and it adds **five tools**: create/update AI Automation, create/update AI Agent and toggle AI Agent status.

- **Problem:** Integrators using the MCP today cannot create or modify AI Agents or AI Automations programmatically.

- **Goal:** Expose create and update operations for AI Agents and AI Automations as MCP tools, with clear parameters, Service Account–based auth and success confirmation in the tool response.

---

## What was done

- **Settings:** `PIPEFY_INTERNAL_API_URL` and `PIPEFY_OAUTH_URL` for the internal API and OAuth (AI Automation uses internal API; AI Agent uses existing GraphQL + same OAuth).
- **Models:** Pydantic input validation for AI Automation (Create/Update with event_id, pipe_id, prompt, field_ids, condition) and AI Agent (Create with name/repo_uuid; Update with 1–5 behaviors, instruction, referenceId injection). Shared `NonBlankStr` validator; blacklist for `scheduler` event_id on automations.
- **Services:**
  - **Internal API client** – HTTP client for `internal_api` with OAuth2 client credentials; used only for AI Automation mutations.
  - **AI Automation service** – create/update automations via `createAutomation` / `updateAutomation` (flat variables, `generate_with_ai` action).
  - **AI Agent service** – create/update/toggle agents via GraphQL; `inject_reference_ids()` for behavior actions (UUID v4, `%{action:<id>}` in instruction).
- **Tools:** `AiAutomationTools` (create_ai_automation, update_ai_automation) and `AiAgentTools` (create_ai_agent, update_ai_agent, toggle_ai_agent_status). TypedDict payloads and builders in `ai_tool_helpers.py`; validation and error mapping aligned with existing pipe tools.
- **Integration:** Container creates Internal API client and AI services only when OAuth is configured; registry registers the five AI tools when those services are available. Exports updated in `services.pipefy.__init__`.
- **Docs:** README and AGENTS.md updated with the five tools, env vars and usage notes.

💡 Implementation followed **TDD** (tests first), existing patterns (e.g. `pipe_tool_helpers`, `PipeService`) and the PRD’s technical notes (two endpoints, referenceId generation, 1–5 behaviors, non-empty `fieldIds` for automation).

---

## Why a single PR?

Per the task plan’s **PR strategy**, this feature is delivered in **one PR** because:

1. **Shared infrastructure** – AI Automation and AI Agent tools share settings (internal API URL, OAuth), the same registry wiring, and the same container lifecycle. Splitting would either duplicate this or force awkward dependencies between PRs.
2. **Same PRD** – Both capabilities are defined in the same PRD and the same success criteria (create/update via MCP, clear success message, Service Account auth).
3. **Review efficiency** – A single PR with **atomic commits** (7 commits: settings → models → services automation → services agent → tools → core wiring → docs) gives reviewers a clear path (infra → models → services → tools → integration) without cross-PR back-and-forth.

👉 Splitting would create cross-dependencies (e.g. “AI tools” PR depending on “internal API client” PR) and duplicate review cycles for the same product change.

---

## Guided review path

1. **refactor(services)** – Fresh transport per `execute_query` call; services receive `PipefySettings + auth` instead of `gql.Client`.
2. **feat(settings)** – New env vars for internal API and OAuth URL.
3. **feat(models)** – AI Agent and AI Automation input models + validators; `min_length=1` on `field_ids` for both create and update; tests.
4. **feat(services): Internal API + AI Automation** – `InternalApiClient`, `AiAutomationService` with `error_details` checking, `AutomationServiceResult` TypedDict, queries, tests.
5. **feat(services): AI Agent** – `AiAgentService` with `AgentServiceResult`/`ToggleAgentStatusResult` typed returns, `inject_reference_ids`, `agent_uuid` param naming, tests.
6. **feat(tools)** – AI automation/agent tools with `ctx.debug()`, uuid blank validation on toggle, helpers, shared `conftest.py` for `extract_payload` fixture, tool tests.
7. **feat(core)** – Container and registry wiring when OAuth is set; server tool list tests.
8. **docs** – README and AGENTS.md.
