### PR TITLE
fix: address pipe-full-toolset code review findings

### DIFF
--- a/src/pipefy_mcp/core/container.py
+++ b/src/pipefy_mcp/core/container.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Self
 
 from httpx_auth import OAuth2ClientCredentials

--- a/src/pipefy_mcp/server.py
+++ b/src/pipefy_mcp/server.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import textwrap
 from collections.abc import AsyncIterator

--- a/src/pipefy_mcp/services/pipefy/__init__.py
+++ b/src/pipefy_mcp/services/pipefy/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .ai_agent_service import AiAgentService
 from .ai_automation_service import AiAutomationService
 from .automation_service import AutomationService

--- a/src/pipefy_mcp/services/pipefy/card_service.py
+++ b/src/pipefy_mcp/services/pipefy/card_service.py
@@ -79,13 +79,18 @@ class CardService(BasePipefyClient):
         pipe_id: int,
         search: CardSearch | None = None,
         include_fields: bool = False,
+        *,
+        first: int | None = None,
+        after: str | None = None,
     ) -> dict:
-        """Get all cards in the pipe.
+        """Get cards in the pipe with optional pagination.
 
         Args:
             pipe_id: The ID of the pipe.
             search: Optional search filters.
             include_fields: If True, include each card's custom fields (name, value) in the response.
+            first: Max cards to return per page.
+            after: Cursor for fetching the next page (from ``pageInfo.endCursor``).
         """
         variables: dict[str, Any] = {
             "pipe_id": pipe_id,
@@ -94,6 +99,10 @@ class CardService(BasePipefyClient):
         }
         if search is not None:
             variables["search"] = search
+        if first is not None:
+            variables["first"] = first
+        if after is not None:
+            variables["after"] = after
         return await self.execute_query(GET_CARDS_QUERY, variables)
 
     async def find_cards(

--- a/src/pipefy_mcp/services/pipefy/client.py
+++ b/src/pipefy_mcp/services/pipefy/client.py
@@ -524,12 +524,10 @@ class PipefyClient:
             name: Rule name.
             trigger_id: Event ID.
             action_id: Action ID.
-            active: When True (default), create the rule enabled. Set False to start disabled, or use ``extra_input`` / ``update_automation`` later.
-            extra_input: Extra ``CreateAutomationInput`` keys; ``active`` here overrides the ``active`` argument when both are set.
+            active: When True (default), create the rule enabled. Set False to start disabled.
+            extra_input: Extra ``CreateAutomationInput`` keys; ``active`` here overrides the ``active`` argument.
         """
-        merged: dict[str, Any] = dict(extra_input or {})
-        if "active" not in merged:
-            merged["active"] = active
+        merged: dict[str, Any] = {"active": active, **(extra_input or {})}
         return await self._automation_service.create_automation(
             pipe_id,
             name,

--- a/src/pipefy_mcp/services/pipefy/client.py
+++ b/src/pipefy_mcp/services/pipefy/client.py
@@ -600,16 +600,21 @@ class PipefyClient:
         pipe_id: int,
         search: CardSearch | None = None,
         include_fields: bool = False,
+        *,
+        first: int | None = None,
+        after: str | None = None,
     ) -> dict:
-        """Get all cards in the pipe with optional search filters.
+        """Get cards in the pipe with optional search filters and pagination.
 
         Args:
             pipe_id: The ID of the pipe.
             search: Optional search filters.
             include_fields: If True, include each card's custom fields (name, value) in the response.
+            first: Max cards to return per page.
+            after: Cursor for fetching the next page (from ``pageInfo.endCursor``).
         """
         return await self._card_service.get_cards(
-            pipe_id, search, include_fields=include_fields
+            pipe_id, search, include_fields=include_fields, first=first, after=after
         )
 
     async def find_cards(

--- a/src/pipefy_mcp/services/pipefy/client.py
+++ b/src/pipefy_mcp/services/pipefy/client.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from httpx_auth import OAuth2ClientCredentials
@@ -30,8 +29,6 @@ from pipefy_mcp.services.pipefy.table_service import TableService
 from pipefy_mcp.services.pipefy.types import AiAgentGraphPayload, CardSearch
 from pipefy_mcp.services.pipefy.webhook_service import WebhookService
 from pipefy_mcp.settings import PipefySettings
-
-logger = logging.getLogger(__name__)
 
 
 class PipefyClient:
@@ -387,27 +384,7 @@ class PipefyClient:
             body: Email body (plain text).
             from_: Sender email address (required by API).
             **attrs: Extra CreateAndSendInboxEmailInput fields (html, cc, bcc, repoId, etc.).
-
-        When ``repoId`` is omitted and ``card_id`` is numeric, the client best-effort
-        fills ``repoId`` from the card's pipe. Non-numeric ``card_id`` skips this
-        (pass ``repoId`` in ``attrs`` if the API requires it).
         """
-        if "repoId" not in attrs and card_id.isdigit():
-            try:
-                card_data = await self._card_service.get_card(int(card_id))
-                pipe_id = (
-                    card_data.get("card", {}).get("pipe", {}).get("id")
-                    if isinstance(card_data.get("card", {}).get("pipe"), dict)
-                    else None
-                )
-                if pipe_id is not None:
-                    attrs = dict(attrs, repoId=str(pipe_id))
-            except Exception:  # noqa: BLE001
-                logger.debug(
-                    "Could not auto-resolve repoId for card %s",
-                    card_id,
-                    exc_info=True,
-                )
         return await self._webhook_service.send_inbox_email(
             card_id, to, subject, body, from_=from_, **attrs
         )

--- a/src/pipefy_mcp/services/pipefy/observability_service.py
+++ b/src/pipefy_mcp/services/pipefy/observability_service.py
@@ -103,12 +103,10 @@ def _build_usage_variables(
 class ObservabilityService(BasePipefyClient):
     """Reads for AI agent logs, automation logs, usage stats, and credit dashboard."""
 
-    async def _organization_uuid_for_ai_credit_usage(
-        self, organization_identifier: str
-    ) -> str:
-        """Return the organization UUID expected by ``aiCreditUsageStats``.
+    async def _resolve_organization_uuid(self, organization_identifier: str) -> str:
+        """Return the organization UUID, resolving numeric IDs via GraphQL.
 
-        Pipefy accepts a numeric organization id in URLs, but ``aiCreditUsageStats`` expects
+        Pipefy accepts a numeric organization id in URLs, but several GraphQL queries expect
         ``organizationUuid``. When the caller passes digits only, resolve via ``organization``.
 
         Args:
@@ -245,14 +243,16 @@ class ObservabilityService(BasePipefyClient):
         """Get AI agent usage stats for an org within a date range.
 
         Args:
-            organization_uuid: Organization UUID.
+            organization_uuid: Organization UUID, or numeric organization id (string).
+                Numeric ids are resolved to UUID via a short GraphQL query.
             filter_date: DateRange dict with ``from`` and ``to`` ISO8601 strings.
             filters: Optional FilterParams (action, event, pipe, status).
             search: Free-text search.
             sort: SortCriteria (field + direction).
         """
+        resolved = await self._resolve_organization_uuid(organization_uuid)
         variables = _build_usage_variables(
-            organization_uuid,
+            resolved,
             filter_date,
             filters=filters,
             search=search,
@@ -272,14 +272,16 @@ class ObservabilityService(BasePipefyClient):
         """Get automation usage stats for an org within a date range.
 
         Args:
-            organization_uuid: Organization UUID.
+            organization_uuid: Organization UUID, or numeric organization id (string).
+                Numeric ids are resolved to UUID via a short GraphQL query.
             filter_date: DateRange dict with ``from`` and ``to`` ISO8601 strings.
             filters: Optional FilterParams (action, event, pipe, status).
             search: Free-text search.
             sort: SortCriteria (field + direction).
         """
+        resolved = await self._resolve_organization_uuid(organization_uuid)
         variables = _build_usage_variables(
-            organization_uuid,
+            resolved,
             filter_date,
             filters=filters,
             search=search,
@@ -299,7 +301,7 @@ class ObservabilityService(BasePipefyClient):
                 are resolved to UUID via a short GraphQL query before calling ``aiCreditUsageStats``.
             period: PeriodFilter enum value (current_month, last_month, last_3_months).
         """
-        resolved = await self._organization_uuid_for_ai_credit_usage(organization_uuid)
+        resolved = await self._resolve_organization_uuid(organization_uuid)
         return await self.execute_query(
             GET_AI_CREDIT_USAGE_QUERY,
             {"organizationUuid": resolved, "period": period},

--- a/src/pipefy_mcp/services/pipefy/pipe_service.py
+++ b/src/pipefy_mcp/services/pipefy/pipe_service.py
@@ -101,11 +101,14 @@ class PipeService(BasePipefyClient):
             matching_pipes = []
             for pipe in org.get("pipes", []):
                 pipe_display_name = pipe.get("name", "")
-                score = fuzz.WRatio(
-                    pipe_name, pipe_display_name, score_cutoff=match_threshold
-                )
-                if score:
-                    matching_pipes.append((score, pipe))
+                if pipe_name.lower() in pipe_display_name.lower():
+                    matching_pipes.append((100.0, pipe))
+                else:
+                    score = fuzz.WRatio(
+                        pipe_name, pipe_display_name, score_cutoff=match_threshold
+                    )
+                    if score:
+                        matching_pipes.append((score, pipe))
 
             if matching_pipes:
                 matching_pipes.sort(key=lambda x: x[0], reverse=True)

--- a/src/pipefy_mcp/services/pipefy/queries/ai_agent_queries.py
+++ b/src/pipefy_mcp/services/pipefy/queries/ai_agent_queries.py
@@ -1,5 +1,7 @@
 """GraphQL queries and mutations for AI Agent operations."""
 
+from __future__ import annotations
+
 from gql import gql
 
 GET_AI_AGENT_QUERY = gql(

--- a/src/pipefy_mcp/services/pipefy/queries/ai_automation_queries.py
+++ b/src/pipefy_mcp/services/pipefy/queries/ai_automation_queries.py
@@ -3,6 +3,8 @@
 Plain strings (not gql()) since internal_api does not support schema validation.
 """
 
+from __future__ import annotations
+
 CREATE_AUTOMATION_MUTATION = """
 mutation createAutomation(
   $name: String!,

--- a/src/pipefy_mcp/services/pipefy/queries/card_queries.py
+++ b/src/pipefy_mcp/services/pipefy/queries/card_queries.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gql import gql
 
 CREATE_CARD_MUTATION = gql(
@@ -82,8 +84,8 @@ GET_CARD_QUERY = gql(
 
 GET_CARDS_QUERY = gql(
     """
-    query ($pipe_id: ID!, $search: CardSearch, $includeFields: Boolean!) {
-        cards(pipe_id: $pipe_id, search: $search) {
+    query ($pipe_id: ID!, $search: CardSearch, $first: Int, $after: String, $includeFields: Boolean!) {
+        cards(pipe_id: $pipe_id, search: $search, first: $first, after: $after) {
             edges {
                 node {
                     id
@@ -97,6 +99,10 @@ GET_CARDS_QUERY = gql(
                         value
                     }
                 }
+            }
+            pageInfo {
+                hasNextPage
+                endCursor
             }
         }
     }

--- a/src/pipefy_mcp/services/pipefy/queries/pipe_config_queries.py
+++ b/src/pipefy_mcp/services/pipefy/queries/pipe_config_queries.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gql import gql
 
 CREATE_PIPE_MUTATION = gql(

--- a/src/pipefy_mcp/services/pipefy/queries/pipe_queries.py
+++ b/src/pipefy_mcp/services/pipefy/queries/pipe_queries.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gql import gql
 
 GET_PIPE_QUERY = gql(

--- a/src/pipefy_mcp/services/pipefy/webhook_service.py
+++ b/src/pipefy_mcp/services/pipefy/webhook_service.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
+from gql.transport.exceptions import TransportQueryError
 from httpx_auth import OAuth2ClientCredentials
 
 from pipefy_mcp.services.pipefy.base_client import BasePipefyClient
@@ -17,6 +19,8 @@ from pipefy_mcp.services.pipefy.queries.webhook_queries import (
     GET_PARSED_EMAIL_TEMPLATE_QUERY,
 )
 from pipefy_mcp.settings import PipefySettings
+
+logger = logging.getLogger(__name__)
 
 _DEFAULT_WEBHOOK_NAME = "Pipefy Webhook"
 
@@ -79,6 +83,34 @@ class WebhookService(BasePipefyClient):
             variables["cardUuid"] = card_uuid.strip()
         return await self.execute_query(GET_PARSED_EMAIL_TEMPLATE_QUERY, variables)
 
+    async def _resolve_repo_id(
+        self, card_id: str, attrs: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Best-effort resolve ``repoId`` from the card's pipe when omitted.
+
+        Args:
+            card_id: Numeric card ID.
+            attrs: Mutable copy of extra input fields.
+
+        Returns:
+            Updated attrs with ``repoId`` if resolution succeeded, unchanged otherwise.
+        """
+        if "repoId" in attrs or not card_id.isdigit():
+            return attrs
+        try:
+            card_data = await self._card_service.get_card(int(card_id))
+            pipe_obj = card_data.get("card", {}).get("pipe")
+            pipe_id = pipe_obj.get("id") if isinstance(pipe_obj, dict) else None
+            if pipe_id is not None:
+                return {**attrs, "repoId": str(pipe_id)}
+        except (TransportQueryError, KeyError, TypeError):
+            logger.debug(
+                "Could not auto-resolve repoId for card %s",
+                card_id,
+                exc_info=True,
+            )
+        return attrs
+
     async def send_inbox_email(
         self,
         card_id: str,
@@ -91,6 +123,9 @@ class WebhookService(BasePipefyClient):
     ) -> dict[str, Any]:
         """Send an email from a card's inbox (createAndSendInboxEmail).
 
+        When ``repoId`` is omitted and ``card_id`` is numeric, the service best-effort
+        fills ``repoId`` from the card's pipe.
+
         Args:
             card_id: ID of the card with inbox.
             to: List of recipient email addresses.
@@ -99,6 +134,7 @@ class WebhookService(BasePipefyClient):
             from_: Sender email address (required by API).
             **attrs: Extra CreateAndSendInboxEmailInput fields (html, cc, bcc, etc.).
         """
+        attrs = await self._resolve_repo_id(card_id, attrs)
         input_obj: dict[str, Any] = {
             "cardId": card_id,
             "from": from_,

--- a/src/pipefy_mcp/settings.py
+++ b/src/pipefy_mcp/settings.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 

--- a/src/pipefy_mcp/tools/ai_agent_tools.py
+++ b/src/pipefy_mcp/tools/ai_agent_tools.py
@@ -146,7 +146,7 @@ class AiAgentTools:
             return build_toggle_agent_status_success(message=result["message"])
 
         @mcp.tool(
-            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            annotations=ToolAnnotations(readOnlyHint=True),
         )
         async def get_ai_agent(ctx: Context, uuid: str) -> dict:
             """Get an AI Agent by UUID. Use get_pipe to find the pipe's uuid field, then get_ai_agents to list agents.
@@ -167,7 +167,7 @@ class AiAgentTools:
             return build_get_agent_success(agent)
 
         @mcp.tool(
-            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            annotations=ToolAnnotations(readOnlyHint=True),
         )
         async def get_ai_agents(ctx: Context, repo_uuid: str) -> dict:
             """List all AI Agents for a pipe. Use before creating an agent to avoid duplicates.

--- a/src/pipefy_mcp/tools/automation_tools.py
+++ b/src/pipefy_mcp/tools/automation_tools.py
@@ -192,7 +192,7 @@ class AutomationTools:
             )
 
         @mcp.tool(
-            annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False),
+            annotations=ToolAnnotations(readOnlyHint=False),
         )
         async def create_automation(
             ctx: Context,
@@ -257,7 +257,7 @@ class AutomationTools:
             return build_automation_mutation_success_payload(automation, "created")
 
         @mcp.tool(
-            annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False),
+            annotations=ToolAnnotations(readOnlyHint=False),
         )
         async def update_automation(
             ctx: Context,

--- a/src/pipefy_mcp/tools/field_condition_tools.py
+++ b/src/pipefy_mcp/tools/field_condition_tools.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
@@ -13,7 +12,10 @@ from pipefy_mcp.tools.pipe_config_tool_helpers import (
     build_field_condition_delete_payload,
     build_field_condition_success_payload,
     build_pipe_tool_error_payload,
+    field_condition_actions_error_message,
     handle_pipe_config_tool_graphql_error,
+    normalize_field_condition_actions,
+    strip_expression_ids_for_create,
 )
 from pipefy_mcp.tools.pipe_config_validators import valid_phase_field_id
 
@@ -31,107 +33,6 @@ _CREATE_FIELD_CONDITION_EXTRA_RESERVED = frozenset(
     }
 )
 _UPDATE_FIELD_CONDITION_EXTRA_RESERVED = frozenset({"id"})
-
-_FIELD_CONDITION_PHASE_FIELD_UUID_RE = re.compile(
-    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
-)
-
-
-def field_condition_phase_field_id_looks_like_slug(value: object) -> bool:
-    """True when ``value`` is probably a phase field slug (``id``) instead of ``internal_id``."""
-    if isinstance(value, int):
-        return False
-    if not isinstance(value, str):
-        return False
-    s = value.strip()
-    if not s:
-        return False
-    if _FIELD_CONDITION_PHASE_FIELD_UUID_RE.fullmatch(s):
-        return False
-    if s.isdigit():
-        return False
-    return any(c.isalpha() for c in s)
-
-
-def _normalize_field_condition_actions(
-    actions: list[dict[str, Any]],
-) -> list[dict[str, Any]]:
-    """Shallow-copy each action and map legacy ``hidden`` → ``hide``."""
-    normalized: list[dict[str, Any]] = []
-    for item in actions:
-        row = dict(item)
-        aid = row.get("actionId")
-        if isinstance(aid, str) and aid.strip().lower() == "hidden":
-            row["actionId"] = "hide"
-        normalized.append(row)
-    return normalized
-
-
-def _strip_expression_ids_for_create(condition: dict[str, Any]) -> dict[str, Any]:
-    """Return a copy of ``condition`` with ``id`` removed and nested ints coerced.
-
-    Output keys mirror the input ``condition`` (typically ``expressions``,
-    ``expressions_structure``, plus any other ``ConditionInput`` fields present).
-
-    ``ConditionExpressionInput.id`` is a persisted primary key — sending arbitrary
-    client tokens on create causes ``RECORD_NOT_FOUND``. ``structure_id`` is coerced
-    to ``int`` for consistency (GraphQL ``ID`` scalar).
-    """
-    expressions = condition.get("expressions")
-
-    def _coerce_int(value: Any) -> Any:
-        try:
-            return int(value)
-        except (ValueError, TypeError):
-            return value
-
-    if not isinstance(expressions, list):
-        return condition
-    cleaned: list[dict[str, Any]] = []
-    for expr in expressions:
-        row = {k: v for k, v in expr.items() if k != "id"}
-        sid = row.get("structure_id")
-        if sid is not None:
-            try:
-                row["structure_id"] = int(sid)
-            except (ValueError, TypeError):
-                pass
-        cleaned.append(row)
-    es = condition.get("expressions_structure")
-    if isinstance(es, list):
-        coerced_ints: list[list[Any]] = []
-        for group in es:
-            if isinstance(group, list):
-                coerced_ints.append([_coerce_int(v) for v in group])
-            else:
-                coerced_ints.append([_coerce_int(group)])
-        return {
-            **condition,
-            "expressions": cleaned,
-            "expressions_structure": coerced_ints,
-        }
-    return {**condition, "expressions": cleaned}
-
-
-def _field_condition_actions_error_message(
-    actions: list[dict[str, Any]],
-) -> str | None:
-    if not isinstance(actions, list) or not actions:
-        return "Invalid 'actions': provide a non-empty list of action objects."
-    if not all(isinstance(item, dict) for item in actions):
-        return "Invalid 'actions': each item must be an object/dict."
-    for index, item in enumerate(actions):
-        raw_id = item.get("phaseFieldId")
-        if raw_id is None:
-            continue
-        if field_condition_phase_field_id_looks_like_slug(raw_id):
-            return (
-                f"Invalid actions[{index}] 'phaseFieldId': value looks like a field "
-                "slug (the `id` from get_phase_fields), but Pipefy expects "
-                "`internal_id` from get_phase_fields for field-condition actions. "
-                "See README (Field condition tools)."
-            )
-    return None
 
 
 class FieldConditionTools:
@@ -186,7 +87,7 @@ class FieldConditionTools:
                 return build_pipe_tool_error_payload(
                     message="Invalid 'extra_input': provide an object/dict or omit.",
                 )
-            act_err = _field_condition_actions_error_message(actions)
+            act_err = field_condition_actions_error_message(actions)
             if act_err:
                 return build_pipe_tool_error_payload(message=act_err)
             merged: dict[str, Any] = {
@@ -194,8 +95,8 @@ class FieldConditionTools:
                 for k, v in (extra_input or {}).items()
                 if k not in _CREATE_FIELD_CONDITION_EXTRA_RESERVED
             }
-            condition_for_api = _strip_expression_ids_for_create(condition)
-            actions_for_api = _normalize_field_condition_actions(actions)
+            condition_for_api = strip_expression_ids_for_create(condition)
+            actions_for_api = normalize_field_condition_actions(actions)
             try:
                 raw = await client.create_field_condition(
                     phase_id,
@@ -266,7 +167,7 @@ class FieldConditionTools:
                         ),
                     )
             if actions is not None:
-                act_err = _field_condition_actions_error_message(actions)
+                act_err = field_condition_actions_error_message(actions)
                 if act_err:
                     return build_pipe_tool_error_payload(message=act_err)
 
@@ -276,9 +177,9 @@ class FieldConditionTools:
                 if k not in _UPDATE_FIELD_CONDITION_EXTRA_RESERVED
             }
             if condition is not None:
-                update_attrs["condition"] = _strip_expression_ids_for_create(condition)
+                update_attrs["condition"] = strip_expression_ids_for_create(condition)
             if actions is not None:
-                update_attrs["actions"] = _normalize_field_condition_actions(actions)
+                update_attrs["actions"] = normalize_field_condition_actions(actions)
             if not update_attrs:
                 return build_pipe_tool_error_payload(
                     message=(

--- a/src/pipefy_mcp/tools/observability_tools.py
+++ b/src/pipefy_mcp/tools/observability_tools.py
@@ -15,10 +15,15 @@ from pipefy_mcp.tools.observability_tool_helpers import (
     handle_observability_tool_graphql_error,
 )
 
+# --- Validation constants ---
+
 _VALID_PERIODS = {"current_month", "last_month", "last_3_months"}
+
+# Pagination
 _MIN_PAGE_SIZE = 1
 _MAX_PAGE_SIZE = 100
 
+# CSV / export download limits
 _MIN_CSV_CHARS = 256
 _MAX_CSV_CHARS = 2_000_000
 _DEFAULT_CSV_CHARS = 400_000
@@ -209,7 +214,7 @@ class ObservabilityTools:
             """Get AI agent usage stats for an org within a date range. Returns total AI credits consumed and per-agent breakdown. `filter_date_from` and `filter_date_to` are ISO8601 datetime strings. Optional `filters` for action/event/pipe/status filtering.
 
             Args:
-                organization_uuid: Organization UUID.
+                organization_uuid: Organization UUID, or numeric organization id (string).
                 filter_date_from: Start of date range (ISO8601).
                 filter_date_to: End of date range (ISO8601).
                 filters: Optional FilterParams dict (action, event, pipe, status keys).
@@ -256,7 +261,7 @@ class ObservabilityTools:
             """Get automation usage stats for an org within a date range. Returns total execution count and per-automation breakdown. Same input shape as `get_agents_usage`.
 
             Args:
-                organization_uuid: Organization UUID.
+                organization_uuid: Organization UUID, or numeric organization id (string).
                 filter_date_from: Start of date range (ISO8601).
                 filter_date_to: End of date range (ISO8601).
                 filters: Optional FilterParams dict (action, event, pipe, status keys).
@@ -394,7 +399,7 @@ class ObservabilityTools:
             max_download_bytes: int = _DEFAULT_EXPORT_DOWNLOAD_BYTES,
             debug: bool = False,
         ) -> dict[str, Any]:
-            """Download a finished automation jobs export (xlsx) and return the first worksheet as CSV text for LLM consumption. Requires export `status` `finished`. Only https URLs on `*.pipefy.com` from the API are fetched. Large exports are capped by `max_output_chars` and `max_download_bytes`.
+            """Download a finished automation-jobs export and return the first worksheet as CSV text for LLM consumption. The API provides an xlsx file which is converted to CSV automatically. Requires export ``status`` ``finished``. Only https URLs on ``*.pipefy.com`` from the API are fetched. Large exports are capped by ``max_output_chars`` and ``max_download_bytes``.
 
             Args:
                 export_id: Export id from `export_automation_jobs` after the export is `finished`.

--- a/src/pipefy_mcp/tools/pipe_config_tool_helpers.py
+++ b/src/pipefy_mcp/tools/pipe_config_tool_helpers.py
@@ -11,6 +11,7 @@ from pipefy_mcp.tools.graphql_error_helpers import (
     extract_graphql_error_codes,
     with_debug_suffix,
 )
+from pipefy_mcp.tools.validation_helpers import UUID_RE
 
 
 class DeletePipePreviewPayload(TypedDict):
@@ -223,6 +224,104 @@ def map_delete_pipe_error_to_message(
     )
 
 
+def field_condition_phase_field_id_looks_like_slug(value: object) -> bool:
+    """True when ``value`` is probably a phase field slug (``id``) instead of ``internal_id``."""
+    if isinstance(value, int):
+        return False
+    if not isinstance(value, str):
+        return False
+    s = value.strip()
+    if not s:
+        return False
+    if UUID_RE.fullmatch(s):
+        return False
+    if s.isdigit():
+        return False
+    return any(c.isalpha() for c in s)
+
+
+def normalize_field_condition_actions(
+    actions: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Shallow-copy each action and map legacy ``hidden`` → ``hide``."""
+    normalized: list[dict[str, Any]] = []
+    for item in actions:
+        row = dict(item)
+        aid = row.get("actionId")
+        if isinstance(aid, str) and aid.strip().lower() == "hidden":
+            row["actionId"] = "hide"
+        normalized.append(row)
+    return normalized
+
+
+def strip_expression_ids_for_create(condition: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of ``condition`` with ``id`` removed and nested ints coerced.
+
+    Output keys mirror the input ``condition`` (typically ``expressions``,
+    ``expressions_structure``, plus any other ``ConditionInput`` fields present).
+
+    ``ConditionExpressionInput.id`` is a persisted primary key — sending arbitrary
+    client tokens on create causes ``RECORD_NOT_FOUND``. ``structure_id`` is coerced
+    to ``int`` for consistency (GraphQL ``ID`` scalar).
+    """
+    expressions = condition.get("expressions")
+
+    def _coerce_int(value: Any) -> Any:
+        try:
+            return int(value)
+        except (ValueError, TypeError):
+            return value
+
+    if not isinstance(expressions, list):
+        return condition
+    cleaned: list[dict[str, Any]] = []
+    for expr in expressions:
+        row = {k: v for k, v in expr.items() if k != "id"}
+        sid = row.get("structure_id")
+        if sid is not None:
+            try:
+                row["structure_id"] = int(sid)
+            except (ValueError, TypeError):
+                pass
+        cleaned.append(row)
+    es = condition.get("expressions_structure")
+    if isinstance(es, list):
+        coerced_ints: list[list[Any]] = []
+        for group in es:
+            if isinstance(group, list):
+                coerced_ints.append([_coerce_int(v) for v in group])
+            else:
+                coerced_ints.append([_coerce_int(group)])
+        return {
+            **condition,
+            "expressions": cleaned,
+            "expressions_structure": coerced_ints,
+        }
+    return {**condition, "expressions": cleaned}
+
+
+def field_condition_actions_error_message(
+    actions: list[dict[str, Any]],
+) -> str | None:
+    """Return an error string when ``actions`` fails validation, else ``None``."""
+    if not isinstance(actions, list) or not actions:
+        return "Invalid 'actions': provide a non-empty list of action objects."
+    if not all(isinstance(item, dict) for item in actions):
+        return "Invalid 'actions': each item must be an object/dict."
+    for index, item in enumerate(actions):
+        raw_id = item.get("phaseFieldId")
+        if raw_id is None:
+            continue
+        if field_condition_phase_field_id_looks_like_slug(raw_id):
+            return (
+                f"Invalid actions[{index}] 'phaseFieldId': value looks like a field "
+                "slug (the `id` from get_phase_fields), but Pipefy expects "
+                "`internal_id` from get_phase_fields for field-condition actions. "
+                "See README (Field condition tools)."
+            )
+    return None
+
+
 __all__ = [
     "DeletePipeErrorPayload",
     "DeletePipePayload",
@@ -240,6 +339,10 @@ __all__ = [
     "build_field_condition_success_payload",
     "build_pipe_mutation_success_payload",
     "build_pipe_tool_error_payload",
+    "field_condition_actions_error_message",
+    "field_condition_phase_field_id_looks_like_slug",
     "handle_pipe_config_tool_graphql_error",
     "map_delete_pipe_error_to_message",
+    "normalize_field_condition_actions",
+    "strip_expression_ids_for_create",
 ]

--- a/src/pipefy_mcp/tools/pipe_config_validators.py
+++ b/src/pipefy_mcp/tools/pipe_config_validators.py
@@ -1,5 +1,7 @@
 """Shared validation helpers for pipe configuration MCP tools."""
 
+from __future__ import annotations
+
 
 def valid_phase_field_id(field_id: str | int) -> bool:
     """True for a non-blank string ID or a positive integer ID (phases, fields, conditions)."""

--- a/src/pipefy_mcp/tools/pipe_tool_helpers.py
+++ b/src/pipefy_mcp/tools/pipe_tool_helpers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Literal, cast
 
 from pydantic import BaseModel, Field

--- a/src/pipefy_mcp/tools/pipe_tools.py
+++ b/src/pipefy_mcp/tools/pipe_tools.py
@@ -238,19 +238,26 @@ class PipeTools:
             pipe_id: int,
             search: CardSearch | None = None,
             include_fields: bool = False,
+            first: int | None = None,
+            after: str | None = None,
         ) -> dict:
-            """Get all cards in the pipe.
+            """Get cards in the pipe with optional pagination.
+
+            Use ``first`` and ``after`` (from ``pageInfo.endCursor``) to paginate through
+            large result sets. Without pagination params, returns the API default page.
 
             Args:
                 pipe_id: The ID of the pipe.
                 search: Optional search filters.
                 include_fields: If True, include each card's custom fields (name, value) in the response.
+                first: Max cards to return per page.
+                after: Cursor for fetching the next page (from ``pageInfo.endCursor`` of a previous call).
             """
             await ctx.debug(
                 f"Getting cards for pipe {pipe_id} (include_fields={include_fields}, search={search})"
             )
             return await client.get_cards(
-                pipe_id, search, include_fields=include_fields
+                pipe_id, search, include_fields=include_fields, first=first, after=after
             )
 
         @mcp.tool(

--- a/src/pipefy_mcp/tools/pipe_tools.py
+++ b/src/pipefy_mcp/tools/pipe_tools.py
@@ -58,9 +58,7 @@ class PipeTools:
         """Register the tools in the MCP server"""
 
         @mcp.tool(
-            annotations=ToolAnnotations(
-                idempotentHint=False,
-            ),
+            annotations=ToolAnnotations(readOnlyHint=False),
         )
         async def create_card(
             ctx: Context[ServerSession, None],
@@ -134,9 +132,7 @@ class PipeTools:
             return await client.get_card(card_id, include_fields=include_fields)
 
         @mcp.tool(
-            annotations=ToolAnnotations(
-                idempotentHint=False,
-            ),
+            annotations=ToolAnnotations(readOnlyHint=False),
         )
         async def add_card_comment(card_id: int, text: str) -> AddCardCommentPayload:
             """Add a text comment to a Pipefy card.
@@ -166,9 +162,7 @@ class PipeTools:
             return build_add_card_comment_success_payload(comment_id=comment_id)
 
         @mcp.tool(
-            annotations=ToolAnnotations(
-                idempotentHint=False,
-            ),
+            annotations=ToolAnnotations(readOnlyHint=False),
         )
         async def update_comment(
             comment_id: int, text: str
@@ -200,9 +194,7 @@ class PipeTools:
             return build_update_comment_success_payload(comment_id=comment_id_out)
 
         @mcp.tool(
-            annotations=ToolAnnotations(
-                idempotentHint=False,
-            ),
+            annotations=ToolAnnotations(readOnlyHint=False),
         )
         async def delete_comment(
             comment_id: int,
@@ -279,7 +271,10 @@ class PipeTools:
 
             Args:
                 pipe_id: The ID of the pipe to search in.
-                field_id: Pipefy field identifier (e.g. from get_start_form_fields or get_phase_fields).
+                field_id: Pipefy field slug (e.g. "status", "id_da_solicita_o") — the ``id``
+                    value returned by get_start_form_fields or get_phase_fields, NOT the
+                    human-readable label. Call get_start_form_fields first to discover valid
+                    field slugs for your pipe.
                 field_value: Value to match for that field (string; use the format expected by the field type).
                 include_fields: If True, include each card's custom fields (name, value) in the response.
             """
@@ -313,10 +308,7 @@ class PipeTools:
             return await client.get_pipe_members(pipe_id)
 
         @mcp.tool(
-            annotations=ToolAnnotations(
-                destructiveHint=False,
-                idempotentHint=True,
-            ),
+            annotations=ToolAnnotations(idempotentHint=True),
         )
         async def move_card_to_phase(card_id: int, destination_phase_id: int) -> dict:
             """Move a card to a specific phase."""
@@ -324,9 +316,7 @@ class PipeTools:
             return await client.move_card_to_phase(card_id, destination_phase_id)
 
         @mcp.tool(
-            annotations=ToolAnnotations(
-                idempotentHint=False,
-            ),
+            annotations=ToolAnnotations(readOnlyHint=False),
         )
         async def update_card_field(
             card_id: int, field_id: str, new_value: Any
@@ -348,9 +338,7 @@ class PipeTools:
             return await client.update_card_field(card_id, field_id, new_value)
 
         @mcp.tool(
-            annotations=ToolAnnotations(
-                idempotentHint=False,
-            ),
+            annotations=ToolAnnotations(readOnlyHint=False),
         )
         async def update_card(
             card_id: int,
@@ -477,9 +465,7 @@ class PipeTools:
             return await client.get_phase_fields(phase_id, required_only)
 
         @mcp.tool(
-            annotations=ToolAnnotations(
-                idempotentHint=False,
-            ),
+            annotations=ToolAnnotations(readOnlyHint=False),
         )
         async def fill_card_phase_fields(
             ctx: Context[ServerSession, None],

--- a/src/pipefy_mcp/tools/pipe_tools.py
+++ b/src/pipefy_mcp/tools/pipe_tools.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 from mcp.server.fastmcp import Context, FastMCP

--- a/src/pipefy_mcp/tools/registry.py
+++ b/src/pipefy_mcp/tools/registry.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from mcp.server.fastmcp import FastMCP
 
 from pipefy_mcp.core.container import ServicesContainer

--- a/src/pipefy_mcp/tools/table_tools.py
+++ b/src/pipefy_mcp/tools/table_tools.py
@@ -758,14 +758,9 @@ class TableTools:
                 )
             fid = field_id.strip() if isinstance(field_id, str) else field_id
             try:
-                # Always pass table_id if we have it, otherwise let service handle the error
-                if table_id_to_use is not None:
-                    raw = await client.update_table_field(
-                        fid, table_id=table_id_to_use, **update_attrs
-                    )
-                else:
-                    # No table_id provided - API will return error, but we try anyway
-                    raw = await client.update_table_field(fid, **update_attrs)
+                raw = await client.update_table_field(
+                    fid, table_id=table_id_to_use, **update_attrs
+                )
             except Exception as exc:
                 return handle_table_tool_graphql_error(
                     exc, "Update table field failed.", debug=debug

--- a/src/pipefy_mcp/tools/validation_helpers.py
+++ b/src/pipefy_mcp/tools/validation_helpers.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
+
+UUID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
 
 
 def valid_repo_id(value: object) -> bool:

--- a/tests/services/pipefy/test_observability_service.py
+++ b/tests/services/pipefy/test_observability_service.py
@@ -473,3 +473,55 @@ async def test_get_agents_usage_transport_error(mock_settings):
     filter_date = {"from": "2026-03-01T00:00:00Z", "to": "2026-03-31T23:59:59Z"}
     with pytest.raises(TransportQueryError):
         await service.get_agents_usage("org-uuid-1", filter_date)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_agents_usage_resolves_numeric_organization_id(mock_settings):
+    resolve_payload = {
+        "organization": {"uuid": "341c1327-261c-4766-bb96-7953e4c3970d"}
+    }
+    usage_payload = {
+        "agentsUsage": {
+            "data": [{"agentName": "Bot", "totalCredits": 5.0}],
+            "totalCredits": 5.0,
+        }
+    }
+    service = ObservabilityService(settings=mock_settings)
+    service.execute_query = AsyncMock(side_effect=[resolve_payload, usage_payload])
+    filter_date = {"from": "2026-03-01T00:00:00Z", "to": "2026-03-31T23:59:59Z"}
+    result = await service.get_agents_usage("300514213", filter_date)
+
+    assert service.execute_query.call_count == 2
+    calls = service.execute_query.call_args_list
+    assert calls[0][0][0] is RESOLVE_ORGANIZATION_UUID_QUERY
+    assert calls[0][0][1] == {"id": "300514213"}
+    assert calls[1][0][0] is GET_AGENTS_USAGE_QUERY
+    assert calls[1][0][1]["organizationUuid"] == "341c1327-261c-4766-bb96-7953e4c3970d"
+    assert result["agentsUsage"]["totalCredits"] == 5.0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_automations_usage_resolves_numeric_organization_id(mock_settings):
+    resolve_payload = {
+        "organization": {"uuid": "341c1327-261c-4766-bb96-7953e4c3970d"}
+    }
+    usage_payload = {
+        "automationsUsage": {
+            "data": [{"automationName": "Rule 1", "totalExecutions": 42}],
+            "totalExecutions": 42,
+        }
+    }
+    service = ObservabilityService(settings=mock_settings)
+    service.execute_query = AsyncMock(side_effect=[resolve_payload, usage_payload])
+    filter_date = {"from": "2026-03-01T00:00:00Z", "to": "2026-03-31T23:59:59Z"}
+    result = await service.get_automations_usage("300514213", filter_date)
+
+    assert service.execute_query.call_count == 2
+    calls = service.execute_query.call_args_list
+    assert calls[0][0][0] is RESOLVE_ORGANIZATION_UUID_QUERY
+    assert calls[0][0][1] == {"id": "300514213"}
+    assert calls[1][0][0] is GET_AUTOMATIONS_USAGE_QUERY
+    assert calls[1][0][1]["organizationUuid"] == "341c1327-261c-4766-bb96-7953e4c3970d"
+    assert result["automationsUsage"]["totalExecutions"] == 42

--- a/tests/services/test_pipe_service.py
+++ b/tests/services/test_pipe_service.py
@@ -23,7 +23,7 @@ def mock_settings() -> PipefySettings:
     )
 
 
-def _make_service(mock_settings: PipefySettings, return_value: dict) -> PipeService:
+def _make_service(mock_settings, return_value):
     service = PipeService(settings=mock_settings)
     service.execute_query = AsyncMock(return_value=return_value)
     return service
@@ -191,43 +191,43 @@ async def test_search_pipes_without_name_returns_all(
         pytest.param(
             "Custaudio",
             ["1"],
-            [["Custaudio", "Custaudio pipe"]],
-            [[100.0, 90.0]],
+            [["Custaudio pipe", "Custaudio"]],
+            [[100.0, 100.0]],
             id="exact_match_ranked_first",
         ),
         pytest.param(
             "custaudio",
             ["1"],
-            [["Custaudio", "Custaudio pipe"]],
-            [[88.9, 80.0]],
+            [["Custaudio pipe", "Custaudio"]],
+            [[100.0, 100.0]],
             id="case_insensitive_match",
         ),
         pytest.param(
             "drico",
             ["1"],
             [["Drico pipe"]],
-            [[72.0]],
+            [[100.0]],
             id="single_match_in_org",
         ),
         pytest.param(
             "pipe",
             ["1"],
             [["Custaudio pipe", "Drico pipe"]],
-            [[90.0, 90.0]],
+            [[100.0, 100.0]],
             id="matches_across_multiple_pipes",
         ),
         pytest.param(
             "Vendas",
             ["2"],
             [["Vendas São Paulo"]],
-            [[90.0]],
+            [[100.0]],
             id="accented_substring_match",
         ),
         pytest.param(
             "São Paulo",
             ["2"],
             [["Vendas São Paulo"]],
-            [[90.0]],
+            [[100.0]],
             id="accented_exact_substring",
         ),
         pytest.param(
@@ -262,7 +262,7 @@ async def test_search_pipes_without_name_returns_all(
             "Bug Tracker",
             ["3"],
             [["Bug Tracker [v2.0]"]],
-            [[90.0]],
+            [[100.0]],
             id="special_chars_brackets",
         ),
         pytest.param(
@@ -276,7 +276,7 @@ async def test_search_pipes_without_name_returns_all(
             "R&D",
             ["3"],
             [["R&D / Innovation"]],
-            [[90.0]],
+            [[100.0]],
             id="special_chars_ampersand_slash",
         ),
     ],
@@ -358,6 +358,39 @@ async def test_search_pipes_all_organizations_empty(mock_settings):
 
     result = await service.search_pipes(pipe_name="anything")
     assert result == {"organizations": []}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_search_pipes_short_keyword_matches_substring(
+    mock_settings, mock_organizations,
+):
+    """Substring match finds pipes even when fuzzy score is below threshold."""
+    service = _make_service(mock_settings, {"organizations": mock_organizations})
+    result = await service.search_pipes(pipe_name="pipe")
+    pipe_names = [
+        p["name"]
+        for org in result["organizations"]
+        for p in org["pipes"]
+    ]
+    assert "Custaudio pipe" in pipe_names
+    assert "Drico pipe" in pipe_names
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_search_pipes_case_insensitive_substring(
+    mock_settings, mock_organizations,
+):
+    """Case-insensitive substring matches correctly."""
+    service = _make_service(mock_settings, {"organizations": mock_organizations})
+    result = await service.search_pipes(pipe_name="bug")
+    pipe_names = [
+        p["name"]
+        for org in result["organizations"]
+        for p in org["pipes"]
+    ]
+    assert "Bug Tracker [v2.0]" in pipe_names
 
 
 @pytest.mark.unit

--- a/tests/services/test_pipefy_client.py
+++ b/tests/services/test_pipefy_client.py
@@ -648,7 +648,9 @@ async def test_get_cards_with_include_fields_true_passes_include_fields_to_servi
 
     result = await client.get_cards(pipe_id, search=None, include_fields=True)
 
-    card_service.get_cards.assert_awaited_once_with(pipe_id, None, include_fields=True)
+    card_service.get_cards.assert_awaited_once_with(
+        pipe_id, None, include_fields=True, first=None, after=None
+    )
     assert result == expected
 
 
@@ -668,7 +670,9 @@ async def test_get_cards_with_include_fields_false_passes_include_fields_to_serv
 
     result = await client.get_cards(pipe_id, search=None, include_fields=False)
 
-    card_service.get_cards.assert_awaited_once_with(pipe_id, None, include_fields=False)
+    card_service.get_cards.assert_awaited_once_with(
+        pipe_id, None, include_fields=False, first=None, after=None
+    )
     assert result == expected
 
 

--- a/tests/services/test_pipefy_facade.py
+++ b/tests/services/test_pipefy_facade.py
@@ -175,7 +175,7 @@ async def test_pipefy_client_facade_delegates_to_services_without_modifying_args
 
     assert await client.get_cards(5, {"title": "x"}) == {"ok": "cards"}
     card_service.get_cards.assert_awaited_once_with(
-        5, {"title": "x"}, include_fields=False
+        5, {"title": "x"}, include_fields=False, first=None, after=None
     )
 
     assert await client.move_card_to_phase(6, 7) == {"ok": "move"}

--- a/tests/tools/test_ai_agent_tools.py
+++ b/tests/tools/test_ai_agent_tools.py
@@ -478,4 +478,3 @@ async def test_get_ai_agent_tools_have_read_only_hint(client_session):
         tool = by_name[name]
         assert tool.annotations is not None
         assert tool.annotations.readOnlyHint is True
-        assert tool.annotations.destructiveHint is False

--- a/tests/tools/test_automation_tools.py
+++ b/tests/tools/test_automation_tools.py
@@ -518,4 +518,4 @@ async def test_create_and_update_automation_tools_are_not_read_only(
         ann = by_name[name].annotations
         assert ann is not None
         assert ann.readOnlyHint is False
-        assert ann.destructiveHint is False
+        assert ann.destructiveHint is not True

--- a/tests/tools/test_pipe_config_tools.py
+++ b/tests/tools/test_pipe_config_tools.py
@@ -11,14 +11,12 @@ from mcp.shared.memory import (
 )
 
 from pipefy_mcp.services.pipefy import PipefyClient
-from pipefy_mcp.tools.field_condition_tools import (
-    FieldConditionTools,
-    field_condition_phase_field_id_looks_like_slug,
-)
+from pipefy_mcp.tools.field_condition_tools import FieldConditionTools
 from pipefy_mcp.tools.pipe_config_tool_helpers import (
     DeletePipeErrorPayload,
     build_field_condition_delete_payload,
     build_field_condition_success_payload,
+    field_condition_phase_field_id_looks_like_slug,
 )
 from pipefy_mcp.tools.pipe_config_tools import PipeConfigTools
 

--- a/tests/tools/test_pipe_tools.py
+++ b/tests/tools/test_pipe_tools.py
@@ -563,7 +563,7 @@ class TestGetCardsTool:
 
         assert result.isError is False, "Unexpected tool error"
         mock_pipefy_client.get_cards.assert_called_once_with(
-            pipe_id, None, include_fields=True
+            pipe_id, None, include_fields=True, first=None, after=None
         )
 
 


### PR DESCRIPTION
## Summary
Resolves all findings documented in `.cursor/dev-planning/code-review/pipe-full-toolset-vs-main.md` (RF-01–RF-03, DD/IM/NIT items): future annotations, field-condition helper extraction, `search_pipes` substring matching, numeric org ID resolution for usage queries, `repoId` resolution moved to `WebhookService`, `create_automation` `active` merge order, `get_cards` pagination (`first`/`after` + `pageInfo`), ToolAnnotations cleanup, `find_cards` docstring, and `update_table_field` delegation.

## Commits (atomic)
- `style:` from `__future__` annotations
- `refactor(tools):` UUID + field-condition helpers
- `fix(services):` search_pipes matching
- `fix(observability):` org id resolution for usage
- `fix(webhook):` repoId for inbox email
- `fix(client):` create_automation merge
- `fix(cards):` get_cards pagination
- `style(tools):` ToolAnnotations + find_cards docs
- `refactor(tools):` update_table_field table_id

## Testing
`uv run pytest -m "not integration" -q` — 778 passed.