### PR TITLE
feat(queries): startFormPhaseId on pipe queries and eventId on get AI agent

### DIFF
--- a/src/pipefy_mcp/services/pipefy/queries/ai_agent_queries.py
+++ b/src/pipefy_mcp/services/pipefy/queries/ai_agent_queries.py
@@ -19,6 +19,7 @@ GET_AI_AGENT_QUERY = gql(
                 id
                 name
                 active
+                eventId: event_id
             }
         }
     }

--- a/src/pipefy_mcp/services/pipefy/queries/pipe_config_queries.py
+++ b/src/pipefy_mcp/services/pipefy/queries/pipe_config_queries.py
@@ -9,6 +9,7 @@ CREATE_PIPE_MUTATION = gql(
             pipe {
                 id
                 name
+                startFormPhaseId
             }
         }
     }

--- a/src/pipefy_mcp/services/pipefy/queries/pipe_queries.py
+++ b/src/pipefy_mcp/services/pipefy/queries/pipe_queries.py
@@ -9,6 +9,7 @@ GET_PIPE_QUERY = gql(
             id
             uuid
             name
+            startFormPhaseId
             phases {
                 id
                 name


### PR DESCRIPTION
## Summary
Expose fields the LLM needs without extra round-trips or guessing:

- **get_pipe** — `startFormPhaseId` for the hidden start-form phase (e.g. `create_phase_field`).
- **create_pipe** — `startFormPhaseId` in the mutation response right after creation.
- **get_ai_agent** — `eventId` (from `event_id`) on each behavior for `update_ai_agent`.

## Commits
- `feat(queries): expose startFormPhaseId in get pipe query`
- `feat(queries): return startFormPhaseId from create pipe mutation`
- `feat(queries): return eventId per behavior in get AI agent query`

## Testing
- `uv run pytest` (unit) on pipe / pipe-config / AI agent modules — green.
- Manual MCP: `get_pipe`, `create_pipe`, `get_ai_agent` (with service account on pipe for AI agent read).