### PR TITLE
fix(ai-tools): harden AI agent validation and error context

### DIFF
--- a/src/pipefy_mcp/tools/ai_agent_tools.py
+++ b/src/pipefy_mcp/tools/ai_agent_tools.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.types import ToolAnnotations
 from pydantic import ValidationError
@@ -22,6 +24,8 @@ from pipefy_mcp.tools.ai_tool_helpers import (
 )
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.graphql_error_helpers import extract_error_strings
+
+VALIDATE_FETCH_TIMEOUT_SECONDS = 30
 
 
 class AiAgentTools:
@@ -122,6 +126,12 @@ class AiAgentTools:
                 f"instruction_len={len(instruction)}, behaviors_count={len(behaviors)}, "
                 f"data_source_ids={data_source_ids!r}"
             )
+            if not name or not name.strip():
+                return build_ai_tool_error("name must not be blank")
+            if not repo_uuid or not repo_uuid.strip():
+                return build_ai_tool_error("repo_uuid must not be blank")
+            if not instruction or not instruction.strip():
+                return build_ai_tool_error("instruction must not be blank")
             try:
                 validated = CreateAiAgentInput(
                     name=name,
@@ -136,7 +146,7 @@ class AiAgentTools:
             try:
                 create_result = await client.create_ai_agent(validated)
             except Exception as exc:  # noqa: BLE001
-                return error_payload_from_exception(exc)
+                return build_ai_tool_error(enrich_behavior_error(exc, behaviors))
 
             agent_uuid = create_result["agent_uuid"]
 
@@ -193,6 +203,12 @@ class AiAgentTools:
                 data_source_ids: Optional list of data source IDs.
             """
             ctx.debug(f"update_ai_agent: uuid={uuid}, behaviors_count={len(behaviors)}")
+            if not uuid or not uuid.strip():
+                return build_ai_tool_error("uuid must not be blank")
+            if not name or not name.strip():
+                return build_ai_tool_error("name must not be blank")
+            if not repo_uuid or not repo_uuid.strip():
+                return build_ai_tool_error("repo_uuid must not be blank")
             try:
                 validated = UpdateAiAgentInput(
                     uuid=uuid,
@@ -394,9 +410,16 @@ class AiAgentTools:
                     "message": "Behavior dicts failed structural validation (BehaviorInput).",
                 }
 
-            # Fetch pipe context
+            # Fetch pipe context (with timeout to avoid indefinite hangs)
             try:
-                pipe_data = await client.get_pipe(int(pid))
+                pipe_data = await asyncio.wait_for(
+                    client.get_pipe(int(pid)),
+                    timeout=VALIDATE_FETCH_TIMEOUT_SECONDS,
+                )
+            except asyncio.TimeoutError:
+                return build_ai_tool_error(
+                    f"Timed out fetching pipe {pid} after {VALIDATE_FETCH_TIMEOUT_SECONDS}s"
+                )
             except Exception as exc:  # noqa: BLE001
                 return build_ai_tool_error(f"Failed to fetch pipe {pid}: {exc}")
 
@@ -421,7 +444,10 @@ class AiAgentTools:
             tool_warnings: list[str] = []
             related_pipe_ids: set[str] | None
             try:
-                relations = await client.get_pipe_relations(pid)
+                relations = await asyncio.wait_for(
+                    client.get_pipe_relations(pid),
+                    timeout=VALIDATE_FETCH_TIMEOUT_SECONDS,
+                )
                 related_pipe_ids = set()
                 for rel in relations.get("children") or []:
                     child_id = rel.get("child", {}).get("id")
@@ -439,6 +465,55 @@ class AiAgentTools:
                     "were not verified against relations."
                 )
 
+            # Collect target pipe IDs from cross-pipe actions and fetch their fields.
+            # Skip when relations failed to load — without relation data, cross-pipe
+            # field checks produce unreliable results.
+            cross_pipe_field_ids: dict[str, set[str]] = {}
+            target_pipe_ids: set[str] = set()
+            if related_pipe_ids is not None:
+                for b in behaviors:
+                    ap = b.get("actionParams") or b.get("action_params") or {}
+                    abp = (
+                        ap.get("aiBehaviorParams") or ap.get("ai_behavior_params") or {}
+                    )
+                    for a in (
+                        abp.get("actionsAttributes")
+                        or abp.get("actions_attributes")
+                        or []
+                    ):
+                        if not isinstance(a, dict):
+                            continue
+                        meta_pipe = str((a.get("metadata") or {}).get("pipeId", ""))
+                        if meta_pipe and meta_pipe != pid:
+                            target_pipe_ids.add(meta_pipe)
+
+            for target_pid in target_pipe_ids:
+                try:
+                    target_data = await asyncio.wait_for(
+                        client.get_pipe(int(target_pid)),
+                        timeout=VALIDATE_FETCH_TIMEOUT_SECONDS,
+                    )
+                    target_info = target_data.get("pipe", {})
+                    target_fields: set[str] = set()
+                    for phase in target_info.get("phases") or []:
+                        for field in phase.get("fields") or []:
+                            fid = field.get("id") or field.get("internal_id")
+                            if fid:
+                                target_fields.add(str(fid))
+                    for field in target_info.get("start_form_fields") or []:
+                        fid = field.get("id") or field.get("internal_id")
+                        if fid:
+                            target_fields.add(str(fid))
+                    cross_pipe_field_ids[target_pid] = target_fields
+                except Exception:  # noqa: BLE001
+                    ctx.debug(
+                        f"Could not fetch target pipe {target_pid}; skipping its field checks"
+                    )
+                    tool_warnings.append(
+                        f"Could not load fields for target pipe {target_pid}; "
+                        f"fieldIds targeting it were not verified."
+                    )
+
             unknown_action_types = "error" if strict_unknown_action_types else "warning"
             problems, helper_warnings = validate_behaviors_against_pipe(
                 behaviors,
@@ -446,6 +521,7 @@ class AiAgentTools:
                 pipe_field_ids=field_ids,
                 pipe_phase_ids=phase_ids,
                 related_pipe_ids=related_pipe_ids,
+                cross_pipe_field_ids=cross_pipe_field_ids or None,
                 unknown_action_types=unknown_action_types,
             )
             warnings = [*tool_warnings, *helper_warnings]

--- a/src/pipefy_mcp/tools/ai_tool_helpers.py
+++ b/src/pipefy_mcp/tools/ai_tool_helpers.py
@@ -196,21 +196,31 @@ _ERROR_HINTS: list[tuple[re.Pattern[str], str]] = [
 def _summarize_behaviors(behaviors: list[dict[str, Any]]) -> str:
     """Build a compact one-line-per-behavior summary for error context.
 
+    Tolerates malformed entries (non-dict behaviors, actionParams as string, etc.)
+    so it never raises when called from an error handler.
+
     Args:
         behaviors: Raw behavior dicts (pre-validation, may use either key style).
     """
     lines: list[str] = []
     for i, b in enumerate(behaviors):
+        if not isinstance(b, dict):
+            lines.append(f"  [{i}] <malformed: {type(b).__name__}>")
+            continue
         name = b.get("name", "<unnamed>")
         event = b.get("eventId") or b.get("event_id") or "?"
         actions_desc: list[str] = []
 
-        ap = b.get("actionParams") or b.get("action_params") or {}
-        abp = ap.get("aiBehaviorParams") or ap.get("ai_behavior_params") or {}
-        attrs = abp.get("actionsAttributes") or abp.get("actions_attributes") or []
-        for a in attrs:
-            if isinstance(a, dict):
-                actions_desc.append(a.get("actionType", "?"))
+        ap = b.get("actionParams") or b.get("action_params")
+        if isinstance(ap, dict):
+            abp = ap.get("aiBehaviorParams") or ap.get("ai_behavior_params")
+            if isinstance(abp, dict):
+                attrs = (
+                    abp.get("actionsAttributes") or abp.get("actions_attributes") or []
+                )
+                for a in attrs:
+                    if isinstance(a, dict):
+                        actions_desc.append(a.get("actionType", "?"))
 
         actions_str = ", ".join(actions_desc) if actions_desc else "none"
         lines.append(f'  [{i}] "{name}" (event={event}, actions=[{actions_str}])')
@@ -232,6 +242,7 @@ def validate_behaviors_against_pipe(
     pipe_field_ids: set[str],
     pipe_phase_ids: set[str],
     related_pipe_ids: set[str] | None,
+    cross_pipe_field_ids: dict[str, set[str]] | None = None,
     unknown_action_types: Literal["error", "warning", "ignore"] = "error",
 ) -> tuple[list[str], list[str]]:
     """Check behaviors against resolved pipe context and return problems and warnings.
@@ -248,6 +259,10 @@ def validate_behaviors_against_pipe(
             ``create_connected_card`` validation; ``None`` skips that check
             (avoids false positives when relations were not loaded). A set
             (possibly empty) runs the relation check as before.
+        cross_pipe_field_ids: Optional mapping of ``{pipe_id: field_ids}`` for
+            target pipes referenced by cross-pipe actions. When provided,
+            fieldIds targeting those pipes are validated against the map.
+            When ``None`` (default), cross-pipe fieldIds are skipped.
         unknown_action_types: How to treat non-empty ``actionType`` values not in
             ``KNOWN_AI_ACTION_TYPES``: ``error`` adds to problems, ``warning``
             adds the same message to warnings, ``ignore`` skips.
@@ -301,23 +316,36 @@ def validate_behaviors_against_pipe(
                         f'destinationPhaseId "{dest}" not found in pipe phases.'
                     )
 
-            # Check fieldsAttributes fieldId references — only when the action
-            # targets the same pipe (or no pipeId is set in metadata).
-            # Cross-pipe actions (create_connected_card, create_card on another
-            # pipe) reference fields from the *target* pipe, which we don't have.
+            # Check fieldsAttributes fieldId references.
+            # Same-pipe actions check against pipe_field_ids; cross-pipe actions
+            # check against cross_pipe_field_ids when available.
             action_pipe = str(metadata.get("pipeId", ""))
             targets_source = not action_pipe or action_pipe == pipe_id
             if targets_source:
+                check_fields = pipe_field_ids
+            elif (
+                cross_pipe_field_ids is not None and action_pipe in cross_pipe_field_ids
+            ):
+                check_fields = cross_pipe_field_ids[action_pipe]
+            else:
+                check_fields = None
+
+            if check_fields is not None:
                 fields_attrs = metadata.get("fieldsAttributes") or []
                 for k, fa in enumerate(fields_attrs):
                     if not isinstance(fa, dict):
                         continue
                     fid = fa.get("fieldId", "")
-                    if fid and pipe_field_ids and fid not in pipe_field_ids:
+                    if fid and check_fields and fid not in check_fields:
+                        pipe_label = (
+                            "pipe fields"
+                            if targets_source
+                            else f"target pipe {action_pipe} fields"
+                        )
                         problems.append(
                             f"{prefix}, action [{j}] ({action_type}): "
                             f'fieldsAttributes[{k}].fieldId "{fid}" '
-                            f"not found in pipe fields."
+                            f"not found in {pipe_label}."
                         )
 
             # Check create_connected_card relation (skipped when related_pipe_ids is None)

--- a/tests/tools/test_ai_agent_tools.py
+++ b/tests/tools/test_ai_agent_tools.py
@@ -274,6 +274,50 @@ class TestCreateAiAgent:
         assert payload["success"] is False
         assert "error" in payload
 
+    async def test_blank_repo_uuid_returns_error_payload(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_ai_agent",
+                {
+                    "name": "My Agent",
+                    "repo_uuid": "   ",
+                    "instruction": "Purpose",
+                    "behaviors": [minimal_behavior_dict(name="B1")],
+                },
+            )
+        assert result.isError is False
+        mock_pipefy_client.create_ai_agent.assert_not_called()
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "repo_uuid" in payload["error"]
+
+    async def test_blank_name_returns_error_before_api_call(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_ai_agent",
+                {
+                    "name": "",
+                    "repo_uuid": "repo-456",
+                    "instruction": "Purpose",
+                    "behaviors": [minimal_behavior_dict(name="B1")],
+                },
+            )
+        assert result.isError is False
+        mock_pipefy_client.create_ai_agent.assert_not_called()
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "name" in payload["error"]
+
 
 @pytest.mark.anyio
 class TestUpdateAiAgent:
@@ -355,6 +399,29 @@ class TestUpdateAiAgent:
         payload = extract_payload(result)
         assert payload["success"] is False
         assert "error" in payload
+
+    async def test_blank_uuid_returns_error_before_api_call(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        async with client_session as session:
+            result = await session.call_tool(
+                "update_ai_agent",
+                {
+                    "uuid": "  ",
+                    "name": "Agent",
+                    "repo_uuid": "repo-456",
+                    "instruction": "Do things",
+                    "behaviors": [minimal_behavior_dict(name="B1")],
+                },
+            )
+        assert result.isError is False
+        mock_pipefy_client.update_ai_agent.assert_not_called()
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "uuid" in payload["error"]
 
     async def test_service_error_returns_error_payload(
         self,

--- a/tests/tools/test_ai_tool_helpers.py
+++ b/tests/tools/test_ai_tool_helpers.py
@@ -435,3 +435,79 @@ def test_get_ai_agent_like_payload_passes_validation_helpers():
     )
     assert problems == []
     assert warnings == []
+
+
+# --- cross-pipe field validation ---
+
+
+@pytest.mark.unit
+def test_validate_cross_pipe_field_ids_valid():
+    problems, warnings = validate_behaviors_against_pipe(
+        [_connected_card_behavior(target_pipe_id="child-pipe")],
+        pipe_id="1",
+        pipe_field_ids=PIPE_FIELDS,
+        pipe_phase_ids=PIPE_PHASES,
+        related_pipe_ids=RELATED_PIPES,
+        cross_pipe_field_ids={"child-pipe": {"200", "201"}},
+    )
+    assert problems == []
+
+
+@pytest.mark.unit
+def test_validate_cross_pipe_field_ids_invalid():
+    problems, warnings = validate_behaviors_against_pipe(
+        [_connected_card_behavior(target_pipe_id="child-pipe")],
+        pipe_id="1",
+        pipe_field_ids=PIPE_FIELDS,
+        pipe_phase_ids=PIPE_PHASES,
+        related_pipe_ids=RELATED_PIPES,
+        cross_pipe_field_ids={"child-pipe": {"300", "301"}},
+    )
+    assert len(problems) == 1
+    assert '"200"' in problems[0]
+    assert "target pipe child-pipe fields" in problems[0]
+
+
+@pytest.mark.unit
+def test_validate_cross_pipe_not_in_map_skips_field_check():
+    problems, warnings = validate_behaviors_against_pipe(
+        [_connected_card_behavior(target_pipe_id="child-pipe")],
+        pipe_id="1",
+        pipe_field_ids=PIPE_FIELDS,
+        pipe_phase_ids=PIPE_PHASES,
+        related_pipe_ids=RELATED_PIPES,
+        cross_pipe_field_ids={"other-pipe": {"200"}},
+    )
+    assert problems == []
+
+
+# --- _summarize_behaviors malformed input ---
+
+
+@pytest.mark.unit
+def test_summarize_behaviors_malformed_non_dict():
+    from pipefy_mcp.tools.ai_tool_helpers import _summarize_behaviors
+
+    result = _summarize_behaviors(["not a dict", 42])
+    assert "<malformed: str>" in result
+    assert "<malformed: int>" in result
+
+
+@pytest.mark.unit
+def test_summarize_behaviors_action_params_as_string():
+    from pipefy_mcp.tools.ai_tool_helpers import _summarize_behaviors
+
+    result = _summarize_behaviors(
+        [{"name": "Bad", "event_id": "x", "actionParams": "garbage"}]
+    )
+    assert '"Bad"' in result
+    assert "actions=[none]" in result
+
+
+@pytest.mark.unit
+def test_summarize_behaviors_missing_action_params():
+    from pipefy_mcp.tools.ai_tool_helpers import _summarize_behaviors
+
+    result = _summarize_behaviors([{"name": "Bare", "event_id": "card_created"}])
+    assert '"Bare"' in result
+    assert "actions=[none]" in result


### PR DESCRIPTION
## Summary
Hardens AI agent MCP tools: safer error summaries, cross-pipe field validation when target pipes can be loaded, client-call timeouts for validate, early blank checks on create/update, and richer errors on create failure.

## Commits
1. **Resilient `_summarize_behaviors`** + **`cross_pipe_field_ids`** in `validate_behaviors_against_pipe` (with tests).
2. **`validate_ai_agent_behaviors`**: `asyncio.wait_for` (30s) on pipe/relations/target fetches; fetch target pipe fields for cross-pipe actions; **`create_ai_agent`/** `update_*` blank guards; `enrich_behavior_error` on create GraphQL errors; MCP tests.

## Verification
- `uv run pytest -m "not integration" -q` — 902 passed
- `ruff check` / `ruff format --check` on `src/` + `tests/`