### PR TITLE
feat(ai-agent): eventParams on behaviors and deeper get/update query fields

### DIFF
--- a/docs/tools/automations-and-ai.md
+++ b/docs/tools/automations-and-ai.md
@@ -71,9 +71,16 @@ AI automations are separate from traditional rules above. They are prompt-driven
 | `actionType` | Required `metadata` |
 |---|---|
 | `move_card` | `{ "destinationPhaseId": "<phase_id>" }` |
-| `update_card_field` | `{ "fieldsAttributes": [{ "fieldId": "...", "value": "..." }] }` |
+| `update_card` | `{ "pipeId": "<pipe_id>", "fieldsAttributes": [{ "fieldId": "...", "inputMode": "fill_with_ai", "value": "" }] }` |
 | `create_card` | `{ "pipeId": "<pipe_id>", "fieldsAttributes": [...] }` |
 | `create_connected_card` | `{ "pipeId": "<pipe_id>", "fieldsAttributes": [...] }` |
+
+### Optional `eventParams` (trigger filters)
+
+| `event_id` | `eventParams` key | Purpose |
+|---|---|---|
+| `field_updated` | `triggerFieldIds` | Fire only when specific fields change |
+| `card_moved` | `to_phase_id` | Fire only when card moves to a specific phase |
 
 ### AI Agent read & delete
 

--- a/src/pipefy_mcp/models/ai_agent.py
+++ b/src/pipefy_mcp/models/ai_agent.py
@@ -26,6 +26,7 @@ class BehaviorInput(BaseModel):
     action_id: str = Field(default=ACTION_ID_AI_BEHAVIOR, alias="actionId")
     active: bool = True
     condition: dict | None = None
+    event_params: dict | None = Field(default=None, alias="eventParams")
     action_params: dict | None = Field(default=None, alias="actionParams")
 
     @model_validator(mode="after")

--- a/src/pipefy_mcp/services/pipefy/queries/ai_agent_queries.py
+++ b/src/pipefy_mcp/services/pipefy/queries/ai_agent_queries.py
@@ -20,6 +20,47 @@ GET_AI_AGENT_QUERY = gql(
                 name
                 active
                 eventId: event_id
+                eventParams: event_params {
+                    fromPhaseId
+                    inPhaseId
+                    to_phase_id
+                    triggerFieldIds
+                    triggerAutomationId
+                }
+                actionId: action_id
+                condition {
+                    expressions_structure
+                    expressions {
+                        id
+                        field_address
+                        operation
+                        value
+                        structure_id
+                    }
+                }
+                actionParams: action_params {
+                    aiBehaviorParams {
+                        instruction
+                        dataSourceIds
+                        referencedFieldIds
+                        actionsAttributes {
+                            id
+                            name
+                            actionType
+                            referenceId
+                            metadata {
+                                destinationPhaseId
+                                pipeId
+                                tableId
+                                fieldsAttributes {
+                                    fieldId
+                                    inputMode
+                                    value
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     }
@@ -95,6 +136,13 @@ UPDATE_AI_AGENT_MUTATION = gql(
                     name
                     active
                     eventId: event_id
+                    eventParams: event_params {
+                        fromPhaseId
+                        inPhaseId
+                        to_phase_id
+                        triggerFieldIds
+                        triggerAutomationId
+                    }
                     actionId: action_id
                     condition {
                         expressions_structure

--- a/src/pipefy_mcp/tools/ai_agent_tools.py
+++ b/src/pipefy_mcp/tools/ai_agent_tools.py
@@ -80,9 +80,13 @@ class AiAgentTools:
 
             Known ``actionType`` values and their required ``metadata``:
               - ``move_card`` → ``{"destinationPhaseId": "<phase_id>"}``
-              - ``update_card_field`` → ``{"fieldsAttributes": [{"fieldId": "...", "value": "..."}]}``
+              - ``update_card`` → ``{"pipeId": "<pipe_id>", "fieldsAttributes": [{"fieldId": "...", "inputMode": "fill_with_ai", "value": ""}]}``
               - ``create_card`` → ``{"pipeId": "<pipe_id>", "fieldsAttributes": [...]}``
               - ``create_connected_card`` → ``{"pipeId": "<pipe_id>", "fieldsAttributes": [...]}``
+
+            Optional ``eventParams`` per behavior (filters when the trigger fires):
+              - ``field_updated`` event → ``{"triggerFieldIds": ["<field_id>"]}`` to fire only on specific fields.
+              - ``card_moved`` event → ``{"to_phase_id": "<phase_id>"}`` to fire only when moving to a specific phase.
 
             Args:
                 name: Agent display name.
@@ -90,6 +94,7 @@ class AiAgentTools:
                 instruction: Agent-level purpose (Pipefy UI "Description"; API ``instruction``).
                 behaviors: 1–5 behavior dicts. Each requires ``name``, ``event_id``, and
                     ``actionParams.aiBehaviorParams`` with a non-empty ``actionsAttributes`` list.
+                    Optional: ``eventParams`` to filter event triggers (e.g. ``triggerFieldIds``, ``to_phase_id``).
                     See example above for the full shape.
                 data_source_ids: Optional knowledge-source IDs (same as ``update_ai_agent``).
             """

--- a/tests/ai_agent_test_payloads.py
+++ b/tests/ai_agent_test_payloads.py
@@ -2,7 +2,11 @@
 
 
 def minimal_behavior_dict(name="Test Behavior", event_id="card_created"):
-    """One behavior with actionParams.aiBehaviorParams.actionsAttributes (required by live API)."""
+    """One behavior with actionParams.aiBehaviorParams.actionsAttributes (required by live API).
+
+    Uses ``update_card`` with realistic metadata matching Pipefy's golden payload shape.
+    The API rejects empty ``metadata: {}`` — it must include at least the required keys.
+    """
     return {
         "name": name,
         "event_id": event_id,
@@ -11,9 +15,19 @@ def minimal_behavior_dict(name="Test Behavior", event_id="card_created"):
                 "instruction": "Test behavior instruction.",
                 "actionsAttributes": [
                     {
-                        "name": "Move card",
-                        "actionType": "move_card",
-                        "metadata": {},
+                        "name": "Update card fields",
+                        "actionType": "update_card",
+                        "metadata": {
+                            "destinationPhaseId": "",
+                            "pipeId": "306996636",
+                            "fieldsAttributes": [
+                                {
+                                    "fieldId": "425829426",
+                                    "inputMode": "fill_with_ai",
+                                    "value": "",
+                                },
+                            ],
+                        },
                     },
                 ],
             }

--- a/tests/models/test_ai_agent.py
+++ b/tests/models/test_ai_agent.py
@@ -3,8 +3,6 @@
 import pytest
 from pydantic import ValidationError
 
-from tests.ai_agent_test_payloads import minimal_behavior_dict
-
 from pipefy_mcp.models.ai_agent import (
     ACTION_ID_AI_BEHAVIOR,
     MAX_BEHAVIORS,
@@ -12,6 +10,7 @@ from pipefy_mcp.models.ai_agent import (
     CreateAiAgentInput,
     UpdateAiAgentInput,
 )
+from tests.ai_agent_test_payloads import minimal_behavior_dict
 
 
 def _make_behavior(name="Test Behavior", event_id="card_created"):
@@ -301,3 +300,38 @@ def test_update_ai_agent_input_accepts_instruction_and_data_source_ids():
     )
     assert inp.instruction == "Do something"
     assert inp.data_source_ids == ["ds1", "ds2"]
+
+
+@pytest.mark.unit
+def test_behavior_input_accepts_event_params_with_trigger_field_ids():
+    payload = minimal_behavior_dict(event_id="field_updated")
+    payload["eventParams"] = {"triggerFieldIds": ["425829426"]}
+    inp = BehaviorInput.model_validate(payload)
+    assert inp.event_params == {"triggerFieldIds": ["425829426"]}
+
+
+@pytest.mark.unit
+def test_behavior_input_accepts_event_params_with_to_phase_id():
+    payload = minimal_behavior_dict(event_id="card_moved")
+    payload["eventParams"] = {"to_phase_id": "12345678"}
+    inp = BehaviorInput.model_validate(payload)
+    assert inp.event_params == {"to_phase_id": "12345678"}
+
+
+@pytest.mark.unit
+def test_behavior_input_event_params_included_in_alias_dump():
+    payload = minimal_behavior_dict(event_id="field_updated")
+    payload["eventParams"] = {"triggerFieldIds": ["425829426"]}
+    inp = BehaviorInput.model_validate(payload)
+    dumped = inp.model_dump(by_alias=True, exclude_none=True)
+    assert dumped["eventParams"] == {"triggerFieldIds": ["425829426"]}
+    assert "event_params" not in dumped
+
+
+@pytest.mark.unit
+def test_behavior_input_event_params_defaults_none():
+    payload = minimal_behavior_dict()
+    inp = BehaviorInput.model_validate(payload)
+    assert inp.event_params is None
+    dumped = inp.model_dump(by_alias=True, exclude_none=True)
+    assert "eventParams" not in dumped

--- a/tests/services/test_ai_agent_service.py
+++ b/tests/services/test_ai_agent_service.py
@@ -8,8 +8,6 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from gql.transport.exceptions import TransportQueryError
 
-from tests.ai_agent_test_payloads import minimal_behavior_dict
-
 from pipefy_mcp.models.ai_agent import CreateAiAgentInput, UpdateAiAgentInput
 from pipefy_mcp.services.pipefy.ai_agent_service import (
     AiAgentService,
@@ -22,6 +20,7 @@ from pipefy_mcp.services.pipefy.queries.ai_agent_queries import (
     GET_AI_AGENTS_QUERY,
 )
 from pipefy_mcp.settings import PipefySettings
+from tests.ai_agent_test_payloads import minimal_behavior_dict
 
 UUID_PATTERN = re.compile(r"%\{action:([a-f0-9-]{36})\}")
 

--- a/tests/services/test_pipefy_facade.py
+++ b/tests/services/test_pipefy_facade.py
@@ -575,7 +575,9 @@ async def test_pipefy_client_ai_agent_write_methods_delegate_to_ai_agent_service
         repo_uuid="00000000-0000-0000-0000-000000000001",
         instruction="purpose",
         behaviors=[
-            BehaviorInput.model_validate(minimal_behavior_dict(name="b", event_id="evt"))
+            BehaviorInput.model_validate(
+                minimal_behavior_dict(name="b", event_id="evt")
+            )
         ],
     )
     assert await client.create_ai_agent(cin) == {
@@ -589,7 +591,9 @@ async def test_pipefy_client_ai_agent_write_methods_delegate_to_ai_agent_service
         name="n",
         repo_uuid="00000000-0000-0000-0000-000000000001",
         behaviors=[
-            BehaviorInput.model_validate(minimal_behavior_dict(name="b", event_id="evt"))
+            BehaviorInput.model_validate(
+                minimal_behavior_dict(name="b", event_id="evt")
+            )
         ],
     )
     assert await client.update_ai_agent(uin) == {


### PR DESCRIPTION
## Summary
- `BehaviorInput` accepts optional `eventParams` (e.g. `triggerFieldIds`, `to_phase_id`) for trigger filters.
- `GET_AI_AGENT_QUERY` and `UPDATE_AI_AGENT_MUTATION` return expanded behavior shapes (`event_params`, condition, `action_params` with actions/metadata).
- Docs and `create_ai_agent` tool text: `update_card` metadata shape and optional `eventParams` table.
- Tests: model coverage, `minimal_behavior_dict` aligned with `update_card`; ruff cleanup in related tests.

## Commits
1. `feat(models): add optional eventParams to BehaviorInput`
2. `feat(queries): expand get/update AI agent behavior selection sets`
3. `docs(ai-agent): document update_card metadata and optional eventParams`
4. `test(ai-agent): eventParams model coverage and update_card test payload`
5. `style(tests): ruff import order and line wrap in ai agent tests`

## Testing
`uv run ruff check src/ tests/` — OK  
`uv run pytest tests/models/test_ai_agent.py tests/services/test_ai_agent_service.py tests/services/test_pipefy_facade.py tests/tools/test_ai_agent_tools.py -q` — 100 passed