### PR TITLE
feat(tools): destructive confirmation guard for MCP deletes

### DIFF
--- a/src/pipefy_mcp/tools/ai_agent_tools.py
+++ b/src/pipefy_mcp/tools/ai_agent_tools.py
@@ -18,6 +18,7 @@ from pipefy_mcp.tools.ai_tool_helpers import (
     build_toggle_agent_status_success,
     build_update_agent_success,
 )
+from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.graphql_error_helpers import extract_error_strings
 
 
@@ -266,16 +267,32 @@ class AiAgentTools:
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
         )
-        async def delete_ai_agent(ctx: Context, uuid: str) -> dict:
-            """Delete an AI Agent permanently. This action is irreversible. Always confirm with the user before executing.
+        async def delete_ai_agent(
+            ctx: Context, uuid: str, confirm: bool = False
+        ) -> dict:
+            """Delete an AI Agent permanently. This action is irreversible.
+
+            Two-step operation: call without ``confirm`` to preview, then with
+            ``confirm=True`` after user approval. When the MCP client supports
+            elicitation, the user is prompted interactively instead.
 
             Args:
                 uuid: Agent UUID.
+                confirm: Set to True to execute the deletion (step 2).
             """
             agent_uuid = uuid.strip()
             ctx.debug(f"delete_ai_agent: uuid={agent_uuid}")
             if not agent_uuid:
                 return build_ai_tool_error("uuid must not be blank")
+
+            guard = await check_destructive_confirmation(
+                ctx,
+                confirm=confirm,
+                resource_descriptor=f"AI agent (UUID: {agent_uuid})",
+            )
+            if guard is not None:
+                return guard
+
             try:
                 result = await client.delete_ai_agent(agent_uuid)
             except Exception as exc:  # noqa: BLE001

--- a/src/pipefy_mcp/tools/automation_tools.py
+++ b/src/pipefy_mcp/tools/automation_tools.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.session import ServerSession
 from mcp.types import ToolAnnotations
 
 from pipefy_mcp.services.pipefy import PipefyClient
@@ -14,6 +15,7 @@ from pipefy_mcp.tools.automation_tool_helpers import (
     build_automation_read_success_payload,
     handle_automation_tool_graphql_error,
 )
+from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.validation_helpers import (
     mutation_error_if_not_optional_dict,
     valid_repo_id,
@@ -305,14 +307,20 @@ class AutomationTools:
             annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
         )
         async def delete_automation(
-            ctx: Context,
+            ctx: Context[ServerSession, None],
             automation_id: str | int,
+            confirm: bool = False,
             debug: bool = False,
         ) -> dict[str, Any]:
-            """Delete an automation rule. This action is irreversible. Always confirm with the user before executing.
+            """Delete an automation rule permanently.
+
+            Two-step operation: call without ``confirm`` to preview, then with
+            ``confirm=True`` after user approval. When the MCP client supports
+            elicitation, the user is prompted interactively instead.
 
             Args:
                 automation_id: Automation rule ID to delete.
+                confirm: Set to True to execute the deletion (step 2).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             rid = _normalize_required_id(automation_id)
@@ -323,6 +331,15 @@ class AutomationTools:
                         "positive integer."
                     ),
                 )
+
+            guard = await check_destructive_confirmation(
+                ctx,
+                confirm=confirm,
+                resource_descriptor=f"automation (ID: {automation_id})",
+            )
+            if guard is not None:
+                return guard
+
             try:
                 raw = await client.delete_automation(rid)
             except Exception as exc:

--- a/src/pipefy_mcp/tools/destructive_tool_guard.py
+++ b/src/pipefy_mcp/tools/destructive_tool_guard.py
@@ -1,0 +1,152 @@
+"""Reusable confirmation guard for destructive MCP tools.
+
+Every tool with ``destructiveHint=True`` should call
+:func:`check_destructive_confirmation` **before** executing the deletion.
+The guard handles three scenarios:
+
+* **Elicitation available** → prompts the user interactively.
+* **No elicitation, ``confirm=False``** → returns a preview payload (no deletion).
+* **``confirm=True``** → returns ``None`` so the caller proceeds.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from mcp.server.fastmcp import Context
+from mcp.server.session import ServerSession
+from pydantic import BaseModel, Field
+from typing_extensions import TypedDict
+
+# ---------------------------------------------------------------------------
+# Pydantic model for interactive elicitation
+# ---------------------------------------------------------------------------
+
+
+class DestructiveActionConfirmation(BaseModel):
+    """Schema shown to the user when the MCP client supports elicitation."""
+
+    confirm: bool = Field(
+        ...,
+        description="Set to true to confirm the action, or false to cancel.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Generic payload types
+# ---------------------------------------------------------------------------
+
+
+class DestructivePreviewPayload(TypedDict):
+    """Returned when the tool needs confirmation and elicitation is not available."""
+
+    success: Literal[False]
+    requires_confirmation: Literal[True]
+    resource: str
+    message: str
+
+
+class DestructiveCancelledPayload(TypedDict):
+    success: Literal[False]
+    error: str
+
+
+# ---------------------------------------------------------------------------
+# Guard function
+# ---------------------------------------------------------------------------
+
+_CANCEL_MESSAGE = "Action cancelled by user."
+
+
+async def check_destructive_confirmation(
+    ctx: Context[ServerSession, None],
+    *,
+    confirm: bool,
+    resource_descriptor: str,
+) -> dict[str, Any] | None:
+    """Gate a destructive operation behind user confirmation.
+
+    Call this **after** fetching resource info but **before** executing the
+    deletion.  The function handles elicitation (when supported) and the
+    two-step ``confirm`` fallback.
+
+    Args:
+        ctx: MCP request context (used to check elicitation support and prompt
+            the user).
+        confirm: Explicit confirmation flag from the tool caller.
+        resource_descriptor: Human-readable description of the resource about
+            to be deleted (e.g. ``"phase 'Initial' (ID: 42)"``).  Used in
+            preview payloads and elicitation prompts.
+
+    Returns:
+        ``None`` when the caller should proceed with the deletion.
+        A ``dict`` payload when the operation was cancelled or needs
+        confirmation — the caller should return this payload as-is.
+    """
+    can_elicit = ctx.session.client_params.capabilities.elicitation
+
+    if not can_elicit and not confirm:
+        return _build_preview_payload(resource_descriptor)
+
+    if can_elicit:
+        return await _elicit_confirmation(ctx, resource_descriptor)
+
+    # confirm=True and no elicitation → proceed
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_preview_payload(resource_descriptor: str) -> DestructivePreviewPayload:
+    return {
+        "success": False,
+        "requires_confirmation": True,
+        "resource": resource_descriptor,
+        "message": (
+            f"⚠️ You are about to permanently delete {resource_descriptor}. "
+            "This action is irreversible. Set 'confirm=True' to proceed."
+        ),
+    }
+
+
+async def _elicit_confirmation(
+    ctx: Context[ServerSession, None],
+    resource_descriptor: str,
+) -> dict[str, Any] | None:
+    """Prompt the user via MCP elicitation. Returns ``None`` to proceed."""
+    confirmation_message = (
+        f"⚠️ You are about to permanently delete {resource_descriptor}. "
+        "This action is irreversible. Are you sure you want to proceed?"
+    )
+
+    try:
+        result = await ctx.elicit(
+            message=confirmation_message,
+            schema=DestructiveActionConfirmation,
+        )
+
+        if result.action != "accept":
+            return _build_cancel_payload()
+
+        if not result.data.model_dump().get("confirm"):
+            return _build_cancel_payload()
+
+    except Exception as e:
+        return {"success": False, "error": f"Failed to request confirmation: {e!s}"}
+
+    return None
+
+
+def _build_cancel_payload() -> DestructiveCancelledPayload:
+    return {"success": False, "error": _CANCEL_MESSAGE}
+
+
+__all__ = [
+    "DestructiveActionConfirmation",
+    "DestructiveCancelledPayload",
+    "DestructivePreviewPayload",
+    "check_destructive_confirmation",
+]

--- a/src/pipefy_mcp/tools/field_condition_tools.py
+++ b/src/pipefy_mcp/tools/field_condition_tools.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 from typing import Any
 
 from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.session import ServerSession
 from mcp.types import ToolAnnotations
 
 from pipefy_mcp.services.pipefy import PipefyClient
+from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.pipe_config_tool_helpers import (
     build_field_condition_delete_payload,
     build_field_condition_success_payload,
@@ -225,17 +227,21 @@ class FieldConditionTools:
             ),
         )
         async def delete_field_condition(
-            ctx: Context,
+            ctx: Context[ServerSession, None],
             condition_id: str | int,
+            confirm: bool = False,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Delete a field condition permanently.
 
-            This action is irreversible. Always confirm with the user before executing.
+            Two-step operation: call without ``confirm`` to preview, then with
+            ``confirm=True`` after user approval. When the MCP client supports
+            elicitation, the user is prompted interactively instead.
 
             Args:
                 ctx: MCP context for debug logging.
                 condition_id: Field condition ID to delete.
+                confirm: Set to True to execute the deletion (step 2).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             await ctx.debug(
@@ -247,6 +253,15 @@ class FieldConditionTools:
                         "Invalid 'condition_id'. Use a non-empty string or a positive integer."
                     ),
                 )
+
+            guard = await check_destructive_confirmation(
+                ctx,
+                confirm=confirm,
+                resource_descriptor=f"field condition (ID: {condition_id})",
+            )
+            if guard is not None:
+                return guard
+
             cid_key = (
                 condition_id.strip()
                 if isinstance(condition_id, str)

--- a/src/pipefy_mcp/tools/member_tools.py
+++ b/src/pipefy_mcp/tools/member_tools.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.session import ServerSession
 from mcp.types import ToolAnnotations
 
 from pipefy_mcp.services.pipefy import PipefyClient
+from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.member_tool_helpers import (
     build_member_error_payload,
     build_member_success_payload,
@@ -73,17 +75,22 @@ class MemberTools:
             ),
         )
         async def remove_member_from_pipe(
+            ctx: Context[ServerSession, None],
             pipe_id: str,
             user_ids: list[str],
+            confirm: bool = False,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Permanently remove one or more users from a pipe.
 
-            Always confirm with the user before calling — removal cannot be undone.
+            Two-step operation: call without ``confirm`` to preview, then with
+            ``confirm=True`` after user approval. When the MCP client supports
+            elicitation, the user is prompted interactively instead.
 
             Args:
                 pipe_id: ID of the pipe.
                 user_ids: List of user IDs to remove.
+                confirm: Set to True to execute the removal (step 2).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             if not valid_repo_id(pipe_id):
@@ -98,6 +105,15 @@ class MemberTools:
                 return build_member_error_payload(
                     message="Invalid 'user_ids': each ID must be a non-empty string.",
                 )
+
+            guard = await check_destructive_confirmation(
+                ctx,
+                confirm=confirm,
+                resource_descriptor=f"{len(user_ids)} member(s) from pipe {pipe_id}",
+            )
+            if guard is not None:
+                return guard
+
             try:
                 raw = await client.remove_members_from_pipe(pipe_id, user_ids)
             except ValueError as exc:

--- a/src/pipefy_mcp/tools/pipe_config_tools.py
+++ b/src/pipefy_mcp/tools/pipe_config_tools.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.session import ServerSession
 from mcp.types import ToolAnnotations
 
 from pipefy_mcp.services.pipefy import PipefyClient
+from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.graphql_error_helpers import (
     extract_graphql_correlation_id,
     extract_graphql_error_codes,
@@ -391,19 +393,36 @@ class PipeConfigTools:
                 destructiveHint=True,
             ),
         )
-        async def delete_phase(phase_id: int, debug: bool = False) -> dict[str, Any]:
+        async def delete_phase(
+            ctx: Context[ServerSession, None],
+            phase_id: int,
+            confirm: bool = False,
+            debug: bool = False,
+        ) -> dict[str, Any]:
             """Delete a phase permanently.
 
-            Always confirm impact with the human user before calling this tool.
+            Two-step operation: call without ``confirm`` to preview, then with
+            ``confirm=True`` after user approval. When the MCP client supports
+            elicitation, the user is prompted interactively instead.
 
             Args:
                 phase_id: Phase ID to delete.
+                confirm: Set to True to execute the deletion (step 2).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             if not isinstance(phase_id, int) or phase_id <= 0:
                 return build_pipe_tool_error_payload(
                     message="Invalid 'phase_id'. Use a positive integer.",
                 )
+
+            guard = await check_destructive_confirmation(
+                ctx,
+                confirm=confirm,
+                resource_descriptor=f"phase (ID: {phase_id})",
+            )
+            if guard is not None:
+                return guard
+
             try:
                 raw = await client.delete_phase(phase_id)
             except Exception as exc:
@@ -550,15 +569,20 @@ class PipeConfigTools:
             ),
         )
         async def delete_phase_field(
+            ctx: Context[ServerSession, None],
             field_id: str | int,
+            confirm: bool = False,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Delete a phase field permanently.
 
-            Always confirm impact with the human user before calling this tool.
+            Two-step operation: call without ``confirm`` to preview, then with
+            ``confirm=True`` after user approval. When the MCP client supports
+            elicitation, the user is prompted interactively instead.
 
             Args:
                 field_id: Phase field ID to delete (slug string or positive integer).
+                confirm: Set to True to execute the deletion (step 2).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             if not valid_phase_field_id(field_id):
@@ -569,6 +593,15 @@ class PipeConfigTools:
                     ),
                 )
             fid = field_id.strip() if isinstance(field_id, str) else field_id
+
+            guard = await check_destructive_confirmation(
+                ctx,
+                confirm=confirm,
+                resource_descriptor=f"phase field (ID: {fid})",
+            )
+            if guard is not None:
+                return guard
+
             try:
                 raw = await client.delete_phase_field(fid)
             except Exception as exc:
@@ -681,19 +714,36 @@ class PipeConfigTools:
                 destructiveHint=True,
             ),
         )
-        async def delete_label(label_id: int, debug: bool = False) -> dict[str, Any]:
+        async def delete_label(
+            ctx: Context[ServerSession, None],
+            label_id: int,
+            confirm: bool = False,
+            debug: bool = False,
+        ) -> dict[str, Any]:
             """Delete a label permanently.
 
-            Always confirm impact with the human user before calling this tool.
+            Two-step operation: call without ``confirm`` to preview, then with
+            ``confirm=True`` after user approval. When the MCP client supports
+            elicitation, the user is prompted interactively instead.
 
             Args:
                 label_id: Label ID to delete.
+                confirm: Set to True to execute the deletion (step 2).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             if not isinstance(label_id, int) or label_id <= 0:
                 return build_pipe_tool_error_payload(
                     message="Invalid 'label_id'. Use a positive integer.",
                 )
+
+            guard = await check_destructive_confirmation(
+                ctx,
+                confirm=confirm,
+                resource_descriptor=f"label (ID: {label_id})",
+            )
+            if guard is not None:
+                return guard
+
             try:
                 raw = await client.delete_label(label_id)
             except Exception as exc:

--- a/src/pipefy_mcp/tools/relation_tools.py
+++ b/src/pipefy_mcp/tools/relation_tools.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.session import ServerSession
 from mcp.types import ToolAnnotations
 
 from pipefy_mcp.services.pipefy import PipefyClient
+from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.relation_tool_helpers import (
     build_relation_error_payload,
     build_relation_mutation_success_payload,
@@ -181,21 +183,35 @@ class RelationTools:
             ),
         )
         async def delete_pipe_relation(
+            ctx: Context[ServerSession, None],
             relation_id: str | int,
+            confirm: bool = False,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Permanently delete a pipe relation by ID.
 
-            Always confirm with the user before calling — deletion cannot be undone.
+            Two-step operation: call without ``confirm`` to preview, then with
+            ``confirm=True`` after user approval. When the MCP client supports
+            elicitation, the user is prompted interactively instead.
 
             Args:
                 relation_id: Pipe relation ID to delete.
+                confirm: Set to True to execute the deletion (step 2).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             if not valid_repo_id(relation_id):
                 return build_relation_error_payload(
                     message="Invalid 'relation_id': use a non-empty string or positive integer.",
                 )
+
+            guard = await check_destructive_confirmation(
+                ctx,
+                confirm=confirm,
+                resource_descriptor=f"pipe relation (ID: {relation_id})",
+            )
+            if guard is not None:
+                return guard
+
             try:
                 raw = await client.delete_pipe_relation(relation_id)
             except Exception as exc:

--- a/src/pipefy_mcp/tools/report_tools.py
+++ b/src/pipefy_mcp/tools/report_tools.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.session import ServerSession
 from mcp.types import ToolAnnotations
 
 from pipefy_mcp.services.pipefy import PipefyClient
+from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.report_tool_helpers import (
     build_report_error_payload,
     build_report_mutation_success_payload,
@@ -344,18 +346,34 @@ class ReportTools:
             ),
         )
         async def delete_pipe_report(
+            ctx: Context[ServerSession, None],
             report_id: str,
+            confirm: bool = False,
             debug: bool = False,
         ) -> dict[str, Any]:
-            """Delete a pipe report. This action is irreversible. Always confirm with the user before executing.
+            """Delete a pipe report. This action is irreversible.
+
+            Two-step operation: call without ``confirm`` to preview, then with
+            ``confirm=True`` after user approval. When the MCP client supports
+            elicitation, the user is prompted interactively instead.
 
             Args:
                 report_id: Pipe report ID to delete.
+                confirm: Set to True to execute the deletion (step 2).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             err = _blank_field_error(report_id, "report_id")
             if err is not None:
                 return err
+
+            guard = await check_destructive_confirmation(
+                ctx,
+                confirm=confirm,
+                resource_descriptor=f"pipe report (ID: {report_id})",
+            )
+            if guard is not None:
+                return guard
+
             try:
                 raw = await client.delete_pipe_report(report_id)
             except Exception as exc:  # noqa: BLE001
@@ -462,18 +480,34 @@ class ReportTools:
             ),
         )
         async def delete_organization_report(
+            ctx: Context[ServerSession, None],
             report_id: str,
+            confirm: bool = False,
             debug: bool = False,
         ) -> dict[str, Any]:
-            """Delete an organization report. This action is irreversible. Always confirm with the user before executing.
+            """Delete an organization report. This action is irreversible.
+
+            Two-step operation: call without ``confirm`` to preview, then with
+            ``confirm=True`` after user approval. When the MCP client supports
+            elicitation, the user is prompted interactively instead.
 
             Args:
                 report_id: Organization report ID to delete.
+                confirm: Set to True to execute the deletion (step 2).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             err = _blank_field_error(report_id, "report_id")
             if err is not None:
                 return err
+
+            guard = await check_destructive_confirmation(
+                ctx,
+                confirm=confirm,
+                resource_descriptor=f"organization report (ID: {report_id})",
+            )
+            if guard is not None:
+                return guard
+
             try:
                 raw = await client.delete_organization_report(report_id)
             except Exception as exc:  # noqa: BLE001

--- a/src/pipefy_mcp/tools/table_tools.py
+++ b/src/pipefy_mcp/tools/table_tools.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.session import ServerSession
 from mcp.types import ToolAnnotations
 
 from pipefy_mcp.services.pipefy import PipefyClient
@@ -12,6 +13,7 @@ from pipefy_mcp.services.pipefy.table_service import (
     UPDATE_TABLE_RECORD_ALLOWED_FIELD_KEYS,
     UPDATE_TABLE_RECORD_FIELDS_ERROR_MESSAGE,
 )
+from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.graphql_error_helpers import (
     extract_graphql_correlation_id,
     extract_graphql_error_codes,
@@ -551,19 +553,35 @@ class TableTools:
             ),
         )
         async def delete_table_record(
+            ctx: Context[ServerSession, None],
             record_id: str | int,
+            confirm: bool = False,
             debug: bool = False,
         ) -> dict[str, Any]:
-            """Permanently delete a table record. Confirm with the user before calling.
+            """Delete a table record permanently.
+
+            Two-step operation: call without ``confirm`` to preview, then with
+            ``confirm=True`` after user approval. When the MCP client supports
+            elicitation, the user is prompted interactively instead.
 
             Args:
                 record_id: Record ID to delete.
+                confirm: Set to True to execute the deletion (step 2).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             if not valid_repo_id(record_id):
                 return build_table_mutation_error_payload(
                     message="Invalid 'record_id': provide a non-empty string or positive integer.",
                 )
+
+            guard = await check_destructive_confirmation(
+                ctx,
+                confirm=confirm,
+                resource_descriptor=f"table record (ID: {record_id})",
+            )
+            if guard is not None:
+                return guard
+
             try:
                 raw = await client.delete_table_record(record_id)
             except Exception as exc:
@@ -773,13 +791,20 @@ class TableTools:
             ),
         )
         async def delete_table_field(
+            ctx: Context[ServerSession, None],
             field_id: str | int,
+            confirm: bool = False,
             debug: bool = False,
         ) -> dict[str, Any]:
-            """Permanently remove a column from a database table schema. Confirm with the user first.
+            """Delete a database table field (column) permanently.
+
+            Two-step operation: call without ``confirm`` to preview, then with
+            ``confirm=True`` after user approval. When the MCP client supports
+            elicitation, the user is prompted interactively instead.
 
             Args:
                 field_id: Table field ID to delete.
+                confirm: Set to True to execute the deletion (step 2).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             if not _valid_table_field_id(field_id):
@@ -789,6 +814,15 @@ class TableTools:
                     ),
                 )
             fid = field_id.strip() if isinstance(field_id, str) else field_id
+
+            guard = await check_destructive_confirmation(
+                ctx,
+                confirm=confirm,
+                resource_descriptor=f"table field (ID: {field_id})",
+            )
+            if guard is not None:
+                return guard
+
             try:
                 raw = await client.delete_table_field(fid)
             except Exception as exc:

--- a/src/pipefy_mcp/tools/webhook_tools.py
+++ b/src/pipefy_mcp/tools/webhook_tools.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.session import ServerSession
 from mcp.types import ToolAnnotations
 
 from pipefy_mcp.services.pipefy import PipefyClient
+from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.validation_helpers import (
     mutation_error_if_not_optional_dict,
     valid_repo_id,
@@ -311,21 +313,36 @@ class WebhookTools:
             ),
         )
         async def delete_webhook(
+            ctx: Context[ServerSession, None],
             webhook_id: str,
+            confirm: bool = False,
             debug: bool = False,
         ) -> dict[str, Any]:
-            """Permanently delete a webhook by ID.
+            """Delete a webhook permanently.
 
-            Always confirm with the user before calling — deletion cannot be undone.
+            Two-step operation: call without ``confirm`` to preview, then with
+            ``confirm=True`` after user approval. When the MCP client supports
+            elicitation, the user is prompted interactively instead.
 
             Args:
+                ctx: MCP context for debug logging.
                 webhook_id: ID of the webhook to delete.
+                confirm: Set to True to execute the deletion (step 2).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             if not isinstance(webhook_id, str) or not webhook_id.strip():
                 return build_webhook_error_payload(
                     message="Invalid 'webhook_id': provide a non-empty string.",
                 )
+
+            guard = await check_destructive_confirmation(
+                ctx,
+                confirm=confirm,
+                resource_descriptor=f"webhook (ID: {webhook_id})",
+            )
+            if guard is not None:
+                return guard
+
             try:
                 raw = await client.delete_webhook(webhook_id.strip())
             except Exception as exc:

--- a/tests/tools/test_ai_agent_tools.py
+++ b/tests/tools/test_ai_agent_tools.py
@@ -573,7 +573,7 @@ class TestDeleteAiAgent:
         async with client_session as session:
             result = await session.call_tool(
                 "delete_ai_agent",
-                {"uuid": "to-delete"},
+                {"uuid": "to-delete", "confirm": True},
             )
         assert result.isError is False
         mock_pipefy_client.delete_ai_agent.assert_awaited_once_with("to-delete")
@@ -590,7 +590,9 @@ class TestDeleteAiAgent:
     ):
         mock_pipefy_client.delete_ai_agent.return_value = {"success": False}
         async with client_session as session:
-            result = await session.call_tool("delete_ai_agent", {"uuid": "fail"})
+            result = await session.call_tool(
+                "delete_ai_agent", {"uuid": "fail", "confirm": True}
+            )
         payload = extract_payload(result)
         assert payload["success"] is False
         assert "success=false" in payload["error"].lower()
@@ -617,7 +619,7 @@ class TestDeleteAiAgent:
         async with client_session as session:
             result = await session.call_tool(
                 "delete_ai_agent",
-                {"uuid": "bad"},
+                {"uuid": "bad", "confirm": True},
             )
         assert result.isError is False
         payload = extract_payload(result)

--- a/tests/tools/test_automation_tools.py
+++ b/tests/tools/test_automation_tools.py
@@ -468,7 +468,7 @@ async def test_delete_automation_success(
     async with automation_session as session:
         result = await session.call_tool(
             "delete_automation",
-            {"automation_id": "rm-1", "debug": False},
+            {"automation_id": "rm-1", "confirm": True, "debug": False},
         )
 
     assert result.isError is False
@@ -488,7 +488,7 @@ async def test_delete_automation_error(
     async with automation_session as session:
         result = await session.call_tool(
             "delete_automation",
-            {"automation_id": "z"},
+            {"automation_id": "z", "confirm": True},
         )
 
     assert extract_payload(result)["success"] is False

--- a/tests/tools/test_destructive_tool_guard.py
+++ b/tests/tools/test_destructive_tool_guard.py
@@ -1,0 +1,109 @@
+"""Tests for the reusable destructive tool confirmation guard."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
+
+RESOURCE = "phase 'Initial' (ID: 42)"
+
+
+def _make_ctx(*, can_elicit, elicit_result=None, elicit_side_effect=None):
+    ctx = MagicMock()
+    ctx.session.client_params.capabilities.elicitation = can_elicit
+    if elicit_side_effect:
+        ctx.elicit = AsyncMock(side_effect=elicit_side_effect)
+    elif elicit_result is not None:
+        ctx.elicit = AsyncMock(return_value=elicit_result)
+    else:
+        ctx.elicit = AsyncMock()
+    return ctx
+
+
+def _elicit_result(action, confirm_value=True):
+    result = MagicMock()
+    result.action = action
+    result.data.model_dump.return_value = {"confirm": confirm_value}
+    return result
+
+
+@pytest.mark.anyio
+class TestNoElicitation:
+    async def test_no_confirm_returns_preview(self):
+        ctx = _make_ctx(can_elicit=False)
+        payload = await check_destructive_confirmation(
+            ctx, confirm=False, resource_descriptor=RESOURCE
+        )
+        assert payload is not None
+        assert payload["success"] is False
+        assert payload["requires_confirmation"] is True
+        assert payload["resource"] == RESOURCE
+        assert "confirm=True" in payload["message"]
+
+    async def test_confirm_true_returns_none(self):
+        ctx = _make_ctx(can_elicit=False)
+        result = await check_destructive_confirmation(
+            ctx, confirm=True, resource_descriptor=RESOURCE
+        )
+        assert result is None
+
+
+@pytest.mark.anyio
+class TestWithElicitation:
+    async def test_user_accepts_returns_none(self):
+        ctx = _make_ctx(
+            can_elicit=True,
+            elicit_result=_elicit_result(action="accept", confirm_value=True),
+        )
+        result = await check_destructive_confirmation(
+            ctx, confirm=False, resource_descriptor=RESOURCE
+        )
+        assert result is None
+
+    async def test_user_declines_returns_cancel(self):
+        ctx = _make_ctx(
+            can_elicit=True,
+            elicit_result=_elicit_result(action="decline"),
+        )
+        payload = await check_destructive_confirmation(
+            ctx, confirm=False, resource_descriptor=RESOURCE
+        )
+        assert payload is not None
+        assert payload["success"] is False
+        assert "cancelled" in payload["error"].lower()
+
+    async def test_user_accepts_but_confirm_false_returns_cancel(self):
+        ctx = _make_ctx(
+            can_elicit=True,
+            elicit_result=_elicit_result(action="accept", confirm_value=False),
+        )
+        payload = await check_destructive_confirmation(
+            ctx, confirm=False, resource_descriptor=RESOURCE
+        )
+        assert payload is not None
+        assert payload["success"] is False
+
+    async def test_elicitation_raises_returns_error(self):
+        ctx = _make_ctx(
+            can_elicit=True,
+            elicit_side_effect=RuntimeError("elicit broke"),
+        )
+        payload = await check_destructive_confirmation(
+            ctx, confirm=False, resource_descriptor=RESOURCE
+        )
+        assert payload is not None
+        assert payload["success"] is False
+        assert "Failed to request confirmation" in payload["error"]
+
+    async def test_confirm_true_ignored_when_elicitation_available(self):
+        """Even with confirm=True, elicitation takes precedence when available."""
+        ctx = _make_ctx(
+            can_elicit=True,
+            elicit_result=_elicit_result(action="accept", confirm_value=True),
+        )
+        result = await check_destructive_confirmation(
+            ctx, confirm=True, resource_descriptor=RESOURCE
+        )
+        assert result is None
+        ctx.elicit.assert_called_once()

--- a/tests/tools/test_member_tools.py
+++ b/tests/tools/test_member_tools.py
@@ -144,7 +144,7 @@ async def test_remove_member_from_pipe_value_error_from_client(
     async with member_session as session:
         result = await session.call_tool(
             "remove_member_from_pipe",
-            {"pipe_id": "bad", "user_ids": ["u1"]},
+            {"pipe_id": "bad", "user_ids": ["u1"], "confirm": True},
         )
 
     assert result.isError is False
@@ -165,7 +165,7 @@ async def test_remove_member_from_pipe_success(
     async with member_session as session:
         result = await session.call_tool(
             "remove_member_from_pipe",
-            {"pipe_id": "pipe-1", "user_ids": ["user-1", "user-2"]},
+            {"pipe_id": "pipe-1", "user_ids": ["user-1", "user-2"], "confirm": True},
         )
 
     assert result.isError is False
@@ -189,7 +189,7 @@ async def test_remove_member_from_pipe_graphql_error(
     async with member_session as session:
         result = await session.call_tool(
             "remove_member_from_pipe",
-            {"pipe_id": "p1", "user_ids": ["u1"]},
+            {"pipe_id": "p1", "user_ids": ["u1"], "confirm": True},
         )
 
     assert result.isError is False

--- a/tests/tools/test_pipe_config_tools.py
+++ b/tests/tools/test_pipe_config_tools.py
@@ -401,10 +401,30 @@ async def test_delete_phase_success(
     }
 
     async with pipe_config_session as session:
-        result = await session.call_tool("delete_phase", {"phase_id": 55})
+        result = await session.call_tool(
+            "delete_phase", {"phase_id": 55, "confirm": True}
+        )
 
     mock_pipe_config_client.delete_phase.assert_awaited_once_with(55)
     assert extract_payload(result)["success"] is True
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_delete_phase_preview_does_not_delete(
+    pipe_config_session, mock_pipe_config_client, extract_payload
+):
+    async with pipe_config_session as session:
+        result = await session.call_tool("delete_phase", {"phase_id": 55})
+
+    assert result.isError is False
+    mock_pipe_config_client.delete_phase.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert payload["requires_confirmation"] is True
+    assert payload["resource"] == "phase (ID: 55)"
+    assert "⚠️" in payload["message"]
+    assert "confirm=True" in payload["message"]
 
 
 @pytest.mark.anyio
@@ -516,11 +536,29 @@ async def test_delete_phase_field_success(
     async with pipe_config_session as session:
         result = await session.call_tool(
             "delete_phase_field",
-            {"field_id": 100},
+            {"field_id": 100, "confirm": True},
         )
 
     mock_pipe_config_client.delete_phase_field.assert_awaited_once_with(100)
     assert extract_payload(result)["success"] is True
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_delete_phase_field_preview_does_not_delete(
+    pipe_config_session, mock_pipe_config_client, extract_payload
+):
+    async with pipe_config_session as session:
+        result = await session.call_tool("delete_phase_field", {"field_id": 100})
+
+    assert result.isError is False
+    mock_pipe_config_client.delete_phase_field.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert payload["requires_confirmation"] is True
+    assert payload["resource"] == "phase field (ID: 100)"
+    assert "⚠️" in payload["message"]
+    assert "confirm=True" in payload["message"]
 
 
 @pytest.mark.anyio
@@ -535,7 +573,7 @@ async def test_delete_phase_field_success_with_string_slug(
     async with pipe_config_session as session:
         result = await session.call_tool(
             "delete_phase_field",
-            {"field_id": "detalhe_mcp"},
+            {"field_id": "detalhe_mcp", "confirm": True},
         )
 
     mock_pipe_config_client.delete_phase_field.assert_awaited_once_with(
@@ -617,10 +655,30 @@ async def test_delete_label_success(
     }
 
     async with pipe_config_session as session:
-        result = await session.call_tool("delete_label", {"label_id": 40})
+        result = await session.call_tool(
+            "delete_label", {"label_id": 40, "confirm": True}
+        )
 
     mock_pipe_config_client.delete_label.assert_awaited_once_with(40)
     assert extract_payload(result)["success"] is True
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_delete_label_preview_does_not_delete(
+    pipe_config_session, mock_pipe_config_client, extract_payload
+):
+    async with pipe_config_session as session:
+        result = await session.call_tool("delete_label", {"label_id": 40})
+
+    assert result.isError is False
+    mock_pipe_config_client.delete_label.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert payload["requires_confirmation"] is True
+    assert payload["resource"] == "label (ID: 40)"
+    assert "⚠️" in payload["message"]
+    assert "confirm=True" in payload["message"]
 
 
 @pytest.mark.anyio
@@ -747,7 +805,9 @@ async def test_delete_phase_graphql_error_returns_failure__no_integration(
         errors=[{"message": "Cannot delete"}],
     )
     async with pipe_config_session as session:
-        result = await session.call_tool("delete_phase", {"phase_id": 1})
+        result = await session.call_tool(
+            "delete_phase", {"phase_id": 1, "confirm": True}
+        )
     payload = extract_payload(result)
     assert payload["success"] is False
     assert "Cannot delete" in payload["error"]
@@ -803,7 +863,7 @@ async def test_delete_phase_field_graphql_error_returns_failure__no_integration(
     async with pipe_config_session as session:
         result = await session.call_tool(
             "delete_phase_field",
-            {"field_id": 100},
+            {"field_id": 100, "confirm": True},
         )
     payload = extract_payload(result)
     assert payload["success"] is False
@@ -858,7 +918,9 @@ async def test_delete_label_graphql_error_returns_failure__no_integration(
         errors=[{"message": "Still in use"}],
     )
     async with pipe_config_session as session:
-        result = await session.call_tool("delete_label", {"label_id": 40})
+        result = await session.call_tool(
+            "delete_label", {"label_id": 40, "confirm": True}
+        )
     payload = extract_payload(result)
     assert payload["success"] is False
     assert "Still in use" in payload["error"]
@@ -946,7 +1008,9 @@ async def test_delete_phase_rejects_invalid_id__no_integration(
     async with pipe_config_session as session:
         result = await session.call_tool("delete_phase", {"phase_id": 0})
     mock_pipe_config_client.delete_phase.assert_not_called()
-    assert extract_payload(result)["success"] is False
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "requires_confirmation" not in payload
 
 
 @pytest.mark.anyio
@@ -957,7 +1021,9 @@ async def test_delete_label_rejects_invalid_id__no_integration(
     async with pipe_config_session as session:
         result = await session.call_tool("delete_label", {"label_id": -1})
     mock_pipe_config_client.delete_label.assert_not_called()
-    assert extract_payload(result)["success"] is False
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "requires_confirmation" not in payload
 
 
 @pytest.mark.anyio
@@ -1327,7 +1393,7 @@ async def test_delete_field_condition_success(
     async with pipe_config_session as session:
         result = await session.call_tool(
             "delete_field_condition",
-            {"condition_id": "cond-9"},
+            {"condition_id": "cond-9", "confirm": True},
         )
 
     assert result.isError is False
@@ -1350,7 +1416,7 @@ async def test_delete_field_condition_error(
     async with pipe_config_session as session:
         result = await session.call_tool(
             "delete_field_condition",
-            {"condition_id": "cond-x"},
+            {"condition_id": "cond-x", "confirm": True},
         )
 
     assert result.isError is False

--- a/tests/tools/test_relation_tools.py
+++ b/tests/tools/test_relation_tools.py
@@ -278,7 +278,7 @@ async def test_delete_pipe_relation_success(
     async with relation_session as session:
         result = await session.call_tool(
             "delete_pipe_relation",
-            {"relation_id": 100},
+            {"relation_id": 100, "confirm": True},
         )
 
     assert result.isError is False
@@ -298,7 +298,7 @@ async def test_delete_pipe_relation_graphql_error(
     async with relation_session as session:
         result = await session.call_tool(
             "delete_pipe_relation",
-            {"relation_id": 1},
+            {"relation_id": 1, "confirm": True},
         )
 
     assert extract_payload(result)["success"] is False

--- a/tests/tools/test_report_tools.py
+++ b/tests/tools/test_report_tools.py
@@ -418,7 +418,9 @@ async def test_delete_pipe_report_success(
     }
 
     async with report_session as session:
-        result = await session.call_tool("delete_pipe_report", {"report_id": "r10"})
+        result = await session.call_tool(
+            "delete_pipe_report", {"report_id": "r10", "confirm": True}
+        )
 
     assert result.isError is False
     mock_report_client.delete_pipe_report.assert_awaited_once_with("r10")
@@ -495,7 +497,7 @@ async def test_delete_organization_report_success(
 
     async with report_session as session:
         result = await session.call_tool(
-            "delete_organization_report", {"report_id": "or5"}
+            "delete_organization_report", {"report_id": "or5", "confirm": True}
         )
 
     assert result.isError is False

--- a/tests/tools/test_table_tools.py
+++ b/tests/tools/test_table_tools.py
@@ -642,7 +642,7 @@ async def test_delete_table_record_success(
     async with table_session as session:
         result = await session.call_tool(
             "delete_table_record",
-            {"record_id": 99},
+            {"record_id": 99, "confirm": True},
         )
 
     mock_table_client.delete_table_record.assert_awaited_once_with(99)
@@ -659,7 +659,9 @@ async def test_delete_table_record_graphql_error(
     )
 
     async with table_session as session:
-        result = await session.call_tool("delete_table_record", {"record_id": 1})
+        result = await session.call_tool(
+            "delete_table_record", {"record_id": 1, "confirm": True}
+        )
 
     assert extract_payload(result)["success"] is False
 
@@ -789,7 +791,9 @@ async def test_delete_table_field_success(
     }
 
     async with table_session as session:
-        result = await session.call_tool("delete_table_field", {"field_id": 88})
+        result = await session.call_tool(
+            "delete_table_field", {"field_id": 88, "confirm": True}
+        )
 
     mock_table_client.delete_table_field.assert_awaited_once_with(88)
     assert extract_payload(result)["success"] is True
@@ -805,6 +809,8 @@ async def test_delete_table_field_graphql_error(
     )
 
     async with table_session as session:
-        result = await session.call_tool("delete_table_field", {"field_id": "x"})
+        result = await session.call_tool(
+            "delete_table_field", {"field_id": "x", "confirm": True}
+        )
 
     assert extract_payload(result)["success"] is False

--- a/tests/tools/test_webhook_tools.py
+++ b/tests/tools/test_webhook_tools.py
@@ -336,6 +336,27 @@ async def test_create_webhook_graphql_error(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("webhook_session", [None], indirect=True)
+async def test_delete_webhook_preview_does_not_delete(
+    webhook_session, mock_webhook_client, extract_payload
+):
+    async with webhook_session as session:
+        result = await session.call_tool(
+            "delete_webhook",
+            {"webhook_id": "webhook-1"},
+        )
+
+    assert result.isError is False
+    mock_webhook_client.delete_webhook.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert payload["requires_confirmation"] is True
+    assert payload["resource"] == "webhook (ID: webhook-1)"
+    assert "⚠️" in payload["message"]
+    assert "confirm=True" in payload["message"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("webhook_session", [None], indirect=True)
 async def test_delete_webhook_success(
     webhook_session, mock_webhook_client, extract_payload
 ):
@@ -346,7 +367,7 @@ async def test_delete_webhook_success(
     async with webhook_session as session:
         result = await session.call_tool(
             "delete_webhook",
-            {"webhook_id": "webhook-1"},
+            {"webhook_id": "webhook-1", "confirm": True},
         )
 
     assert result.isError is False
@@ -368,7 +389,7 @@ async def test_delete_webhook_graphql_error(
     async with webhook_session as session:
         result = await session.call_tool(
             "delete_webhook",
-            {"webhook_id": "w1"},
+            {"webhook_id": "w1", "confirm": True},
         )
 
     assert result.isError is False


### PR DESCRIPTION
## Summary
Adds a reusable `check_destructive_confirmation` guard (preview when there is no elicitation; interactive prompt when there is) and wires it to destructive MCP tools: phase/phase field/label, field condition, webhook, table/record, org/pipe reports, pipe member removal, pipe relation, automation, and AI agent delete.

## Testing
- `uv run ruff check src/ tests/` / `uv run ruff format --check src/ tests/`
- `uv run pytest -m "not integration"` (824 passed)

## Commits
10 atomic commits on `feat/elicitation-improvements`.