### PR TITLE
feat(ai-tools): resolve behavior field slugs; harden destructive elicitation

### DIFF
--- a/src/pipefy_mcp/services/pipefy/queries/pipe_queries.py
+++ b/src/pipefy_mcp/services/pipefy/queries/pipe_queries.py
@@ -20,6 +20,7 @@ GET_PIPE_QUERY = gql(
             }
             start_form_fields {
                 id
+                internal_id
                 label
                 required
                 type
@@ -36,6 +37,7 @@ GET_START_FORM_FIELDS_QUERY = gql(
         pipe(id: $pipe_id) {
             start_form_fields {
                 id
+                internal_id
                 label
                 type
                 required

--- a/src/pipefy_mcp/tools/ai_agent_tools.py
+++ b/src/pipefy_mcp/tools/ai_agent_tools.py
@@ -20,6 +20,7 @@ from pipefy_mcp.tools.ai_tool_helpers import (
     build_toggle_agent_status_success,
     build_update_agent_success,
     enrich_behavior_error,
+    resolve_field_slugs_to_numeric,
     validate_behaviors_against_pipe,
 )
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
@@ -261,12 +262,15 @@ class AiAgentTools:
 
             agent_uuid = create_result["agent_uuid"]
 
+            resolved_behaviors = await resolve_field_slugs_to_numeric(
+                client, validated.behaviors
+            )
             update_input = UpdateAiAgentInput(
                 uuid=agent_uuid,
                 name=validated.name,
                 repo_uuid=validated.repo_uuid,
                 instruction=validated.instruction,
-                behaviors=validated.behaviors,
+                behaviors=resolved_behaviors,
                 data_source_ids=validated.data_source_ids,
             )
             try:
@@ -320,13 +324,14 @@ class AiAgentTools:
                 return build_ai_tool_error("name must not be blank")
             if not repo_uuid or not repo_uuid.strip():
                 return build_ai_tool_error("repo_uuid must not be blank")
+            resolved_behaviors = await resolve_field_slugs_to_numeric(client, behaviors)
             try:
                 validated = UpdateAiAgentInput(
                     uuid=uuid,
                     name=name,
                     repo_uuid=repo_uuid,
                     instruction=instruction,
-                    behaviors=behaviors,
+                    behaviors=resolved_behaviors,
                     data_source_ids=data_source_ids or [],
                 )
             except ValidationError as exc:
@@ -336,7 +341,7 @@ class AiAgentTools:
                 result = await client.update_ai_agent(validated)
             except Exception as exc:  # noqa: BLE001
                 return build_ai_tool_error(
-                    await _enrich_with_validation(exc, behaviors)
+                    await _enrich_with_validation(exc, resolved_behaviors)
                 )
 
             return build_update_agent_success(

--- a/src/pipefy_mcp/tools/ai_tool_helpers.py
+++ b/src/pipefy_mcp/tools/ai_tool_helpers.py
@@ -2,13 +2,20 @@
 
 from __future__ import annotations
 
+import copy
+import logging
 import re
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from typing_extensions import TypedDict
 
 from pipefy_mcp.services.pipefy.types import AiAgentGraphPayload
 from pipefy_mcp.tools.graphql_error_helpers import extract_error_strings
+
+if TYPE_CHECKING:
+    from pipefy_mcp.services.pipefy import PipefyClient
+
+logger = logging.getLogger(__name__)
 
 
 class CreateAiAutomationSuccessPayload(TypedDict):
@@ -360,6 +367,153 @@ def validate_behaviors_against_pipe(
                     )
 
     return problems, warnings
+
+
+# --- Slug → numeric fieldId resolution ---
+
+
+def _extract_slug_field_ids_by_pipe(
+    behaviors: list[dict[str, Any]],
+) -> dict[str, set[str]]:
+    """Scan behaviors and collect non-numeric fieldIds grouped by their target pipeId.
+
+    Args:
+        behaviors: Raw behavior dicts (supports both camelCase and snake_case keys).
+
+    Returns:
+        Dict mapping pipeId → set of slug fieldIds found in that pipe's actions.
+        Empty dict when no slugs are present.
+    """
+    slugs_by_pipe: dict[str, set[str]] = {}
+    for b in behaviors:
+        if not isinstance(b, dict):
+            continue
+        ap = b.get("actionParams") or b.get("action_params") or {}
+        if not isinstance(ap, dict):
+            continue
+        abp = ap.get("aiBehaviorParams") or ap.get("ai_behavior_params") or {}
+        if not isinstance(abp, dict):
+            continue
+        for a in abp.get("actionsAttributes") or abp.get("actions_attributes") or []:
+            if not isinstance(a, dict):
+                continue
+            metadata = a.get("metadata") or {}
+            pipe_id = str(metadata.get("pipeId", ""))
+            if not pipe_id:
+                continue
+            for fa in metadata.get("fieldsAttributes") or []:
+                if not isinstance(fa, dict):
+                    continue
+                fid = str(fa.get("fieldId", ""))
+                if fid and not fid.isdigit():
+                    slugs_by_pipe.setdefault(pipe_id, set()).add(fid)
+    return slugs_by_pipe
+
+
+async def build_field_slug_map(
+    client: PipefyClient,
+    pipe_id: int,
+) -> dict[str, str]:
+    """Build a slug → numeric internal_id map for all fields in a pipe.
+
+    Fetches pipe info (for phase IDs and start form fields), then calls
+    ``get_phase_fields`` per phase to collect ``internal_id`` values.
+
+    Args:
+        client: PipefyClient instance.
+        pipe_id: Numeric pipe ID.
+
+    Returns:
+        Dict mapping field slug to its numeric ``internal_id`` string.
+        Only includes entries where the slug is non-numeric.
+    """
+    slug_map: dict[str, str] = {}
+
+    pipe_data = await client.get_pipe(pipe_id)
+    pipe_info = pipe_data.get("pipe", {})
+
+    for field in pipe_info.get("start_form_fields") or []:
+        slug = str(field.get("id", ""))
+        internal = str(field.get("internal_id", ""))
+        if slug and internal and not slug.isdigit():
+            slug_map[slug] = internal
+
+    for phase in pipe_info.get("phases") or []:
+        phase_id = phase.get("id")
+        if not phase_id:
+            continue
+        try:
+            phase_data = await client.get_phase_fields(int(phase_id))
+            for field in phase_data.get("fields") or []:
+                slug = str(field.get("id", ""))
+                internal = str(field.get("internal_id", ""))
+                if slug and internal and not slug.isdigit():
+                    slug_map[slug] = internal
+        except Exception:  # noqa: BLE001
+            logger.debug("Failed to fetch fields for phase %s", phase_id, exc_info=True)
+    return slug_map
+
+
+async def resolve_field_slugs_to_numeric(
+    client: PipefyClient,
+    behaviors: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Replace slug fieldIds with numeric internal_ids in behavior metadata.
+
+    Scans ``fieldsAttributes[].fieldId`` across all behaviors for non-numeric values.
+    When found, fetches each target pipe's fields to build a slug→numeric map and
+    replaces matches. Returns a deep copy; the original ``behaviors`` list is not mutated.
+
+    Unresolvable slugs are left as-is (the API will reject them with the existing
+    enriched error).
+
+    Args:
+        client: PipefyClient for fetching pipe field data.
+        behaviors: Behavior dicts (same shape as ``create_ai_agent`` / ``update_ai_agent``).
+
+    Returns:
+        Behaviors with slug fieldIds replaced by numeric IDs where resolvable.
+    """
+    slugs_by_pipe = _extract_slug_field_ids_by_pipe(behaviors)
+    if not slugs_by_pipe:
+        return behaviors
+
+    slug_to_numeric: dict[str, str] = {}
+    for pipe_id_str in slugs_by_pipe:
+        try:
+            field_map = await build_field_slug_map(client, int(pipe_id_str))
+            slug_to_numeric.update(field_map)
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "Failed to fetch field map for pipe %s; slugs left as-is",
+                pipe_id_str,
+                exc_info=True,
+            )
+
+    if not slug_to_numeric:
+        return behaviors
+
+    resolved = copy.deepcopy(behaviors)
+    for b in resolved:
+        if not isinstance(b, dict):
+            continue
+        ap = b.get("actionParams") or b.get("action_params") or {}
+        if not isinstance(ap, dict):
+            continue
+        abp = ap.get("aiBehaviorParams") or ap.get("ai_behavior_params") or {}
+        if not isinstance(abp, dict):
+            continue
+        for a in abp.get("actionsAttributes") or abp.get("actions_attributes") or []:
+            if not isinstance(a, dict):
+                continue
+            for fa in (a.get("metadata") or {}).get("fieldsAttributes") or []:
+                if not isinstance(fa, dict):
+                    continue
+                fid = str(fa.get("fieldId", ""))
+                if fid in slug_to_numeric:
+                    fa["fieldId"] = slug_to_numeric[fid]
+
+    return resolved
 
 
 def enrich_behavior_error(

--- a/src/pipefy_mcp/tools/destructive_tool_guard.py
+++ b/src/pipefy_mcp/tools/destructive_tool_guard.py
@@ -115,8 +115,8 @@ async def _elicit_confirmation(
         if not result.data.model_dump().get("confirm"):
             return _build_cancel_payload()
 
-    except Exception as exc:  # noqa: BLE001
-        return {"success": False, "error": f"Failed to request confirmation: {exc!s}"}
+    except Exception:  # noqa: BLE001
+        return _build_preview_payload(resource_descriptor)
 
     return None
 

--- a/tests/tools/test_ai_tool_helpers_slug_resolution.py
+++ b/tests/tools/test_ai_tool_helpers_slug_resolution.py
@@ -1,0 +1,362 @@
+"""Tests for resolve_field_slugs_to_numeric (slug → numeric fieldId resolution)."""
+
+import copy
+from unittest.mock import AsyncMock
+
+import pytest
+
+from pipefy_mcp.tools.ai_tool_helpers import (
+    build_field_slug_map,
+    resolve_field_slugs_to_numeric,
+)
+
+
+def _behavior_with_fields(pipe_id, field_ids, action_type="update_card"):
+    """Build a minimal behavior dict with fieldsAttributes targeting pipe_id."""
+    return {
+        "name": "Test behavior",
+        "event_id": "card_created",
+        "actionParams": {
+            "aiBehaviorParams": {
+                "instruction": "test",
+                "actionsAttributes": [
+                    {
+                        "name": "action",
+                        "actionType": action_type,
+                        "metadata": {
+                            "pipeId": pipe_id,
+                            "fieldsAttributes": [
+                                {
+                                    "fieldId": fid,
+                                    "inputMode": "fill_with_ai",
+                                    "value": "",
+                                }
+                                for fid in field_ids
+                            ],
+                        },
+                    },
+                ],
+            }
+        },
+    }
+
+
+# --- build_field_slug_map tests ---
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_field_slug_map_from_start_form_and_phases():
+    client = AsyncMock()
+    client.get_pipe = AsyncMock(
+        return_value={
+            "pipe": {
+                "phases": [{"id": "100"}, {"id": "200"}],
+                "start_form_fields": [
+                    {"id": "company_name", "internal_id": "427911700"},
+                    {"id": "email", "internal_id": "427911701"},
+                ],
+            }
+        }
+    )
+    client.get_phase_fields = AsyncMock(
+        side_effect=[
+            {
+                "phase_id": "100",
+                "fields": [
+                    {"id": "summary_field", "internal_id": "427911728"},
+                    {"id": "427911729", "internal_id": "427911729"},
+                ],
+            },
+            {
+                "phase_id": "200",
+                "fields": [
+                    {"id": "approval_status", "internal_id": "427911750"},
+                ],
+            },
+        ]
+    )
+
+    slug_map = await build_field_slug_map(client, 306996636)
+
+    assert slug_map == {
+        "company_name": "427911700",
+        "email": "427911701",
+        "summary_field": "427911728",
+        "approval_status": "427911750",
+    }
+    # numeric-id field "427911729" is NOT in the map (already numeric)
+    assert "427911729" not in slug_map
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_field_slug_map_skips_failed_phase():
+    client = AsyncMock()
+    client.get_pipe = AsyncMock(
+        return_value={
+            "pipe": {
+                "phases": [{"id": "100"}, {"id": "200"}],
+                "start_form_fields": [],
+            }
+        }
+    )
+    client.get_phase_fields = AsyncMock(
+        side_effect=[
+            Exception("timeout"),
+            {"phase_id": "200", "fields": [{"id": "slug_a", "internal_id": "999"}]},
+        ]
+    )
+
+    slug_map = await build_field_slug_map(client, 1)
+
+    assert slug_map == {"slug_a": "999"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_field_slug_map_empty_pipe():
+    client = AsyncMock()
+    client.get_pipe = AsyncMock(
+        return_value={"pipe": {"phases": [], "start_form_fields": []}}
+    )
+
+    slug_map = await build_field_slug_map(client, 1)
+
+    assert slug_map == {}
+
+
+# --- resolve_field_slugs_to_numeric tests ---
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resolve_replaces_slug_with_numeric_id():
+    client = AsyncMock()
+    client.get_pipe = AsyncMock(
+        return_value={
+            "pipe": {
+                "phases": [{"id": "100"}],
+                "start_form_fields": [
+                    {"id": "resumo_de_briefing_ia", "internal_id": "427911728"},
+                ],
+            }
+        }
+    )
+    client.get_phase_fields = AsyncMock(return_value={"phase_id": "100", "fields": []})
+
+    behaviors = [_behavior_with_fields("306996636", ["resumo_de_briefing_ia"])]
+    resolved = await resolve_field_slugs_to_numeric(client, behaviors)
+
+    fa = resolved[0]["actionParams"]["aiBehaviorParams"]["actionsAttributes"][0][
+        "metadata"
+    ]["fieldsAttributes"]
+    assert fa[0]["fieldId"] == "427911728"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resolve_leaves_numeric_ids_untouched():
+    client = AsyncMock()
+
+    behaviors = [_behavior_with_fields("100", ["427911728", "427911729"])]
+    resolved = await resolve_field_slugs_to_numeric(client, behaviors)
+
+    # No API calls because all fieldIds are already numeric
+    client.get_pipe.assert_not_called()
+    fa = resolved[0]["actionParams"]["aiBehaviorParams"]["actionsAttributes"][0][
+        "metadata"
+    ]["fieldsAttributes"]
+    assert fa[0]["fieldId"] == "427911728"
+    assert fa[1]["fieldId"] == "427911729"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resolve_does_not_mutate_original():
+    client = AsyncMock()
+    client.get_pipe = AsyncMock(
+        return_value={
+            "pipe": {
+                "phases": [],
+                "start_form_fields": [
+                    {"id": "slug_x", "internal_id": "999"},
+                ],
+            }
+        }
+    )
+
+    behaviors = [_behavior_with_fields("1", ["slug_x"])]
+    original = copy.deepcopy(behaviors)
+    resolved = await resolve_field_slugs_to_numeric(client, behaviors)
+
+    assert behaviors == original
+    assert (
+        resolved[0]["actionParams"]["aiBehaviorParams"]["actionsAttributes"][0][
+            "metadata"
+        ]["fieldsAttributes"][0]["fieldId"]
+        == "999"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resolve_leaves_unresolvable_slugs_as_is():
+    client = AsyncMock()
+    client.get_pipe = AsyncMock(
+        return_value={
+            "pipe": {
+                "phases": [],
+                "start_form_fields": [
+                    {"id": "known_slug", "internal_id": "111"},
+                ],
+            }
+        }
+    )
+
+    behaviors = [_behavior_with_fields("1", ["known_slug", "unknown_slug"])]
+    resolved = await resolve_field_slugs_to_numeric(client, behaviors)
+
+    fa = resolved[0]["actionParams"]["aiBehaviorParams"]["actionsAttributes"][0][
+        "metadata"
+    ]["fieldsAttributes"]
+    assert fa[0]["fieldId"] == "111"
+    assert fa[1]["fieldId"] == "unknown_slug"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resolve_handles_multiple_pipes():
+    client = AsyncMock()
+
+    async def mock_get_pipe(pipe_id):
+        if pipe_id == 100:
+            return {
+                "pipe": {
+                    "phases": [],
+                    "start_form_fields": [
+                        {"id": "field_a", "internal_id": "1001"},
+                    ],
+                }
+            }
+        return {
+            "pipe": {
+                "phases": [],
+                "start_form_fields": [
+                    {"id": "field_b", "internal_id": "2001"},
+                ],
+            }
+        }
+
+    client.get_pipe = AsyncMock(side_effect=mock_get_pipe)
+
+    behaviors = [
+        _behavior_with_fields("100", ["field_a"]),
+        _behavior_with_fields("200", ["field_b"]),
+    ]
+    resolved = await resolve_field_slugs_to_numeric(client, behaviors)
+
+    fa0 = resolved[0]["actionParams"]["aiBehaviorParams"]["actionsAttributes"][0][
+        "metadata"
+    ]["fieldsAttributes"]
+    fa1 = resolved[1]["actionParams"]["aiBehaviorParams"]["actionsAttributes"][0][
+        "metadata"
+    ]["fieldsAttributes"]
+    assert fa0[0]["fieldId"] == "1001"
+    assert fa1[0]["fieldId"] == "2001"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resolve_survives_api_failure():
+    client = AsyncMock()
+    client.get_pipe = AsyncMock(side_effect=Exception("API down"))
+
+    behaviors = [_behavior_with_fields("1", ["some_slug"])]
+    resolved = await resolve_field_slugs_to_numeric(client, behaviors)
+
+    # Falls back gracefully — slug left as-is
+    fa = resolved[0]["actionParams"]["aiBehaviorParams"]["actionsAttributes"][0][
+        "metadata"
+    ]["fieldsAttributes"]
+    assert fa[0]["fieldId"] == "some_slug"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resolve_handles_snake_case_keys():
+    client = AsyncMock()
+    client.get_pipe = AsyncMock(
+        return_value={
+            "pipe": {
+                "phases": [],
+                "start_form_fields": [
+                    {"id": "my_slug", "internal_id": "555"},
+                ],
+            }
+        }
+    )
+
+    behaviors = [
+        {
+            "name": "test",
+            "event_id": "card_created",
+            "action_params": {
+                "ai_behavior_params": {
+                    "instruction": "test",
+                    "actions_attributes": [
+                        {
+                            "name": "act",
+                            "actionType": "update_card",
+                            "metadata": {
+                                "pipeId": "1",
+                                "fieldsAttributes": [
+                                    {
+                                        "fieldId": "my_slug",
+                                        "inputMode": "fill_with_ai",
+                                        "value": "",
+                                    }
+                                ],
+                            },
+                        }
+                    ],
+                }
+            },
+        }
+    ]
+    resolved = await resolve_field_slugs_to_numeric(client, behaviors)
+
+    fa = resolved[0]["action_params"]["ai_behavior_params"]["actions_attributes"][0][
+        "metadata"
+    ]["fieldsAttributes"]
+    assert fa[0]["fieldId"] == "555"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resolve_skips_behaviors_without_pipe_id():
+    client = AsyncMock()
+
+    behaviors = [
+        {
+            "name": "move only",
+            "event_id": "card_created",
+            "actionParams": {
+                "aiBehaviorParams": {
+                    "instruction": "test",
+                    "actionsAttributes": [
+                        {
+                            "name": "move",
+                            "actionType": "move_card",
+                            "metadata": {"destinationPhaseId": "100"},
+                        }
+                    ],
+                }
+            },
+        }
+    ]
+    resolved = await resolve_field_slugs_to_numeric(client, behaviors)
+
+    # No API calls, behaviors returned as-is
+    client.get_pipe.assert_not_called()
+    assert resolved == behaviors

--- a/tests/tools/test_destructive_tool_guard.py
+++ b/tests/tools/test_destructive_tool_guard.py
@@ -84,7 +84,7 @@ class TestWithElicitation:
         assert payload is not None
         assert payload["success"] is False
 
-    async def test_elicitation_raises_returns_error(self):
+    async def test_elicitation_raises_falls_back_to_preview(self):
         ctx = _make_ctx(
             can_elicit=True,
             elicit_side_effect=RuntimeError("elicit broke"),
@@ -94,7 +94,8 @@ class TestWithElicitation:
         )
         assert payload is not None
         assert payload["success"] is False
-        assert "Failed to request confirmation" in payload["error"]
+        assert payload["requires_confirmation"] is True
+        assert payload["resource"] == RESOURCE
 
     async def test_confirm_true_ignored_when_elicitation_available(self):
         """Even with confirm=True, elicitation takes precedence when available."""


### PR DESCRIPTION
## Summary
- **Pipe queries:** `GET_PIPE_QUERY` and `GET_START_FORM_FIELDS_QUERY` now request `internal_id` on start form fields so slug → numeric mapping is possible.
- **AI tools:** `build_field_slug_map` / `resolve_field_slugs_to_numeric` replace non-numeric `fieldsAttributes[].fieldId` values with `internal_id` before API calls; `create_ai_agent` / `update_ai_agent` MCP tools use this for chained updates and validation errors.
- **Destructive guard:** If `ctx.elicit` raises, fall back to the same `requires_confirmation` preview as the non-elicitation path (users can still use `confirm=True`).

## Commits (atomic)
1. `feat(pipefy):` expose `internal_id` on start_form_fields queries
2. `feat(ai-tools):` resolve behavior field slugs to numeric IDs + tests
3. `feat(tools):` wire slug resolution into AI agent create/update
4. `fix(tools):` elicitation failure → preview fallback

## Testing
- `uv run pytest -m "not integration"` — 950 passed
- `ruff check` / `ruff format --check` on `src/` and `tests/`

**Base branch:** `pipe-full-toolset`