### PR TITLE
feat(tools): add search_tables for org-wide database discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 | Category | Tools | Description | Docs |
 |----------|:-----:|-------------|------|
 | **Pipes & cards** | 33 | Read, create, update, and delete pipes, phases, fields, labels, cards, and field conditions. | [Details](docs/tools/pipes-and-cards.md) |
-| **Database tables** | 15 | Tables, records (rows), and schema columns (table fields). | [Details](docs/tools/database-tables.md) |
+| **Database tables** | 16 | Tables, records (rows), schema columns (table fields), and org-wide table discovery. | [Details](docs/tools/database-tables.md) |
 | **Relations** | 6 | Link pipes, tables, and cards across workflows. | [Details](docs/tools/relations.md) |
 | **Reports** | 16 | Pipe and organization reports: discovery, CRUD, and async exports. | [Details](docs/tools/reports.md) |
 | **Automations & AI** | 15 | Traditional automations (rules engine) and AI-powered automations and agents. | [Details](docs/tools/automations-and-ai.md) |

--- a/src/pipefy_mcp/services/pipefy/client.py
+++ b/src/pipefy_mcp/services/pipefy/client.py
@@ -717,6 +717,10 @@ class PipefyClient:
         """Search for pipes across all organizations"""
         return await self._pipe_service.search_pipes(pipe_name)
 
+    async def search_tables(self, table_name: str | None = None) -> dict:
+        """Search for databases (tables) across all organizations"""
+        return await self._table_service.search_tables(table_name)
+
     async def get_phase_fields(
         self, phase_id: int, required_only: bool = False
     ) -> dict:

--- a/src/pipefy_mcp/services/pipefy/queries/table_queries.py
+++ b/src/pipefy_mcp/services/pipefy/queries/table_queries.py
@@ -257,6 +257,25 @@ __all__ = [
     "GET_TABLES_QUERY",
     "SET_TABLE_RECORD_FIELD_VALUE_MUTATION",
     "UPDATE_TABLE_FIELD_MUTATION",
+    "SEARCH_TABLES_QUERY",
     "UPDATE_TABLE_MUTATION",
     "UPDATE_TABLE_RECORD_MUTATION",
 ]
+
+SEARCH_TABLES_QUERY = gql(
+    """
+    {
+        organizations {
+            id
+            name
+            tables {
+                nodes {
+                    id
+                    name
+                    description
+                }
+            }
+        }
+    }
+    """
+)

--- a/src/pipefy_mcp/services/pipefy/table_service.py
+++ b/src/pipefy_mcp/services/pipefy/table_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from httpx_auth import OAuth2ClientCredentials
+from rapidfuzz import fuzz
 
 from pipefy_mcp.services.pipefy.base_client import BasePipefyClient
 from pipefy_mcp.services.pipefy.queries.table_queries import (
@@ -19,6 +20,7 @@ from pipefy_mcp.services.pipefy.queries.table_queries import (
     GET_TABLE_RECORD_QUERY,
     GET_TABLE_RECORDS_QUERY,
     GET_TABLES_QUERY,
+    SEARCH_TABLES_QUERY,
     SET_TABLE_RECORD_FIELD_VALUE_MUTATION,
     UPDATE_TABLE_FIELD_MUTATION,
     UPDATE_TABLE_MUTATION,
@@ -270,3 +272,59 @@ class TableService(BasePipefyClient):
             DELETE_TABLE_FIELD_MUTATION,
             {"input": {"id": field_id}},
         )
+
+    async def search_tables(
+        self, table_name: str | None = None, match_threshold: int = 70
+    ) -> dict[str, Any]:
+        """Search for databases (tables) across all organizations using fuzzy matching.
+
+        Args:
+            table_name: Optional table name to search for (fuzzy match).
+                        Supports partial matches.
+                        If not provided, returns all tables.
+            match_threshold: Minimum fuzzy match score (0-100). Default: 70.
+
+        Returns:
+            dict: Organizations with their matching tables, sorted by match score.
+        """
+        result = await self.execute_query(SEARCH_TABLES_QUERY, {})
+        organizations = result.get("organizations", [])
+
+        if not table_name:
+            return {
+                "organizations": [
+                    {
+                        "id": org.get("id"),
+                        "name": org.get("name"),
+                        "tables": org.get("tables", {}).get("nodes", []),
+                    }
+                    for org in organizations
+                ]
+            }
+
+        filtered_orgs = []
+
+        for org in organizations:
+            matching_tables = []
+            for table in org.get("tables", {}).get("nodes", []):
+                table_display_name = table.get("name", "")
+                score = fuzz.WRatio(
+                    table_name, table_display_name, score_cutoff=match_threshold
+                )
+                if score:
+                    matching_tables.append((score, table))
+
+            if matching_tables:
+                matching_tables.sort(key=lambda x: x[0], reverse=True)
+                filtered_orgs.append(
+                    {
+                        "id": org.get("id"),
+                        "name": org.get("name"),
+                        "tables": [
+                            {**table, "match_score": round(score, 1)}
+                            for score, table in matching_tables
+                        ],
+                    }
+                )
+
+        return {"organizations": filtered_orgs}

--- a/src/pipefy_mcp/services/pipefy/table_service.py
+++ b/src/pipefy_mcp/services/pipefy/table_service.py
@@ -308,11 +308,14 @@ class TableService(BasePipefyClient):
             matching_tables = []
             for table in org.get("tables", {}).get("nodes", []):
                 table_display_name = table.get("name", "")
-                score = fuzz.WRatio(
-                    table_name, table_display_name, score_cutoff=match_threshold
-                )
-                if score:
-                    matching_tables.append((score, table))
+                if table_name.lower() in table_display_name.lower():
+                    matching_tables.append((100.0, table))
+                else:
+                    score = fuzz.WRatio(
+                        table_name, table_display_name, score_cutoff=match_threshold
+                    )
+                    if score:
+                        matching_tables.append((score, table))
 
             if matching_tables:
                 matching_tables.sort(key=lambda x: x[0], reverse=True)

--- a/src/pipefy_mcp/tools/table_tools.py
+++ b/src/pipefy_mcp/tools/table_tools.py
@@ -61,11 +61,30 @@ class TableTools:
             annotations=ToolAnnotations(readOnlyHint=True),
         )
         async def search_tables(table_name: str | None = None) -> dict[str, Any]:
-            """Search for databases (tables) across all organizations.
+            """Search for all accessible databases (tables) across all organizations.
+
+            Use this tool to find a table's ID when you only know its name.
+            Returns all tables from all organizations, optionally filtered by name.
+
+            When filtering by name, uses substring matching first (score 100) and
+            falls back to fuzzy matching with a 70% similarity threshold.
+            Only tables with a match score of 70 or higher are included in results.
+            Results are sorted by match score (best matches first).
 
             Args:
-                table_name: Optional name to search for (fuzzy match, 70% threshold).
-                            If not provided, returns all tables in all organizations.
+                table_name: Optional table name to search for (case-insensitive partial match).
+                            If not provided, returns all available tables.
+
+            Returns:
+                dict: Contains 'organizations' array, each with:
+                      - id: Organization ID
+                      - name: Organization name
+                      - tables: Array of tables in the organization, each with:
+                          - id: Table ID (use this for get_table, get_table_records, etc.)
+                          - name: Table name
+                          - description: Table description
+                          - match_score: Match score (0-100) when table_name is provided,
+                                         100 for substring matches, fuzzy score otherwise.
             """
             return await client.search_tables(table_name)
 

--- a/src/pipefy_mcp/tools/table_tools.py
+++ b/src/pipefy_mcp/tools/table_tools.py
@@ -60,6 +60,18 @@ class TableTools:
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
         )
+        async def search_tables(table_name: str | None = None) -> dict[str, Any]:
+            """Search for databases (tables) across all organizations.
+
+            Args:
+                table_name: Optional name to search for (fuzzy match, 70% threshold).
+                            If not provided, returns all tables in all organizations.
+            """
+            return await client.search_tables(table_name)
+
+        @mcp.tool(
+            annotations=ToolAnnotations(readOnlyHint=True),
+        )
         async def get_table(table_id: str | int) -> dict[str, Any]:
             """Load one database table: name, description, fields, and authorization.
 

--- a/tests/services/test_table_service.py
+++ b/tests/services/test_table_service.py
@@ -1,0 +1,140 @@
+"""Unit tests for TableService.search_tables."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from pipefy_mcp.services.pipefy.table_service import TableService
+from pipefy_mcp.settings import PipefySettings
+
+
+@pytest.fixture
+def mock_settings() -> PipefySettings:
+    return PipefySettings(
+        graphql_url="https://api.pipefy.com/graphql",
+        oauth_url="https://auth.pipefy.com/oauth/token",
+        oauth_client="client_id",
+        oauth_secret="client_secret",
+    )
+
+
+def _make_service(mock_settings: PipefySettings, return_value: dict) -> TableService:
+    service = TableService(settings=mock_settings)
+    service.execute_query = AsyncMock(return_value=return_value)
+    return service
+
+
+@pytest.fixture
+def mock_organizations() -> list[dict]:
+    return [
+        {
+            "id": "org1",
+            "name": "Acme Corp",
+            "tables": {
+                "nodes": [
+                    {"id": "T1", "name": "Clients", "description": "Client list"},
+                    {"id": "T2", "name": "Products", "description": "Product catalog"},
+                ]
+            },
+        },
+        {
+            "id": "org2",
+            "name": "Globo",
+            "tables": {
+                "nodes": [
+                    {"id": "T3", "name": "Fornecedores", "description": "Supplier database"},
+                    {"id": "T4", "name": "Clientes VIP", "description": None},
+                ]
+            },
+        },
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_without_name_returns_all_tables(mock_settings, mock_organizations):
+    """search_tables with no name returns every table across all organizations."""
+    service = _make_service(mock_settings, {"organizations": mock_organizations})
+    result = await service.search_tables()
+
+    assert len(result["organizations"]) == 2
+    assert result["organizations"][0]["id"] == "org1"
+    assert len(result["organizations"][0]["tables"]) == 2
+    assert result["organizations"][1]["id"] == "org2"
+    assert len(result["organizations"][1]["tables"]) == 2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fuzzy_match_filters_tables(mock_settings, mock_organizations):
+    """search_tables with a name returns only tables that meet the threshold."""
+    service = _make_service(mock_settings, {"organizations": mock_organizations})
+    result = await service.search_tables(table_name="Clients")
+
+    # "Clients" must match "Clients" (exact) and likely "Clientes VIP" (partial)
+    org_ids = [o["id"] for o in result["organizations"]]
+    assert "org1" in org_ids
+
+    org1 = next(o for o in result["organizations"] if o["id"] == "org1")
+    assert any(t["name"] == "Clients" for t in org1["tables"])
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_no_match_returns_empty_organizations(mock_settings, mock_organizations):
+    """search_tables returns empty list when nothing matches the query."""
+    service = _make_service(mock_settings, {"organizations": mock_organizations})
+    result = await service.search_tables(table_name="XyzNonExistent999")
+
+    assert result == {"organizations": []}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_matched_tables_include_match_score(mock_settings, mock_organizations):
+    """Matched tables include a match_score field."""
+    service = _make_service(mock_settings, {"organizations": mock_organizations})
+    result = await service.search_tables(table_name="Products")
+
+    assert len(result["organizations"]) >= 1
+    for org in result["organizations"]:
+        for table in org["tables"]:
+            assert "match_score" in table
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_tables_sorted_by_score_descending(mock_settings):
+    """Tables within an organization are sorted by match_score descending."""
+    orgs = [
+        {
+            "id": "org1",
+            "name": "Org",
+            "tables": {
+                "nodes": [
+                    {"id": "T1", "name": "Client Records", "description": None},
+                    {"id": "T2", "name": "Clients", "description": None},
+                    {"id": "T3", "name": "Client Database", "description": None},
+                ]
+            },
+        }
+    ]
+    service = _make_service(mock_settings, {"organizations": orgs})
+    result = await service.search_tables(table_name="Clients")
+
+    tables = result["organizations"][0]["tables"]
+    scores = [t["match_score"] for t in tables]
+    assert scores == sorted(scores, reverse=True)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_empty_organizations(mock_settings):
+    """search_tables handles an empty organizations list gracefully."""
+    service = _make_service(mock_settings, {"organizations": []})
+
+    result = await service.search_tables()
+    assert result == {"organizations": []}
+
+    result = await service.search_tables(table_name="anything")
+    assert result == {"organizations": []}

--- a/tests/tools/test_table_tools.py
+++ b/tests/tools/test_table_tools.py
@@ -37,6 +37,7 @@ def mock_table_client():
     client.create_table_field = AsyncMock()
     client.update_table_field = AsyncMock()
     client.delete_table_field = AsyncMock()
+    client.search_tables = AsyncMock()
     return client
 
 
@@ -808,3 +809,56 @@ async def test_delete_table_field_graphql_error(
         result = await session.call_tool("delete_table_field", {"field_id": "x"})
 
     assert extract_payload(result)["success"] is False
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_search_tables_without_name_calls_client_with_none(
+    table_session, mock_table_client
+):
+    mock_table_client.search_tables.return_value = {
+        "organizations": [{"id": "org1", "name": "Acme", "tables": []}]
+    }
+
+    async with table_session as session:
+        result = await session.call_tool("search_tables", {})
+
+    assert result.isError is False
+    mock_table_client.search_tables.assert_awaited_once_with(None)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_search_tables_with_name_passes_it_to_client(
+    table_session, mock_table_client
+):
+    mock_table_client.search_tables.return_value = {"organizations": []}
+
+    async with table_session as session:
+        result = await session.call_tool("search_tables", {"table_name": "Clients"})
+
+    assert result.isError is False
+    mock_table_client.search_tables.assert_awaited_once_with("Clients")
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_search_tables_returns_client_response(
+    table_session, mock_table_client, extract_payload
+):
+    expected = {
+        "organizations": [
+            {
+                "id": "org1",
+                "name": "Acme",
+                "tables": [{"id": "T1", "name": "Clients", "match_score": 100.0}],
+            }
+        ]
+    }
+    mock_table_client.search_tables.return_value = expected
+
+    async with table_session as session:
+        result = await session.call_tool("search_tables", {"table_name": "Clients"})
+
+    payload = extract_payload(result)
+    assert payload == expected


### PR DESCRIPTION
## Summary

- Adds `search_tables` to `TableService`, mirroring the `search_pipes` pattern (rapidfuzz WRatio, 70% threshold)
- Adds `SEARCH_TABLES_QUERY` to `table_queries.py`
- Registers `search_tables` MCP tool in `TableTools` with `readOnlyHint=True`
- Adds `search_tables` delegation in `PipefyClient`
- 6 unit tests for the service layer (`tests/services/test_table_service.py`)

## Why

`pipe-full-toolset` exposes `get_table` and `get_tables` for fetching by known ID, but there is no way to discover tables when the ID is unknown. `search_tables` fills that gap — same UX as `search_pipes`.

## Test plan

- [ ] `pytest tests/services/test_table_service.py` — 6 tests (fuzzy match, no match, sort order, score field, empty orgs)
- [ ] `pytest tests/tools/test_table_tools.py` — all 48 existing table tool tests still pass (no regressions)
- [ ] Call `search_tables` without arguments → returns all tables across all orgs
- [ ] Call `search_tables(table_name="Clients")` → returns only fuzzy-matched tables with `match_score`
