### PR TITLE
fix: observability org id + update_phase doc

### DIFF
--- a/src/pipefy_mcp/tools/observability_tools.py
+++ b/src/pipefy_mcp/tools/observability_tools.py
@@ -203,7 +203,7 @@ class ObservabilityTools:
             annotations=ToolAnnotations(readOnlyHint=True),
         )
         async def get_agents_usage(
-            organization_uuid: str,
+            organization_uuid: str | int,
             filter_date_from: str,
             filter_date_to: str,
             filters: dict[str, Any] | None = None,
@@ -214,7 +214,7 @@ class ObservabilityTools:
             """Get AI agent usage stats for an org within a date range. Returns total AI credits consumed and per-agent breakdown. `filter_date_from` and `filter_date_to` are ISO8601 datetime strings. Optional `filters` for action/event/pipe/status filtering.
 
             Args:
-                organization_uuid: Organization UUID, or numeric organization id (string).
+                organization_uuid: Organization UUID, or numeric organization id.
                 filter_date_from: Start of date range (ISO8601).
                 filter_date_to: End of date range (ISO8601).
                 filters: Optional FilterParams dict (action, event, pipe, status keys).
@@ -222,10 +222,11 @@ class ObservabilityTools:
                 sort: SortCriteria dict (field + direction).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
-            if not organization_uuid or not isinstance(organization_uuid, str):
+            if not organization_uuid or not isinstance(organization_uuid, (str, int)):
                 return build_observability_error_payload(
-                    message="Invalid 'organization_uuid': provide a non-empty string.",
+                    message="Invalid 'organization_uuid': provide a non-empty string or integer.",
                 )
+            organization_uuid = str(organization_uuid)
             if not filter_date_from or not filter_date_to:
                 return build_observability_error_payload(
                     message="Both 'filter_date_from' and 'filter_date_to' are required.",
@@ -250,7 +251,7 @@ class ObservabilityTools:
             annotations=ToolAnnotations(readOnlyHint=True),
         )
         async def get_automations_usage(
-            organization_uuid: str,
+            organization_uuid: str | int,
             filter_date_from: str,
             filter_date_to: str,
             filters: dict[str, Any] | None = None,
@@ -261,7 +262,7 @@ class ObservabilityTools:
             """Get automation usage stats for an org within a date range. Returns total execution count and per-automation breakdown. Same input shape as `get_agents_usage`.
 
             Args:
-                organization_uuid: Organization UUID, or numeric organization id (string).
+                organization_uuid: Organization UUID, or numeric organization id.
                 filter_date_from: Start of date range (ISO8601).
                 filter_date_to: End of date range (ISO8601).
                 filters: Optional FilterParams dict (action, event, pipe, status keys).
@@ -269,10 +270,11 @@ class ObservabilityTools:
                 sort: SortCriteria dict (field + direction).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
-            if not organization_uuid or not isinstance(organization_uuid, str):
+            if not organization_uuid or not isinstance(organization_uuid, (str, int)):
                 return build_observability_error_payload(
-                    message="Invalid 'organization_uuid': provide a non-empty string.",
+                    message="Invalid 'organization_uuid': provide a non-empty string or integer.",
                 )
+            organization_uuid = str(organization_uuid)
             if not filter_date_from or not filter_date_to:
                 return build_observability_error_payload(
                     message="Both 'filter_date_from' and 'filter_date_to' are required.",
@@ -297,7 +299,7 @@ class ObservabilityTools:
             annotations=ToolAnnotations(readOnlyHint=True),
         )
         async def get_ai_credit_usage(
-            organization_uuid: str,
+            organization_uuid: str | int,
             period: str,
             debug: bool = False,
         ) -> dict[str, Any]:
@@ -309,10 +311,11 @@ class ObservabilityTools:
                 period: PeriodFilter (current_month, last_month, last_3_months).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
-            if not organization_uuid or not isinstance(organization_uuid, str):
+            if not organization_uuid or not isinstance(organization_uuid, (str, int)):
                 return build_observability_error_payload(
-                    message="Invalid 'organization_uuid': provide a non-empty string.",
+                    message="Invalid 'organization_uuid': provide a non-empty string or integer.",
                 )
+            organization_uuid = str(organization_uuid)
             if period not in _VALID_PERIODS:
                 return build_observability_error_payload(
                     message=f"Invalid 'period': must be one of {sorted(_VALID_PERIODS)}.",
@@ -333,21 +336,22 @@ class ObservabilityTools:
             annotations=ToolAnnotations(readOnlyHint=False),
         )
         async def export_automation_jobs(
-            organization_id: str,
+            organization_id: str | int,
             period: str,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Trigger async export of automation job history for an org. `period`: 'current_month', 'last_month', or 'last_3_months'. The export file is delivered to the requesting user.
 
             Args:
-                organization_id: Organization ID.
+                organization_id: Organization ID (string or numeric).
                 period: PeriodFilter (current_month, last_month, last_3_months).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
-            if not organization_id or not isinstance(organization_id, str):
+            if not organization_id or not isinstance(organization_id, (str, int)):
                 return build_observability_error_payload(
-                    message="Invalid 'organization_id': provide a non-empty string.",
+                    message="Invalid 'organization_id': provide a non-empty string or integer.",
                 )
+            organization_id = str(organization_id)
             if period not in _VALID_PERIODS:
                 return build_observability_error_payload(
                     message=f"Invalid 'period': must be one of {sorted(_VALID_PERIODS)}.",

--- a/src/pipefy_mcp/tools/pipe_config_tools.py
+++ b/src/pipefy_mcp/tools/pipe_config_tools.py
@@ -319,7 +319,8 @@ class PipeConfigTools:
             """Update a phase.
 
             Pipefy requires the phase name on update. Omit `name` to keep the current
-            name (resolved via get_phase_fields).
+            name (resolved via get_phase_fields). Values identical to the current state
+            are accepted but result in a no-op API call.
 
             Args:
                 phase_id: Phase ID to update.

--- a/tests/tools/test_observability_tools.py
+++ b/tests/tools/test_observability_tools.py
@@ -764,3 +764,111 @@ async def test_get_ai_credit_usage_debug_true_appends_codes(
     assert p["success"] is False
     assert "forbidden" in p["error"]
     assert "FORBIDDEN" in p["error"]
+
+
+# --- Int-to-str coercion tests ---
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+async def test_export_automation_jobs_coerces_int_organization_id(
+    observability_session, mock_observability_client, extract_payload
+):
+    mock_observability_client.export_automation_jobs.return_value = {
+        "createAutomationJobsExport": {
+            "automationJobsExport": {"id": "exp-1", "status": "processing"}
+        }
+    }
+
+    async with observability_session as session:
+        result = await session.call_tool(
+            "export_automation_jobs",
+            {"organization_id": 302398434, "period": "last_month"},
+        )
+
+    assert result.isError is False
+    mock_observability_client.export_automation_jobs.assert_awaited_once_with(
+        "302398434", "last_month"
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+async def test_get_agents_usage_coerces_int_organization_uuid(
+    observability_session, mock_observability_client, extract_payload
+):
+    mock_observability_client.get_agents_usage.return_value = {
+        "agentsUsageDetails": {"usage": 0, "agents": {"nodes": [], "totalCount": 0}}
+    }
+
+    async with observability_session as session:
+        result = await session.call_tool(
+            "get_agents_usage",
+            {
+                "organization_uuid": 302398434,
+                "filter_date_from": "2026-03-01T00:00:00Z",
+                "filter_date_to": "2026-03-31T23:59:59Z",
+            },
+        )
+
+    assert result.isError is False
+    mock_observability_client.get_agents_usage.assert_awaited_once_with(
+        "302398434",
+        {"from": "2026-03-01T00:00:00Z", "to": "2026-03-31T23:59:59Z"},
+        filters=None,
+        search=None,
+        sort=None,
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+async def test_get_automations_usage_coerces_int_organization_uuid(
+    observability_session, mock_observability_client, extract_payload
+):
+    mock_observability_client.get_automations_usage.return_value = {
+        "automationsUsageDetails": {
+            "usage": 0,
+            "automations": {"nodes": [], "totalCount": 0},
+        }
+    }
+
+    async with observability_session as session:
+        result = await session.call_tool(
+            "get_automations_usage",
+            {
+                "organization_uuid": 302398434,
+                "filter_date_from": "2026-03-01T00:00:00Z",
+                "filter_date_to": "2026-03-31T23:59:59Z",
+            },
+        )
+
+    assert result.isError is False
+    mock_observability_client.get_automations_usage.assert_awaited_once_with(
+        "302398434",
+        {"from": "2026-03-01T00:00:00Z", "to": "2026-03-31T23:59:59Z"},
+        filters=None,
+        search=None,
+        sort=None,
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+async def test_get_ai_credit_usage_coerces_int_organization_uuid(
+    observability_session, mock_observability_client, extract_payload
+):
+    mock_observability_client.get_ai_credit_usage.return_value = {
+        "aiCreditUsage": {"creditLimit": 100, "totalConsumption": 50}
+    }
+
+    async with observability_session as session:
+        result = await session.call_tool(
+            "get_ai_credit_usage",
+            {"organization_uuid": 302398434, "period": "current_month"},
+        )
+
+    assert result.isError is False
+    mock_observability_client.get_ai_credit_usage.assert_awaited_once_with(
+        "302398434", "current_month"
+    )


### PR DESCRIPTION
## Changes
- **Observability tools:** `organization_uuid` / `organization_id` accept `str | int` and coerce to string for the Pipefy client (matches org ids returned as numbers from other tools).
- **Docs:** `update_phase` docstring notes that unchanged values still yield a no-op API call.

## Testing
- `uv run pytest -m "not integration"` (828 passed)