### PR TITLE
feat(ai-agent): require instruction/behaviors and orchestrate create→update in create_ai_agent

### DIFF
--- a/docs/tools/automations-and-ai.md
+++ b/docs/tools/automations-and-ai.md
@@ -30,9 +30,50 @@ AI automations are separate from traditional rules above. They are prompt-driven
 |------|------|
 | `create_ai_automation` | Prompt-driven automation writing to one or more card fields (AI must be enabled on the pipe). |
 | `update_ai_automation` | Change name, `active`, prompt, `field_ids`, or `condition`. |
-| `create_ai_agent` | Create an agent on a pipe; `repo_uuid` is the pipe UUID from `get_pipe`. |
+| `create_ai_agent` | Creates and configures an AI agent with `instruction` (= Pipefy UI "Description") and 1–5 `behaviors` in one call. `repo_uuid` is the pipe UUID from `get_pipe`. Optional: `data_source_ids`. |
 | `update_ai_agent` | Replaces full agent config; send the complete `behaviors` list (1-5). |
 | `toggle_ai_agent_status` | Enable/disable without resending configuration. |
+
+**Tip:** Pipefy UI **Description** maps to the API/tool field `instruction` (agent-level purpose). The per-behavior prompt in the UI maps to `actionParams.aiBehaviorParams.instruction` on each behavior (behavior-level).
+
+**Tip:** For `create_ai_agent` / `update_ai_agent`, each behavior must include `actionParams.aiBehaviorParams.actionsAttributes` with **at least one** action. The API returns *"The instructions must contain at least 1 action"* if this list is missing or empty.
+
+**Discovery workflow** — call these tools before `create_ai_agent`:
+
+1. `get_pipe(pipe_id)` → get the pipe `uuid` (use as `repo_uuid`) and its phase IDs.
+2. `get_ai_agents(repo_uuid)` → check existing agents to avoid duplicates.
+3. `get_automation_events(pipe_id)` → pick a valid `event_id` for the behavior trigger.
+4. `get_automation_actions(pipe_id)` → find available action types for `actionsAttributes`.
+
+### Behavior dict shape
+
+```json
+{
+  "name": "When card is created: move to Doing",
+  "event_id": "card_created",
+  "actionParams": {
+    "aiBehaviorParams": {
+      "instruction": "Analyze the card and summarize key points.",
+      "actionsAttributes": [
+        {
+          "name": "Move to Doing",
+          "actionType": "move_card",
+          "metadata": { "destinationPhaseId": "<phase_id>" }
+        }
+      ]
+    }
+  }
+}
+```
+
+### Known `actionType` values
+
+| `actionType` | Required `metadata` |
+|---|---|
+| `move_card` | `{ "destinationPhaseId": "<phase_id>" }` |
+| `update_card_field` | `{ "fieldsAttributes": [{ "fieldId": "...", "value": "..." }] }` |
+| `create_card` | `{ "pipeId": "<pipe_id>", "fieldsAttributes": [...] }` |
+| `create_connected_card` | `{ "pipeId": "<pipe_id>", "fieldsAttributes": [...] }` |
 
 ### AI Agent read & delete
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,8 @@ format.exclude = ["src/pipefy_mcp/_version.py"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+# Root on pythonpath so tests can import shared helpers (e.g. tests.ai_agent_test_payloads)
+pythonpath = ["."]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]

--- a/src/pipefy_mcp/models/ai_agent.py
+++ b/src/pipefy_mcp/models/ai_agent.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from pipefy_mcp.models.validators import NonBlankStr
 
@@ -10,15 +12,12 @@ ACTION_ID_AI_BEHAVIOR = "ai_behavior"
 MAX_BEHAVIORS = 5
 
 
-class CreateAiAgentInput(BaseModel):
-    """Validated input for creating an AI Agent."""
-
-    name: NonBlankStr
-    repo_uuid: NonBlankStr
-
-
 class BehaviorInput(BaseModel):
-    """One AI agent behavior; accepts snake_case or camelCase, dumps with camelCase aliases."""
+    """One AI agent behavior; accepts snake_case or camelCase, dumps with camelCase aliases.
+
+    The Pipefy API requires ``actionParams.aiBehaviorParams.actionsAttributes`` with at least
+    one action; otherwise ``updateAiAgent`` fails (e.g. "The instructions must contain at least 1 action").
+    """
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -28,6 +27,45 @@ class BehaviorInput(BaseModel):
     active: bool = True
     condition: dict | None = None
     action_params: dict | None = Field(default=None, alias="actionParams")
+
+    @model_validator(mode="after")
+    def ai_behavior_must_include_at_least_one_action(self) -> Self:
+        """Reject behaviors that would fail updateAiAgent in production."""
+        params = self.action_params
+        if not params:
+            raise ValueError(
+                "Each behavior must include actionParams with aiBehaviorParams.actionsAttributes "
+                'containing at least one action (e.g. actionType "move_card" with metadata).'
+            )
+        abp = None
+        if isinstance(params, dict):
+            abp = params.get("aiBehaviorParams") or params.get("ai_behavior_params")
+        if not isinstance(abp, dict):
+            raise ValueError(
+                "Each behavior must include actionParams.aiBehaviorParams with "
+                "a non-empty actionsAttributes list."
+            )
+        actions = abp.get("actionsAttributes") or abp.get("actions_attributes")
+        if not isinstance(actions, list) or not actions:
+            raise ValueError(
+                "Each behavior must set actionParams.aiBehaviorParams.actionsAttributes with "
+                'at least one action (Pipefy: "The instructions must contain at least 1 action").'
+            )
+        return self
+
+
+class CreateAiAgentInput(BaseModel):
+    """Validated input for create-and-configure flow: create mutation uses name and repo_uuid only."""
+
+    name: NonBlankStr
+    repo_uuid: NonBlankStr
+    instruction: NonBlankStr
+    behaviors: list[BehaviorInput] = Field(
+        min_length=1,
+        max_length=MAX_BEHAVIORS,
+        description="List of behaviors (1 to MAX_BEHAVIORS)",
+    )
+    data_source_ids: list[str] = Field(default_factory=list)
 
 
 class UpdateAiAgentInput(BaseModel):

--- a/src/pipefy_mcp/tools/ai_agent_tools.py
+++ b/src/pipefy_mcp/tools/ai_agent_tools.py
@@ -10,6 +10,7 @@ from pipefy_mcp.models.ai_agent import CreateAiAgentInput, UpdateAiAgentInput
 from pipefy_mcp.services.pipefy import PipefyClient
 from pipefy_mcp.tools.ai_tool_helpers import (
     build_ai_tool_error,
+    build_create_agent_partial_failure,
     build_create_agent_success,
     build_delete_agent_success,
     build_get_agent_success,
@@ -39,32 +40,102 @@ class AiAgentTools:
             ctx: Context,
             name: str,
             repo_uuid: str,
+            instruction: str,
+            behaviors: list[dict],
+            data_source_ids: list[str] | None = None,
         ) -> dict:
-            """Create an AI Agent (empty, no behaviors) attached to a pipe.
+            """Create an AI Agent and configure it in one call (GraphQL create + update).
 
-            Use update_ai_agent to configure 1 to 5 behaviors.
-            repo_uuid is the pipe's unique identifier — not the numeric pipe ID from the URL.
-            Resolve it via pipe query.
+            Requires a non-empty instruction and 1–5 behaviors. Instruction maps to the agent's
+            Description field in the Pipefy UI (agent-level purpose). Each behavior's prompt/instruction
+            lives in ``actionParams.aiBehaviorParams.instruction`` when sent to the API.
+
+            Each behavior must also include ``actionParams.aiBehaviorParams.actionsAttributes`` with
+            at least one action; otherwise the API rejects the update.
+
+            Discovery workflow (call these tools first):
+              1. ``get_pipe(pipe_id)`` → obtain ``uuid`` (use as ``repo_uuid``) and phase IDs.
+              2. ``get_automation_events(pipe_id)`` → pick a valid ``event_id`` for the behavior
+                 (e.g. ``card_created``, ``card_moved``, ``field_updated``).
+              3. ``get_automation_actions(pipe_id)`` → find available ``actionType`` values.
+
+            Behavior dict example::
+
+              {
+                "name": "When card is created: move to Doing",
+                "event_id": "card_created",
+                "actionParams": {
+                  "aiBehaviorParams": {
+                    "instruction": "Analyze the card and summarize key points.",
+                    "actionsAttributes": [
+                      {
+                        "name": "Move to Doing",
+                        "actionType": "move_card",
+                        "metadata": {"destinationPhaseId": "<phase_id from get_pipe>"}
+                      }
+                    ]
+                  }
+                }
+              }
+
+            Known ``actionType`` values and their required ``metadata``:
+              - ``move_card`` → ``{"destinationPhaseId": "<phase_id>"}``
+              - ``update_card_field`` → ``{"fieldsAttributes": [{"fieldId": "...", "value": "..."}]}``
+              - ``create_card`` → ``{"pipeId": "<pipe_id>", "fieldsAttributes": [...]}``
+              - ``create_connected_card`` → ``{"pipeId": "<pipe_id>", "fieldsAttributes": [...]}``
 
             Args:
                 name: Agent display name.
-                repo_uuid: UUID of the pipe the agent belongs to.
+                repo_uuid: UUID of the pipe (from ``get_pipe``), not the numeric pipe ID.
+                instruction: Agent-level purpose (Pipefy UI "Description"; API ``instruction``).
+                behaviors: 1–5 behavior dicts. Each requires ``name``, ``event_id``, and
+                    ``actionParams.aiBehaviorParams`` with a non-empty ``actionsAttributes`` list.
+                    See example above for the full shape.
+                data_source_ids: Optional knowledge-source IDs (same as ``update_ai_agent``).
             """
-            ctx.debug(f"create_ai_agent: name={name}, repo_uuid={repo_uuid}")
+            ctx.debug(
+                f"create_ai_agent: name={name}, repo_uuid={repo_uuid}, "
+                f"instruction_len={len(instruction)}, behaviors_count={len(behaviors)}, "
+                f"data_source_ids={data_source_ids!r}"
+            )
             try:
-                validated = CreateAiAgentInput(name=name, repo_uuid=repo_uuid)
+                validated = CreateAiAgentInput(
+                    name=name,
+                    repo_uuid=repo_uuid,
+                    instruction=instruction,
+                    behaviors=behaviors,
+                    data_source_ids=data_source_ids or [],
+                )
             except ValidationError as exc:
                 return build_ai_tool_error(str(exc))
 
             try:
-                result = await client.create_ai_agent(validated)
+                create_result = await client.create_ai_agent(validated)
             except Exception as exc:  # noqa: BLE001
-                return build_ai_tool_error(str(exc))
+                return error_payload_from_exception(exc)
 
-            return build_create_agent_success(
-                agent_uuid=result["agent_uuid"],
-                message=result["message"],
+            agent_uuid = create_result["agent_uuid"]
+
+            update_input = UpdateAiAgentInput(
+                uuid=agent_uuid,
+                name=validated.name,
+                repo_uuid=validated.repo_uuid,
+                instruction=validated.instruction,
+                behaviors=validated.behaviors,
+                data_source_ids=validated.data_source_ids,
             )
+            try:
+                await client.update_ai_agent(update_input)
+            except Exception as exc:  # noqa: BLE001
+                msgs = extract_error_strings(exc)
+                text = "; ".join(msgs) if msgs else str(exc)
+                return build_create_agent_partial_failure(
+                    agent_uuid=agent_uuid,
+                    error=text,
+                )
+
+            msg = f"AI Agent created and configured successfully. UUID: {agent_uuid}"
+            return build_create_agent_success(agent_uuid=agent_uuid, message=msg)
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
@@ -78,17 +149,19 @@ class AiAgentTools:
             behaviors: list[dict],
             data_source_ids: list[str] | None = None,
         ) -> dict:
-            """Update an AI Agent with an instruction and 1 to 5 behaviors that can execute complex actions (e.g. move card, update fields conditionally).
+            """Update an AI Agent — replaces the entire config, so always send the complete behaviors list.
 
-            The API replaces the entire agent payload, so always send the complete list of behaviors.
-            Other agents (e.g. OpenClaw) can use this tool to configure Pipefy AI Agents programmatically.
+            Each behavior must include ``actionParams.aiBehaviorParams.actionsAttributes`` with at least
+            one action (same constraint and shape as ``create_ai_agent`` — see its docstring for the
+            full behavior dict example, discovery workflow, and known ``actionType`` values).
 
             Args:
                 uuid: UUID of the agent to update.
                 name: Agent display name.
-                repo_uuid: UUID of the pipe the agent belongs to.
-                instruction: Global instruction for the agent.
-                behaviors: List of 1 to 5 behavior dicts (name, event_id required per behavior).
+                repo_uuid: UUID of the pipe (from ``get_pipe``).
+                instruction: Agent-level purpose (Pipefy UI "Description"; API ``instruction``).
+                behaviors: 1–5 behavior dicts. Same shape as ``create_ai_agent``: each needs ``name``,
+                    ``event_id``, and ``actionParams.aiBehaviorParams.actionsAttributes``.
                 data_source_ids: Optional list of data source IDs.
             """
             ctx.debug(f"update_ai_agent: uuid={uuid}, behaviors_count={len(behaviors)}")

--- a/src/pipefy_mcp/tools/ai_tool_helpers.py
+++ b/src/pipefy_mcp/tools/ai_tool_helpers.py
@@ -58,6 +58,12 @@ class AiToolErrorPayload(TypedDict):
     error: str
 
 
+class CreateAgentPartialFailurePayload(TypedDict):
+    success: Literal[False]
+    agent_uuid: str
+    error: str
+
+
 def build_create_automation_success(
     *, automation_id: str, message: str
 ) -> CreateAiAutomationSuccessPayload:
@@ -113,3 +119,15 @@ def build_delete_agent_success(*, message: str) -> DeleteAiAgentSuccessPayload:
 def build_ai_tool_error(message: str) -> AiToolErrorPayload:
     """Build error payload for any AI tool."""
     return {"success": False, "error": message}
+
+
+def build_create_agent_partial_failure(
+    *, agent_uuid: str, error: str
+) -> CreateAgentPartialFailurePayload:
+    """Build payload when create succeeded but chained update failed.
+
+    Args:
+        agent_uuid: UUID of the agent returned by create (for recovery via update/delete).
+        error: Message describing the update failure.
+    """
+    return {"success": False, "agent_uuid": agent_uuid, "error": error}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package (enables shared helpers under ``tests.*``)."""

--- a/tests/ai_agent_test_payloads.py
+++ b/tests/ai_agent_test_payloads.py
@@ -1,0 +1,21 @@
+"""Minimal valid AI agent behavior dicts for unit tests (matches Pipefy API constraints)."""
+
+
+def minimal_behavior_dict(name="Test Behavior", event_id="card_created"):
+    """One behavior with actionParams.aiBehaviorParams.actionsAttributes (required by live API)."""
+    return {
+        "name": name,
+        "event_id": event_id,
+        "actionParams": {
+            "aiBehaviorParams": {
+                "instruction": "Test behavior instruction.",
+                "actionsAttributes": [
+                    {
+                        "name": "Move card",
+                        "actionType": "move_card",
+                        "metadata": {},
+                    },
+                ],
+            }
+        },
+    }

--- a/tests/models/test_ai_agent.py
+++ b/tests/models/test_ai_agent.py
@@ -3,6 +3,8 @@
 import pytest
 from pydantic import ValidationError
 
+from tests.ai_agent_test_payloads import minimal_behavior_dict
+
 from pipefy_mcp.models.ai_agent import (
     ACTION_ID_AI_BEHAVIOR,
     MAX_BEHAVIORS,
@@ -13,39 +15,108 @@ from pipefy_mcp.models.ai_agent import (
 
 
 def _make_behavior(name="Test Behavior", event_id="card_created"):
-    return {"name": name, "event_id": event_id}
+    return minimal_behavior_dict(name=name, event_id=event_id)
 
 
 @pytest.mark.unit
-def test_create_ai_agent_input_requires_name_and_repo_uuid():
-    inp = CreateAiAgentInput(name="My Agent", repo_uuid="repo-123")
+def test_create_ai_agent_input_requires_name_repo_instruction_behaviors():
+    inp = CreateAiAgentInput(
+        name="My Agent",
+        repo_uuid="repo-123",
+        instruction="Purpose",
+        behaviors=[_make_behavior()],
+    )
     assert inp.name == "My Agent"
     assert inp.repo_uuid == "repo-123"
+    assert inp.instruction == "Purpose"
+    assert len(inp.behaviors) == 1
+    assert inp.data_source_ids == []
 
 
 @pytest.mark.unit
 @pytest.mark.parametrize("name", ["", "   ", "\n\t  "])
 def test_create_ai_agent_input_rejects_blank_name(name):
     with pytest.raises(ValidationError):
-        CreateAiAgentInput(name=name, repo_uuid="repo-123")
+        CreateAiAgentInput(
+            name=name,
+            repo_uuid="repo-123",
+            instruction="Purpose",
+            behaviors=[_make_behavior()],
+        )
 
 
 @pytest.mark.unit
 @pytest.mark.parametrize("repo_uuid", ["", "   "])
 def test_create_ai_agent_input_rejects_blank_repo_uuid(repo_uuid):
     with pytest.raises(ValidationError):
-        CreateAiAgentInput(name="My Agent", repo_uuid=repo_uuid)
+        CreateAiAgentInput(
+            name="My Agent",
+            repo_uuid=repo_uuid,
+            instruction="Purpose",
+            behaviors=[_make_behavior()],
+        )
 
 
 @pytest.mark.unit
 def test_create_ai_agent_input_strips_name():
-    inp = CreateAiAgentInput(name="  My Agent  ", repo_uuid="repo-123")
+    inp = CreateAiAgentInput(
+        name="  My Agent  ",
+        repo_uuid="repo-123",
+        instruction="Purpose",
+        behaviors=[_make_behavior()],
+    )
     assert inp.name == "My Agent"
 
 
 @pytest.mark.unit
+def test_create_ai_agent_input_rejects_blank_instruction():
+    with pytest.raises(ValidationError):
+        CreateAiAgentInput(
+            name="My Agent",
+            repo_uuid="repo-123",
+            instruction="   ",
+            behaviors=[_make_behavior()],
+        )
+
+
+@pytest.mark.unit
+def test_create_ai_agent_input_rejects_empty_behaviors():
+    with pytest.raises(ValidationError):
+        CreateAiAgentInput(
+            name="My Agent",
+            repo_uuid="repo-123",
+            instruction="Purpose",
+            behaviors=[],
+        )
+
+
+@pytest.mark.unit
+def test_create_ai_agent_input_rejects_more_than_five_behaviors():
+    behaviors = [_make_behavior(name=f"Behavior {i}") for i in range(MAX_BEHAVIORS + 1)]
+    with pytest.raises(ValidationError):
+        CreateAiAgentInput(
+            name="My Agent",
+            repo_uuid="repo-123",
+            instruction="Purpose",
+            behaviors=behaviors,
+        )
+
+
+@pytest.mark.unit
+def test_create_ai_agent_input_accepts_data_source_ids():
+    inp = CreateAiAgentInput(
+        name="My Agent",
+        repo_uuid="repo-123",
+        instruction="Purpose",
+        behaviors=[_make_behavior()],
+        data_source_ids=["ds-1", "ds-2"],
+    )
+    assert inp.data_source_ids == ["ds-1", "ds-2"]
+
+
+@pytest.mark.unit
 def test_behavior_input_requires_name_and_event_id():
-    inp = BehaviorInput(name="Test Behavior", event_id="card_created")
+    inp = BehaviorInput.model_validate(minimal_behavior_dict())
     assert inp.name == "Test Behavior"
     assert inp.event_id == "card_created"
     assert inp.action_id == ACTION_ID_AI_BEHAVIOR
@@ -55,29 +126,35 @@ def test_behavior_input_requires_name_and_event_id():
 @pytest.mark.unit
 @pytest.mark.parametrize("name", ["", "   ", "\n\t  "])
 def test_behavior_input_rejects_blank_name(name):
+    payload = minimal_behavior_dict()
+    payload["name"] = name
     with pytest.raises(ValidationError):
-        BehaviorInput(name=name, event_id="card_created")
+        BehaviorInput.model_validate(payload)
 
 
 @pytest.mark.unit
-def test_behavior_input_optional_fields():
-    inp = BehaviorInput(name="Test", event_id="card_created")
-    assert inp.condition is None
-    assert inp.action_params is None
+def test_behavior_input_rejects_missing_action_params():
+    with pytest.raises(ValidationError, match="actionParams"):
+        BehaviorInput(name="Test", event_id="card_created")
+
+
+@pytest.mark.unit
+def test_behavior_input_rejects_empty_actions_attributes():
+    payload = minimal_behavior_dict()
+    payload["actionParams"]["aiBehaviorParams"]["actionsAttributes"] = []
+    with pytest.raises(ValidationError, match="at least one action"):
+        BehaviorInput.model_validate(payload)
 
 
 @pytest.mark.unit
 def test_behavior_input_accepts_condition_and_action_params():
     condition = {"expressions": []}
-    action_params = {"key": "value"}
-    inp = BehaviorInput(
-        name="Test",
-        event_id="card_created",
-        condition=condition,
-        action_params=action_params,
-    )
+    payload = minimal_behavior_dict()
+    payload["condition"] = condition
+    inp = BehaviorInput.model_validate(payload)
     assert inp.condition == condition
-    assert inp.action_params == action_params
+    assert inp.action_params is not None
+    assert "aiBehaviorParams" in inp.action_params
 
 
 @pytest.mark.unit

--- a/tests/services/test_ai_agent_service.py
+++ b/tests/services/test_ai_agent_service.py
@@ -8,6 +8,8 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from gql.transport.exceptions import TransportQueryError
 
+from tests.ai_agent_test_payloads import minimal_behavior_dict
+
 from pipefy_mcp.models.ai_agent import CreateAiAgentInput, UpdateAiAgentInput
 from pipefy_mcp.services.pipefy.ai_agent_service import (
     AiAgentService,
@@ -235,7 +237,12 @@ async def test_create_agent_calls_execute_query_with_correct_variables():
     service = _create_mock_service(
         {"createAiAgent": {"agent": {"uuid": "new-uuid-123"}}}
     )
-    inp = CreateAiAgentInput(name="My Agent", repo_uuid="repo-456")
+    inp = CreateAiAgentInput(
+        name="My Agent",
+        repo_uuid="repo-456",
+        instruction="Purpose",
+        behaviors=[minimal_behavior_dict(name="B")],
+    )
 
     result = await service.create_agent(inp)
 
@@ -255,7 +262,12 @@ async def test_create_agent_calls_execute_query_with_correct_variables():
 async def test_create_agent_returns_success_format():
     """create_agent returns agent_uuid and message in success format."""
     service = _create_mock_service({"createAiAgent": {"agent": {"uuid": "xyz-789"}}})
-    inp = CreateAiAgentInput(name="Test", repo_uuid="repo-1")
+    inp = CreateAiAgentInput(
+        name="Test",
+        repo_uuid="repo-1",
+        instruction="Purpose",
+        behaviors=[minimal_behavior_dict(name="B")],
+    )
 
     result = await service.create_agent(inp)
 
@@ -276,7 +288,7 @@ async def test_update_agent_calls_execute_query_with_correct_variables():
         repo_uuid="repo-456",
         instruction="Do things",
         data_source_ids=["ds1"],
-        behaviors=[{"name": "B1", "event_id": "card_created"}],
+        behaviors=[minimal_behavior_dict(name="B1")],
     )
 
     result = await service.update_agent(inp)
@@ -304,7 +316,7 @@ async def test_update_agent_calls_inject_reference_ids():
         uuid="agent-uuid",
         name="Agent",
         repo_uuid="repo-1",
-        behaviors=[{"name": "B1", "event_id": "card_created"}],
+        behaviors=[minimal_behavior_dict(name="B1")],
     )
 
     with patch(
@@ -321,7 +333,12 @@ async def test_create_agent_propagates_execute_query_error():
     """create_agent propagates errors when execute_query raises."""
     service = _create_mock_service()
     service.execute_query = AsyncMock(side_effect=ValueError("GraphQL error"))
-    inp = CreateAiAgentInput(name="Test", repo_uuid="repo-1")
+    inp = CreateAiAgentInput(
+        name="Test",
+        repo_uuid="repo-1",
+        instruction="Purpose",
+        behaviors=[minimal_behavior_dict(name="B")],
+    )
 
     with pytest.raises(ValueError, match="GraphQL error"):
         await service.create_agent(inp)
@@ -337,7 +354,7 @@ async def test_update_agent_propagates_execute_query_error():
         uuid="agent-uuid",
         name="Agent",
         repo_uuid="repo-1",
-        behaviors=[{"name": "B1", "event_id": "card_created"}],
+        behaviors=[minimal_behavior_dict(name="B1")],
     )
 
     with pytest.raises(RuntimeError, match="Network error"):
@@ -349,7 +366,12 @@ async def test_update_agent_propagates_execute_query_error():
 async def test_create_agent_missing_uuid_returns_clear_error():
     """create_agent returns clear error when API response missing agent.uuid."""
     service = _create_mock_service({"createAiAgent": {}})
-    inp = CreateAiAgentInput(name="Test", repo_uuid="repo-1")
+    inp = CreateAiAgentInput(
+        name="Test",
+        repo_uuid="repo-1",
+        instruction="Purpose",
+        behaviors=[minimal_behavior_dict(name="B")],
+    )
 
     with pytest.raises(ValueError, match="agent.*uuid|unexpected.*payload"):
         await service.create_agent(inp)
@@ -364,7 +386,7 @@ async def test_update_agent_missing_uuid_returns_clear_error():
         uuid="agent-uuid",
         name="Agent",
         repo_uuid="repo-1",
-        behaviors=[{"name": "B1", "event_id": "card_created"}],
+        behaviors=[minimal_behavior_dict(name="B1")],
     )
 
     with pytest.raises(ValueError, match="agent.*uuid|unexpected.*payload"):

--- a/tests/services/test_pipefy_facade.py
+++ b/tests/services/test_pipefy_facade.py
@@ -554,6 +554,7 @@ async def test_pipefy_client_ai_agent_write_methods_delegate_to_ai_agent_service
         CreateAiAgentInput,
         UpdateAiAgentInput,
     )
+    from tests.ai_agent_test_payloads import minimal_behavior_dict
 
     ai_agent_service = AsyncMock()
     ai_agent_service.create_agent = AsyncMock(
@@ -572,6 +573,10 @@ async def test_pipefy_client_ai_agent_write_methods_delegate_to_ai_agent_service
     cin = CreateAiAgentInput(
         name="n",
         repo_uuid="00000000-0000-0000-0000-000000000001",
+        instruction="purpose",
+        behaviors=[
+            BehaviorInput.model_validate(minimal_behavior_dict(name="b", event_id="evt"))
+        ],
     )
     assert await client.create_ai_agent(cin) == {
         "agent_uuid": "new-1",
@@ -583,7 +588,9 @@ async def test_pipefy_client_ai_agent_write_methods_delegate_to_ai_agent_service
         uuid="00000000-0000-0000-0000-000000000002",
         name="n",
         repo_uuid="00000000-0000-0000-0000-000000000001",
-        behaviors=[BehaviorInput(name="b", event_id="evt")],
+        behaviors=[
+            BehaviorInput.model_validate(minimal_behavior_dict(name="b", event_id="evt"))
+        ],
     )
     assert await client.update_ai_agent(uin) == {
         "agent_uuid": "new-1",

--- a/tests/tools/test_ai_agent_tools.py
+++ b/tests/tools/test_ai_agent_tools.py
@@ -10,7 +10,9 @@ from mcp.shared.memory import (
     create_connected_server_and_client_session as create_client_session,
 )
 
+from pipefy_mcp.models.ai_agent import UpdateAiAgentInput
 from pipefy_mcp.tools.ai_agent_tools import AiAgentTools
+from tests.ai_agent_test_payloads import minimal_behavior_dict
 
 
 @pytest.fixture
@@ -48,7 +50,7 @@ def client_session(mcp_server):
 
 @pytest.mark.anyio
 class TestCreateAiAgent:
-    async def test_success(
+    async def test_data_source_ids_defaults_to_empty_list(
         self,
         client_session,
         mock_pipefy_client,
@@ -56,22 +58,28 @@ class TestCreateAiAgent:
     ):
         mock_pipefy_client.create_ai_agent.return_value = {
             "agent_uuid": "abc-123",
-            "message": "AI Agent created successfully. UUID: abc-123",
+            "message": "created",
+        }
+        mock_pipefy_client.update_ai_agent.return_value = {
+            "agent_uuid": "abc-123",
+            "message": "updated",
         }
         async with client_session as session:
             result = await session.call_tool(
                 "create_ai_agent",
-                {"name": "My Agent", "repo_uuid": "repo-456"},
+                {
+                    "name": "My Agent",
+                    "repo_uuid": "repo-456",
+                    "instruction": "Do the thing",
+                    "behaviors": [minimal_behavior_dict(name="B1")],
+                },
             )
         assert result.isError is False
         payload = extract_payload(result)
-        assert payload == {
-            "success": True,
-            "agent_uuid": "abc-123",
-            "message": "AI Agent created successfully. UUID: abc-123",
-        }
-        assert isinstance(payload["message"], str)
-        assert isinstance(payload["agent_uuid"], str)
+        assert payload["success"] is True
+        update_arg = mock_pipefy_client.update_ai_agent.call_args[0][0]
+        assert isinstance(update_arg, UpdateAiAgentInput)
+        assert update_arg.data_source_ids == []
 
     async def test_service_error_returns_error_payload(
         self,
@@ -83,13 +91,20 @@ class TestCreateAiAgent:
         async with client_session as session:
             result = await session.call_tool(
                 "create_ai_agent",
-                {"name": "My Agent", "repo_uuid": "repo-456"},
+                {
+                    "name": "My Agent",
+                    "repo_uuid": "repo-456",
+                    "instruction": "Purpose",
+                    "behaviors": [minimal_behavior_dict(name="B1")],
+                },
             )
         assert result.isError is False
         payload = extract_payload(result)
         assert payload["success"] is False
         assert "error" in payload
         assert isinstance(payload["error"], str)
+        assert "GraphQL error" in payload["error"]
+        mock_pipefy_client.update_ai_agent.assert_not_called()
 
     async def test_validation_error_returns_error_payload(
         self,
@@ -100,10 +115,159 @@ class TestCreateAiAgent:
         async with client_session as session:
             result = await session.call_tool(
                 "create_ai_agent",
-                {"name": "", "repo_uuid": "repo-456"},
+                {
+                    "name": "",
+                    "repo_uuid": "repo-456",
+                    "instruction": "Purpose",
+                    "behaviors": [minimal_behavior_dict(name="B1")],
+                },
             )
         assert result.isError is False
         mock_pipefy_client.create_ai_agent.assert_not_called()
+        mock_pipefy_client.update_ai_agent.assert_not_called()
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "error" in payload
+
+    async def test_create_and_configure_success(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.create_ai_agent.return_value = {
+            "agent_uuid": "new-uuid",
+            "message": "created",
+        }
+        mock_pipefy_client.update_ai_agent.return_value = {
+            "agent_uuid": "new-uuid",
+            "message": "updated",
+        }
+        behaviors = [minimal_behavior_dict(name="B1")]
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_ai_agent",
+                {
+                    "name": "Configured Agent",
+                    "repo_uuid": "repo-789",
+                    "instruction": "Tell users about the pipe",
+                    "behaviors": behaviors,
+                    "data_source_ids": ["ds-1", "ds-2"],
+                },
+            )
+        assert result.isError is False
+        mock_pipefy_client.create_ai_agent.assert_awaited_once()
+        mock_pipefy_client.update_ai_agent.assert_awaited_once()
+        update_arg = mock_pipefy_client.update_ai_agent.call_args[0][0]
+        assert isinstance(update_arg, UpdateAiAgentInput)
+        assert update_arg.uuid == "new-uuid"
+        assert update_arg.name == "Configured Agent"
+        assert update_arg.repo_uuid == "repo-789"
+        assert update_arg.instruction == "Tell users about the pipe"
+        assert len(update_arg.behaviors) == 1
+        assert update_arg.behaviors[0].name == "B1"
+        assert update_arg.behaviors[0].event_id == "card_created"
+        assert update_arg.data_source_ids == ["ds-1", "ds-2"]
+        payload = extract_payload(result)
+        assert payload["success"] is True
+        assert payload["agent_uuid"] == "new-uuid"
+
+    async def test_partial_failure_returns_uuid_and_error(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.create_ai_agent.return_value = {
+            "agent_uuid": "created-uuid",
+            "message": "AI Agent created successfully. UUID: created-uuid",
+        }
+        mock_pipefy_client.update_ai_agent.side_effect = ValueError("update failed")
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_ai_agent",
+                {
+                    "name": "My Agent",
+                    "repo_uuid": "repo-456",
+                    "instruction": "Purpose",
+                    "behaviors": [minimal_behavior_dict(name="B1")],
+                },
+            )
+        assert result.isError is False
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert payload["agent_uuid"] == "created-uuid"
+        assert "error" in payload
+        assert "update failed" in payload["error"]
+
+    async def test_graphql_error_extracts_messages(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.create_ai_agent.side_effect = TransportQueryError(
+            "failed", errors=[{"message": "permission denied"}]
+        )
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_ai_agent",
+                {
+                    "name": "My Agent",
+                    "repo_uuid": "repo-456",
+                    "instruction": "Purpose",
+                    "behaviors": [minimal_behavior_dict(name="B1")],
+                },
+            )
+        assert result.isError is False
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "permission denied" in payload["error"]
+        mock_pipefy_client.update_ai_agent.assert_not_called()
+
+    async def test_empty_behaviors_returns_validation_error(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_ai_agent",
+                {
+                    "name": "My Agent",
+                    "repo_uuid": "repo-456",
+                    "instruction": "Purpose",
+                    "behaviors": [],
+                },
+            )
+        assert result.isError is False
+        mock_pipefy_client.create_ai_agent.assert_not_called()
+        mock_pipefy_client.update_ai_agent.assert_not_called()
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "error" in payload
+
+    async def test_six_behaviors_returns_validation_error(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        six = [minimal_behavior_dict(name=f"B{i}") for i in range(6)]
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_ai_agent",
+                {
+                    "name": "My Agent",
+                    "repo_uuid": "repo-456",
+                    "instruction": "Purpose",
+                    "behaviors": six,
+                },
+            )
+        assert result.isError is False
+        mock_pipefy_client.create_ai_agent.assert_not_called()
+        mock_pipefy_client.update_ai_agent.assert_not_called()
         payload = extract_payload(result)
         assert payload["success"] is False
         assert "error" in payload
@@ -129,7 +293,7 @@ class TestUpdateAiAgent:
                     "name": "Updated Agent",
                     "repo_uuid": "repo-456",
                     "instruction": "Do things",
-                    "behaviors": [{"name": "B1", "event_id": "card_created"}],
+                    "behaviors": [minimal_behavior_dict(name="B1")],
                 },
             )
         assert result.isError is False
@@ -180,7 +344,7 @@ class TestUpdateAiAgent:
                     "repo_uuid": "repo-456",
                     "instruction": "Do things",
                     "behaviors": [
-                        {"name": f"B{i}", "event_id": "card_created"} for i in range(6)
+                        minimal_behavior_dict(name=f"B{i}") for i in range(6)
                     ],
                 },
             )
@@ -205,7 +369,7 @@ class TestUpdateAiAgent:
                     "name": "Updated Agent",
                     "repo_uuid": "repo-456",
                     "instruction": "Do things",
-                    "behaviors": [{"name": "B1", "event_id": "card_created"}],
+                    "behaviors": [minimal_behavior_dict(name="B1")],
                 },
             )
         assert result.isError is False


### PR DESCRIPTION
## Summary

- **`create_ai_agent` is now a single-call create-and-configure operation**: requires `instruction` (agent-level purpose, maps to Pipefy UI "Description") and 1–5 `behaviors` upfront, orchestrating `createAiAgent` → `updateAiAgent` internally.
- **`BehaviorInput` model validator** ensures each behavior includes `actionParams.aiBehaviorParams.actionsAttributes` with at least one action, catching invalid payloads before they hit the API.
- **Partial-failure handling**: if create succeeds but update fails, the response includes the agent UUID for recovery (via `update_ai_agent` or `delete_ai_agent`).
- **Consistent error extraction**: all error paths now use `extract_error_strings` for clean GraphQL error messages.
- **LLM-facing docs**: behavior dict shape, discovery workflow, and known `actionType` values added to tool docstrings and `docs/tools/automations-and-ai.md`.

## Test plan

- [x] 96 unit tests pass for AI agent models, services, tools, and facade
- [x] Full non-integration suite: 796 passed
- [x] `ruff check` and `ruff format` clean
- [ ] Manual Cursor MCP smoke test of `create_ai_agent` with real pipe (integration)