### PR TITLE
docs(ai-agent): update_card actionType and test payload

### DIFF
--- a/docs/tools/automations-and-ai.md
+++ b/docs/tools/automations-and-ai.md
@@ -71,7 +71,7 @@ AI automations are separate from traditional rules above. They are prompt-driven
 | `actionType` | Required `metadata` |
 |---|---|
 | `move_card` | `{ "destinationPhaseId": "<phase_id>" }` |
-| `update_card_field` | `{ "fieldsAttributes": [{ "fieldId": "...", "value": "..." }] }` |
+| `update_card` | `{ "pipeId": "<pipe_id>", "fieldsAttributes": [{ "fieldId": "...", "inputMode": "fill_with_ai", "value": "" }] }` |
 | `create_card` | `{ "pipeId": "<pipe_id>", "fieldsAttributes": [...] }` |
 | `create_connected_card` | `{ "pipeId": "<pipe_id>", "fieldsAttributes": [...] }` |
 

--- a/src/pipefy_mcp/tools/ai_agent_tools.py
+++ b/src/pipefy_mcp/tools/ai_agent_tools.py
@@ -80,7 +80,7 @@ class AiAgentTools:
 
             Known ``actionType`` values and their required ``metadata``:
               - ``move_card`` → ``{"destinationPhaseId": "<phase_id>"}``
-              - ``update_card_field`` → ``{"fieldsAttributes": [{"fieldId": "...", "value": "..."}]}``
+              - ``update_card`` → ``{"pipeId": "<pipe_id>", "fieldsAttributes": [{"fieldId": "...", "inputMode": "fill_with_ai", "value": ""}]}``
               - ``create_card`` → ``{"pipeId": "<pipe_id>", "fieldsAttributes": [...]}``
               - ``create_connected_card`` → ``{"pipeId": "<pipe_id>", "fieldsAttributes": [...]}``
 

--- a/tests/ai_agent_test_payloads.py
+++ b/tests/ai_agent_test_payloads.py
@@ -2,7 +2,11 @@
 
 
 def minimal_behavior_dict(name="Test Behavior", event_id="card_created"):
-    """One behavior with actionParams.aiBehaviorParams.actionsAttributes (required by live API)."""
+    """One behavior with actionParams.aiBehaviorParams.actionsAttributes (required by live API).
+
+    Uses ``update_card`` with realistic metadata matching Pipefy's golden payload shape.
+    The API rejects empty ``metadata: {}`` — it must include at least the required keys.
+    """
     return {
         "name": name,
         "event_id": event_id,
@@ -11,9 +15,19 @@ def minimal_behavior_dict(name="Test Behavior", event_id="card_created"):
                 "instruction": "Test behavior instruction.",
                 "actionsAttributes": [
                     {
-                        "name": "Move card",
-                        "actionType": "move_card",
-                        "metadata": {},
+                        "name": "Update card fields",
+                        "actionType": "update_card",
+                        "metadata": {
+                            "destinationPhaseId": "",
+                            "pipeId": "306996636",
+                            "fieldsAttributes": [
+                                {
+                                    "fieldId": "425829426",
+                                    "inputMode": "fill_with_ai",
+                                    "value": "",
+                                },
+                            ],
+                        },
                     },
                 ],
             }

--- a/tests/models/test_ai_agent.py
+++ b/tests/models/test_ai_agent.py
@@ -3,8 +3,6 @@
 import pytest
 from pydantic import ValidationError
 
-from tests.ai_agent_test_payloads import minimal_behavior_dict
-
 from pipefy_mcp.models.ai_agent import (
     ACTION_ID_AI_BEHAVIOR,
     MAX_BEHAVIORS,
@@ -12,6 +10,7 @@ from pipefy_mcp.models.ai_agent import (
     CreateAiAgentInput,
     UpdateAiAgentInput,
 )
+from tests.ai_agent_test_payloads import minimal_behavior_dict
 
 
 def _make_behavior(name="Test Behavior", event_id="card_created"):

--- a/tests/services/test_ai_agent_service.py
+++ b/tests/services/test_ai_agent_service.py
@@ -8,8 +8,6 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from gql.transport.exceptions import TransportQueryError
 
-from tests.ai_agent_test_payloads import minimal_behavior_dict
-
 from pipefy_mcp.models.ai_agent import CreateAiAgentInput, UpdateAiAgentInput
 from pipefy_mcp.services.pipefy.ai_agent_service import (
     AiAgentService,
@@ -22,6 +20,7 @@ from pipefy_mcp.services.pipefy.queries.ai_agent_queries import (
     GET_AI_AGENTS_QUERY,
 )
 from pipefy_mcp.settings import PipefySettings
+from tests.ai_agent_test_payloads import minimal_behavior_dict
 
 UUID_PATTERN = re.compile(r"%\{action:([a-f0-9-]{36})\}")
 

--- a/tests/services/test_pipefy_facade.py
+++ b/tests/services/test_pipefy_facade.py
@@ -575,7 +575,9 @@ async def test_pipefy_client_ai_agent_write_methods_delegate_to_ai_agent_service
         repo_uuid="00000000-0000-0000-0000-000000000001",
         instruction="purpose",
         behaviors=[
-            BehaviorInput.model_validate(minimal_behavior_dict(name="b", event_id="evt"))
+            BehaviorInput.model_validate(
+                minimal_behavior_dict(name="b", event_id="evt")
+            )
         ],
     )
     assert await client.create_ai_agent(cin) == {
@@ -589,7 +591,9 @@ async def test_pipefy_client_ai_agent_write_methods_delegate_to_ai_agent_service
         name="n",
         repo_uuid="00000000-0000-0000-0000-000000000001",
         behaviors=[
-            BehaviorInput.model_validate(minimal_behavior_dict(name="b", event_id="evt"))
+            BehaviorInput.model_validate(
+                minimal_behavior_dict(name="b", event_id="evt")
+            )
         ],
     )
     assert await client.update_ai_agent(uin) == {


### PR DESCRIPTION
## Summary
Aligns AI agent / automation documentation and test fixtures with Pipefy's `update_card` action (replacing `update_card_field`) and a realistic `metadata` shape (`pipeId`, `fieldsAttributes` with `fill_with_ai`).

## Commits
- `docs(ai-agent): align update_card actionType and metadata examples`
- `test(ai-agent): use update_card metadata shape in minimal_behavior_dict`
- `style(tests): ruff import order and line wrap in ai agent tests`

## Testing
`uv run pytest tests/models/test_ai_agent.py tests/services/test_ai_agent_service.py tests/services/test_pipefy_facade.py -q` — 68 passed.