### PR TITLE
feat(tools): AI agent behavior validation and get_ai_agent ergonomics

### DIFF
--- a/src/pipefy_mcp/tools/ai_agent_tools.py
+++ b/src/pipefy_mcp/tools/ai_agent_tools.py
@@ -17,6 +17,8 @@ from pipefy_mcp.tools.ai_tool_helpers import (
     build_get_agents_success,
     build_toggle_agent_status_success,
     build_update_agent_success,
+    enrich_behavior_error,
+    validate_behaviors_against_pipe,
 )
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.graphql_error_helpers import extract_error_strings
@@ -84,10 +86,26 @@ class AiAgentTools:
               - ``update_card`` → ``{"pipeId": "<pipe_id>", "fieldsAttributes": [{"fieldId": "...", "inputMode": "fill_with_ai", "value": ""}]}``
               - ``create_card`` → ``{"pipeId": "<pipe_id>", "fieldsAttributes": [...]}``
               - ``create_connected_card`` → ``{"pipeId": "<pipe_id>", "fieldsAttributes": [...]}``
+                Requires a pipe relation between source and destination pipes
+                (verify with ``get_pipe_relations``).
 
             Optional ``eventParams`` per behavior (filters when the trigger fires):
               - ``field_updated`` event → ``{"triggerFieldIds": ["<field_id>"]}`` to fire only on specific fields.
               - ``card_moved`` event → ``{"to_phase_id": "<phase_id>"}`` to fire only when moving to a specific phase.
+
+            Behavior keys accept both ``snake_case`` (``event_id``, ``event_params``,
+            ``action_params``) and ``camelCase`` (``eventId``, ``eventParams``, ``actionParams``).
+            The canonical wire format is camelCase.
+
+            Important constraints:
+              - **All-or-nothing save**: the API replaces the entire behaviors list on every call.
+                Always send the complete set (1–5). Omitting a behavior deletes it.
+              - **``update_card`` vs ``update_card_field``**: use ``update_card``; the API does
+                not accept ``update_card_field`` as an actionType for AI behaviors.
+              - **``metadata: {}`` is never valid** for known action types — it causes
+                ``RECORD_NOT_SAVED``. Always include the required keys.
+              - The server injects ``referenceId`` UUIDs and ``%{action:<uuid>}`` placeholders
+                into each behavior's instruction automatically — do not set them manually.
 
             Args:
                 name: Agent display name.
@@ -133,11 +151,9 @@ class AiAgentTools:
             try:
                 await client.update_ai_agent(update_input)
             except Exception as exc:  # noqa: BLE001
-                msgs = extract_error_strings(exc)
-                text = "; ".join(msgs) if msgs else str(exc)
                 return build_create_agent_partial_failure(
                     agent_uuid=agent_uuid,
-                    error=text,
+                    error=enrich_behavior_error(exc, behaviors),
                 )
 
             msg = f"AI Agent created and configured successfully. UUID: {agent_uuid}"
@@ -155,11 +171,16 @@ class AiAgentTools:
             behaviors: list[dict],
             data_source_ids: list[str] | None = None,
         ) -> dict:
-            """Update an AI Agent — replaces the entire config, so always send the complete behaviors list.
+            """Update an AI Agent — replaces the entire config (all-or-nothing save).
 
+            Always send the **complete** behaviors list (1–5). Omitting a behavior deletes it.
             Each behavior must include ``actionParams.aiBehaviorParams.actionsAttributes`` with at least
             one action (same constraint and shape as ``create_ai_agent`` — see its docstring for the
-            full behavior dict example, discovery workflow, and known ``actionType`` values).
+            full behavior dict example, discovery workflow, known ``actionType`` values, and constraints).
+
+            To modify an existing agent: call ``get_ai_agent`` first, edit the returned config,
+            and send the full payload back. The server injects ``referenceId`` and ``%{action:<uuid>}``
+            placeholders automatically — do not set or preserve them from ``get_ai_agent``.
 
             Args:
                 uuid: UUID of the agent to update.
@@ -168,6 +189,7 @@ class AiAgentTools:
                 instruction: Agent-level purpose (Pipefy UI "Description"; API ``instruction``).
                 behaviors: 1–5 behavior dicts. Same shape as ``create_ai_agent``: each needs ``name``,
                     ``event_id``, and ``actionParams.aiBehaviorParams.actionsAttributes``.
+                    Accepts both ``snake_case`` and ``camelCase`` keys.
                 data_source_ids: Optional list of data source IDs.
             """
             ctx.debug(f"update_ai_agent: uuid={uuid}, behaviors_count={len(behaviors)}")
@@ -186,7 +208,7 @@ class AiAgentTools:
             try:
                 result = await client.update_ai_agent(validated)
             except Exception as exc:  # noqa: BLE001
-                return build_ai_tool_error(str(exc))
+                return build_ai_tool_error(enrich_behavior_error(exc, behaviors))
 
             return build_update_agent_success(
                 agent_uuid=result["agent_uuid"],
@@ -220,7 +242,7 @@ class AiAgentTools:
                     agent_uuid=agent_uuid, active=active
                 )
             except Exception as exc:  # noqa: BLE001
-                return build_ai_tool_error(str(exc))
+                return error_payload_from_exception(exc)
 
             return build_toggle_agent_status_success(message=result["message"])
 
@@ -228,7 +250,17 @@ class AiAgentTools:
             annotations=ToolAnnotations(readOnlyHint=True),
         )
         async def get_ai_agent(ctx: Context, uuid: str) -> dict:
-            """Get an AI Agent by UUID. Use get_pipe to find the pipe's uuid field, then get_ai_agents to list agents.
+            """Get an AI Agent by UUID with full behavior configuration.
+
+            Returns the complete agent config including, per behavior: ``eventParams``
+            (trigger filters like ``to_phase_id``, ``triggerFieldIds``),
+            ``actionParams.aiBehaviorParams`` with ``instruction``, ``actionsAttributes``
+            (each with ``actionType``, ``metadata``, ``referenceId``), ``referencedFieldIds``,
+            and ``dataSourceIds``.
+
+            The response is complete enough to re-send via ``update_ai_agent`` (clone/modify
+            workflow). Use ``get_pipe`` to find the pipe's ``uuid`` field, then ``get_ai_agents``
+            to list agents and obtain UUIDs.
 
             Args:
                 uuid: Agent UUID.
@@ -304,3 +336,131 @@ class AiAgentTools:
             return build_delete_agent_success(
                 message=f"AI Agent deleted successfully. UUID: {agent_uuid}",
             )
+
+        @mcp.tool(
+            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+        )
+        async def validate_ai_agent_behaviors(
+            ctx: Context,
+            pipe_id: str | int,
+            behaviors: list[dict],
+            strict_unknown_action_types: bool = True,
+        ) -> dict:
+            """Dry-run validation of AI Agent behaviors against a pipe's fields, phases, and relations.
+
+            Call **before** ``create_ai_agent`` / ``update_ai_agent`` to catch problems early
+            (invalid fieldIds, missing phase IDs, absent pipe relations for ``create_connected_card``).
+
+            Runs Pydantic model validation (same as the mutation tools) plus cross-references
+            against live pipe data. Does not persist anything.
+
+            Response fields:
+              - ``success``: the tool finished without an unexpected failure (same idea as other
+                read tools); ``False`` only when returning a generic tool error (e.g. blank
+                ``pipe_id``, or pipe fetch failed).
+              - ``valid``: ``True`` only when ``problems`` is empty (no blocking issues).
+              - ``warnings``: non-blocking notices (e.g. unknown ``actionType`` when
+                ``strict_unknown_action_types`` is ``False``, or relations could not be loaded).
+              - ``problems``, ``message``: blocking issues and a short summary.
+
+            Example shapes::
+
+              {"success": true, "valid": true, "problems": [], "warnings": [], "message": "..."}
+              {"success": true, "valid": false, "problems": ["..."], "warnings": [], "message": "..."}
+              {"success": true, "valid": true, "problems": [], "warnings": ["..."], "message": "..."}
+
+            Args:
+                pipe_id: Numeric pipe ID (used to fetch fields, phases, and relations).
+                behaviors: 1–5 behavior dicts (same shape as ``create_ai_agent``).
+                strict_unknown_action_types: When ``True`` (default), unknown ``actionType`` values
+                    are reported in ``problems``. When ``False``, they appear in ``warnings`` only.
+            """
+            pid = str(pipe_id).strip()
+            if not pid:
+                return build_ai_tool_error("pipe_id must not be blank")
+
+            # Pydantic structural validation
+            try:
+                from pipefy_mcp.models.ai_agent import BehaviorInput
+
+                for b in behaviors:
+                    BehaviorInput.model_validate(b)
+            except ValidationError as exc:
+                return {
+                    "success": True,
+                    "valid": False,
+                    "problems": [str(exc)],
+                    "warnings": [],
+                    "message": "Behavior dicts failed structural validation (BehaviorInput).",
+                }
+
+            # Fetch pipe context
+            try:
+                pipe_data = await client.get_pipe(int(pid))
+            except Exception as exc:  # noqa: BLE001
+                return build_ai_tool_error(f"Failed to fetch pipe {pid}: {exc}")
+
+            pipe_info = pipe_data.get("pipe", {})
+            phases = pipe_info.get("phases") or []
+            phase_ids: set[str] = set()
+            field_ids: set[str] = set()
+            for phase in phases:
+                phase_ids.add(str(phase.get("id", "")))
+                for field in phase.get("fields") or []:
+                    fid = field.get("id") or field.get("internal_id")
+                    if fid:
+                        field_ids.add(str(fid))
+
+            # Also include start form fields
+            start_fields = pipe_info.get("start_form_fields") or []
+            for field in start_fields:
+                fid = field.get("id") or field.get("internal_id")
+                if fid:
+                    field_ids.add(str(fid))
+
+            tool_warnings: list[str] = []
+            related_pipe_ids: set[str] | None
+            try:
+                relations = await client.get_pipe_relations(pid)
+                related_pipe_ids = set()
+                for rel in relations.get("children") or []:
+                    child_id = rel.get("child", {}).get("id")
+                    if child_id:
+                        related_pipe_ids.add(str(child_id))
+                for rel in relations.get("parents") or []:
+                    parent_id = rel.get("parent", {}).get("id")
+                    if parent_id:
+                        related_pipe_ids.add(str(parent_id))
+            except Exception:  # noqa: BLE001
+                ctx.debug("Could not fetch pipe relations; skipping relation checks")
+                related_pipe_ids = None
+                tool_warnings.append(
+                    "Could not load pipe relations; create_connected_card pipeId targets "
+                    "were not verified against relations."
+                )
+
+            unknown_action_types = "error" if strict_unknown_action_types else "warning"
+            problems, helper_warnings = validate_behaviors_against_pipe(
+                behaviors,
+                pipe_id=pid,
+                pipe_field_ids=field_ids,
+                pipe_phase_ids=phase_ids,
+                related_pipe_ids=related_pipe_ids,
+                unknown_action_types=unknown_action_types,
+            )
+            warnings = [*tool_warnings, *helper_warnings]
+
+            if problems:
+                msg = f"Found {len(problems)} problem(s) in behaviors."
+            elif warnings:
+                msg = f"Validation passed with {len(warnings)} warning(s)."
+            else:
+                msg = "All behaviors passed validation."
+
+            return {
+                "success": True,
+                "valid": len(problems) == 0,
+                "problems": problems,
+                "warnings": warnings,
+                "message": msg,
+            }

--- a/src/pipefy_mcp/tools/ai_tool_helpers.py
+++ b/src/pipefy_mcp/tools/ai_tool_helpers.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Literal
+import re
+from typing import Any, Literal
 
 from typing_extensions import TypedDict
 
 from pipefy_mcp.services.pipefy.types import AiAgentGraphPayload
+from pipefy_mcp.tools.graphql_error_helpers import extract_error_strings
 
 
 class CreateAiAutomationSuccessPayload(TypedDict):
@@ -171,3 +173,193 @@ def build_create_agent_partial_failure(
         error: Why the chained update failed.
     """
     return {"success": False, "agent_uuid": agent_uuid, "error": error}
+
+
+# --- Error enrichment for behavior-level failures ---
+
+# Patterns the Pipefy API returns that map to actionable advice.
+_ERROR_HINTS: list[tuple[re.Pattern[str], str]] = [
+    (
+        re.compile(r"RECORD_NOT_SAVED", re.IGNORECASE),
+        "Check that metadata is complete for each actionType "
+        "(e.g. update_card needs pipeId + fieldsAttributes; "
+        "move_card needs destinationPhaseId).",
+    ),
+    (
+        re.compile(r"must contain at least 1 action", re.IGNORECASE),
+        "Each behavior requires actionParams.aiBehaviorParams.actionsAttributes "
+        "with at least one action entry.",
+    ),
+]
+
+
+def _summarize_behaviors(behaviors: list[dict[str, Any]]) -> str:
+    """Build a compact one-line-per-behavior summary for error context.
+
+    Args:
+        behaviors: Raw behavior dicts (pre-validation, may use either key style).
+    """
+    lines: list[str] = []
+    for i, b in enumerate(behaviors):
+        name = b.get("name", "<unnamed>")
+        event = b.get("eventId") or b.get("event_id") or "?"
+        actions_desc: list[str] = []
+
+        ap = b.get("actionParams") or b.get("action_params") or {}
+        abp = ap.get("aiBehaviorParams") or ap.get("ai_behavior_params") or {}
+        attrs = abp.get("actionsAttributes") or abp.get("actions_attributes") or []
+        for a in attrs:
+            if isinstance(a, dict):
+                actions_desc.append(a.get("actionType", "?"))
+
+        actions_str = ", ".join(actions_desc) if actions_desc else "none"
+        lines.append(f'  [{i}] "{name}" (event={event}, actions=[{actions_str}])')
+    return "\n".join(lines)
+
+
+# --- Behavior validation against pipe context ---
+
+# actionTypes that the Pipefy AI behavior system recognizes.
+KNOWN_AI_ACTION_TYPES = frozenset(
+    {"move_card", "update_card", "create_card", "create_connected_card"}
+)
+
+
+def validate_behaviors_against_pipe(
+    behaviors: list[dict[str, Any]],
+    *,
+    pipe_id: str = "",
+    pipe_field_ids: set[str],
+    pipe_phase_ids: set[str],
+    related_pipe_ids: set[str] | None,
+    unknown_action_types: Literal["error", "warning", "ignore"] = "error",
+) -> tuple[list[str], list[str]]:
+    """Check behaviors against resolved pipe context and return problems and warnings.
+
+    Pure function — no API calls. The caller is responsible for fetching
+    pipe fields, phases, and relations beforehand.
+
+    Args:
+        behaviors: Raw behavior dicts (pre-validation format).
+        pipe_id: Source pipe ID (used to decide whether fieldId checks apply).
+        pipe_field_ids: Set of valid field internal IDs for the source pipe.
+        pipe_phase_ids: Set of valid phase IDs (as strings) for the source pipe.
+        related_pipe_ids: Pipe IDs related to the source pipe for
+            ``create_connected_card`` validation; ``None`` skips that check
+            (avoids false positives when relations were not loaded). A set
+            (possibly empty) runs the relation check as before.
+        unknown_action_types: How to treat non-empty ``actionType`` values not in
+            ``KNOWN_AI_ACTION_TYPES``: ``error`` adds to problems, ``warning``
+            adds the same message to warnings, ``ignore`` skips.
+
+    Returns:
+        Tuple ``(problems, warnings)`` of human-readable strings. Empty lists
+        mean no issues at that severity.
+    """
+    problems: list[str] = []
+    warnings: list[str] = []
+
+    for i, b in enumerate(behaviors):
+        name = b.get("name", f"<behavior {i}>")
+        prefix = f'Behavior [{i}] "{name}"'
+
+        ap = b.get("actionParams") or b.get("action_params") or {}
+        abp = ap.get("aiBehaviorParams") or ap.get("ai_behavior_params") or {}
+        attrs = abp.get("actionsAttributes") or abp.get("actions_attributes") or []
+
+        # Check eventParams phase references
+        ep = b.get("eventParams") or b.get("event_params") or {}
+        to_phase = ep.get("to_phase_id") or ep.get("toPhaseId")
+        if to_phase and str(to_phase) not in pipe_phase_ids:
+            problems.append(
+                f'{prefix}: eventParams.to_phase_id / toPhaseId "{to_phase}" '
+                f"not found in pipe phases."
+            )
+
+        for j, action in enumerate(attrs):
+            if not isinstance(action, dict):
+                continue
+            action_type = action.get("actionType", "")
+            metadata = action.get("metadata") or {}
+
+            if action_type and action_type not in KNOWN_AI_ACTION_TYPES:
+                msg = (
+                    f"{prefix}, action [{j}]: unknown actionType "
+                    f'"{action_type}". Known types: {sorted(KNOWN_AI_ACTION_TYPES)}.'
+                )
+                if unknown_action_types == "error":
+                    problems.append(msg)
+                elif unknown_action_types == "warning":
+                    warnings.append(msg)
+
+            # Check destinationPhaseId for move_card
+            if action_type == "move_card":
+                dest = metadata.get("destinationPhaseId", "")
+                if dest and str(dest) not in pipe_phase_ids:
+                    problems.append(
+                        f"{prefix}, action [{j}] (move_card): "
+                        f'destinationPhaseId "{dest}" not found in pipe phases.'
+                    )
+
+            # Check fieldsAttributes fieldId references — only when the action
+            # targets the same pipe (or no pipeId is set in metadata).
+            # Cross-pipe actions (create_connected_card, create_card on another
+            # pipe) reference fields from the *target* pipe, which we don't have.
+            action_pipe = str(metadata.get("pipeId", ""))
+            targets_source = not action_pipe or action_pipe == pipe_id
+            if targets_source:
+                fields_attrs = metadata.get("fieldsAttributes") or []
+                for k, fa in enumerate(fields_attrs):
+                    if not isinstance(fa, dict):
+                        continue
+                    fid = fa.get("fieldId", "")
+                    if fid and pipe_field_ids and fid not in pipe_field_ids:
+                        problems.append(
+                            f"{prefix}, action [{j}] ({action_type}): "
+                            f'fieldsAttributes[{k}].fieldId "{fid}" '
+                            f"not found in pipe fields."
+                        )
+
+            # Check create_connected_card relation (skipped when related_pipe_ids is None)
+            if action_type == "create_connected_card" and related_pipe_ids is not None:
+                target_pipe = metadata.get("pipeId", "")
+                if target_pipe and str(target_pipe) not in related_pipe_ids:
+                    problems.append(
+                        f"{prefix}, action [{j}] (create_connected_card): "
+                        f'pipeId "{target_pipe}" has no relation with the '
+                        f"source pipe. Create a pipe relation first "
+                        f"(get_pipe_relations / create_pipe_relation)."
+                    )
+
+    return problems, warnings
+
+
+def enrich_behavior_error(
+    exc: BaseException,
+    behaviors: list[dict[str, Any]],
+) -> str:
+    """Build an enriched error message with behavior context and actionable hints.
+
+    Extracts raw GraphQL messages, appends a behavior summary, and matches
+    known error patterns to actionable advice.
+
+    Args:
+        exc: The exception from the service call.
+        behaviors: The original behavior dicts sent by the caller (for context).
+    """
+    msgs = extract_error_strings(exc)
+    base = "; ".join(msgs) if msgs else str(exc)
+
+    hints: list[str] = []
+    for pattern, hint in _ERROR_HINTS:
+        if pattern.search(base):
+            hints.append(hint)
+
+    parts = [base]
+    if behaviors:
+        parts.append(
+            f"Behaviors sent ({len(behaviors)}):\n{_summarize_behaviors(behaviors)}"
+        )
+    if hints:
+        parts.append("Hints: " + " ".join(hints))
+    return "\n".join(parts)

--- a/tests/models/test_ai_agent.py
+++ b/tests/models/test_ai_agent.py
@@ -466,5 +466,93 @@ def test_metadata_passes_through_unknown_action_type():
 @pytest.mark.unit
 def test_metadata_allows_empty_dict_for_unknown_action_type():
     payload = behavior_with_action("send_email", {})
+    BehaviorInput.model_validate(payload)
+
+
+# --- snake_case / camelCase normalization ---
+
+
+@pytest.mark.unit
+def test_behavior_input_accepts_snake_case_keys():
+    payload = {
+        "name": "Snake Behavior",
+        "event_id": "card_created",
+        "action_params": {
+            "aiBehaviorParams": {
+                "instruction": "Test instruction.",
+                "actionsAttributes": [
+                    {
+                        "name": "Update card fields",
+                        "actionType": "update_card",
+                        "metadata": {
+                            "pipeId": "123",
+                            "fieldsAttributes": [
+                                {
+                                    "fieldId": "1",
+                                    "inputMode": "fill_with_ai",
+                                    "value": "",
+                                },
+                            ],
+                        },
+                    },
+                ],
+            }
+        },
+    }
     inp = BehaviorInput.model_validate(payload)
+    assert inp.event_id == "card_created"
+    assert inp.action_params is not None
+
+
+@pytest.mark.unit
+def test_behavior_input_accepts_camel_case_keys():
+    payload = {
+        "name": "Camel Behavior",
+        "eventId": "card_moved",
+        "actionParams": {
+            "aiBehaviorParams": {
+                "instruction": "Test instruction.",
+                "actionsAttributes": [
+                    {
+                        "name": "Move",
+                        "actionType": "move_card",
+                        "metadata": {"destinationPhaseId": "999"},
+                    },
+                ],
+            }
+        },
+    }
+    inp = BehaviorInput.model_validate(payload)
+    assert inp.event_id == "card_moved"
+
+
+@pytest.mark.unit
+def test_behavior_input_snake_case_dumps_to_camel_case():
+    payload = {
+        "name": "Mixed",
+        "event_id": "field_updated",
+        "event_params": {"triggerFieldIds": ["1"]},
+        "action_params": {
+            "aiBehaviorParams": {
+                "instruction": "Go.",
+                "actionsAttributes": [
+                    {
+                        "name": "Move",
+                        "actionType": "move_card",
+                        "metadata": {"destinationPhaseId": "5"},
+                    },
+                ],
+            }
+        },
+    }
+    inp = BehaviorInput.model_validate(payload)
+    dumped = inp.model_dump(by_alias=True, exclude_none=True)
+    assert "eventId" in dumped
+    assert "event_id" not in dumped
+    assert "eventParams" in dumped
+    assert "event_params" not in dumped
+    assert "actionParams" in dumped
+    assert "action_params" not in dumped
+    assert "actionId" in dumped
+    assert "action_id" not in dumped
     assert inp.action_params is not None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -148,6 +148,7 @@ async def test_register_tools(client_session):
         "update_table",
         "update_table_field",
         "update_table_record",
+        "validate_ai_agent_behaviors",
     ]
 
     with patch("pipefy_mcp.server.settings", _MINIMAL_PIPEFY_SETTINGS):

--- a/tests/tools/test_ai_agent_tools.py
+++ b/tests/tools/test_ai_agent_tools.py
@@ -29,6 +29,8 @@ def mock_pipefy_client():
     client.get_ai_agent = AsyncMock()
     client.get_ai_agents = AsyncMock()
     client.delete_ai_agent = AsyncMock()
+    client.get_pipe = AsyncMock()
+    client.get_pipe_relations = AsyncMock()
     return client
 
 
@@ -443,6 +445,197 @@ class TestToggleAiAgentStatus:
         assert "error" in payload
         assert isinstance(payload["error"], str)
 
+    async def test_graphql_error_extracts_message(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.toggle_ai_agent_status.side_effect = TransportQueryError(
+            "failed", errors=[{"message": "Agent is locked"}]
+        )
+        async with client_session as session:
+            result = await session.call_tool(
+                "toggle_ai_agent_status",
+                {"uuid": "agent-uuid", "active": True},
+            )
+        assert result.isError is False
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "locked" in payload["error"]
+
+
+def _behavior_update_card_on_pipe(pipe_id="1", field_id="100"):
+    return {
+        "name": "Fill",
+        "event_id": "card_created",
+        "actionParams": {
+            "aiBehaviorParams": {
+                "instruction": "go",
+                "actionsAttributes": [
+                    {
+                        "name": "u",
+                        "actionType": "update_card",
+                        "metadata": {
+                            "pipeId": pipe_id,
+                            "fieldsAttributes": [
+                                {
+                                    "fieldId": field_id,
+                                    "inputMode": "fill_with_ai",
+                                    "value": "",
+                                },
+                            ],
+                        },
+                    },
+                ],
+            }
+        },
+    }
+
+
+def _pipe_graph_with_field(field_id="100", phase_id="ph-1"):
+    return {
+        "pipe": {
+            "phases": [
+                {
+                    "id": phase_id,
+                    "fields": [{"id": field_id}],
+                }
+            ],
+            "start_form_fields": [],
+        }
+    }
+
+
+@pytest.mark.anyio
+class TestValidateAiAgentBehaviors:
+    async def test_success(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.get_pipe.return_value = _pipe_graph_with_field()
+        mock_pipefy_client.get_pipe_relations.return_value = {
+            "children": [],
+            "parents": [],
+        }
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_agent_behaviors",
+                {
+                    "pipe_id": "1",
+                    "behaviors": [_behavior_update_card_on_pipe()],
+                    "strict_unknown_action_types": True,
+                },
+            )
+        assert result.isError is False
+        payload = extract_payload(result)
+        assert payload["success"] is True
+        assert payload["valid"] is True
+        assert payload["problems"] == []
+        assert payload["warnings"] == []
+        mock_pipefy_client.get_pipe.assert_awaited_once_with(1)
+        mock_pipefy_client.get_pipe_relations.assert_awaited_once_with("1")
+
+    async def test_relations_fetch_failure_adds_warning_skips_relation_check(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.get_pipe.return_value = _pipe_graph_with_field()
+        mock_pipefy_client.get_pipe_relations.side_effect = TransportQueryError(
+            "failed", errors=[{"message": "denied"}]
+        )
+        behavior = {
+            "name": "Child",
+            "event_id": "card_created",
+            "actionParams": {
+                "aiBehaviorParams": {
+                    "instruction": "go",
+                    "actionsAttributes": [
+                        {
+                            "name": "c",
+                            "actionType": "create_connected_card",
+                            "metadata": {
+                                "pipeId": "99999",
+                                "fieldsAttributes": [
+                                    {
+                                        "fieldId": "200",
+                                        "inputMode": "fill_with_ai",
+                                        "value": "",
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                }
+            },
+        }
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_agent_behaviors",
+                {"pipe_id": "1", "behaviors": [behavior]},
+            )
+        payload = extract_payload(result)
+        assert payload["success"] is True
+        assert payload["valid"] is True
+        assert payload["problems"] == []
+        assert len(payload["warnings"]) == 1
+        assert "relations" in payload["warnings"][0].lower()
+
+    async def test_invalid_field_id_blocking(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.get_pipe.return_value = _pipe_graph_with_field()
+        mock_pipefy_client.get_pipe_relations.return_value = {
+            "children": [],
+            "parents": [],
+        }
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_agent_behaviors",
+                {
+                    "pipe_id": "1",
+                    "behaviors": [_behavior_update_card_on_pipe(field_id="999")],
+                },
+            )
+        payload = extract_payload(result)
+        assert payload["valid"] is False
+        assert any("999" in p for p in payload["problems"])
+
+    async def test_strict_unknown_action_types_false_warns_only(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        from tests.ai_agent_test_payloads import behavior_with_action
+
+        mock_pipefy_client.get_pipe.return_value = _pipe_graph_with_field()
+        mock_pipefy_client.get_pipe_relations.return_value = {
+            "children": [],
+            "parents": [],
+        }
+        b = behavior_with_action("custom_future_type", {"x": 1})
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_agent_behaviors",
+                {
+                    "pipe_id": "1",
+                    "behaviors": [b],
+                    "strict_unknown_action_types": False,
+                },
+            )
+        payload = extract_payload(result)
+        assert payload["valid"] is True
+        assert payload["problems"] == []
+        assert any("custom_future_type" in w for w in payload["warnings"])
+
 
 @pytest.mark.anyio
 class TestGetAiAgent:
@@ -640,7 +833,7 @@ async def test_get_ai_agent_tools_have_read_only_hint(client_session):
     async with client_session as session:
         listed = await session.list_tools()
     by_name = {t.name: t for t in listed.tools}
-    for name in ("get_ai_agent", "get_ai_agents"):
+    for name in ("get_ai_agent", "get_ai_agents", "validate_ai_agent_behaviors"):
         tool = by_name[name]
         assert tool.annotations is not None
         assert tool.annotations.readOnlyHint is True

--- a/tests/tools/test_ai_tool_helpers.py
+++ b/tests/tools/test_ai_tool_helpers.py
@@ -1,0 +1,437 @@
+"""Tests for AI tool helper functions (error enrichment, validation, payload builders)."""
+
+import pytest
+from gql.transport.exceptions import TransportQueryError
+
+from pipefy_mcp.tools.ai_tool_helpers import (
+    enrich_behavior_error,
+    validate_behaviors_against_pipe,
+)
+
+
+def _make_behaviors(*specs):
+    """Build minimal behavior dicts from (name, event_id, actionType) tuples."""
+    result = []
+    for name, event_id, action_type in specs:
+        result.append(
+            {
+                "name": name,
+                "event_id": event_id,
+                "actionParams": {
+                    "aiBehaviorParams": {
+                        "instruction": "test",
+                        "actionsAttributes": [
+                            {
+                                "name": f"{action_type} action",
+                                "actionType": action_type,
+                                "metadata": {},
+                            },
+                        ],
+                    }
+                },
+            }
+        )
+    return result
+
+
+@pytest.mark.unit
+def test_enrich_includes_behavior_summary():
+    behaviors = _make_behaviors(
+        ("When created: classify", "card_created", "update_card"),
+        ("When moved: notify", "card_moved", "move_card"),
+    )
+    exc = ValueError("Something went wrong")
+    result = enrich_behavior_error(exc, behaviors)
+    assert "Something went wrong" in result
+    assert '[0] "When created: classify"' in result
+    assert "event=card_created" in result
+    assert "actions=[update_card]" in result
+    assert '[1] "When moved: notify"' in result
+    assert "event=card_moved" in result
+    assert "actions=[move_card]" in result
+
+
+@pytest.mark.unit
+def test_enrich_adds_record_not_saved_hint():
+    behaviors = _make_behaviors(("B1", "card_created", "update_card"))
+    exc = TransportQueryError(
+        "RECORD_NOT_SAVED", errors=[{"message": "RECORD_NOT_SAVED"}]
+    )
+    result = enrich_behavior_error(exc, behaviors)
+    assert "RECORD_NOT_SAVED" in result
+    assert "metadata is complete" in result
+    assert "update_card needs pipeId" in result
+
+
+@pytest.mark.unit
+def test_enrich_adds_at_least_one_action_hint():
+    behaviors = _make_behaviors(("B1", "card_created", "update_card"))
+    exc = ValueError("must contain at least 1 action")
+    result = enrich_behavior_error(exc, behaviors)
+    assert "actionsAttributes" in result
+
+
+@pytest.mark.unit
+def test_enrich_no_hint_for_unknown_errors():
+    behaviors = _make_behaviors(("B1", "card_created", "move_card"))
+    exc = ValueError("timeout")
+    result = enrich_behavior_error(exc, behaviors)
+    assert "timeout" in result
+    assert "Hints:" not in result
+
+
+@pytest.mark.unit
+def test_enrich_with_empty_behaviors():
+    exc = ValueError("bad request")
+    result = enrich_behavior_error(exc, [])
+    assert "bad request" in result
+    assert "Behaviors sent" not in result
+
+
+@pytest.mark.unit
+def test_enrich_handles_camel_case_behavior_keys():
+    behaviors = [
+        {
+            "name": "CamelBehavior",
+            "eventId": "field_updated",
+            "actionParams": {
+                "aiBehaviorParams": {
+                    "instruction": "test",
+                    "actionsAttributes": [
+                        {
+                            "name": "a",
+                            "actionType": "create_connected_card",
+                            "metadata": {},
+                        },
+                    ],
+                }
+            },
+        }
+    ]
+    exc = ValueError("RECORD_NOT_SAVED: missing relation")
+    result = enrich_behavior_error(exc, behaviors)
+    assert '"CamelBehavior"' in result
+    assert "event=field_updated" in result
+    assert "actions=[create_connected_card]" in result
+
+
+# --- validate_behaviors_against_pipe ---
+
+
+def _update_card_behavior(field_id="100", pipe_id="1"):
+    return {
+        "name": "Fill fields",
+        "event_id": "card_created",
+        "actionParams": {
+            "aiBehaviorParams": {
+                "instruction": "go",
+                "actionsAttributes": [
+                    {
+                        "name": "update",
+                        "actionType": "update_card",
+                        "metadata": {
+                            "pipeId": pipe_id,
+                            "fieldsAttributes": [
+                                {
+                                    "fieldId": field_id,
+                                    "inputMode": "fill_with_ai",
+                                    "value": "",
+                                },
+                            ],
+                        },
+                    },
+                ],
+            }
+        },
+    }
+
+
+def _move_card_behavior(dest_phase_id="ph-1"):
+    return {
+        "name": "Move to done",
+        "event_id": "card_moved",
+        "eventParams": {"to_phase_id": "ph-start"},
+        "actionParams": {
+            "aiBehaviorParams": {
+                "instruction": "go",
+                "actionsAttributes": [
+                    {
+                        "name": "move",
+                        "actionType": "move_card",
+                        "metadata": {"destinationPhaseId": dest_phase_id},
+                    },
+                ],
+            }
+        },
+    }
+
+
+def _connected_card_behavior(target_pipe_id="child-pipe"):
+    return {
+        "name": "Create child",
+        "event_id": "card_created",
+        "actionParams": {
+            "aiBehaviorParams": {
+                "instruction": "go",
+                "actionsAttributes": [
+                    {
+                        "name": "connect",
+                        "actionType": "create_connected_card",
+                        "metadata": {
+                            "pipeId": target_pipe_id,
+                            "fieldsAttributes": [
+                                {
+                                    "fieldId": "200",
+                                    "inputMode": "fill_with_ai",
+                                    "value": "",
+                                },
+                            ],
+                        },
+                    },
+                ],
+            }
+        },
+    }
+
+
+PIPE_FIELDS = {"100", "101", "102"}
+PIPE_PHASES = {"ph-start", "ph-1", "ph-done"}
+RELATED_PIPES = {"child-pipe", "sibling-pipe"}
+
+
+@pytest.mark.unit
+def test_validate_all_valid():
+    problems, warnings = validate_behaviors_against_pipe(
+        [_update_card_behavior(), _move_card_behavior()],
+        pipe_id="1",
+        pipe_field_ids=PIPE_FIELDS,
+        pipe_phase_ids=PIPE_PHASES,
+        related_pipe_ids=RELATED_PIPES,
+    )
+    assert problems == []
+    assert warnings == []
+
+
+@pytest.mark.unit
+def test_validate_invalid_field_id():
+    problems, warnings = validate_behaviors_against_pipe(
+        [_update_card_behavior(field_id="999")],
+        pipe_id="1",
+        pipe_field_ids=PIPE_FIELDS,
+        pipe_phase_ids=PIPE_PHASES,
+        related_pipe_ids=RELATED_PIPES,
+    )
+    assert len(problems) == 1
+    assert warnings == []
+    assert '"999"' in problems[0]
+    assert "not found in pipe fields" in problems[0]
+
+
+@pytest.mark.unit
+def test_validate_invalid_destination_phase():
+    problems, warnings = validate_behaviors_against_pipe(
+        [_move_card_behavior(dest_phase_id="ph-nonexistent")],
+        pipe_id="1",
+        pipe_field_ids=PIPE_FIELDS,
+        pipe_phase_ids=PIPE_PHASES,
+        related_pipe_ids=RELATED_PIPES,
+    )
+    assert warnings == []
+    assert any(
+        "ph-nonexistent" in p and "not found in pipe phases" in p for p in problems
+    )
+
+
+@pytest.mark.unit
+def test_validate_invalid_event_params_to_phase_id():
+    behavior = _move_card_behavior()
+    behavior["eventParams"]["to_phase_id"] = "ph-ghost"
+    problems, warnings = validate_behaviors_against_pipe(
+        [behavior],
+        pipe_id="1",
+        pipe_field_ids=PIPE_FIELDS,
+        pipe_phase_ids=PIPE_PHASES,
+        related_pipe_ids=RELATED_PIPES,
+    )
+    assert warnings == []
+    assert any(
+        "ph-ghost" in p and "eventParams" in p and "toPhaseId" in p for p in problems
+    )
+
+
+@pytest.mark.unit
+def test_validate_invalid_event_params_to_phase_id_camel_case():
+    behavior = _move_card_behavior()
+    del behavior["eventParams"]["to_phase_id"]
+    behavior["eventParams"]["toPhaseId"] = "ph-ghost"
+    problems, warnings = validate_behaviors_against_pipe(
+        [behavior],
+        pipe_id="1",
+        pipe_field_ids=PIPE_FIELDS,
+        pipe_phase_ids=PIPE_PHASES,
+        related_pipe_ids=RELATED_PIPES,
+    )
+    assert warnings == []
+    assert any("ph-ghost" in p for p in problems)
+
+
+@pytest.mark.unit
+def test_validate_create_connected_card_missing_relation():
+    problems, warnings = validate_behaviors_against_pipe(
+        [_connected_card_behavior(target_pipe_id="unrelated-pipe")],
+        pipe_id="1",
+        pipe_field_ids=PIPE_FIELDS,
+        pipe_phase_ids=PIPE_PHASES,
+        related_pipe_ids=RELATED_PIPES,
+    )
+    assert len(problems) == 1
+    assert warnings == []
+    assert "unrelated-pipe" in problems[0]
+    assert "no relation" in problems[0]
+
+
+@pytest.mark.unit
+def test_validate_create_connected_card_skipped_when_relations_not_loaded():
+    problems, warnings = validate_behaviors_against_pipe(
+        [_connected_card_behavior(target_pipe_id="unrelated-pipe")],
+        pipe_id="1",
+        pipe_field_ids=PIPE_FIELDS,
+        pipe_phase_ids=PIPE_PHASES,
+        related_pipe_ids=None,
+    )
+    assert problems == []
+    assert warnings == []
+
+
+@pytest.mark.unit
+def test_validate_create_connected_card_valid_relation():
+    problems, warnings = validate_behaviors_against_pipe(
+        [_connected_card_behavior(target_pipe_id="child-pipe")],
+        pipe_id="1",
+        pipe_field_ids=PIPE_FIELDS,
+        pipe_phase_ids=PIPE_PHASES,
+        related_pipe_ids=RELATED_PIPES,
+    )
+    assert problems == []
+    assert warnings == []
+
+
+@pytest.mark.unit
+def test_validate_unknown_action_type_error():
+    behavior = {
+        "name": "Bad type",
+        "event_id": "card_created",
+        "actionParams": {
+            "aiBehaviorParams": {
+                "instruction": "go",
+                "actionsAttributes": [
+                    {"name": "x", "actionType": "update_card_field", "metadata": {}},
+                ],
+            }
+        },
+    }
+    problems, warnings = validate_behaviors_against_pipe(
+        [behavior],
+        pipe_id="1",
+        pipe_field_ids=PIPE_FIELDS,
+        pipe_phase_ids=PIPE_PHASES,
+        related_pipe_ids=RELATED_PIPES,
+    )
+    assert any("update_card_field" in p and "unknown" in p for p in problems)
+    assert warnings == []
+
+
+@pytest.mark.unit
+def test_validate_unknown_action_type_warning_mode():
+    behavior = {
+        "name": "Bad type",
+        "event_id": "card_created",
+        "actionParams": {
+            "aiBehaviorParams": {
+                "instruction": "go",
+                "actionsAttributes": [
+                    {"name": "x", "actionType": "update_card_field", "metadata": {}},
+                ],
+            }
+        },
+    }
+    problems, warnings = validate_behaviors_against_pipe(
+        [behavior],
+        pipe_id="1",
+        pipe_field_ids=PIPE_FIELDS,
+        pipe_phase_ids=PIPE_PHASES,
+        related_pipe_ids=RELATED_PIPES,
+        unknown_action_types="warning",
+    )
+    assert problems == []
+    assert any("update_card_field" in w and "unknown" in w for w in warnings)
+
+
+@pytest.mark.unit
+def test_validate_unknown_action_type_ignore_mode():
+    behavior = {
+        "name": "Bad type",
+        "event_id": "card_created",
+        "actionParams": {
+            "aiBehaviorParams": {
+                "instruction": "go",
+                "actionsAttributes": [
+                    {"name": "x", "actionType": "update_card_field", "metadata": {}},
+                ],
+            }
+        },
+    }
+    problems, warnings = validate_behaviors_against_pipe(
+        [behavior],
+        pipe_id="1",
+        pipe_field_ids=PIPE_FIELDS,
+        pipe_phase_ids=PIPE_PHASES,
+        related_pipe_ids=RELATED_PIPES,
+        unknown_action_types="ignore",
+    )
+    assert problems == []
+    assert warnings == []
+
+
+@pytest.mark.unit
+def test_validate_empty_field_ids_skips_field_check():
+    problems, warnings = validate_behaviors_against_pipe(
+        [_update_card_behavior(field_id="any-id")],
+        pipe_id="1",
+        pipe_field_ids=set(),
+        pipe_phase_ids=PIPE_PHASES,
+        related_pipe_ids=RELATED_PIPES,
+    )
+    assert problems == []
+    assert warnings == []
+
+
+@pytest.mark.unit
+def test_get_ai_agent_like_payload_passes_validation_helpers():
+    """Round-trip style dict (camelCase eventParams) still validates cross-refs."""
+    behavior = {
+        "name": "Moved to review",
+        "eventId": "card_moved",
+        "eventParams": {"toPhaseId": "ph-start"},
+        "actionParams": {
+            "aiBehaviorParams": {
+                "instruction": "Summarize.",
+                "actionsAttributes": [
+                    {
+                        "name": "Move",
+                        "actionType": "move_card",
+                        "metadata": {"destinationPhaseId": "ph-1"},
+                    },
+                ],
+            }
+        },
+    }
+    problems, warnings = validate_behaviors_against_pipe(
+        [behavior],
+        pipe_id="1",
+        pipe_field_ids=PIPE_FIELDS,
+        pipe_phase_ids=PIPE_PHASES,
+        related_pipe_ids=RELATED_PIPES,
+    )
+    assert problems == []
+    assert warnings == []


### PR DESCRIPTION
## Summary
Improves **`validate_ai_agent_behaviors`** and shared helpers so agents get actionable, non-misleading feedback; aligns **`toggle_ai_agent_status`** error handling with read tools.

## Changes
- **`validate_behaviors_against_pipe`**: returns `(problems, warnings)`; `related_pipe_ids=None` skips `create_connected_card` checks (no false positives when relations fail to load); `unknown_action_types` error/warning/ignore; **`toPhaseId`** supported alongside `to_phase_id`.
- **`validate_ai_agent_behaviors`**: `strict_unknown_action_types`, explicit **warnings** when pipe relations cannot be fetched, documented `success` / `valid` / `warnings`.
- **`toggle_ai_agent_status`**: `error_payload_from_exception` for GraphQL messages.
- **Tests**: `test_ai_tool_helpers.py`; MCP tests for validate + toggle; **`BehaviorInput`** snake/camel coverage; server tool list.

## Verification
`uv run pytest -m "not integration" -q` — 893 passed; `ruff check` / `ruff format --check` on `src/` and `tests/`.

## Commits
1. `test(ai-agent): cover BehaviorInput snake_case and camelCase round-trip`
2. `feat(tools): harden validate_ai_agent_behaviors and AI behavior checks`