### PR TITLE
fix(pipefy): coerce GraphQL Int IDs in additional services

### DIFF
--- a/src/pipefy_mcp/services/pipefy/automation_service.py
+++ b/src/pipefy_mcp/services/pipefy/automation_service.py
@@ -74,7 +74,7 @@ class AutomationService(BasePipefyClient):
         """
         payload = await self.execute_query(
             GET_AUTOMATION_QUERY,
-            {"id": automation_id},
+            {"id": int(automation_id)},
         )
         row = payload.get("automation")
         if row is None or not isinstance(row, dict):
@@ -102,7 +102,7 @@ class AutomationService(BasePipefyClient):
         if org_id is None and pipe_id is not None:
             org_row = await self.execute_query(
                 GET_PIPE_ORGANIZATION_ID_QUERY,
-                {"id": pipe_id},
+                {"id": int(pipe_id)},
             )
             pipe = org_row.get("pipe") or {}
             oid = pipe.get("organizationId")
@@ -116,12 +116,12 @@ class AutomationService(BasePipefyClient):
         if pipe_id is None:
             payload = await self.execute_query(
                 GET_AUTOMATIONS_BY_ORG_QUERY,
-                {"organizationId": org_id},
+                {"organizationId": int(org_id)},
             )
         else:
             payload = await self.execute_query(
                 GET_AUTOMATIONS_FOR_ORG_AND_REPO_QUERY,
-                {"organizationId": org_id, "repoId": pipe_id},
+                {"organizationId": int(org_id), "repoId": int(pipe_id)},
             )
         conn = payload.get("automations")
         if conn is None:
@@ -139,7 +139,7 @@ class AutomationService(BasePipefyClient):
         """
         payload = await self.execute_query(
             GET_AUTOMATION_ACTIONS_QUERY,
-            {"repoId": pipe_id},
+            {"repoId": int(pipe_id)},
         )
         rows = payload.get("automationActions")
         if rows is None:

--- a/src/pipefy_mcp/services/pipefy/member_service.py
+++ b/src/pipefy_mcp/services/pipefy/member_service.py
@@ -49,7 +49,7 @@ class MemberService(BasePipefyClient):
         emails = [{"email": m["email"], "role_name": m["role_name"]} for m in members]
         return await self.execute_query(
             INVITE_MEMBERS_MUTATION,
-            {"input": {"pipe_id": pipe_id, "emails": emails}},
+            {"input": {"pipe_id": int(pipe_id), "emails": emails}},
         )
 
     async def remove_members_from_pipe(
@@ -125,7 +125,7 @@ class MemberService(BasePipefyClient):
             SET_ROLE_MUTATION,
             {
                 "input": {
-                    "pipe_id": pipe_id,
+                    "pipe_id": int(pipe_id),
                     "member": {"user_id": member_id, "role_name": role_name},
                 }
             },

--- a/src/pipefy_mcp/services/pipefy/observability_service.py
+++ b/src/pipefy_mcp/services/pipefy/observability_service.py
@@ -126,7 +126,7 @@ class ObservabilityService(BasePipefyClient):
         if trimmed.isdigit():
             result = await self.execute_query(
                 RESOLVE_ORGANIZATION_UUID_QUERY,
-                {"id": trimmed},
+                {"id": int(trimmed)},
             )
             org = result.get("organization")
             uuid_value = org.get("uuid") if isinstance(org, dict) else None
@@ -323,7 +323,7 @@ class ObservabilityService(BasePipefyClient):
         """
         return await self.execute_query(
             CREATE_AUTOMATION_JOBS_EXPORT_MUTATION,
-            {"input": {"organizationId": organization_id, "filter": period}},
+            {"input": {"organizationId": int(organization_id), "filter": period}},
         )
 
     async def get_automation_jobs_export(self, export_id: str) -> dict[str, Any]:

--- a/src/pipefy_mcp/services/pipefy/organization_service.py
+++ b/src/pipefy_mcp/services/pipefy/organization_service.py
@@ -29,7 +29,9 @@ class OrganizationService(BasePipefyClient):
         Args:
             organization_id: Numeric organization ID.
         """
-        data = await self.execute_query(GET_ORGANIZATION_QUERY, {"id": organization_id})
+        data = await self.execute_query(
+            GET_ORGANIZATION_QUERY, {"id": int(organization_id)}
+        )
         org = data.get("organization")
         if org is None:
             return {

--- a/src/pipefy_mcp/services/pipefy/relation_service.py
+++ b/src/pipefy_mcp/services/pipefy/relation_service.py
@@ -58,7 +58,7 @@ class RelationService(BasePipefyClient):
         """
         return await self.execute_query(
             GET_PIPE_RELATIONS_QUERY,
-            {"pipeId": pipe_id},
+            {"pipeId": int(pipe_id)},
         )
 
     async def get_table_relations(
@@ -71,7 +71,7 @@ class RelationService(BasePipefyClient):
         """
         return await self.execute_query(
             GET_TABLE_RELATIONS_QUERY,
-            {"ids": list(relation_ids)},
+            {"ids": [int(r) for r in relation_ids]},
         )
 
     async def create_pipe_relation(

--- a/src/pipefy_mcp/services/pipefy/report_service.py
+++ b/src/pipefy_mcp/services/pipefy/report_service.py
@@ -101,7 +101,7 @@ class ReportService(BasePipefyClient):
         """
         return await self.execute_query(
             GET_ORGANIZATION_REPORT_QUERY,
-            {"id": report_id},
+            {"id": int(report_id)},
         )
 
     async def get_organization_reports(
@@ -118,7 +118,10 @@ class ReportService(BasePipefyClient):
             first: Page size (default 30).
             after: Cursor for next page.
         """
-        variables: dict[str, Any] = {"organizationId": organization_id, "first": first}
+        variables: dict[str, Any] = {
+            "organizationId": int(organization_id),
+            "first": first,
+        }
         if after is not None:
             variables["after"] = after
         return await self.execute_query(GET_ORGANIZATION_REPORTS_QUERY, variables)

--- a/src/pipefy_mcp/services/pipefy/table_service.py
+++ b/src/pipefy_mcp/services/pipefy/table_service.py
@@ -49,11 +49,13 @@ class TableService(BasePipefyClient):
 
     async def get_table(self, table_id: str | int) -> dict[str, Any]:
         """Fetch one database table by ID (metadata and fields)."""
-        return await self.execute_query(GET_TABLE_QUERY, {"id": table_id})
+        return await self.execute_query(GET_TABLE_QUERY, {"id": int(table_id)})
 
     async def get_tables(self, table_ids: list[str | int]) -> dict[str, Any]:
         """Fetch multiple database tables by ID."""
-        return await self.execute_query(GET_TABLES_QUERY, {"ids": list(table_ids)})
+        return await self.execute_query(
+            GET_TABLES_QUERY, {"ids": [int(t) for t in table_ids]}
+        )
 
     async def get_table_records(
         self,
@@ -68,14 +70,14 @@ class TableService(BasePipefyClient):
             first: Page size (forwarded to the API; callers may cap, e.g. max 200).
             after: Opaque cursor from the previous page's `pageInfo.endCursor`.
         """
-        variables: dict[str, Any] = {"tableId": table_id, "first": first}
+        variables: dict[str, Any] = {"tableId": int(table_id), "first": first}
         if after is not None:
             variables["after"] = after
         return await self.execute_query(GET_TABLE_RECORDS_QUERY, variables)
 
     async def get_table_record(self, record_id: str | int) -> dict[str, Any]:
         """Fetch a single table record by ID."""
-        return await self.execute_query(GET_TABLE_RECORD_QUERY, {"id": record_id})
+        return await self.execute_query(GET_TABLE_RECORD_QUERY, {"id": int(record_id)})
 
     async def find_records(
         self,
@@ -120,7 +122,7 @@ class TableService(BasePipefyClient):
 
     async def update_table(self, table_id: str | int, **attrs: Any) -> dict[str, Any]:
         """Update a database table by ID. Pass only `UpdateTableInput` fields (omit or None to skip)."""
-        payload: dict[str, Any] = {"id": table_id}
+        payload: dict[str, Any] = {"id": int(table_id)}
         for key, value in attrs.items():
             if value is not None:
                 payload[key] = value
@@ -130,7 +132,7 @@ class TableService(BasePipefyClient):
         """Delete a database table by ID (permanent). Caller must enforce preview/confirm UX."""
         return await self.execute_query(
             DELETE_TABLE_MUTATION,
-            {"input": {"id": table_id}},
+            {"input": {"id": int(table_id)}},
         )
 
     async def create_table_record(
@@ -147,7 +149,7 @@ class TableService(BasePipefyClient):
             **attrs: Other `CreateTableRecordInput` keys (e.g. title, assignee_ids), when not None.
         """
         input_obj: dict[str, Any] = {
-            "table_id": table_id,
+            "table_id": int(table_id),
             "fields_attributes": convert_fields_to_array(fields),
         }
         for key, value in attrs.items():
@@ -174,7 +176,7 @@ class TableService(BasePipefyClient):
             for key, value in fields.items()
         ):
             raise ValueError(UPDATE_TABLE_RECORD_FIELDS_ERROR_MESSAGE)
-        payload: dict[str, Any] = {"id": record_id}
+        payload: dict[str, Any] = {"id": int(record_id)}
         for key, value in fields.items():
             if value is None:
                 continue
@@ -191,7 +193,7 @@ class TableService(BasePipefyClient):
         """Delete a table record by ID (permanent)."""
         return await self.execute_query(
             DELETE_TABLE_RECORD_MUTATION,
-            {"input": {"id": record_id}},
+            {"input": {"id": int(record_id)}},
         )
 
     async def set_table_record_field_value(
@@ -206,7 +208,7 @@ class TableService(BasePipefyClient):
             SET_TABLE_RECORD_FIELD_VALUE_MUTATION,
             {
                 "input": {
-                    "table_record_id": record_id,
+                    "table_record_id": int(record_id),
                     "field_id": field_id,
                     "value": api_value,
                 }
@@ -229,7 +231,7 @@ class TableService(BasePipefyClient):
             **attrs: Other input fields (e.g. description, required, options), when not None.
         """
         input_obj: dict[str, Any] = {
-            "table_id": table_id,
+            "table_id": int(table_id),
             "label": label,
             "type": field_type,
         }
@@ -253,7 +255,7 @@ class TableService(BasePipefyClient):
         """
         payload: dict[str, Any] = {"id": field_id}
         if table_id is not None:
-            payload["table_id"] = table_id
+            payload["table_id"] = int(table_id)
         for key, value in attrs.items():
             if value is not None:
                 payload[key] = value

--- a/src/pipefy_mcp/services/pipefy/webhook_service.py
+++ b/src/pipefy_mcp/services/pipefy/webhook_service.py
@@ -60,7 +60,7 @@ class WebhookService(BasePipefyClient):
             filter_by_name: Optional case-insensitive partial match on template name.
             first: Max templates to return (default 50).
         """
-        variables: dict[str, Any] = {"repoId": repo_id, "first": first}
+        variables: dict[str, Any] = {"repoId": int(repo_id), "first": first}
         if filter_by_name is not None and filter_by_name.strip():
             variables["filterByName"] = filter_by_name.strip()
         return await self.execute_query(GET_EMAIL_TEMPLATES_QUERY, variables)
@@ -226,7 +226,7 @@ class WebhookService(BasePipefyClient):
         """
         _require_https(url, "url")
         input_obj: dict[str, Any] = {
-            "pipe_id": pipe_id,
+            "pipe_id": int(pipe_id),
             "url": url,
             "actions": actions,
             "name": attrs.get("name", _DEFAULT_WEBHOOK_NAME),
@@ -266,7 +266,7 @@ class WebhookService(BasePipefyClient):
         """
         raw = await self.execute_query(
             GET_CARD_INBOX_EMAILS_QUERY,
-            {"card_id": card_id},
+            {"card_id": int(card_id)},
         )
         card_data = raw.get("card") or {}
         emails = card_data.get("inbox_emails") or []

--- a/tests/services/pipefy/test_automation_service.py
+++ b/tests/services/pipefy/test_automation_service.py
@@ -51,12 +51,12 @@ async def test_get_automation_success(mock_settings):
         "event_repo": {"id": "p1", "name": "Pipe A"},
     }
     service = _make_service(mock_settings, {"automation": automation})
-    result = await service.get_automation("a1")
+    result = await service.get_automation("101")
 
     service.execute_query.assert_awaited_once()
     query, variables = service.execute_query.call_args[0]
     assert query is GET_AUTOMATION_QUERY
-    assert variables == {"id": "a1"}
+    assert variables == {"id": 101}
     assert result["id"] == "a1"
     assert result["name"] == "Notify assignee"
 
@@ -65,11 +65,11 @@ async def test_get_automation_success(mock_settings):
 @pytest.mark.asyncio
 async def test_get_automation_when_api_returns_null(mock_settings):
     service = _make_service(mock_settings, {"automation": None})
-    result = await service.get_automation("missing-id")
+    result = await service.get_automation("999")
 
     query, variables = service.execute_query.call_args[0]
     assert query is GET_AUTOMATION_QUERY
-    assert variables == {"id": "missing-id"}
+    assert variables == {"id": 999}
     assert result is None
 
 
@@ -81,7 +81,7 @@ async def test_get_automation_transport_error(mock_settings):
         side_effect=TransportQueryError("failed", errors=[{"message": "not found"}])
     )
     with pytest.raises(TransportQueryError):
-        await service.get_automation("missing")
+        await service.get_automation("998")
 
 
 @pytest.mark.unit
@@ -92,11 +92,11 @@ async def test_get_automations_success(mock_settings):
         {"id": "a2", "name": "Rule 2", "active": False},
     ]
     service = _make_service(mock_settings, {"automations": {"nodes": rows}})
-    result = await service.get_automations(organization_id="o1", pipe_id="p9")
+    result = await service.get_automations(organization_id="101", pipe_id="901")
 
     query, variables = service.execute_query.call_args[0]
     assert query is GET_AUTOMATIONS_FOR_ORG_AND_REPO_QUERY
-    assert variables == {"organizationId": "o1", "repoId": "p9"}
+    assert variables == {"organizationId": 101, "repoId": 901}
     assert isinstance(result, list)
     assert result == rows
 
@@ -112,15 +112,15 @@ async def test_get_automations_success_resolves_org_from_pipe(mock_settings):
             {"automations": {"nodes": rows}},
         ],
     )
-    result = await service.get_automations(pipe_id="p9")
+    result = await service.get_automations(pipe_id="901")
 
     assert service.execute_query.await_count == 2
     q1, v1 = service.execute_query.call_args_list[0][0]
     q2, v2 = service.execute_query.call_args_list[1][0]
     assert q1 is GET_PIPE_ORGANIZATION_ID_QUERY
-    assert v1 == {"id": "p9"}
+    assert v1 == {"id": 901}
     assert q2 is GET_AUTOMATIONS_FOR_ORG_AND_REPO_QUERY
-    assert v2 == {"organizationId": "300", "repoId": "p9"}
+    assert v2 == {"organizationId": 300, "repoId": 901}
     assert result == rows
 
 
@@ -129,11 +129,11 @@ async def test_get_automations_success_resolves_org_from_pipe(mock_settings):
 async def test_get_automations_organization_only_omits_repo_id(mock_settings):
     rows = [{"id": "a1", "name": "R", "active": True}]
     service = _make_service(mock_settings, {"automations": {"nodes": rows}})
-    result = await service.get_automations(organization_id="o1")
+    result = await service.get_automations(organization_id="201")
 
     query, variables = service.execute_query.call_args[0]
     assert query is GET_AUTOMATIONS_BY_ORG_QUERY
-    assert variables == {"organizationId": "o1"}
+    assert variables == {"organizationId": 201}
     assert result == rows
 
 
@@ -174,11 +174,11 @@ async def test_get_automation_actions_success(mock_settings):
         }
     ]
     service = _make_service(mock_settings, {"automationActions": actions})
-    result = await service.get_automation_actions("pipe-1")
+    result = await service.get_automation_actions("601")
 
     query, variables = service.execute_query.call_args[0]
     assert query is GET_AUTOMATION_ACTIONS_QUERY
-    assert variables == {"repoId": "pipe-1"}
+    assert variables == {"repoId": 601}
     assert isinstance(result, list)
     assert result[0]["id"] == "act1"
     assert result[0]["enabled"] is True
@@ -192,7 +192,7 @@ async def test_get_automation_actions_transport_error(mock_settings):
         side_effect=TransportQueryError("failed", errors=[{"message": "bad pipe"}])
     )
     with pytest.raises(TransportQueryError):
-        await service.get_automation_actions("x")
+        await service.get_automation_actions("999")
 
 
 @pytest.mark.unit

--- a/tests/services/pipefy/test_member_service.py
+++ b/tests/services/pipefy/test_member_service.py
@@ -42,13 +42,13 @@ async def test_invite_members_success(mock_settings):
     }
     service = _make_service(mock_settings, payload)
     members = [{"email": "a@x.com", "role_name": "member"}]
-    result = await service.invite_members("pipe-1", members)
+    result = await service.invite_members("601", members)
 
     service.execute_query.assert_awaited_once()
     query, variables = service.execute_query.call_args[0]
     assert query is INVITE_MEMBERS_MUTATION
     inp = variables["input"]
-    assert inp["pipe_id"] == "pipe-1"
+    assert inp["pipe_id"] == 601
     assert inp["emails"] == [{"email": "a@x.com", "role_name": "member"}]
     assert result == payload
 
@@ -62,7 +62,7 @@ async def test_invite_members_transport_error(mock_settings):
     )
     with pytest.raises(TransportQueryError):
         await service.invite_members(
-            "p1", [{"email": "x@y.com", "role_name": "member"}]
+            "602", [{"email": "x@y.com", "role_name": "member"}]
         )
 
 
@@ -161,13 +161,13 @@ async def test_set_role_success(mock_settings):
         }
     }
     service = _make_service(mock_settings, payload)
-    result = await service.set_role("pipe-1", "member-1", "admin")
+    result = await service.set_role("603", "member-1", "admin")
 
     service.execute_query.assert_awaited_once()
     query, variables = service.execute_query.call_args[0]
     assert query is SET_ROLE_MUTATION
     inp = variables["input"]
-    assert inp["pipe_id"] == "pipe-1"
+    assert inp["pipe_id"] == 603
     assert inp["member"] == {"user_id": "member-1", "role_name": "admin"}
     assert result == payload
 
@@ -180,4 +180,4 @@ async def test_set_role_transport_error(mock_settings):
         side_effect=TransportQueryError("failed", errors=[{"message": "invalid"}])
     )
     with pytest.raises(TransportQueryError):
-        await service.set_role("p1", "m1", "member")
+        await service.set_role("604", "m1", "member")

--- a/tests/services/pipefy/test_observability_service.py
+++ b/tests/services/pipefy/test_observability_service.py
@@ -323,7 +323,7 @@ async def test_get_ai_credit_usage_resolves_numeric_organization_id(mock_setting
     assert service.execute_query.call_count == 2
     calls = service.execute_query.call_args_list
     assert calls[0][0][0] is RESOLVE_ORGANIZATION_UUID_QUERY
-    assert calls[0][0][1] == {"id": "300514213"}
+    assert calls[0][0][1] == {"id": 300514213}
     assert calls[1][0][0] is GET_AI_CREDIT_USAGE_QUERY
     assert calls[1][0][1] == {
         "organizationUuid": "341c1327-261c-4766-bb96-7953e4c3970d",
@@ -356,11 +356,11 @@ async def test_export_automation_jobs_success(mock_settings):
         }
     }
     service = _make_service(mock_settings, payload)
-    result = await service.export_automation_jobs("org-123", "last_month")
+    result = await service.export_automation_jobs("123", "last_month")
 
     query, variables = service.execute_query.call_args[0]
     assert query is CREATE_AUTOMATION_JOBS_EXPORT_MUTATION
-    assert variables == {"input": {"organizationId": "org-123", "filter": "last_month"}}
+    assert variables == {"input": {"organizationId": 123, "filter": "last_month"}}
     assert result["createAutomationJobsExport"]["automationJobsExport"]["id"] == "exp-1"
 
 
@@ -510,7 +510,7 @@ async def test_get_agents_usage_resolves_numeric_organization_id(mock_settings):
     assert service.execute_query.call_count == 2
     calls = service.execute_query.call_args_list
     assert calls[0][0][0] is RESOLVE_ORGANIZATION_UUID_QUERY
-    assert calls[0][0][1] == {"id": "300514213"}
+    assert calls[0][0][1] == {"id": 300514213}
     assert calls[1][0][0] is GET_AGENTS_USAGE_QUERY
     assert calls[1][0][1]["organizationUuid"] == "341c1327-261c-4766-bb96-7953e4c3970d"
     assert result["agentsUsage"]["totalCredits"] == 5.0
@@ -534,7 +534,7 @@ async def test_get_automations_usage_resolves_numeric_organization_id(mock_setti
     assert service.execute_query.call_count == 2
     calls = service.execute_query.call_args_list
     assert calls[0][0][0] is RESOLVE_ORGANIZATION_UUID_QUERY
-    assert calls[0][0][1] == {"id": "300514213"}
+    assert calls[0][0][1] == {"id": 300514213}
     assert calls[1][0][0] is GET_AUTOMATIONS_USAGE_QUERY
     assert calls[1][0][1]["organizationUuid"] == "341c1327-261c-4766-bb96-7953e4c3970d"
     assert result["automationsUsage"]["totalExecutions"] == 42

--- a/tests/services/pipefy/test_organization_service.py
+++ b/tests/services/pipefy/test_organization_service.py
@@ -47,7 +47,7 @@ async def test_get_organization_returns_org_details(mock_settings):
     service.execute_query.assert_called_once()
     query_used, variables = service.execute_query.call_args[0]
     assert query_used is GET_ORGANIZATION_QUERY
-    assert variables == {"id": "123"}
+    assert variables == {"id": 123}
     assert result == org_data
 
 
@@ -72,4 +72,4 @@ async def test_get_organization_uses_correct_query_and_variables(mock_settings):
 
     query_used, variables = service.execute_query.call_args[0]
     assert query_used is GET_ORGANIZATION_QUERY
-    assert variables == {"id": "456"}
+    assert variables == {"id": 456}

--- a/tests/services/pipefy/test_relation_service.py
+++ b/tests/services/pipefy/test_relation_service.py
@@ -44,12 +44,12 @@ async def test_get_pipe_relations_sends_pipe_id(mock_settings):
         }
     }
     service = _make_service(mock_settings, payload)
-    result = await service.get_pipe_relations("p1")
+    result = await service.get_pipe_relations("701")
 
     service.execute_query.assert_awaited_once()
     query, variables = service.execute_query.call_args[0]
     assert query is GET_PIPE_RELATIONS_QUERY
-    assert variables == {"pipeId": "p1"}
+    assert variables == {"pipeId": 701}
     assert result["pipe"]["parentsRelations"][0]["name"] == "Up"
 
 
@@ -69,11 +69,11 @@ async def test_get_pipe_relations_transport_error(mock_settings):
 async def test_get_table_relations_sends_ids_list(mock_settings):
     rows = [{"id": "t1", "name": "Link"}]
     service = _make_service(mock_settings, {"table_relations": rows})
-    result = await service.get_table_relations(["a", "b"])
+    result = await service.get_table_relations(["801", "802"])
 
     query, variables = service.execute_query.call_args[0]
     assert query is GET_TABLE_RELATIONS_QUERY
-    assert variables == {"ids": ["a", "b"]}
+    assert variables == {"ids": [801, 802]}
     assert result["table_relations"] == rows
 
 

--- a/tests/services/pipefy/test_report_service.py
+++ b/tests/services/pipefy/test_report_service.py
@@ -197,11 +197,11 @@ async def test_get_organization_report_success(mock_settings):
         }
     }
     service = _make_service(mock_settings, payload)
-    result = await service.get_organization_report("or1")
+    result = await service.get_organization_report("901")
 
     query, variables = service.execute_query.call_args[0]
     assert query is GET_ORGANIZATION_REPORT_QUERY
-    assert variables == {"id": "or1"}
+    assert variables == {"id": 901}
     assert result["organizationReport"]["name"] == "Org Overview"
 
 
@@ -232,11 +232,11 @@ async def test_get_organization_reports_success(mock_settings):
         }
     }
     service = _make_service(mock_settings, payload)
-    result = await service.get_organization_reports("org-1", first=5, after="cursor-1")
+    result = await service.get_organization_reports("1001", first=5, after="cursor-1")
 
     query, variables = service.execute_query.call_args[0]
     assert query is GET_ORGANIZATION_REPORTS_QUERY
-    assert variables["organizationId"] == "org-1"
+    assert variables["organizationId"] == 1001
     assert variables["first"] == 5
     assert variables["after"] == "cursor-1"
     assert len(result["organizationReports"]["edges"]) == 2

--- a/tests/services/pipefy/test_table_service.py
+++ b/tests/services/pipefy/test_table_service.py
@@ -49,12 +49,12 @@ async def test_get_table_sends_id_and_returns_payload(mock_settings):
         mock_settings,
         {"table": {"id": "t1", "name": "Refs", "table_fields": []}},
     )
-    result = await service.get_table("t1")
+    result = await service.get_table("101")
 
     service.execute_query.assert_awaited_once()
     query, variables = service.execute_query.call_args[0]
     assert query is GET_TABLE_QUERY
-    assert variables == {"id": "t1"}
+    assert variables == {"id": 101}
     assert result["table"]["name"] == "Refs"
 
 
@@ -65,11 +65,11 @@ async def test_get_tables_sends_ids_list(mock_settings):
         mock_settings,
         {"tables": [{"id": "a"}, {"id": "b"}]},
     )
-    result = await service.get_tables(["a", "b"])
+    result = await service.get_tables(["101", "102"])
 
     query, variables = service.execute_query.call_args[0]
     assert query is GET_TABLES_QUERY
-    assert variables == {"ids": ["a", "b"]}
+    assert variables == {"ids": [101, 102]}
     assert len(result["tables"]) == 2
 
 
@@ -98,10 +98,10 @@ async def test_get_table_records_default_first_and_pagination_passthrough(
 @pytest.mark.asyncio
 async def test_get_table_records_includes_after_when_provided(mock_settings):
     service = _make_service(mock_settings, {"table_records": {"edges": []}})
-    await service.get_table_records("tbl", first=10, after="c1")
+    await service.get_table_records("201", first=10, after="c1")
 
     variables = service.execute_query.call_args[0][1]
-    assert variables == {"tableId": "tbl", "first": 10, "after": "c1"}
+    assert variables == {"tableId": 201, "first": 10, "after": "c1"}
 
 
 @pytest.mark.unit
@@ -195,7 +195,7 @@ async def test_update_table_merges_id_and_attrs(mock_settings):
 
     query, variables = service.execute_query.call_args[0]
     assert query is UPDATE_TABLE_MUTATION
-    assert variables == {"input": {"id": "1", "name": "X"}}
+    assert variables == {"input": {"id": 1, "name": "X"}}
 
 
 @pytest.mark.unit
@@ -269,7 +269,7 @@ async def test_update_table_record_raises_when_no_supported_attributes(
 ):
     service = _make_service(mock_settings, {"updateTableRecord": {}})
     with pytest.raises(ValueError, match="Invalid 'fields'"):
-        await service.update_table_record("r1", {"unknown": "x"})
+        await service.update_table_record("100", {"unknown": "x"})
 
     service.execute_query.assert_not_called()
 
@@ -282,14 +282,14 @@ async def test_update_table_record_maps_status_id(mock_settings):
         {"updateTableRecord": {"table_record": {"id": "1"}}},
     )
     await service.update_table_record(
-        "r9",
+        "901",
         {"title": "Hi", "status_id": "st1"},
     )
 
     query, variables = service.execute_query.call_args[0]
     assert query is UPDATE_TABLE_RECORD_MUTATION
     assert variables == {
-        "input": {"id": "r9", "title": "Hi", "statusId": "st1"},
+        "input": {"id": 901, "title": "Hi", "statusId": "st1"},
     }
 
 
@@ -308,11 +308,11 @@ async def test_update_table_record_raises_transport_query_error(mock_settings):
 @pytest.mark.asyncio
 async def test_delete_table_record_sends_id(mock_settings):
     service = _make_service(mock_settings, {"deleteTableRecord": {"success": True}})
-    await service.delete_table_record("rec")
+    await service.delete_table_record("301")
 
     query, variables = service.execute_query.call_args[0]
     assert query is DELETE_TABLE_RECORD_MUTATION
-    assert variables == {"input": {"id": "rec"}}
+    assert variables == {"input": {"id": 301}}
 
 
 @pytest.mark.unit
@@ -333,13 +333,13 @@ async def test_set_table_record_field_value_wraps_scalar(mock_settings):
         mock_settings,
         {"setTableRecordFieldValue": {"table_record": {"id": "1"}}},
     )
-    await service.set_table_record_field_value("r1", "f1", "text")
+    await service.set_table_record_field_value("401", "f1", "text")
 
     query, variables = service.execute_query.call_args[0]
     assert query is SET_TABLE_RECORD_FIELD_VALUE_MUTATION
     assert variables == {
         "input": {
-            "table_record_id": "r1",
+            "table_record_id": 401,
             "field_id": "f1",
             "value": ["text"],
         },
@@ -371,7 +371,7 @@ async def test_create_table_field_sends_input(mock_settings):
         },
     )
     result = await service.create_table_field(
-        "tbl1",
+        "501",
         "Code",
         "short_text",
         required=True,
@@ -381,7 +381,7 @@ async def test_create_table_field_sends_input(mock_settings):
     assert query is CREATE_TABLE_FIELD_MUTATION
     assert variables == {
         "input": {
-            "table_id": "tbl1",
+            "table_id": 501,
             "label": "Code",
             "type": "short_text",
             "required": True,

--- a/tests/services/pipefy/test_webhook_service.py
+++ b/tests/services/pipefy/test_webhook_service.py
@@ -47,7 +47,7 @@ async def test_get_email_templates_success(mock_settings):
     service.execute_query.assert_awaited_once()
     query, variables = service.execute_query.call_args[0]
     assert query is GET_EMAIL_TEMPLATES_QUERY
-    assert variables["repoId"] == "307061640"
+    assert variables["repoId"] == 307061640
     assert variables["first"] == 50
     assert result == payload
 
@@ -214,7 +214,7 @@ async def test_create_webhook_success(mock_settings):
     }
     service = _make_service(mock_settings, payload)
     result = await service.create_webhook(
-        pipe_id="pipe-1",
+        pipe_id="601",
         url="https://example.com/hook",
         actions=["card.create"],
     )
@@ -223,7 +223,7 @@ async def test_create_webhook_success(mock_settings):
     query, variables = service.execute_query.call_args[0]
     assert query is CREATE_WEBHOOK_MUTATION
     inp = variables["input"]
-    assert inp["pipe_id"] == "pipe-1"
+    assert inp["pipe_id"] == 601
     assert inp["url"] == "https://example.com/hook"
     assert inp["actions"] == ["card.create"]
     assert result == payload
@@ -237,7 +237,7 @@ async def test_create_webhook_transport_error(mock_settings):
         side_effect=TransportQueryError("failed", errors=[{"message": "bad"}])
     )
     with pytest.raises(TransportQueryError):
-        await service.create_webhook("p1", "https://x.com/hook", ["card.move"])
+        await service.create_webhook("602", "https://x.com/hook", ["card.move"])
 
 
 @pytest.mark.unit
@@ -309,7 +309,7 @@ async def test_get_card_inbox_emails_success(mock_settings):
     service.execute_query.assert_awaited_once()
     query, variables = service.execute_query.call_args[0]
     assert query is GET_CARD_INBOX_EMAILS_QUERY
-    assert variables["card_id"] == "12345"
+    assert variables["card_id"] == 12345
     assert result == payload
     assert len(result["card"]["inbox_emails"]) == 2
 


### PR DESCRIPTION
## Summary
Coerces string or mixed numeric IDs to Python `int` before `execute_query` in several Pipefy services whose GraphQL variables are typed as `Int` / `[Int]`. This aligns variables with the schema when MCP/tools pass string IDs.

## Scope (8 atomic commits)
- **AutomationService** — automation, org, repo, pipe variables
- **MemberService** — `pipe_id` in invite and set-role mutations
- **ObservabilityService** — org ID resolution and automation jobs export
- **OrganizationService** — `get_organization`
- **RelationService** — pipe relations and table relation ID lists
- **ReportService** — organization report IDs
- **TableService** — table, record, and field-related IDs
- **WebhookService** — repo and card-related variables

## Testing
- `uv run pytest -m "not integration"` — 939 passed
- `uv run ruff check src/ tests/` and `ruff format --check` — clean

## Base branch
Targets **`pipe-full-toolset`** as requested.