### PR TITLE
fix(ai-agent): validate behavior action metadata by actionType

### DIFF
--- a/src/pipefy_mcp/models/ai_agent.py
+++ b/src/pipefy_mcp/models/ai_agent.py
@@ -11,12 +11,89 @@ from pipefy_mcp.models.validators import NonBlankStr
 ACTION_ID_AI_BEHAVIOR = "ai_behavior"
 MAX_BEHAVIORS = 5
 
+# actionTypes that require pipeId + fieldsAttributes in metadata
+_CARD_FIELD_ACTION_TYPES = frozenset(
+    {"update_card", "create_card", "create_connected_card"}
+)
+
+
+def _validate_card_field_metadata(action_type: str, metadata: dict) -> None:
+    """Validate metadata for actions that operate on card fields.
+
+    Args:
+        action_type: The actionType string (used in error messages).
+        metadata: The metadata dict from the action.
+
+    Raises:
+        ValueError: When required keys are missing or malformed.
+    """
+    if not metadata.get("pipeId"):
+        raise ValueError(
+            f"actionType '{action_type}' requires metadata.pipeId "
+            f"(the pipe where the action executes)."
+        )
+    fields = metadata.get("fieldsAttributes")
+    if not isinstance(fields, list) or not fields:
+        raise ValueError(
+            f"actionType '{action_type}' requires metadata.fieldsAttributes "
+            f"as a non-empty list of field entries."
+        )
+    for i, entry in enumerate(fields):
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"actionType '{action_type}': fieldsAttributes[{i}] must be a dict."
+            )
+        if not entry.get("fieldId"):
+            raise ValueError(
+                f"actionType '{action_type}': fieldsAttributes[{i}] requires 'fieldId'."
+            )
+        if not entry.get("inputMode"):
+            raise ValueError(
+                f"actionType '{action_type}': fieldsAttributes[{i}] "
+                f"requires 'inputMode'."
+            )
+
+
+def _validate_move_card_metadata(metadata: dict) -> None:
+    """Validate metadata for move_card actions.
+
+    Raises:
+        ValueError: When destinationPhaseId is missing or blank.
+    """
+    dest = metadata.get("destinationPhaseId")
+    if not isinstance(dest, str) or not dest.strip():
+        raise ValueError(
+            "actionType 'move_card' requires metadata.destinationPhaseId "
+            "(the target phase ID)."
+        )
+
+
+def _validate_action_metadata(action: dict) -> None:
+    """Validate metadata for a single action based on its actionType.
+
+    Unknown actionTypes are passed through without validation.
+    """
+    action_type = action.get("actionType", "")
+    metadata = action.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+
+    if action_type in _CARD_FIELD_ACTION_TYPES:
+        _validate_card_field_metadata(action_type, metadata)
+    elif action_type == "move_card":
+        _validate_move_card_metadata(metadata)
+
 
 class BehaviorInput(BaseModel):
     """One AI agent behavior; accepts snake_case or camelCase, dumps with camelCase aliases.
 
     The Pipefy API requires ``actionParams.aiBehaviorParams.actionsAttributes`` with at least
     one action; otherwise ``updateAiAgent`` fails (e.g. "The instructions must contain at least 1 action").
+
+    Optional ``eventParams`` configures the trigger. For each action dict, known ``actionType``
+    values get ``metadata`` checks: ``update_card`` / ``create_card`` / ``create_connected_card``
+    need ``pipeId`` and non-empty ``fieldsAttributes`` (each entry needs ``fieldId`` and
+    ``inputMode``); ``move_card`` needs ``destinationPhaseId``. Other types are not validated here.
     """
 
     model_config = ConfigDict(populate_by_name=True)
@@ -52,6 +129,9 @@ class BehaviorInput(BaseModel):
                 "Each behavior must set actionParams.aiBehaviorParams.actionsAttributes with "
                 'at least one action (Pipefy: "The instructions must contain at least 1 action").'
             )
+        for action in actions:
+            if isinstance(action, dict):
+                _validate_action_metadata(action)
         return self
 
 

--- a/tests/ai_agent_test_payloads.py
+++ b/tests/ai_agent_test_payloads.py
@@ -33,3 +33,25 @@ def minimal_behavior_dict(name="Test Behavior", event_id="card_created"):
             }
         },
     }
+
+
+def behavior_with_action(
+    action_type, metadata, *, name="Test Behavior", event_id="card_created"
+):
+    """Build a behavior dict with a single action of the given type and metadata."""
+    return {
+        "name": name,
+        "event_id": event_id,
+        "actionParams": {
+            "aiBehaviorParams": {
+                "instruction": "Test instruction.",
+                "actionsAttributes": [
+                    {
+                        "name": f"{action_type} action",
+                        "actionType": action_type,
+                        "metadata": metadata,
+                    },
+                ],
+            }
+        },
+    }

--- a/tests/models/test_ai_agent.py
+++ b/tests/models/test_ai_agent.py
@@ -10,7 +10,7 @@ from pipefy_mcp.models.ai_agent import (
     CreateAiAgentInput,
     UpdateAiAgentInput,
 )
-from tests.ai_agent_test_payloads import minimal_behavior_dict
+from tests.ai_agent_test_payloads import behavior_with_action, minimal_behavior_dict
 
 
 def _make_behavior(name="Test Behavior", event_id="card_created"):
@@ -335,3 +335,136 @@ def test_behavior_input_event_params_defaults_none():
     assert inp.event_params is None
     dumped = inp.model_dump(by_alias=True, exclude_none=True)
     assert "eventParams" not in dumped
+
+
+# --- metadata validation per actionType ---
+
+VALID_FIELDS_ATTR = {"fieldId": "425829426", "inputMode": "fill_with_ai", "value": ""}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "action_type", ["update_card", "create_card", "create_connected_card"]
+)
+def test_metadata_valid_for_card_field_actions(action_type):
+    metadata = {
+        "pipeId": "306996636",
+        "fieldsAttributes": [VALID_FIELDS_ATTR],
+    }
+    payload = behavior_with_action(action_type, metadata)
+    inp = BehaviorInput.model_validate(payload)
+    action = inp.action_params["aiBehaviorParams"]["actionsAttributes"][0]
+    assert action["metadata"]["pipeId"] == "306996636"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "action_type", ["update_card", "create_card", "create_connected_card"]
+)
+def test_metadata_rejects_empty_dict_for_card_field_actions(action_type):
+    payload = behavior_with_action(action_type, {})
+    with pytest.raises(ValidationError, match="pipeId"):
+        BehaviorInput.model_validate(payload)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "action_type", ["update_card", "create_card", "create_connected_card"]
+)
+def test_metadata_rejects_missing_fields_attributes(action_type):
+    payload = behavior_with_action(action_type, {"pipeId": "123"})
+    with pytest.raises(ValidationError, match="fieldsAttributes"):
+        BehaviorInput.model_validate(payload)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "action_type", ["update_card", "create_card", "create_connected_card"]
+)
+def test_metadata_rejects_empty_fields_attributes(action_type):
+    payload = behavior_with_action(
+        action_type, {"pipeId": "123", "fieldsAttributes": []}
+    )
+    with pytest.raises(ValidationError, match="fieldsAttributes"):
+        BehaviorInput.model_validate(payload)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "action_type", ["update_card", "create_card", "create_connected_card"]
+)
+def test_metadata_rejects_field_entry_missing_field_id(action_type):
+    metadata = {
+        "pipeId": "123",
+        "fieldsAttributes": [{"inputMode": "fill_with_ai", "value": ""}],
+    }
+    payload = behavior_with_action(action_type, metadata)
+    with pytest.raises(ValidationError, match="fieldId"):
+        BehaviorInput.model_validate(payload)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "action_type", ["update_card", "create_card", "create_connected_card"]
+)
+def test_metadata_rejects_field_entry_missing_input_mode(action_type):
+    metadata = {
+        "pipeId": "123",
+        "fieldsAttributes": [{"fieldId": "425829426", "value": ""}],
+    }
+    payload = behavior_with_action(action_type, metadata)
+    with pytest.raises(ValidationError, match="inputMode"):
+        BehaviorInput.model_validate(payload)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "action_type", ["update_card", "create_card", "create_connected_card"]
+)
+def test_metadata_allows_empty_value_in_fields_attributes(action_type):
+    metadata = {
+        "pipeId": "123",
+        "fieldsAttributes": [
+            {"fieldId": "1", "inputMode": "fill_with_ai", "value": ""}
+        ],
+    }
+    payload = behavior_with_action(action_type, metadata)
+    inp = BehaviorInput.model_validate(payload)
+    assert inp.action_params is not None
+
+
+@pytest.mark.unit
+def test_metadata_valid_for_move_card():
+    payload = behavior_with_action("move_card", {"destinationPhaseId": "999"})
+    inp = BehaviorInput.model_validate(payload)
+    action = inp.action_params["aiBehaviorParams"]["actionsAttributes"][0]
+    assert action["metadata"]["destinationPhaseId"] == "999"
+
+
+@pytest.mark.unit
+def test_metadata_rejects_empty_dict_for_move_card():
+    payload = behavior_with_action("move_card", {})
+    with pytest.raises(ValidationError, match="destinationPhaseId"):
+        BehaviorInput.model_validate(payload)
+
+
+@pytest.mark.unit
+def test_metadata_rejects_blank_destination_phase_id_for_move_card():
+    payload = behavior_with_action("move_card", {"destinationPhaseId": "  "})
+    with pytest.raises(ValidationError, match="destinationPhaseId"):
+        BehaviorInput.model_validate(payload)
+
+
+@pytest.mark.unit
+def test_metadata_passes_through_unknown_action_type():
+    payload = behavior_with_action("send_email", {"to": "user@example.com"})
+    inp = BehaviorInput.model_validate(payload)
+    action = inp.action_params["aiBehaviorParams"]["actionsAttributes"][0]
+    assert action["metadata"]["to"] == "user@example.com"
+
+
+@pytest.mark.unit
+def test_metadata_allows_empty_dict_for_unknown_action_type():
+    payload = behavior_with_action("send_email", {})
+    inp = BehaviorInput.model_validate(payload)
+    assert inp.action_params is not None


### PR DESCRIPTION
## Summary
Stricter validation on `BehaviorInput` so AI agent behaviors fail fast with clear errors when `actionsAttributes` metadata does not match what Pipefy expects for common action types.

## Behavior
- **`update_card` / `create_card` / `create_connected_card`:** require `metadata.pipeId`, non-empty `metadata.fieldsAttributes` (list of dicts with `fieldId` and `inputMode`).
- **`move_card`:** require non-blank `metadata.destinationPhaseId` (string).
- **Other `actionType` values:** unchanged (no extra validation).

## Docs
- `BehaviorInput` class docstring now describes optional `eventParams` and the metadata rules above.

## Tests
- `behavior_with_action` helper in `tests/ai_agent_test_payloads.py`.
- Parametrized unit tests for valid/invalid metadata.

## Verification
- `uv run pytest tests/ -q` — 881 passed, 7 skipped
- `uv run pytest -m "not integration" -q` — 866 passed
- `uv run ruff check src/ tests/` / `ruff format --check` — clean