### PR TITLE
docs(onboarding): .env.example + Claude Desktop/Code no README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Pipefy MCP Server — Environment Variables
+# Copy this file: cp .env.example .env
+# Then fill in your Service Account credentials from Pipefy Admin Panel.
+
+PIPEFY_GRAPHQL_URL=https://app.pipefy.com/graphql
+PIPEFY_INTERNAL_API_URL=https://app.pipefy.com/internal_api
+PIPEFY_OAUTH_URL=https://app.pipefy.com/oauth/token
+PIPEFY_OAUTH_CLIENT=<YOUR_SERVICE_ACCOUNT_CLIENT_ID>
+PIPEFY_OAUTH_SECRET=<YOUR_SERVICE_ACCOUNT_CLIENT_SECRET>

--- a/README.md
+++ b/README.md
@@ -73,7 +73,13 @@ cd pipefy-mcp-server
 
 # Sync dependencies
 uv sync
+
+# Optional: local credentials (see also MCP client env blocks below)
+cp .env.example .env
+# Edit .env with your Service Account client ID and secret.
 ```
+
+The MCP server loads configuration with **Pydantic Settings** (`pipefy_mcp.settings.Settings`): it reads a `.env` file in the **current working directory** (when you run `uv run pipefy-mcp-server` from the repo root, that is the project `.env`) and merges **process environment variables**, which **override** values from `.env`. The nested `pipefy` block maps to variables named `PIPEFY_GRAPHQL_URL`, `PIPEFY_INTERNAL_API_URL`, `PIPEFY_OAUTH_URL`, `PIPEFY_OAUTH_CLIENT`, and `PIPEFY_OAUTH_SECRET` — the same keys as in [`.env.example`](.env.example). For details on nested env names and priority, see the [Pydantic settings docs](https://docs.pydantic.dev/latest/concepts/pydantic_settings/).
 
 ## Usage with Cursor
 To use this with Cursor, you need to register it as an MCP server in your settings.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@
   <a href="#mcp-tools">MCP tools</a> •
   <a href="#getting-started">Getting started</a> •
   <a href="#usage-with-cursor">Usage with Cursor</a> •
+  <a href="#usage-with-claude-desktop">Usage with Claude Desktop</a> •
+  <a href="#usage-with-claude-code">Usage with Claude Code</a> •
   <a href="#development--testing">Development & Testing</a> •
   <a href="#contributing">Contributing</a>
 </p>
@@ -103,6 +105,87 @@ To use this with Cursor, you need to register it as an MCP server in your settin
     }
 }
 ```
+
+## Usage with Claude Desktop
+
+Claude Desktop discovers MCP servers via a configuration file. Copy [`.env.example`](.env.example) to `.env` at the repo root and fill in your Service Account credentials (same variables as in the `env` block below).
+
+**Config file location**
+- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+    "mcpServers": {
+        "pipefy": {
+            "command": "uv",
+            "args": [
+                "run",
+                "--directory",
+                "/absolute/path/to/pipefy-mcp-server",
+                "pipefy-mcp-server"
+            ],
+            "env": {
+                "PIPEFY_GRAPHQL_URL": "https://app.pipefy.com/graphql",
+                "PIPEFY_INTERNAL_API_URL": "https://app.pipefy.com/internal_api",
+                "PIPEFY_OAUTH_URL": "https://app.pipefy.com/oauth/token",
+                "PIPEFY_OAUTH_CLIENT": "<SERVICE_ACCOUNT_CLIENT_ID>",
+                "PIPEFY_OAUTH_SECRET": "<SERVICE_ACCOUNT_CLIENT_SECRET>"
+            }
+        }
+    }
+}
+```
+
+Replace `/absolute/path/to/pipefy-mcp-server` with your clone path. For the full variable list and placeholders, see [`.env.example`](.env.example).
+
+## Usage with Claude Code
+
+Copy [`.env.example`](.env.example) to `.env` and set credentials, or pass the same keys via `claude mcp add-env` as shown below.
+
+**CLI (per project)**
+
+```bash
+claude mcp add --scope project pipefy \
+  -- uv run --directory /absolute/path/to/pipefy-mcp-server pipefy-mcp-server
+```
+
+Then set environment variables (repeat for each key from [`.env.example`](.env.example)):
+
+```bash
+claude mcp add-env pipefy PIPEFY_OAUTH_CLIENT <YOUR_CLIENT_ID>
+claude mcp add-env pipefy PIPEFY_OAUTH_SECRET <YOUR_CLIENT_SECRET>
+claude mcp add-env pipefy PIPEFY_GRAPHQL_URL https://app.pipefy.com/graphql
+claude mcp add-env pipefy PIPEFY_INTERNAL_API_URL https://app.pipefy.com/internal_api
+claude mcp add-env pipefy PIPEFY_OAUTH_URL https://app.pipefy.com/oauth/token
+```
+
+**`.mcp.json` (project root)**
+
+```json
+{
+    "mcpServers": {
+        "pipefy": {
+            "command": "uv",
+            "args": [
+                "run",
+                "--directory",
+                "/absolute/path/to/pipefy-mcp-server",
+                "pipefy-mcp-server"
+            ],
+            "env": {
+                "PIPEFY_GRAPHQL_URL": "https://app.pipefy.com/graphql",
+                "PIPEFY_INTERNAL_API_URL": "https://app.pipefy.com/internal_api",
+                "PIPEFY_OAUTH_URL": "https://app.pipefy.com/oauth/token",
+                "PIPEFY_OAUTH_CLIENT": "<SERVICE_ACCOUNT_CLIENT_ID>",
+                "PIPEFY_OAUTH_SECRET": "<SERVICE_ACCOUNT_CLIENT_SECRET>"
+            }
+        }
+    }
+}
+```
+
+The CLI approach is quicker for testing. The `.mcp.json` approach is better for teams — commit it to the repo and everyone gets the same config (use placeholders for secrets or inject them via your environment).
 
 ## Development & Testing
 

--- a/src/pipefy_mcp/settings.py
+++ b/src/pipefy_mcp/settings.py
@@ -32,6 +32,15 @@ class PipefySettings(BaseModel):
 
 
 class Settings(BaseSettings):
+    """Application configuration via pydantic-settings.
+
+    On import, values are read from process environment variables and from a ``.env`` file
+    in the current working directory (see ``env_file`` in ``model_config``). The nested
+    ``pipefy`` model uses names ``PIPEFY_*`` (e.g. ``PIPEFY_GRAPHQL_URL`` →
+    ``pipefy.graphql_url``). Environment variables override values from ``.env``. See
+    https://docs.pydantic.dev/latest/concepts/pydantic_settings/
+    """
+
     model_config = SettingsConfigDict(
         env_nested_delimiter="_",
         env_nested_max_split=1,


### PR DESCRIPTION
## Summary
- Add root `.env.example` with five `PIPEFY_*` placeholders (aligned with `settings.py`).
- Document **Claude Desktop** (config paths for macOS/Windows + `claude_desktop_config.json` snippet).
- Document **Claude Code** (`claude mcp add`, `claude mcp add-env`, `.mcp.json` example).
- Update table of contents.

## Testing
- `uv run pytest -m "not integration"`
- `uv run ruff check src/`

## Target
Merge into `pipe-full-toolset`.