### PR TITLE
fix(automation): optional action_repo_id for cross-pipe automations

### DIFF
--- a/src/pipefy_mcp/models/ai_automation.py
+++ b/src/pipefy_mcp/models/ai_automation.py
@@ -39,6 +39,10 @@ class CreateAiAutomationInput(BaseModel):
     name: NonBlankStr
     event_id: _EventId
     pipe_id: NonBlankStr
+    action_repo_id: NonBlankStr | None = Field(
+        default=None,
+        description="Pipe ID where the action executes. Defaults to pipe_id when omitted.",
+    )
     prompt: NonBlankStr
     field_ids: list[str] = Field(
         min_length=1,

--- a/src/pipefy_mcp/services/pipefy/ai_agent_service.py
+++ b/src/pipefy_mcp/services/pipefy/ai_agent_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import uuid
+from typing import Any
 
 from httpx_auth import OAuth2ClientCredentials
 
@@ -28,19 +29,11 @@ from pipefy_mcp.services.pipefy.types import (
 from pipefy_mcp.settings import PipefySettings
 
 
-def inject_reference_ids(behaviors: list[dict]) -> list[dict]:
-    """Generate and inject referenceIds into behavior actions.
-
-    For each behavior, generates a UUID v4 per action in actionsAttributes,
-    sets it as the action's referenceId, and appends a %{action:<uuid>}
-    placeholder to the behavior's instruction.
+def inject_reference_ids(behaviors: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Deep-copy behaviors and assign a UUID ``referenceId`` per action; append ``%{action:<uuid>}`` to instruction.
 
     Args:
-        behaviors: List of behavior dicts with actionParams.aiBehaviorParams.
-
-    Returns:
-        New list of behaviors (deep copy) with referenceIds injected.
-        Original input is never mutated.
+        behaviors: Behavior dicts with ``actionParams.aiBehaviorParams.actionsAttributes``.
     """
     result = [copy.deepcopy(b) for b in behaviors]
 
@@ -74,11 +67,11 @@ class AiAgentService(BasePipefyClient):
         settings: PipefySettings,
         auth: OAuth2ClientCredentials | None = None,
     ) -> None:
-        """Create the service.
+        """Initialize the GraphQL client.
 
         Args:
-            settings: Pipefy settings (graphql_url, OAuth credentials).
-            auth: Optional pre-built OAuth2 auth to share token cache.
+            settings: Pipefy API settings.
+            auth: Optional shared OAuth handler (see :class:`BasePipefyClient`).
         """
         super().__init__(settings=settings, auth=auth)
 
@@ -87,9 +80,6 @@ class AiAgentService(BasePipefyClient):
 
         Args:
             agent_input: Validated create input with name and repo_uuid.
-
-        Returns:
-            Dict with agent_uuid and message.
 
         Raises:
             ValueError: When API response is missing agent.uuid.
@@ -123,9 +113,6 @@ class AiAgentService(BasePipefyClient):
 
         Args:
             agent_input: Validated update input with uuid, name, repo_uuid, behaviors.
-
-        Returns:
-            Dict with agent_uuid and message.
 
         Raises:
             ValueError: When API response is missing agent.uuid.
@@ -170,9 +157,6 @@ class AiAgentService(BasePipefyClient):
             agent_uuid: Agent UUID.
             active: True to activate, False to deactivate.
 
-        Returns:
-            Dict with success flag and message.
-
         Raises:
             ValueError: When the API reports failure.
         """
@@ -216,7 +200,7 @@ class AiAgentService(BasePipefyClient):
         )
         return unwrap_relay_connection_nodes(response.get("aiAgents"))
 
-    async def delete_agent(self, agent_uuid: str) -> dict:
+    async def delete_agent(self, agent_uuid: str) -> dict[str, Any]:
         """Delete an AI Agent permanently.
 
         Args:

--- a/src/pipefy_mcp/services/pipefy/ai_automation_service.py
+++ b/src/pipefy_mcp/services/pipefy/ai_automation_service.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from pipefy_mcp.models.ai_automation import (
     CreateAiAutomationInput,
     UpdateAiAutomationInput,
@@ -20,10 +22,10 @@ class AiAutomationService:
     """Service for creating and updating AI Automations via the internal API."""
 
     def __init__(self, client: InternalApiClient) -> None:
-        """Create the service.
+        """Attach the client used for ``internal_api`` GraphQL calls.
 
         Args:
-            client: InternalApiClient for the internal_api endpoint.
+            client: Configured :class:`InternalApiClient` instance.
         """
         self._client = client
 
@@ -35,9 +37,6 @@ class AiAutomationService:
         Args:
             automation_input: Validated create input.
 
-        Returns:
-            Dict with automation_id and message.
-
         Raises:
             ValueError: When API response is missing automation.id.
         """
@@ -46,7 +45,8 @@ class AiAutomationService:
             "action_id": ACTION_ID_GENERATE_WITH_AI,
             "event_id": automation_input.event_id,
             "event_repo_id": automation_input.pipe_id,
-            "action_repo_id": automation_input.pipe_id,
+            "action_repo_id": automation_input.action_repo_id
+            or automation_input.pipe_id,
             "action_params": {
                 "aiParams": {
                     "value": automation_input.prompt,
@@ -86,19 +86,16 @@ class AiAutomationService:
         Args:
             automation_input: Validated update input.
 
-        Returns:
-            Dict with automation_id and message.
-
         Raises:
             ValueError: When API response is missing automation.id.
         """
-        input_dict: dict = {"id": automation_input.automation_id}
+        input_dict: dict[str, Any] = {"id": automation_input.automation_id}
         if automation_input.name is not None:
             input_dict["name"] = automation_input.name
         if automation_input.active is not None:
             input_dict["active"] = automation_input.active
 
-        ai_params: dict = {}
+        ai_params: dict[str, Any] = {}
         if automation_input.prompt is not None:
             ai_params["value"] = automation_input.prompt
         if automation_input.field_ids is not None:

--- a/src/pipefy_mcp/services/pipefy/automation_service.py
+++ b/src/pipefy_mcp/services/pipefy/automation_service.py
@@ -169,15 +169,20 @@ class AutomationService(BasePipefyClient):
         name: str,
         trigger_id: str,
         action_id: str,
+        *,
+        action_repo_id: str | None = None,
         **attrs: Any,
     ) -> CreateAutomationMutationResult:
         """Create a traditional automation (`CreateAutomationInput`).
 
         Args:
-            pipe_id: Pipe ID used as event and action repository context.
+            pipe_id: Source pipe ID for the trigger (maps to ``event_repo_id``).
             name: Rule display name.
             trigger_id: Event ID from `get_automation_events` (API field `event_id`).
             action_id: Action type ID from `get_automation_actions`.
+            action_repo_id: Pipe ID where the action executes. Defaults to ``pipe_id``
+                (same-pipe automation). For cross-pipe actions like ``create_connected_card``
+                or ``move_card_to_pipe``, set this to the **destination** pipe ID.
             **attrs: Additional `CreateAutomationInput` fields (API key names). ``None`` values are omitted.
                 When ``active`` is omitted, it defaults to ``True`` (rule created enabled in Pipefy).
         """
@@ -186,7 +191,7 @@ class AutomationService(BasePipefyClient):
             "event_id": trigger_id,
             "action_id": action_id,
             "event_repo_id": pipe_id,
-            "action_repo_id": pipe_id,
+            "action_repo_id": action_repo_id or pipe_id,
         }
         for key, value in attrs.items():
             if value is not None:

--- a/src/pipefy_mcp/services/pipefy/client.py
+++ b/src/pipefy_mcp/services/pipefy/client.py
@@ -1,3 +1,5 @@
+"""Facade that wires Pipefy domain services for MCP tools (delegation only)."""
+
 from __future__ import annotations
 
 from typing import Any
@@ -521,16 +523,20 @@ class PipefyClient:
         action_id: str,
         *,
         active: bool = True,
+        action_repo_id: str | None = None,
         extra_input: dict[str, Any] | None = None,
     ) -> CreateAutomationMutationResult:
         """Create a traditional automation rule (optional ``extra_input`` uses CreateAutomationInput field names).
 
         Args:
-            pipe_id: Pipe ID.
+            pipe_id: Pipe ID (event source).
             name: Rule name.
             trigger_id: Event ID.
             action_id: Action ID.
             active: When True (default), create the rule enabled. Set False to start disabled.
+            action_repo_id: Pipe ID where the action executes. Defaults to ``pipe_id``.
+                For cross-pipe actions (``create_connected_card``, ``move_card_to_pipe``),
+                pass the **destination** pipe ID.
             extra_input: Extra ``CreateAutomationInput`` keys; ``active`` here overrides the ``active`` argument.
         """
         merged: dict[str, Any] = {"active": active, **(extra_input or {})}
@@ -539,6 +545,7 @@ class PipefyClient:
             name,
             trigger_id,
             action_id,
+            action_repo_id=action_repo_id,
             **merged,
         )
 

--- a/src/pipefy_mcp/services/pipefy/queries/observability_queries.py
+++ b/src/pipefy_mcp/services/pipefy/queries/observability_queries.py
@@ -1,12 +1,14 @@
-"""GraphQL queries and mutations for Pipefy observability: logs, usage stats, and exports."""
+"""GraphQL queries and mutations for Pipefy observability: logs, usage stats, and exports.
+
+AiAgentLogConnection / AutomationLogConnection: nodes, pageInfo, totalCount. Usage breakdowns use
+StatsDetailsConnection. ``aiCreditUsageStats`` accepts PeriodFilter: current_month | last_month |
+last_3_months. ``CreateAutomationJobsExportInput``: organizationId (ID!), filter (PeriodFilter!),
+optional clientMutationId.
+"""
 
 from __future__ import annotations
 
 from gql import gql
-
-# AiAgentLogConnection / AutomationLogConnection: nodes, pageInfo, totalCount.
-# Usage queries: StatsDetailsConnection for per-item breakdowns.
-# aiCreditUsageStats: PeriodFilter current_month | last_month | last_3_months.
 
 GET_AI_AGENT_LOGS_QUERY = gql(
     """
@@ -259,8 +261,6 @@ GET_AI_CREDIT_USAGE_QUERY = gql(
     }
     """
 )
-
-# CreateAutomationJobsExportInput: organizationId (ID!), filter (PeriodFilter!), optional clientMutationId.
 
 CREATE_AUTOMATION_JOBS_EXPORT_MUTATION = gql(
     """

--- a/src/pipefy_mcp/services/pipefy/queries/relation_queries.py
+++ b/src/pipefy_mcp/services/pipefy/queries/relation_queries.py
@@ -15,7 +15,6 @@ _REPO_TYPES_ID_NAME = """... on Pipe {
     name
 }"""
 
-# Composed with string concatenation (constants only; no runtime string building).
 _PIPE_RELATION_BODY = (
     """
                 id

--- a/src/pipefy_mcp/services/pipefy/relation_service.py
+++ b/src/pipefy_mcp/services/pipefy/relation_service.py
@@ -1,4 +1,13 @@
-"""GraphQL operations for Pipefy pipe, table, and card relations."""
+"""GraphQL operations for Pipefy pipe, table, and card relations.
+
+``CreatePipeRelationInput`` / ``UpdatePipeRelationInput`` require all boolean flags; defaults live
+in ``_PIPE_RELATION_CONSTRAINT_DEFAULTS``. ``CreateCardRelationInput.sourceType`` is
+``PipeRelation`` | ``Field`` (default constant: PipeRelation).
+
+Merged ``**attrs`` / ``extra_input``: ``None`` values are omitted from GraphQL input (leave
+unchanged on the server). Explicit API null to clear a field is not supported — same as
+``PipeConfigService`` / ``TableService``.
+"""
 
 from __future__ import annotations
 
@@ -17,7 +26,6 @@ from pipefy_mcp.services.pipefy.queries.relation_queries import (
 )
 from pipefy_mcp.settings import PipefySettings
 
-# CreatePipeRelationInput / UpdatePipeRelationInput boolean defaults (API requires all flags).
 _PIPE_RELATION_CONSTRAINT_DEFAULTS: dict[str, Any] = {
     "allChildrenMustBeDoneToFinishParent": False,
     "allChildrenMustBeDoneToMoveParent": False,
@@ -29,12 +37,7 @@ _PIPE_RELATION_CONSTRAINT_DEFAULTS: dict[str, Any] = {
     "childMustExistToMoveParent": False,
 }
 
-# Pipefy `CreateCardRelationInput.sourceType`: PipeRelation | Field
 _DEFAULT_CARD_RELATION_SOURCE_TYPE = "PipeRelation"
-
-# Merged ``**attrs`` / ``extra_input``: keys with value ``None`` are skipped so the field is omitted
-# from the GraphQL input (leave unchanged). Explicit API ``null`` to clear a field is not supported
-# here — same choice as ``PipeConfigService`` / ``TableService``.
 
 
 class RelationService(BasePipefyClient):

--- a/src/pipefy_mcp/services/pipefy/report_service.py
+++ b/src/pipefy_mcp/services/pipefy/report_service.py
@@ -46,7 +46,7 @@ class ReportService(BasePipefyClient):
         after: str | None = None,
         search: str | None = None,
         report_id: str | None = None,
-        order: dict | None = None,
+        order: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """List pipe reports with pagination and optional search/filter.
 
@@ -151,7 +151,7 @@ class ReportService(BasePipefyClient):
         name: str,
         *,
         fields: list[str] | None = None,
-        filter: dict | None = None,
+        filter: dict[str, Any] | None = None,
         formulas: list[list[str]] | None = None,
     ) -> dict[str, Any]:
         """Create a pipe report.
@@ -181,7 +181,7 @@ class ReportService(BasePipefyClient):
         name: str | None = None,
         color: str | None = None,
         fields: list[str] | None = None,
-        filter: dict | None = None,
+        filter: dict[str, Any] | None = None,
         formulas: list[list[str]] | None = None,
         featured_field: str | None = None,
     ) -> dict[str, Any]:
@@ -229,7 +229,7 @@ class ReportService(BasePipefyClient):
         pipe_ids: list[str],
         *,
         fields: list[str] | None = None,
-        filter: dict | None = None,
+        filter: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Create an organization report spanning multiple pipes.
 
@@ -260,7 +260,7 @@ class ReportService(BasePipefyClient):
         name: str | None = None,
         color: str | None = None,
         fields: list[str] | None = None,
-        filter: dict | None = None,
+        filter: dict[str, Any] | None = None,
         pipe_ids: list[str] | None = None,
     ) -> dict[str, Any]:
         """Update an organization report. Only provided values are changed.
@@ -303,8 +303,8 @@ class ReportService(BasePipefyClient):
         pipe_id: str,
         pipe_report_id: str,
         *,
-        sort_by: dict | None = None,
-        filter: dict | None = None,
+        sort_by: dict[str, Any] | None = None,
+        filter: dict[str, Any] | None = None,
         columns: list[str] | None = None,
     ) -> dict[str, Any]:
         """Trigger an async pipe report export (poll ``get_pipe_report_export`` for completion).
@@ -336,8 +336,8 @@ class ReportService(BasePipefyClient):
         *,
         organization_report_id: int | None = None,
         pipe_ids: list[int] | None = None,
-        sort_by: dict | None = None,
-        filter: dict | None = None,
+        sort_by: dict[str, Any] | None = None,
+        filter: dict[str, Any] | None = None,
         columns: list[str] | None = None,
     ) -> dict[str, Any]:
         """Trigger an async organization report export (poll ``get_organization_report_export``).

--- a/src/pipefy_mcp/services/pipefy/schema_introspection_service.py
+++ b/src/pipefy_mcp/services/pipefy/schema_introspection_service.py
@@ -1,3 +1,5 @@
+"""GraphQL schema introspection and ad-hoc execute against Pipefy's public endpoint."""
+
 from __future__ import annotations
 
 from typing import Any

--- a/src/pipefy_mcp/services/pipefy/table_service.py
+++ b/src/pipefy_mcp/services/pipefy/table_service.py
@@ -1,4 +1,4 @@
-"""GraphQL queries for Pipefy database tables, records, and search."""
+"""GraphQL operations for Pipefy database tables, records, and search."""
 
 from __future__ import annotations
 
@@ -248,8 +248,8 @@ class TableService(BasePipefyClient):
 
         Args:
             field_id: Table field ID.
-            table_id: Table ID containing this field (required by API; if not provided, must be in attrs).
-            **attrs: Attributes to change (omit or pass None to skip). If table_id is not provided as a parameter, it can be passed here.
+            table_id: Owning table ID when known; otherwise pass ``table_id`` inside ``attrs``.
+            **attrs: ``UpdateTableFieldInput`` fields; ``None`` omits the key.
         """
         payload: dict[str, Any] = {"id": field_id}
         if table_id is not None:
@@ -285,7 +285,7 @@ class TableService(BasePipefyClient):
             match_threshold: Minimum fuzzy match score (0-100). Default: 70.
 
         Returns:
-            dict: Organizations with their matching tables, sorted by match score.
+            Organizations (with nested tables) matching the fuzzy filter, sorted by score.
         """
         result = await self.execute_query(SEARCH_TABLES_QUERY, {})
         organizations = result.get("organizations", [])

--- a/src/pipefy_mcp/tools/ai_tool_helpers.py
+++ b/src/pipefy_mcp/tools/ai_tool_helpers.py
@@ -67,67 +67,107 @@ class CreateAgentPartialFailurePayload(TypedDict):
 def build_create_automation_success(
     *, automation_id: str, message: str
 ) -> CreateAiAutomationSuccessPayload:
-    """Build success payload for create_ai_automation."""
+    """Successful AI automation create.
+
+    Args:
+        automation_id: New automation id from the API.
+        message: Short summary for the client.
+    """
     return {"success": True, "automation_id": automation_id, "message": message}
 
 
 def build_update_automation_success(
     *, automation_id: str, message: str
 ) -> UpdateAiAutomationSuccessPayload:
-    """Build success payload for update_ai_automation."""
+    """Successful AI automation update.
+
+    Args:
+        automation_id: Target automation id.
+        message: Short summary for the client.
+    """
     return {"success": True, "automation_id": automation_id, "message": message}
 
 
 def build_create_agent_success(
     *, agent_uuid: str, message: str
 ) -> CreateAiAgentSuccessPayload:
-    """Build success payload for create_ai_agent."""
+    """Successful AI agent create.
+
+    Args:
+        agent_uuid: New agent UUID from the API.
+        message: Short summary for the client.
+    """
     return {"success": True, "agent_uuid": agent_uuid, "message": message}
 
 
 def build_update_agent_success(
     *, agent_uuid: str, message: str
 ) -> UpdateAiAgentSuccessPayload:
-    """Build success payload for update_ai_agent."""
+    """Successful AI agent update.
+
+    Args:
+        agent_uuid: Target agent UUID.
+        message: Short summary for the client.
+    """
     return {"success": True, "agent_uuid": agent_uuid, "message": message}
 
 
 def build_toggle_agent_status_success(
     *, message: str
 ) -> ToggleAiAgentStatusSuccessPayload:
-    """Build success payload for toggle_ai_agent_status."""
+    """Successful agent enable/disable.
+
+    Args:
+        message: Short summary for the client.
+    """
     return {"success": True, "message": message}
 
 
 def build_get_agent_success(agent: AiAgentGraphPayload) -> GetAiAgentSuccessPayload:
-    """Build success payload for get_ai_agent."""
+    """Single-agent read envelope.
+
+    Args:
+        agent: ``aiAgent`` subtree (may be empty dict when missing).
+    """
     return {"success": True, "agent": agent}
 
 
 def build_get_agents_success(
     agents: list[AiAgentGraphPayload],
 ) -> GetAiAgentsSuccessPayload:
-    """Build success payload for get_ai_agents."""
+    """List-agents read envelope.
+
+    Args:
+        agents: Unwrapped connection nodes for the repo.
+    """
     return {"success": True, "agents": agents}
 
 
 def build_delete_agent_success(*, message: str) -> DeleteAiAgentSuccessPayload:
-    """Build success payload for delete_ai_agent."""
+    """Successful AI agent delete.
+
+    Args:
+        message: Short summary for the client.
+    """
     return {"success": True, "message": message}
 
 
 def build_ai_tool_error(message: str) -> AiToolErrorPayload:
-    """Build error payload for any AI tool."""
+    """Generic AI-tool failure envelope.
+
+    Args:
+        message: User-visible failure reason.
+    """
     return {"success": False, "error": message}
 
 
 def build_create_agent_partial_failure(
     *, agent_uuid: str, error: str
 ) -> CreateAgentPartialFailurePayload:
-    """Build payload when create succeeded but chained update failed.
+    """Create OK but follow-up update failed — surface UUID for recovery.
 
     Args:
-        agent_uuid: UUID of the agent returned by create (for recovery via update/delete).
-        error: Message describing the update failure.
+        agent_uuid: Agent UUID from ``createAiAgent`` (retry update or delete).
+        error: Why the chained update failed.
     """
     return {"success": False, "agent_uuid": agent_uuid, "error": error}

--- a/src/pipefy_mcp/tools/automation_tool_helpers.py
+++ b/src/pipefy_mcp/tools/automation_tool_helpers.py
@@ -49,11 +49,11 @@ def build_automation_mutation_success_payload(
     automation: dict[str, Any],
     action: str,
 ) -> AutomationMutationSuccessPayload:
-    """Build a success payload for traditional automation mutation tools.
+    """``success`` plus labeled ``message`` and raw ``automation`` dict.
 
     Args:
-        automation: ``automation`` object from the mutation response (may be empty for delete).
-        action: Short action key for the user-facing message (e.g. ``created``, ``updated``, ``deleted``).
+        automation: ``automation`` key from the mutation (possibly empty for delete).
+        action: Verb for the canned label (``created`` / ``updated`` / ``deleted`` / other).
     """
     labels = {
         "created": "Automation created.",
@@ -72,11 +72,11 @@ def build_automation_read_success_payload(
     data: AutomationReadToolData,
     label: str,
 ) -> AutomationReadSuccessPayload:
-    """Build a success payload for traditional automation read tools.
+    """``success``, ``message``, and typed read ``data`` (record or list).
 
     Args:
-        data: Automation record, list of summaries, or catalog entries from the API.
-        label: Short user-facing message (shown as ``message``).
+        data: Record, summary list, or catalog rows from the API.
+        label: Shown as ``message``.
     """
     return {
         "success": True,
@@ -89,11 +89,11 @@ def build_automation_error_payload(
     message: str,
     debug: str | None = None,
 ) -> AutomationToolErrorPayload:
-    """Build an error payload for automation tools.
+    """``success: False``; optional ``debug`` suffix in brackets.
 
     Args:
-        message: Primary error text for the caller.
-        debug: Optional extra detail (e.g. correlation hints) appended in brackets.
+        message: Primary error text.
+        debug: Extra detail appended as ``… [debug]`` when set.
     """
     text = message if not debug else f"{message} [{debug}]"
     return {"success": False, "error": text}
@@ -104,12 +104,12 @@ def handle_automation_tool_graphql_error(
     ctx: Context,
     debug: bool,
 ) -> AutomationToolErrorPayload:
-    """Map a GraphQL/client exception to an automation-tool error payload.
+    """Format ``exc`` as ``build_automation_error_payload``; optional MCP debug log.
 
     Args:
-        exc: Exception from the Pipefy client or transport layer.
-        ctx: MCP context (``debug`` logging in MCP clients such as Cursor when ``debug`` is True).
-        debug: When True, log exception detail and append GraphQL codes / correlation_id.
+        exc: Root exception from gql/httpx.
+        ctx: MCP context for ``ctx.debug`` when ``debug`` is True.
+        debug: Log raw exception and append codes / ``correlation_id`` to the message.
     """
     msgs = extract_error_strings(exc)
     base = "; ".join(msgs) if msgs else "Automation request failed."

--- a/src/pipefy_mcp/tools/automation_tools.py
+++ b/src/pipefy_mcp/tools/automation_tools.py
@@ -71,7 +71,7 @@ class AutomationTools:
                 )
             try:
                 raw = await client.get_automation(aid)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_automation_tool_graphql_error(exc, ctx, False)
             message = (
                 "No automation found for the given ID."
@@ -122,7 +122,7 @@ class AutomationTools:
                     organization_id=org,
                     pipe_id=pipe,
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_automation_tool_graphql_error(exc, ctx, False)
             return build_automation_read_success_payload(
                 rows,
@@ -154,7 +154,7 @@ class AutomationTools:
                 )
             try:
                 rows = await client.get_automation_actions(pid)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_automation_tool_graphql_error(exc, ctx, False)
             return build_automation_read_success_payload(
                 rows,
@@ -186,7 +186,7 @@ class AutomationTools:
                 )
             try:
                 rows = await client.get_automation_events(pid)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_automation_tool_graphql_error(exc, ctx, False)
             return build_automation_read_success_payload(
                 rows,
@@ -203,6 +203,7 @@ class AutomationTools:
             trigger_id: str | int,
             action_id: str | int,
             active: bool = True,
+            action_repo_id: str | int | None = None,
             extra_input: Any | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
@@ -213,13 +214,20 @@ class AutomationTools:
             ``CreateAutomationInput`` (camelCase keys). Use ``update_automation`` with ``active: false``
             to disable a rule after creation.
 
+            **Cross-pipe actions** (e.g. ``create_connected_card``, ``move_card_to_pipe``):
+            set ``action_repo_id`` to the **destination** pipe ID. When omitted it defaults to
+            ``pipe_id`` (same-pipe automation). Cross-pipe actions typically require
+            ``action_params`` inside ``extra_input`` — for example, ``create_connected_card`` needs
+            ``{"action_params": {"pipeId": "<child_pipe_id>", "fieldsAttributes": [...]}}``.
+
             Args:
-                pipe_id: Pipe ID (automation context).
+                pipe_id: Pipe ID where the trigger event fires (source pipe).
                 name: Rule name.
                 trigger_id: Event ID from ``get_automation_events``.
                 action_id: Action type ID from ``get_automation_actions``.
                 active: When True (default), the rule is created **enabled**. Set False to start disabled. If ``extra_input`` includes ``active``, that value wins.
-                extra_input: Optional extra fields for the mutation input.
+                action_repo_id: Pipe ID where the action executes (destination pipe). Defaults to ``pipe_id``. Required for cross-pipe actions.
+                extra_input: Optional extra fields for the mutation input (camelCase keys).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             pid = _normalize_required_id(pipe_id)
@@ -236,6 +244,16 @@ class AutomationTools:
                 return build_automation_error_payload(
                     message="Invalid 'name': provide a non-empty string.",
                 )
+            arid: str | None = None
+            if action_repo_id is not None:
+                arid = _normalize_required_id(action_repo_id)
+                if arid is None:
+                    return build_automation_error_payload(
+                        message=(
+                            "Invalid 'action_repo_id': provide a non-empty string or "
+                            "positive integer."
+                        ),
+                    )
             bad = mutation_error_if_not_optional_dict(
                 extra_input, arg_name="extra_input"
             )
@@ -248,9 +266,10 @@ class AutomationTools:
                     tid,
                     aid,
                     active=active,
+                    action_repo_id=arid,
                     extra_input=extra_input,
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_automation_tool_graphql_error(exc, ctx, debug)
             block = raw.get("createAutomation") or {}
             automation = block.get("automation") or {}
@@ -295,7 +314,7 @@ class AutomationTools:
                     rid,
                     extra_input=extra_input,
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_automation_tool_graphql_error(exc, ctx, debug)
             block = raw.get("updateAutomation") or {}
             automation = block.get("automation") or {}
@@ -342,7 +361,7 @@ class AutomationTools:
 
             try:
                 raw = await client.delete_automation(rid)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_automation_tool_graphql_error(exc, ctx, debug)
             if not raw.get("success"):
                 return build_automation_error_payload(

--- a/src/pipefy_mcp/tools/destructive_tool_guard.py
+++ b/src/pipefy_mcp/tools/destructive_tool_guard.py
@@ -18,10 +18,6 @@ from mcp.server.session import ServerSession
 from pydantic import BaseModel, Field
 from typing_extensions import TypedDict
 
-# ---------------------------------------------------------------------------
-# Pydantic model for interactive elicitation
-# ---------------------------------------------------------------------------
-
 
 class DestructiveActionConfirmation(BaseModel):
     """Schema shown to the user when the MCP client supports elicitation."""
@@ -30,11 +26,6 @@ class DestructiveActionConfirmation(BaseModel):
         ...,
         description="Set to true to confirm the action, or false to cancel.",
     )
-
-
-# ---------------------------------------------------------------------------
-# Generic payload types
-# ---------------------------------------------------------------------------
 
 
 class DestructivePreviewPayload(TypedDict):
@@ -50,10 +41,6 @@ class DestructiveCancelledPayload(TypedDict):
     success: Literal[False]
     error: str
 
-
-# ---------------------------------------------------------------------------
-# Guard function
-# ---------------------------------------------------------------------------
 
 _CANCEL_MESSAGE = "Action cancelled by user."
 
@@ -91,13 +78,7 @@ async def check_destructive_confirmation(
     if can_elicit:
         return await _elicit_confirmation(ctx, resource_descriptor)
 
-    # confirm=True and no elicitation → proceed
     return None
-
-
-# ---------------------------------------------------------------------------
-# Internal helpers
-# ---------------------------------------------------------------------------
 
 
 def _build_preview_payload(resource_descriptor: str) -> DestructivePreviewPayload:
@@ -134,8 +115,8 @@ async def _elicit_confirmation(
         if not result.data.model_dump().get("confirm"):
             return _build_cancel_payload()
 
-    except Exception as e:
-        return {"success": False, "error": f"Failed to request confirmation: {e!s}"}
+    except Exception as exc:  # noqa: BLE001
+        return {"success": False, "error": f"Failed to request confirmation: {exc!s}"}
 
     return None
 

--- a/src/pipefy_mcp/tools/field_condition_tools.py
+++ b/src/pipefy_mcp/tools/field_condition_tools.py
@@ -111,7 +111,7 @@ class FieldConditionTools:
                     actions_for_api,
                     **merged,
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
                     exc, "Create field condition failed.", debug=debug
                 )
@@ -206,7 +206,7 @@ class FieldConditionTools:
             )
             try:
                 raw = await client.update_field_condition(cid_key, **update_attrs)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
                     exc, "Update field condition failed.", debug=debug
                 )
@@ -269,7 +269,7 @@ class FieldConditionTools:
             )
             try:
                 raw = await client.delete_field_condition(cid_key)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
                     exc, "Delete field condition failed.", debug=debug
                 )

--- a/src/pipefy_mcp/tools/introspection_tool_helpers.py
+++ b/src/pipefy_mcp/tools/introspection_tool_helpers.py
@@ -1,3 +1,5 @@
+"""MCP payloads for schema introspection and raw GraphQL tools."""
+
 from __future__ import annotations
 
 import json
@@ -5,15 +7,15 @@ from typing import Any
 
 
 def _format_graphql_data_for_llm(data: dict[str, Any]) -> str:
-    """Serialize introspection or execution data as indented JSON for LLM consumption."""
+    """Indented JSON (UTF-8) for LLM-facing tool text."""
     return json.dumps(data, indent=2, default=str, ensure_ascii=False)
 
 
 def build_success_payload(data: dict[str, Any]) -> dict[str, Any]:
-    """Build the MCP success payload for introspection or raw GraphQL tool results.
+    """``success: True`` with stringified ``result`` for MCP text content.
 
     Args:
-        data: Raw dict from SchemaIntrospectionService (or compatible shape).
+        data: Introspection or execution dict from the service layer.
     """
     return {
         "success": True,
@@ -22,10 +24,10 @@ def build_success_payload(data: dict[str, Any]) -> dict[str, Any]:
 
 
 def build_error_payload(error_message: str) -> dict[str, Any]:
-    """Build the MCP error payload for introspection or raw GraphQL tool failures.
+    """``success: False`` with ``error`` string.
 
     Args:
-        error_message: User- or agent-facing explanation.
+        error_message: Agent/user-facing explanation.
     """
     return {
         "success": False,

--- a/src/pipefy_mcp/tools/member_tool_helpers.py
+++ b/src/pipefy_mcp/tools/member_tool_helpers.py
@@ -25,7 +25,12 @@ def build_member_success_payload(
     message: str,
     data: dict[str, Any],
 ) -> MemberMutationSuccessPayload:
-    """Build a success payload for member mutation tools."""
+    """``success``, ``message``, and mutation ``result``.
+
+    Args:
+        message: Short summary for the client.
+        data: Raw mutation payload (stored as ``result``).
+    """
     return cast(
         MemberMutationSuccessPayload,
         {"success": True, "message": message, "result": data},
@@ -33,7 +38,11 @@ def build_member_success_payload(
 
 
 def build_member_error_payload(*, message: str) -> dict[str, Any]:
-    """Build an error payload for member tools."""
+    """``success: False`` with ``error`` text.
+
+    Args:
+        message: User-visible failure reason.
+    """
     return {"success": False, "error": message}
 
 
@@ -43,12 +52,12 @@ def handle_member_tool_graphql_error(
     *,
     debug: bool = False,
 ) -> dict[str, Any]:
-    """Map a GraphQL/client exception to a member-tool error payload.
+    """Turn transport/GraphQL failures into ``build_member_error_payload`` output.
 
     Args:
-        exc: Exception from the Pipefy client or transport layer.
-        fallback_msg: Message when no extractable error strings exist.
-        debug: When True, append GraphQL codes and correlation_id to the message.
+        exc: Root exception from gql/httpx.
+        fallback_msg: Used when ``extract_error_strings`` is empty.
+        debug: When True, append codes and ``correlation_id``.
     """
     msgs = extract_error_strings(exc)
     base = "; ".join(msgs) if msgs else fallback_msg

--- a/src/pipefy_mcp/tools/member_tools.py
+++ b/src/pipefy_mcp/tools/member_tools.py
@@ -59,7 +59,7 @@ class MemberTools:
                     )
             try:
                 raw = await client.invite_members(pipe_id, members)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_member_tool_graphql_error(
                     exc, "Invite members failed.", debug=debug
                 )
@@ -118,7 +118,7 @@ class MemberTools:
                 raw = await client.remove_members_from_pipe(pipe_id, user_ids)
             except ValueError as exc:
                 return build_member_error_payload(message=str(exc))
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_member_tool_graphql_error(
                     exc, "Remove members from pipe failed.", debug=debug
                 )
@@ -160,7 +160,7 @@ class MemberTools:
                 raw = await client.set_role(
                     pipe_id, member_id.strip(), role_name.strip()
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_member_tool_graphql_error(
                     exc, "Set role failed.", debug=debug
                 )

--- a/src/pipefy_mcp/tools/observability_tool_helpers.py
+++ b/src/pipefy_mcp/tools/observability_tool_helpers.py
@@ -31,7 +31,12 @@ def build_observability_read_success_payload(
     *,
     message: str,
 ) -> ObservabilityReadSuccessPayload:
-    """Build a success payload for observability read tools."""
+    """``success``, ``message``, and GraphQL ``data`` for read tools.
+
+    Args:
+        data: Subtree returned by the observability query.
+        message: Short summary for the client.
+    """
     return cast(
         ObservabilityReadSuccessPayload,
         {
@@ -47,7 +52,12 @@ def build_observability_mutation_success_payload(
     message: str,
     data: dict[str, Any],
 ) -> ObservabilityMutationSuccessPayload:
-    """Structured success payload for observability mutation tools."""
+    """``success``, ``message``, and mutation ``result``.
+
+    Args:
+        message: Short summary for the client.
+        data: Raw mutation payload (stored as ``result``).
+    """
     return cast(
         ObservabilityMutationSuccessPayload,
         {"success": True, "message": message, "result": data},
@@ -55,7 +65,11 @@ def build_observability_mutation_success_payload(
 
 
 def build_observability_error_payload(*, message: str) -> dict[str, Any]:
-    """Build a structured error payload for observability tools."""
+    """``success: False`` with ``error`` text.
+
+    Args:
+        message: User-visible failure reason.
+    """
     return {"success": False, "error": message}
 
 
@@ -65,12 +79,12 @@ def handle_observability_tool_graphql_error(
     *,
     debug: bool = False,
 ) -> dict[str, Any]:
-    """Map a GraphQL/client exception to an observability-tool error payload.
+    """Turn transport/GraphQL failures into ``build_observability_error_payload`` output.
 
     Args:
-        exc: Exception from the Pipefy client or transport layer.
-        fallback_msg: Message when no extractable error strings exist.
-        debug: When True, append GraphQL codes and correlation_id to the message.
+        exc: Root exception from gql/httpx.
+        fallback_msg: Used when ``extract_error_strings`` is empty.
+        debug: When True, append codes and ``correlation_id``.
     """
     msgs = extract_error_strings(exc)
     base = "; ".join(msgs) if msgs else fallback_msg

--- a/src/pipefy_mcp/tools/pipe_config_tool_helpers.py
+++ b/src/pipefy_mcp/tools/pipe_config_tool_helpers.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from typing import Any, Literal, cast
 
 from typing_extensions import TypedDict
@@ -11,7 +10,7 @@ from pipefy_mcp.tools.graphql_error_helpers import (
     extract_graphql_error_codes,
     with_debug_suffix,
 )
-from pipefy_mcp.tools.validation_helpers import UUID_RE
+from pipefy_mcp.tools.validation_helpers import UUID_RE, format_json_preview
 
 
 class DeletePipePreviewPayload(TypedDict):
@@ -39,7 +38,7 @@ DeletePipePayload = (
 
 
 class PipeMutationSuccessPayload(TypedDict):
-    """Structured success response for pipe-config mutation tools."""
+    """Pipe create/update/clone tool success shape."""
 
     success: Literal[True]
     message: str
@@ -47,7 +46,7 @@ class PipeMutationSuccessPayload(TypedDict):
 
 
 class FieldConditionMutationSuccessPayload(TypedDict):
-    """Structured success response for create/update field condition tools."""
+    """Field condition create/update success shape."""
 
     success: Literal[True]
     condition_id: str
@@ -70,24 +69,20 @@ FieldConditionDeletePayload = (
 )
 
 
-def _to_readable_json(data: Any) -> str:
-    return json.dumps(data, indent=2, default=str, ensure_ascii=False)
-
-
 def handle_pipe_config_tool_graphql_error(
     exc: BaseException,
     fallback_msg: str,
     *,
     debug: bool = False,
 ) -> dict[str, Any]:
-    """Map a GraphQL/client exception to a pipe-config tool error payload.
+    """Turn transport/GraphQL failures into ``build_pipe_tool_error_payload`` output.
 
-    When ``debug`` is False, skips correlation/code extraction (same user-visible message).
+    When ``debug`` is False, the user-visible string omits codes / ``correlation_id``.
 
     Args:
-        exc: Exception from the Pipefy client or transport layer.
-        fallback_msg: Message when no extractable error strings exist.
-        debug: When True, append GraphQL codes and correlation_id to the message.
+        exc: Root exception from gql/httpx.
+        fallback_msg: Used when ``extract_error_strings`` is empty.
+        debug: When True, append codes and ``correlation_id``.
     """
     msgs = extract_error_strings(exc)
     base = "; ".join(msgs) if msgs else fallback_msg
@@ -103,9 +98,11 @@ def handle_pipe_config_tool_graphql_error(
 def build_pipe_mutation_success_payload(
     *, label: str, data: dict[str, Any]
 ) -> PipeMutationSuccessPayload:
-    """Build a success payload for pipe create/update/clone tools.
+    """``success``, ``message`` (``label``), and raw GraphQL ``result`` dict.
 
-    ``result`` is the raw GraphQL response dict (structured), not a nested JSON string.
+    Args:
+        label: Short summary shown as ``message``.
+        data: Full mutation response subtree (not a JSON string).
     """
     return cast(
         PipeMutationSuccessPayload,
@@ -114,17 +111,22 @@ def build_pipe_mutation_success_payload(
 
 
 def build_pipe_tool_error_payload(*, message: str) -> dict[str, Any]:
+    """``success: False`` with ``error`` text.
+
+    Args:
+        message: User-visible failure reason.
+    """
     return {"success": False, "error": message}
 
 
 def build_field_condition_success_payload(
     condition_id: str, action: str
 ) -> FieldConditionMutationSuccessPayload:
-    """Build a success payload for create_field_condition / update_field_condition.
+    """Field condition mutation envelope with canned ``message``.
 
     Args:
-        condition_id: Field condition ID returned by the API.
-        action: ``'created'`` or ``'updated'`` (passed through for clients).
+        condition_id: ID returned by the API.
+        action: ``created`` or ``updated`` (echoed to clients).
     """
     return {
         "success": True,
@@ -137,10 +139,10 @@ def build_field_condition_success_payload(
 def build_field_condition_delete_payload(
     success: bool,
 ) -> FieldConditionDeletePayload:
-    """Build a payload for delete_field_condition after the API responds.
+    """Post-delete API response as MCP-friendly dict.
 
     Args:
-        success: Whether ``deleteFieldCondition`` reported success.
+        success: Value of ``deleteFieldCondition.success``.
     """
     if success:
         return {
@@ -159,12 +161,18 @@ def build_delete_pipe_preview_payload(
     pipe_name: str,
     pipe_data: dict[str, Any],
 ) -> DeletePipePreviewPayload:
-    """Preview for delete_pipe when confirm is false."""
+    """Two-step delete: preview before ``confirm=True``.
+
+    Args:
+        pipe_id: Target pipe id.
+        pipe_name: Display name for messaging.
+        pipe_data: Subset serialized into ``pipe_summary``.
+    """
     return {
         "success": False,
         "requires_confirmation": True,
         "pipe_id": pipe_id,
-        "pipe_summary": _to_readable_json(
+        "pipe_summary": format_json_preview(
             {
                 "id": pipe_data.get("id"),
                 "name": pipe_name,
@@ -180,6 +188,11 @@ def build_delete_pipe_preview_payload(
 
 
 def build_delete_pipe_success_payload(*, pipe_id: int) -> DeletePipeSuccessPayload:
+    """Confirmed pipe deletion.
+
+    Args:
+        pipe_id: Deleted pipe id.
+    """
     return {
         "success": True,
         "pipe_id": pipe_id,
@@ -188,13 +201,18 @@ def build_delete_pipe_success_payload(*, pipe_id: int) -> DeletePipeSuccessPaylo
 
 
 def build_delete_pipe_error_payload(*, message: str) -> DeletePipeErrorPayload:
+    """Failed delete_pipe attempt.
+
+    Args:
+        message: User-visible failure reason.
+    """
     return cast(DeletePipeErrorPayload, {"success": False, "error": message})
 
 
 def map_delete_pipe_error_to_message(
     *, pipe_id: int, pipe_name: str, codes: list[str]
 ) -> str:
-    """Map GraphQL error codes to user-facing text for delete_pipe."""
+    """Heuristic user string from GraphQL ``extensions.code`` for delete_pipe."""
     for code in codes:
         if code == "RESOURCE_NOT_FOUND":
             return (

--- a/src/pipefy_mcp/tools/pipe_config_tools.py
+++ b/src/pipefy_mcp/tools/pipe_config_tools.py
@@ -63,7 +63,7 @@ class PipeConfigTools:
                 )
             try:
                 raw = await client.create_pipe(name.strip(), organization_id)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
                     exc, "Create pipe failed.", debug=debug
                 )
@@ -116,7 +116,7 @@ class PipeConfigTools:
                     color=color,
                     preferences=preferences,
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
                     exc, "Update pipe failed.", debug=debug
                 )
@@ -156,7 +156,7 @@ class PipeConfigTools:
                 pipe_response = await client.get_pipe(pipe_id)
                 pipe_data = pipe_response.get("pipe") or {}
                 pipe_name = pipe_data.get("name") or "Unknown"
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 codes = extract_graphql_error_codes(exc)
                 correlation_id = extract_graphql_correlation_id(exc)
                 base = map_delete_pipe_error_to_message(
@@ -192,7 +192,7 @@ class PipeConfigTools:
                         codes=[],
                     )
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 codes = extract_graphql_error_codes(exc)
                 correlation_id = extract_graphql_correlation_id(exc)
                 base = map_delete_pipe_error_to_message(
@@ -243,7 +243,7 @@ class PipeConfigTools:
                     pipe_template_id,
                     organization_id=organization_id,
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
                     exc, "Clone pipe failed.", debug=debug
                 )
@@ -291,7 +291,7 @@ class PipeConfigTools:
                     index=index,
                     description=description,
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
                     exc, "Create phase failed.", debug=debug
                 )
@@ -366,7 +366,7 @@ class PipeConfigTools:
             if "name" not in update_attrs:
                 try:
                     phase_info = await client.get_phase_fields(phase_id)
-                except Exception as exc:
+                except Exception as exc:  # noqa: BLE001  # noqa: BLE001
                     return handle_pipe_config_tool_graphql_error(
                         exc, "Could not load phase.", debug=debug
                     )
@@ -379,7 +379,7 @@ class PipeConfigTools:
 
             try:
                 raw = await client.update_phase(phase_id, **update_attrs)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
                     exc, "Update phase failed.", debug=debug
                 )
@@ -426,7 +426,7 @@ class PipeConfigTools:
 
             try:
                 raw = await client.delete_phase(phase_id)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
                     exc, "Delete phase failed.", debug=debug
                 )
@@ -491,7 +491,7 @@ class PipeConfigTools:
                     field_type.strip(),
                     **merged,
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
                     exc, "Create phase field failed.", debug=debug
                 )
@@ -554,7 +554,7 @@ class PipeConfigTools:
             fid = field_id.strip() if isinstance(field_id, str) else field_id
             try:
                 raw = await client.update_phase_field(fid, **update_attrs)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
                     exc, "Update phase field failed.", debug=debug
                 )
@@ -605,7 +605,7 @@ class PipeConfigTools:
 
             try:
                 raw = await client.delete_phase_field(fid)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
                     exc, "Delete phase field failed.", debug=debug
                 )
@@ -651,7 +651,7 @@ class PipeConfigTools:
                     name.strip(),
                     color.strip(),
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
                     exc, "Create label failed.", debug=debug
                 )
@@ -700,7 +700,7 @@ class PipeConfigTools:
                 )
             try:
                 raw = await client.update_label(label_id, **update_attrs)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
                     exc, "Update label failed.", debug=debug
                 )
@@ -747,7 +747,7 @@ class PipeConfigTools:
 
             try:
                 raw = await client.delete_label(label_id)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
                     exc, "Delete label failed.", debug=debug
                 )

--- a/src/pipefy_mcp/tools/pipe_tool_helpers.py
+++ b/src/pipefy_mcp/tools/pipe_tool_helpers.py
@@ -90,7 +90,11 @@ class DeleteCardConfirmation(BaseModel):
 def build_add_card_comment_success_payload(
     *, comment_id: object
 ) -> AddCardCommentSuccessPayload:
-    """Build the public success payload for add_card_comment."""
+    """Recorded comment id.
+
+    Args:
+        comment_id: New comment id from the API (coerced to str).
+    """
     return {"success": True, "comment_id": str(comment_id)}
 
 
@@ -152,7 +156,7 @@ def _map_comment_like_error(
 
 
 def map_add_card_comment_error_to_message(exc: BaseException) -> str:
-    """Map a GraphQL exception into a stable, friendly English message."""
+    """Heuristic English message for add_comment failures."""
     return _map_comment_like_error(
         exc,
         not_found_msg="Card not found. Please verify 'card_id' and access permissions.",
@@ -163,7 +167,7 @@ def map_add_card_comment_error_to_message(exc: BaseException) -> str:
 
 
 def map_update_comment_error_to_message(exc: BaseException) -> str:
-    """Map a GraphQL exception into a stable, friendly English message."""
+    """Heuristic English message for update_comment failures."""
     return _map_comment_like_error(
         exc,
         not_found_msg="Comment not found. Please verify 'comment_id' and access permissions.",
@@ -174,7 +178,7 @@ def map_update_comment_error_to_message(exc: BaseException) -> str:
 
 
 def map_delete_comment_error_to_message(exc: BaseException) -> str:
-    """Map a GraphQL exception into a stable, friendly English message."""
+    """Heuristic English message for delete_comment failures."""
     return _map_comment_like_error(
         exc,
         not_found_msg="Comment not found. Please verify 'comment_id' and access permissions.",
@@ -190,36 +194,58 @@ def _build_comment_error_payload(message: str) -> dict:
 
 
 def build_add_card_comment_error_payload(*, message: str) -> AddCardCommentErrorPayload:
-    """Build the public error payload for add_card_comment."""
+    """add_card_comment failure envelope.
+
+    Args:
+        message: User-visible failure reason.
+    """
     return cast(AddCardCommentErrorPayload, _build_comment_error_payload(message))
 
 
 def build_update_comment_success_payload(
     *, comment_id: object
 ) -> UpdateCommentSuccessPayload:
-    """Build the public success payload for update_comment."""
+    """Updated comment id.
+
+    Args:
+        comment_id: Updated comment id (coerced to str).
+    """
     return {"success": True, "comment_id": str(comment_id)}
 
 
 def build_update_comment_error_payload(*, message: str) -> UpdateCommentErrorPayload:
-    """Build the public error payload for update_comment."""
+    """update_comment failure envelope.
+
+    Args:
+        message: User-visible failure reason.
+    """
     return cast(UpdateCommentErrorPayload, _build_comment_error_payload(message))
 
 
 def build_delete_comment_success_payload() -> DeleteCommentSuccessPayload:
-    """Build the public success payload for delete_comment."""
+    """Minimal success body after delete_comment."""
     return {"success": True}
 
 
 def build_delete_comment_error_payload(*, message: str) -> DeleteCommentErrorPayload:
-    """Build the public error payload for delete_comment."""
+    """delete_comment failure envelope.
+
+    Args:
+        message: User-visible failure reason.
+    """
     return cast(DeleteCommentErrorPayload, _build_comment_error_payload(message))
 
 
 def build_delete_card_preview_payload(
     *, card_id: int, card_title: str, pipe_name: str
 ) -> DeleteCardPreviewPayload:
-    """Build the preview payload for delete_card."""
+    """Two-step delete: preview before ``confirm=True``.
+
+    Args:
+        card_id: Target card id.
+        card_title: Shown in the warning text.
+        pipe_name: Owning pipe name for context.
+    """
     return {
         "success": False,
         "requires_confirmation": True,
@@ -237,7 +263,13 @@ def build_delete_card_preview_payload(
 def build_delete_card_success_payload(
     *, card_id: int, card_title: str, pipe_name: str
 ) -> DeleteCardSuccessPayload:
-    """Build the success payload for delete_card."""
+    """Confirmed card deletion.
+
+    Args:
+        card_id: Deleted card id.
+        card_title: Card title for messaging.
+        pipe_name: Pipe name for messaging.
+    """
     return {
         "success": True,
         "card_id": card_id,
@@ -251,7 +283,11 @@ def build_delete_card_success_payload(
 
 
 def build_delete_card_error_payload(*, message: str) -> DeleteCardErrorPayload:
-    """Build the error payload for delete_card."""
+    """delete_card failure envelope.
+
+    Args:
+        message: User-visible failure reason.
+    """
     return {"success": False, "error": message}
 
 

--- a/src/pipefy_mcp/tools/pipe_tools.py
+++ b/src/pipefy_mcp/tools/pipe_tools.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
@@ -269,11 +269,13 @@ class PipeTools:
                 first: Max cards to return per page.
                 after: Cursor for fetching the next page (from ``pageInfo.endCursor`` of a previous call).
             """
-            merged_search = dict(search) if search else {}
+            merged_search: CardSearch = cast(CardSearch, dict(search) if search else {})
             if title:
                 merged_search["title"] = title
 
-            effective_search: CardSearch | None = merged_search or None  # type: ignore[assignment]
+            effective_search: CardSearch | None = (
+                merged_search if merged_search else None
+            )
 
             await ctx.debug(
                 f"Getting cards for pipe {pipe_id} (include_fields={include_fields}, search={effective_search})"
@@ -654,7 +656,7 @@ class PipeTools:
                 card_data = card_response["card"]
                 card_title = card_data["title"]
                 pipe_name = card_data.get("pipe", {}).get("name", "Unknown Pipe")
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 codes = extract_graphql_error_codes(exc)
                 correlation_id = extract_graphql_correlation_id(exc)
                 base = map_delete_card_error_to_message(
@@ -700,9 +702,9 @@ class PipeTools:
                             message="Card deletion cancelled by user."
                         )
 
-                except Exception as e:
+                except Exception as exc:  # noqa: BLE001
                     return build_delete_card_error_payload(
-                        message=f"Failed to request confirmation: {str(e)}"
+                        message=f"Failed to request confirmation: {exc!s}"
                     )
 
             try:
@@ -720,7 +722,7 @@ class PipeTools:
                     return build_delete_card_error_payload(
                         message=f"Failed to delete card '{card_title}' (ID: {card_id}). Please try again or contact support."
                     )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 codes = extract_graphql_error_codes(exc)
                 correlation_id = extract_graphql_correlation_id(exc)
                 base = map_delete_card_error_to_message(

--- a/src/pipefy_mcp/tools/relation_tool_helpers.py
+++ b/src/pipefy_mcp/tools/relation_tool_helpers.py
@@ -31,7 +31,12 @@ def build_relation_read_success_payload(
     *,
     message: str,
 ) -> RelationReadSuccessPayload:
-    """Build a success payload for relation read tools."""
+    """``success``, ``message``, and GraphQL ``data`` for read tools.
+
+    Args:
+        data: Subtree from the relation query.
+        message: Short summary for the client.
+    """
     return cast(
         RelationReadSuccessPayload,
         {
@@ -43,6 +48,11 @@ def build_relation_read_success_payload(
 
 
 def build_relation_error_payload(*, message: str) -> dict[str, Any]:
+    """``success: False`` with ``error`` text.
+
+    Args:
+        message: User-visible failure reason.
+    """
     return {"success": False, "error": message}
 
 
@@ -51,7 +61,12 @@ def build_relation_mutation_success_payload(
     message: str,
     data: dict[str, Any],
 ) -> RelationMutationSuccessPayload:
-    """Structured success payload for relation mutation tools."""
+    """``success``, ``message``, and mutation ``result``.
+
+    Args:
+        message: Short summary for the client.
+        data: Raw mutation payload (stored as ``result``).
+    """
     return cast(
         RelationMutationSuccessPayload,
         {"success": True, "message": message, "result": data},
@@ -64,12 +79,12 @@ def handle_relation_tool_graphql_error(
     *,
     debug: bool = False,
 ) -> dict[str, Any]:
-    """Map a GraphQL/client exception to a relation-tool error payload.
+    """Turn transport/GraphQL failures into ``build_relation_error_payload`` output.
 
     Args:
-        exc: Exception from the Pipefy client or transport layer.
-        fallback_msg: Message when no extractable error strings exist.
-        debug: When True, append GraphQL codes and correlation_id to the message.
+        exc: Root exception from gql/httpx.
+        fallback_msg: Used when ``extract_error_strings`` is empty.
+        debug: When True, append codes and ``correlation_id``.
     """
     msgs = extract_error_strings(exc)
     base = "; ".join(msgs) if msgs else fallback_msg

--- a/src/pipefy_mcp/tools/relation_tools.py
+++ b/src/pipefy_mcp/tools/relation_tools.py
@@ -42,7 +42,7 @@ class RelationTools:
                 )
             try:
                 raw = await client.get_pipe_relations(pipe_id)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_relation_tool_graphql_error(
                     exc, "Get pipe relations failed."
                 )
@@ -70,7 +70,7 @@ class RelationTools:
                 )
             try:
                 raw = await client.get_table_relations(relation_ids)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_relation_tool_graphql_error(
                     exc, "Get table relations failed."
                 )
@@ -120,7 +120,7 @@ class RelationTools:
                     name.strip(),
                     extra_input=extra_input,
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_relation_tool_graphql_error(
                     exc, "Create pipe relation failed.", debug=debug
                 )
@@ -167,7 +167,7 @@ class RelationTools:
                     name.strip(),
                     extra_input=extra_input,
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_relation_tool_graphql_error(
                     exc, "Update pipe relation failed.", debug=debug
                 )
@@ -214,7 +214,7 @@ class RelationTools:
 
             try:
                 raw = await client.delete_pipe_relation(relation_id)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_relation_tool_graphql_error(
                     exc, "Delete pipe relation failed.", debug=debug
                 )
@@ -264,7 +264,7 @@ class RelationTools:
                     source_id,
                     extra_input=extra_input,
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_relation_tool_graphql_error(
                     exc, "Create card relation failed.", debug=debug
                 )

--- a/src/pipefy_mcp/tools/report_tool_helpers.py
+++ b/src/pipefy_mcp/tools/report_tool_helpers.py
@@ -31,7 +31,12 @@ def build_report_read_success_payload(
     *,
     message: str,
 ) -> ReportReadSuccessPayload:
-    """Build a success payload for report read tools."""
+    """``success``, ``message``, and GraphQL ``data`` for read tools.
+
+    Args:
+        data: Subtree returned by the report query.
+        message: Short summary for the client.
+    """
     return cast(
         ReportReadSuccessPayload,
         {
@@ -47,7 +52,12 @@ def build_report_mutation_success_payload(
     message: str,
     data: dict[str, Any],
 ) -> ReportMutationSuccessPayload:
-    """Build a success payload for report mutation tools."""
+    """``success``, ``message``, and mutation ``result``.
+
+    Args:
+        message: Short summary for the client.
+        data: Raw mutation payload (stored as ``result``).
+    """
     return cast(
         ReportMutationSuccessPayload,
         {"success": True, "message": message, "result": data},
@@ -55,6 +65,11 @@ def build_report_mutation_success_payload(
 
 
 def build_report_error_payload(*, message: str) -> dict[str, Any]:
+    """``success: False`` with ``error`` text.
+
+    Args:
+        message: User-visible failure reason.
+    """
     return {"success": False, "error": message}
 
 
@@ -64,12 +79,12 @@ def handle_report_tool_graphql_error(
     *,
     debug: bool = False,
 ) -> dict[str, Any]:
-    """Map a GraphQL/client exception to a report-tool error payload.
+    """Turn transport/GraphQL failures into ``build_report_error_payload`` output.
 
     Args:
-        exc: Exception from the Pipefy client or transport layer.
-        fallback_msg: Message when no extractable error strings exist.
-        debug: When True, append GraphQL codes and correlation_id to the message.
+        exc: Root exception from gql/httpx.
+        fallback_msg: Used when ``extract_error_strings`` is empty.
+        debug: When True, append codes and ``correlation_id``.
     """
     msgs = extract_error_strings(exc)
     base = "; ".join(msgs) if msgs else fallback_msg

--- a/src/pipefy_mcp/tools/table_tool_helpers.py
+++ b/src/pipefy_mcp/tools/table_tool_helpers.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from typing import Any, Literal, cast
 
 from typing_extensions import TypedDict
@@ -13,10 +12,7 @@ from pipefy_mcp.tools.graphql_error_helpers import (
     extract_graphql_error_codes,
     with_debug_suffix,
 )
-
-
-def _to_readable_json(data: Any) -> str:
-    return json.dumps(data, indent=2, default=str, ensure_ascii=False)
+from pipefy_mcp.tools.validation_helpers import format_json_preview
 
 
 class TableReadSuccessPayload(TypedDict):
@@ -76,10 +72,13 @@ def build_table_read_success_payload(
     *,
     message: str,
 ) -> TableReadSuccessPayload:
-    """Build a success payload for table read tools.
+    """Read envelope with optional ``pagination`` from connection ``pageInfo``.
 
-    When the GraphQL payload includes `table_records` or `findRecords`, copies
-    `hasNextPage` and `endCursor` into `pagination` for clearer LLM consumption.
+    Fills ``pagination`` when ``data`` contains ``table_records`` or ``findRecords``.
+
+    Args:
+        data: Raw GraphQL payload for the tool.
+        message: Short summary for the client.
     """
     return cast(
         TableReadSuccessPayload,
@@ -93,6 +92,11 @@ def build_table_read_success_payload(
 
 
 def build_table_error_payload(*, message: str) -> dict[str, Any]:
+    """``success: False`` with ``error`` text.
+
+    Args:
+        message: User-visible failure reason.
+    """
     return {"success": False, "error": message}
 
 
@@ -103,7 +107,12 @@ build_table_mutation_error_payload = build_table_error_payload
 def build_table_mutation_success_payload(
     *, message: str, data: dict[str, Any]
 ) -> TableMutationSuccessPayload:
-    """Structured success payload for table/record mutation tools."""
+    """``success``, ``message``, and mutation ``result``.
+
+    Args:
+        message: Short summary for the client.
+        data: Raw mutation payload (stored as ``result``).
+    """
     return cast(
         TableMutationSuccessPayload,
         {"success": True, "message": message, "result": data},
@@ -116,12 +125,18 @@ def build_delete_table_preview_payload(
     table_name: str,
     table_data: dict[str, Any],
 ) -> DeleteTablePreviewPayload:
-    """Preview when delete_table is called without confirmation."""
+    """Two-step delete: preview before ``confirm=True``.
+
+    Args:
+        table_id: Target table id.
+        table_name: Display name for messaging.
+        table_data: Subset serialized into ``table_summary``.
+    """
     return {
         "success": False,
         "requires_confirmation": True,
         "table_id": table_id,
-        "table_summary": _to_readable_json(
+        "table_summary": format_json_preview(
             {
                 "id": table_data.get("id"),
                 "name": table_name,
@@ -140,6 +155,11 @@ def build_delete_table_preview_payload(
 def build_delete_table_success_payload(
     *, table_id: str | int
 ) -> DeleteTableSuccessPayload:
+    """Confirmed table deletion.
+
+    Args:
+        table_id: Deleted table id.
+    """
     return {
         "success": True,
         "table_id": table_id,
@@ -148,6 +168,11 @@ def build_delete_table_success_payload(
 
 
 def build_delete_table_error_payload(*, message: str) -> DeleteTableErrorPayload:
+    """Failed delete_table attempt.
+
+    Args:
+        message: User-visible failure reason.
+    """
     return cast(DeleteTableErrorPayload, {"success": False, "error": message})
 
 
@@ -187,12 +212,12 @@ def handle_table_tool_graphql_error(
     *,
     debug: bool = False,
 ) -> dict[str, Any]:
-    """Map a GraphQL/client exception to a table-tool error payload.
+    """Turn transport/GraphQL failures into ``build_table_error_payload`` output.
 
     Args:
-        exc: Exception from the Pipefy client or transport layer.
-        fallback_msg: Message when no extractable error strings exist.
-        debug: When True, append GraphQL codes and correlation_id to the message.
+        exc: Root exception from gql/httpx.
+        fallback_msg: Used when ``extract_error_strings`` is empty.
+        debug: When True, append codes and ``correlation_id``.
     """
     msgs = extract_error_strings(exc)
     base = "; ".join(msgs) if msgs else fallback_msg

--- a/src/pipefy_mcp/tools/table_tools.py
+++ b/src/pipefy_mcp/tools/table_tools.py
@@ -105,7 +105,7 @@ class TableTools:
                 )
             try:
                 raw = await client.get_table(table_id)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_table_tool_graphql_error(exc, "Get table failed.")
             return build_table_read_success_payload(
                 raw,
@@ -131,7 +131,7 @@ class TableTools:
                 )
             try:
                 raw = await client.get_tables(table_ids)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_table_tool_graphql_error(exc, "Get tables failed.")
             return build_table_read_success_payload(
                 raw,
@@ -182,7 +182,7 @@ class TableTools:
                     first=first,
                     after=after.strip() if isinstance(after, str) else after,
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_table_tool_graphql_error(
                     exc, "List table records failed."
                 )
@@ -206,7 +206,7 @@ class TableTools:
                 )
             try:
                 raw = await client.get_table_record(record_id)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_table_tool_graphql_error(exc, "Get table record failed.")
             return build_table_read_success_payload(
                 raw,
@@ -270,7 +270,7 @@ class TableTools:
                     first=first,
                     after=after.strip() if isinstance(after, str) else after,
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_table_tool_graphql_error(exc, "Find records failed.")
             return build_table_read_success_payload(
                 raw,
@@ -313,7 +313,7 @@ class TableTools:
                     merged[k] = v
             try:
                 raw = await client.create_table(name.strip(), organization_id, **merged)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_table_tool_graphql_error(
                     exc, "Create table failed.", debug=debug
                 )
@@ -368,7 +368,7 @@ class TableTools:
                     kwargs[k] = v
             try:
                 raw = await client.update_table(table_id, **kwargs)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_table_tool_graphql_error(
                     exc, "Update table failed.", debug=debug
                 )
@@ -408,7 +408,7 @@ class TableTools:
                 table_response = await client.get_table(table_id)
                 table_data = table_response.get("table") or {}
                 table_name = table_data.get("name") or "Unknown"
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 codes = extract_graphql_error_codes(exc)
                 correlation_id = extract_graphql_correlation_id(exc)
                 base = map_delete_table_error_to_message(
@@ -444,7 +444,7 @@ class TableTools:
                         codes=[],
                     )
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 codes = extract_graphql_error_codes(exc)
                 correlation_id = extract_graphql_correlation_id(exc)
                 base = map_delete_table_error_to_message(
@@ -525,7 +525,7 @@ class TableTools:
                     merged_attrs[k] = v
             try:
                 raw = await client.create_table_record(table_id, fields, **merged_attrs)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_table_tool_graphql_error(
                     exc, "Create table record failed.", debug=debug
                 )
@@ -568,7 +568,7 @@ class TableTools:
                 )
             try:
                 raw = await client.update_table_record(record_id, fields)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_table_tool_graphql_error(
                     exc, "Update table record failed.", debug=debug
                 )
@@ -615,7 +615,7 @@ class TableTools:
 
             try:
                 raw = await client.delete_table_record(record_id)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_table_tool_graphql_error(
                     exc, "Delete table record failed.", debug=debug
                 )
@@ -662,7 +662,7 @@ class TableTools:
                 raw = await client.set_table_record_field_value(
                     record_id, field_id, value
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_table_tool_graphql_error(
                     exc, "Set table record field value failed.", debug=debug
                 )
@@ -725,7 +725,7 @@ class TableTools:
                     field_type.strip(),
                     **merged,
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_table_tool_graphql_error(
                     exc, "Create table field failed.", debug=debug
                 )
@@ -806,7 +806,7 @@ class TableTools:
                 raw = await client.update_table_field(
                     fid, table_id=table_id_to_use, **update_attrs
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_table_tool_graphql_error(
                     exc, "Update table field failed.", debug=debug
                 )
@@ -856,7 +856,7 @@ class TableTools:
 
             try:
                 raw = await client.delete_table_field(fid)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_table_tool_graphql_error(
                     exc, "Delete table field failed.", debug=debug
                 )

--- a/src/pipefy_mcp/tools/validation_helpers.py
+++ b/src/pipefy_mcp/tools/validation_helpers.py
@@ -2,12 +2,22 @@
 
 from __future__ import annotations
 
+import json
 import re
 from typing import Any
 
 UUID_RE = re.compile(
     r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
 )
+
+
+def format_json_preview(data: Any) -> str:
+    """Pretty-print arbitrary data for MCP confirmation summaries (UTF-8, non-ASCII preserved).
+
+    Args:
+        data: Any JSON-serializable or stringifiable structure.
+    """
+    return json.dumps(data, indent=2, default=str, ensure_ascii=False)
 
 
 def valid_repo_id(value: object) -> bool:

--- a/src/pipefy_mcp/tools/webhook_tool_helpers.py
+++ b/src/pipefy_mcp/tools/webhook_tool_helpers.py
@@ -25,7 +25,12 @@ def build_webhook_success_payload(
     message: str,
     data: dict[str, Any],
 ) -> WebhookMutationSuccessPayload:
-    """Build a success payload for webhook/email mutation tools."""
+    """``success``, ``message``, and mutation ``result``.
+
+    Args:
+        message: Short summary for the client.
+        data: Raw mutation payload (stored as ``result``).
+    """
     return cast(
         WebhookMutationSuccessPayload,
         {"success": True, "message": message, "result": data},
@@ -33,7 +38,11 @@ def build_webhook_success_payload(
 
 
 def build_webhook_error_payload(*, message: str) -> dict[str, Any]:
-    """Build an error payload for webhook tools."""
+    """``success: False`` with ``error`` text.
+
+    Args:
+        message: User-visible failure reason.
+    """
     return {"success": False, "error": message}
 
 
@@ -43,12 +52,12 @@ def handle_webhook_tool_graphql_error(
     *,
     debug: bool = False,
 ) -> dict[str, Any]:
-    """Map a GraphQL/client exception to a webhook-tool error payload.
+    """Turn transport/GraphQL failures into ``build_webhook_error_payload`` output.
 
     Args:
-        exc: Exception from the Pipefy client or transport layer.
-        fallback_msg: Message when no extractable error strings exist.
-        debug: When True, append GraphQL codes and correlation_id to the message.
+        exc: Root exception from gql/httpx.
+        fallback_msg: Used when ``extract_error_strings`` is empty.
+        debug: When True, append codes and ``correlation_id``.
     """
     msgs = extract_error_strings(exc)
     base = "; ".join(msgs) if msgs else fallback_msg

--- a/src/pipefy_mcp/tools/webhook_tools.py
+++ b/src/pipefy_mcp/tools/webhook_tools.py
@@ -56,7 +56,7 @@ class WebhookTools:
                     filter_by_name=filter_by_name.strip() if filter_by_name else None,
                     first=first,
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_webhook_tool_graphql_error(
                     exc, "List email templates failed.", debug=debug
                 )
@@ -100,7 +100,7 @@ class WebhookTools:
                     card_id.strip(),
                     email_type=trimmed_email_type,
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_webhook_tool_graphql_error(
                     exc, "Get card inbox emails failed.", debug=debug
                 )
@@ -172,7 +172,7 @@ class WebhookTools:
                     from_=from_.strip(),
                     **(extra_input or {}),
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_webhook_tool_graphql_error(
                     exc, "Send inbox email failed.", debug=debug
                 )
@@ -236,7 +236,7 @@ class WebhookTools:
                 )
             except ValueError as exc:
                 return build_webhook_error_payload(message=str(exc))
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_webhook_tool_graphql_error(
                     exc, "Send email with template failed.", debug=debug
                 )
@@ -297,7 +297,7 @@ class WebhookTools:
                 )
             except ValueError as exc:
                 return build_webhook_error_payload(message=str(exc))
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_webhook_tool_graphql_error(
                     exc, "Create webhook failed.", debug=debug
                 )
@@ -345,7 +345,7 @@ class WebhookTools:
 
             try:
                 raw = await client.delete_webhook(webhook_id.strip())
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 return handle_webhook_tool_graphql_error(
                     exc, "Delete webhook failed.", debug=debug
                 )

--- a/tests/services/pipefy/test_automation_service.py
+++ b/tests/services/pipefy/test_automation_service.py
@@ -258,6 +258,27 @@ async def test_create_automation_success(mock_settings):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_create_automation_with_action_repo_id(mock_settings):
+    created = {
+        "createAutomation": {
+            "automation": {"id": "a-xpipe", "name": "Cross", "active": True},
+        },
+    }
+    service = _make_service(mock_settings, created)
+    await service.create_automation(
+        "p-parent",
+        "Cross",
+        "evt-1",
+        "act-connected",
+        action_repo_id="p-child",
+    )
+    inp = service.execute_query.call_args[0][1]["input"]
+    assert inp["event_repo_id"] == "p-parent"
+    assert inp["action_repo_id"] == "p-child"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_create_automation_active_false_via_attrs(mock_settings):
     created = {
         "createAutomation": {

--- a/tests/services/test_pipefy_facade.py
+++ b/tests/services/test_pipefy_facade.py
@@ -406,21 +406,21 @@ async def test_pipefy_client_facade_delegates_to_services_without_modifying_args
         "ok": "create_automation"
     }
     automation_service.create_automation.assert_awaited_once_with(
-        "p1", "Rule", "ev", "act", active=True
+        "p1", "Rule", "ev", "act", action_repo_id=None, active=True
     )
 
     assert await client.create_automation(
         "p1", "Rule", "ev", "act", extra_input={"customKey": "v"}
     ) == {"ok": "create_automation"}
     automation_service.create_automation.assert_awaited_with(
-        "p1", "Rule", "ev", "act", active=True, customKey="v"
+        "p1", "Rule", "ev", "act", action_repo_id=None, active=True, customKey="v"
     )
 
     assert await client.create_automation("p1", "Rule", "ev", "act", active=False) == {
         "ok": "create_automation"
     }
     automation_service.create_automation.assert_awaited_with(
-        "p1", "Rule", "ev", "act", active=False
+        "p1", "Rule", "ev", "act", action_repo_id=None, active=False
     )
 
     assert await client.create_automation(
@@ -432,7 +432,14 @@ async def test_pipefy_client_facade_delegates_to_services_without_modifying_args
         extra_input={"active": False},
     ) == {"ok": "create_automation"}
     automation_service.create_automation.assert_awaited_with(
-        "p1", "Rule", "ev", "act", active=False
+        "p1", "Rule", "ev", "act", action_repo_id=None, active=False
+    )
+
+    assert await client.create_automation(
+        "p1", "Rule", "ev", "act", action_repo_id="child-pipe"
+    ) == {"ok": "create_automation"}
+    automation_service.create_automation.assert_awaited_with(
+        "p1", "Rule", "ev", "act", action_repo_id="child-pipe", active=True
     )
 
     assert await client.update_automation("a1", extra_input={"name": "N"}) == {

--- a/tests/services/test_table_service_search_tables.py
+++ b/tests/services/test_table_service_search_tables.py
@@ -42,7 +42,11 @@ def mock_organizations() -> list[dict]:
             "name": "Globo",
             "tables": {
                 "nodes": [
-                    {"id": "T3", "name": "Fornecedores", "description": "Supplier database"},
+                    {
+                        "id": "T3",
+                        "name": "Fornecedores",
+                        "description": "Supplier database",
+                    },
                     {"id": "T4", "name": "Clientes VIP", "description": None},
                 ]
             },

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -126,6 +126,7 @@ async def test_register_tools(client_session):
         "remove_member_from_pipe",
         "search_pipes",
         "search_schema",
+        "search_tables",
         "send_email_with_template",
         "send_inbox_email",
         "set_role",

--- a/tests/tools/test_automation_tools.py
+++ b/tests/tools/test_automation_tools.py
@@ -372,6 +372,7 @@ async def test_create_automation_success(
         "evt-1",
         "act-1",
         active=True,
+        action_repo_id=None,
         extra_input=None,
     )
     payload = extract_payload(result)
@@ -381,6 +382,53 @@ async def test_create_automation_success(
         "name": "Notify",
         "active": True,
     }
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("automation_session", [None], indirect=True)
+async def test_create_automation_passes_action_repo_id(
+    automation_session, mock_automation_client, extract_payload
+):
+    mock_automation_client.create_automation.return_value = {
+        "createAutomation": {
+            "automation": {"id": "a-cc", "name": "Connected", "active": True},
+        },
+    }
+
+    async with automation_session as session:
+        result = await session.call_tool(
+            "create_automation",
+            {
+                "pipe_id": "p-parent",
+                "name": "Connected",
+                "trigger_id": "1",
+                "action_id": "2",
+                "action_repo_id": "p-child",
+                "extra_input": {
+                    "action_params": {
+                        "pipeId": "p-child",
+                        "fieldsAttributes": [],
+                    },
+                },
+            },
+        )
+
+    assert result.isError is False
+    mock_automation_client.create_automation.assert_awaited_once_with(
+        "p-parent",
+        "Connected",
+        "1",
+        "2",
+        active=True,
+        action_repo_id="p-child",
+        extra_input={
+            "action_params": {
+                "pipeId": "p-child",
+                "fieldsAttributes": [],
+            },
+        },
+    )
+    assert extract_payload(result)["success"] is True
 
 
 @pytest.mark.anyio

--- a/tests/tools/test_validation_helpers.py
+++ b/tests/tools/test_validation_helpers.py
@@ -3,9 +3,19 @@
 import pytest
 
 from pipefy_mcp.tools.validation_helpers import (
+    format_json_preview,
     mutation_error_if_not_optional_dict,
     valid_repo_id,
 )
+
+
+@pytest.mark.unit
+def test_format_json_preview_pretty_and_utf8():
+    s = format_json_preview({"a": 1, "ç": "β"})
+    assert '"a": 1' in s
+    assert "ç" in s
+    assert "β" in s
+    assert "\n" in s
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Context
`action_repo_id` was always set to the source pipe, matching `event_repo_id`. Pipefy then rejects cross-pipe actions such as `create_connected_card` with triggers like `card_moved` (both repos pointed at the same pipe).

## Changes
- **Traditional and AI automations:** optional `action_repo_id` (defaults to `pipe_id`). For cross-pipe actions, set it to the **destination** (child) pipe.
- **MCP tool `create_automation`:** documents expected `action_params` (`pipeId`, `fieldsAttributes`) via `extra_input`.
- **Tests:** service, MCP tools, and facade coverage.

## Also
- `format_json_preview` for destructive confirmation summaries; tighter typings/docstrings in reports and helpers; `search_tables` tests split into a dedicated file.

## Verification
- `uv run pytest -m "not integration" -q` — 840 passed
- `uv run ruff check src/ tests/` and `ruff format --check` — clean