### PR TITLE
fix(reports): coerce pipeId to int in create_pipe_report

### DIFF
--- a/src/pipefy_mcp/services/pipefy/report_service.py
+++ b/src/pipefy_mcp/services/pipefy/report_service.py
@@ -163,7 +163,7 @@ class ReportService(BasePipefyClient):
             filter: Report filter (``ReportCardsFilter`` shape).
             formulas: Formula definitions (list of [field, operator, ...] tuples).
         """
-        input_obj: dict[str, Any] = {"pipeId": pipe_id, "name": name}
+        input_obj: dict[str, Any] = {"pipeId": int(pipe_id), "name": name}
         if fields is not None:
             input_obj["fields"] = fields
         if filter is not None:

--- a/tests/services/pipefy/test_report_service.py
+++ b/tests/services/pipefy/test_report_service.py
@@ -301,7 +301,7 @@ async def test_create_pipe_report_success(mock_settings):
 
     query, variables = service.execute_query.call_args[0]
     assert query is CREATE_PIPE_REPORT_MUTATION
-    assert variables["input"]["pipeId"] == "123"
+    assert variables["input"]["pipeId"] == 123
     assert variables["input"]["name"] == "New Report"
     assert variables["input"]["fields"] == ["title", "status"]
     assert result["createPipeReport"]["pipeReport"]["id"] == "r10"
@@ -315,7 +315,7 @@ async def test_create_pipe_report_minimal(mock_settings):
     result = await service.create_pipe_report("456", "Minimal")
 
     variables = service.execute_query.call_args[0][1]
-    assert variables["input"] == {"pipeId": "456", "name": "Minimal"}
+    assert variables["input"] == {"pipeId": 456, "name": "Minimal"}
     assert result["createPipeReport"]["pipeReport"]["name"] == "Minimal"
 
 


### PR DESCRIPTION
## Problem
`createPipeReport` input expects `pipeId` as GraphQL `Int`; sending a string could cause API/runtime issues.

## Change
- Coerce `pipe_id` with `int(pipe_id)` when building the mutation `input` in `ReportService.create_pipe_report`.
- Update unit tests to assert numeric `pipeId` in variables.

## Verification
- `uv run pytest tests/services/pipefy/test_report_service.py -q`
- `uv run pytest -m "not integration" -q`
- `ruff check` / `ruff format --check`