### PR TITLE
fix/feat(automations): error_details, simulate_automation, get_automation params

### DIFF
--- a/src/pipefy_mcp/services/pipefy/automation_graphql_types.py
+++ b/src/pipefy_mcp/services/pipefy/automation_graphql_types.py
@@ -14,6 +14,117 @@ class AutomationEventRepoRef(TypedDict, total=False):
     name: str
 
 
+class AutomationEventParamsRecord(TypedDict, total=False):
+    """``event_params`` on ``Automation`` (trigger configuration)."""
+
+    fromPhaseId: str | None
+    inPhaseId: str | None
+    kindOfSla: str | None
+    to_phase_id: str | None
+    triggerAutomationId: str | None
+    triggerFieldIds: list[str] | None
+    phase: AutomationEventRepoRef | None
+
+
+class AutomationAiParamsRecord(TypedDict, total=False):
+    """``aiParams`` under ``action_params``."""
+
+    value: str | None
+    fieldIds: list[str] | None
+    skillsIds: list[str] | None
+
+
+class AiBehaviorParamsRecord(TypedDict, total=False):
+    """``aiBehaviorParams`` (subset: list/object API branches need explicit subselections)."""
+
+    instruction: str
+    providerId: str | None
+    uuid: str
+
+
+class AutomationFieldMapRecord(TypedDict, total=False):
+    """Single ``field_map`` entry."""
+
+    fieldId: str
+    inputMode: str
+    value: str
+
+
+class AutomationSlaDayRecord(TypedDict, total=False):
+    """Working hours row inside ``slaParams``."""
+
+    enabled: bool
+    endHour: str | None
+    startHour: str | None
+
+
+class AutomationSlaHolidayRecord(TypedDict, total=False):
+    """Single holiday inside ``slaParams.holidays``."""
+
+    date: str
+    description: str
+    recurrence: str
+
+
+class AutomationSlaRulesParamsRecord(TypedDict, total=False):
+    """``slaParams`` on ``AutomationActionParams``."""
+
+    timezone: str
+    holidays: list[AutomationSlaHolidayRecord] | None
+    monday: AutomationSlaDayRecord | None
+    tuesday: AutomationSlaDayRecord | None
+    wednesday: AutomationSlaDayRecord | None
+    thursday: AutomationSlaDayRecord | None
+    friday: AutomationSlaDayRecord | None
+    saturday: AutomationSlaDayRecord | None
+    sunday: AutomationSlaDayRecord | None
+
+
+class AutomationTaskParamsRecord(TypedDict, total=False):
+    """``taskParams`` (send-a-task action)."""
+
+    recipients: str
+    title: str
+
+
+class Oauth2ClientDataRecord(TypedDict, total=False):
+    """``oauth2ClientData`` for HTTP Request actions."""
+
+    clientId: str
+    grantType: str
+    name: str
+    ownerId: str
+    ownerType: str
+    scopes: str | None
+    tokenUrl: str
+    uuid: str
+
+
+class AutomationActionParamsRecord(TypedDict, total=False):
+    """``action_params`` on ``Automation`` (subset aligned with query selection)."""
+
+    aiParams: AutomationAiParamsRecord | None
+    aiBehaviorParams: AiBehaviorParamsRecord | None
+    authenticationAddTo: str | None
+    authenticationKey: str | None
+    authenticationType: str | None
+    body: str | None
+    card_id: str | None
+    email_template_id: str | None
+    field_map: list[AutomationFieldMapRecord] | None
+    fields_map_order: list[str] | None
+    hasAuthenticationValue: bool | None
+    headers: str | None
+    httpMethod: str | None
+    oauth2ClientData: Oauth2ClientDataRecord | None
+    phase: AutomationEventRepoRef | None
+    slaParams: AutomationSlaRulesParamsRecord | None
+    strategy: str | None
+    taskParams: AutomationTaskParamsRecord | None
+    to_phase_id: str | None
+    url: str | None
+
+
 class AutomationRuleRecord(TypedDict, total=False):
     """Single automation from ``GET_AUTOMATION_QUERY``."""
 
@@ -26,6 +137,8 @@ class AutomationRuleRecord(TypedDict, total=False):
     disabledReason: str | None
     created_at: str | None
     event_repo: AutomationEventRepoRef | None
+    event_params: AutomationEventParamsRecord | None
+    action_params: AutomationActionParamsRecord | None
 
 
 class AutomationRuleSummary(TypedDict, total=False):

--- a/src/pipefy_mcp/services/pipefy/automation_graphql_types.py
+++ b/src/pipefy_mcp/services/pipefy/automation_graphql_types.py
@@ -96,3 +96,36 @@ class DeleteAutomationServiceResult(TypedDict):
     """Normalized delete outcome exposed by ``AutomationService.delete_automation``."""
 
     success: bool
+
+
+class CreateAutomationSimulationMutationBlock(TypedDict, total=False):
+    """Payload from ``createAutomationSimulation`` (IDs only; full row comes from a follow-up query)."""
+
+    simulationId: str
+    clientMutationId: str | None
+
+
+class CreateAutomationSimulationMutationResult(TypedDict, total=False):
+    createAutomationSimulation: CreateAutomationSimulationMutationBlock
+
+
+class AutomationSimulationLogDetails(TypedDict, total=False):
+    """``details`` on ``AutomationSimulation``."""
+
+    errorType: str | None
+    message: str
+
+
+class AutomationSimulationRow(TypedDict, total=False):
+    """``automationSimulation`` query selection (status, details, simulationResult)."""
+
+    status: str
+    details: AutomationSimulationLogDetails | None
+    simulationResult: Any
+
+
+class SimulateAutomationServiceResult(TypedDict):
+    """Mutation + query outcome from ``AutomationService.simulate_automation``."""
+
+    simulation_id: str
+    automation_simulation: AutomationSimulationRow

--- a/src/pipefy_mcp/services/pipefy/automation_graphql_types.py
+++ b/src/pipefy_mcp/services/pipefy/automation_graphql_types.py
@@ -66,9 +66,17 @@ class AutomationMutationSnapshot(TypedDict, total=False):
     active: bool
 
 
+class InternalErrorDetail(TypedDict, total=False):
+    """Single ``InternalError`` row from ``error_details`` on automation mutations."""
+
+    object_name: str
+    object_key: str
+    messages: list[str]
+
+
 class CreateAutomationMutationBlock(TypedDict, total=False):
-    automation: AutomationMutationSnapshot
-    errors: list[str] | list[Any]
+    automation: AutomationMutationSnapshot | None
+    error_details: list[InternalErrorDetail]
 
 
 class CreateAutomationMutationResult(TypedDict, total=False):
@@ -76,8 +84,8 @@ class CreateAutomationMutationResult(TypedDict, total=False):
 
 
 class UpdateAutomationMutationBlock(TypedDict, total=False):
-    automation: AutomationMutationSnapshot
-    errors: list[str] | list[Any]
+    automation: AutomationMutationSnapshot | None
+    error_details: list[InternalErrorDetail]
 
 
 class UpdateAutomationMutationResult(TypedDict, total=False):

--- a/src/pipefy_mcp/services/pipefy/automation_service.py
+++ b/src/pipefy_mcp/services/pipefy/automation_service.py
@@ -27,22 +27,48 @@ from pipefy_mcp.services.pipefy.queries.automation_queries import (
 )
 
 
-def _format_automation_mutation_errors(errors: Any) -> str:
-    if errors is None:
+def _format_automation_error_details(detail_val: Any) -> str:
+    """Turn ``error_details`` (``[InternalError!]``-shaped payloads) into one line for :class:`ValueError`."""
+
+    if detail_val is None:
         return ""
-    if isinstance(errors, str):
-        return errors
-    if isinstance(errors, list):
+    if isinstance(detail_val, str):
+        return detail_val
+    if isinstance(detail_val, dict):
+        messages = detail_val.get("messages")
+        if isinstance(messages, list):
+            return "; ".join(m for m in messages if isinstance(m, str) and m)
+        return str(detail_val)
+    if isinstance(detail_val, list):
         parts: list[str] = []
-        for item in errors:
+        for item in detail_val:
             if isinstance(item, str) and item:
                 parts.append(item)
-            elif isinstance(item, dict):
-                msg = item.get("message")
-                if isinstance(msg, str) and msg:
-                    parts.append(msg)
+                continue
+            if not isinstance(item, dict):
+                continue
+            chunks: list[str] = []
+            raw_messages = item.get("messages")
+            if isinstance(raw_messages, list):
+                chunks.extend(m for m in raw_messages if isinstance(m, str) and m)
+            single = item.get("message")
+            if isinstance(single, str) and single:
+                chunks.append(single)
+            if not chunks:
+                continue
+            object_name = item.get("object_name")
+            object_key = item.get("object_key")
+            body = "; ".join(chunks)
+            if object_name and object_key:
+                parts.append(f"{object_name} ({object_key}): {body}")
+            elif object_name:
+                parts.append(f"{object_name}: {body}")
+            elif object_key:
+                parts.append(f"{object_key}: {body}")
+            else:
+                parts.append(body)
         return "; ".join(parts)
-    return str(errors)
+    return str(detail_val)
 
 
 def _raise_if_automation_mutation_has_errors(
@@ -52,10 +78,10 @@ def _raise_if_automation_mutation_has_errors(
     block = raw.get(mutation_key)
     if not isinstance(block, dict):
         return
-    err_val = block.get("errors")
+    err_val = block.get("error_details")
     if not err_val:
         return
-    text = _format_automation_mutation_errors(err_val)
+    text = _format_automation_error_details(err_val)
     if text:
         raise ValueError(text)
 

--- a/src/pipefy_mcp/services/pipefy/automation_service.py
+++ b/src/pipefy_mcp/services/pipefy/automation_service.py
@@ -9,13 +9,17 @@ from pipefy_mcp.services.pipefy.automation_graphql_types import (
     AutomationEventRow,
     AutomationRuleRecord,
     AutomationRuleSummary,
+    AutomationSimulationRow,
     CreateAutomationMutationResult,
     DeleteAutomationServiceResult,
+    SimulateAutomationServiceResult,
     UpdateAutomationMutationResult,
 )
 from pipefy_mcp.services.pipefy.base_client import BasePipefyClient
 from pipefy_mcp.services.pipefy.queries.automation_queries import (
+    AUTOMATION_SIMULATION_QUERY,
     CREATE_AUTOMATION_MUTATION,
+    CREATE_AUTOMATION_SIMULATION_MUTATION,
     DELETE_AUTOMATION_MUTATION,
     GET_AUTOMATION_ACTIONS_QUERY,
     GET_AUTOMATION_EVENTS_QUERY,
@@ -252,6 +256,83 @@ class AutomationService(BasePipefyClient):
         )
         _raise_if_automation_mutation_has_errors("updateAutomation", raw)
         return cast(UpdateAutomationMutationResult, raw)
+
+    async def simulate_automation(
+        self,
+        *,
+        pipe_id: str,
+        action_id: str,
+        sample_card_id: str,
+        event_id: str | None = None,
+        event_params: dict[str, Any] | None = None,
+        action_params: dict[str, Any] | None = None,
+        condition: dict[str, Any] | None = None,
+        name: str | None = None,
+        extra_input: dict[str, Any] | None = None,
+    ) -> SimulateAutomationServiceResult:
+        """Dry-run an automation against a real card (``createAutomationSimulation`` + ``automationSimulation``).
+
+        The mutation only returns ``simulationId``; the service loads the full ``AutomationSimulation``
+        row (``status``, ``details``, ``simulationResult``) via the companion query.
+
+        Args:
+            pipe_id: Source pipe ID — sent as ``event_repo_id`` and ``action_repo_id`` so the API
+                can resolve repos (omitting these can yield ``INTERNAL_SERVER_ERROR`` from Pipefy).
+                Override via ``extra_input`` when simulating cross-pipe scenarios.
+            action_id: Simulation action (e.g. ``generate_with_ai``); forward-compatible string.
+            sample_card_id: Card ID the simulation runs against (GraphQL ``sampleCardId``).
+            event_id: Optional trigger event id.
+            event_params: Optional trigger parameters.
+            action_params: Optional action parameters.
+            condition: Optional condition payload.
+            name: Optional rule name for the simulation input.
+            extra_input: Optional extra ``CreateAutomationSimulationInput`` keys merged last.
+        """
+        input_obj: dict[str, Any] = {
+            "action_id": action_id,
+            "sampleCardId": sample_card_id,
+            "event_repo_id": pipe_id,
+            "action_repo_id": pipe_id,
+        }
+        if event_id is not None:
+            input_obj["event_id"] = event_id
+        if event_params is not None:
+            input_obj["event_params"] = event_params
+        if action_params is not None:
+            input_obj["action_params"] = action_params
+        if condition is not None:
+            input_obj["condition"] = condition
+        if name is not None:
+            input_obj["name"] = name
+        for key, value in (extra_input or {}).items():
+            if value is not None:
+                input_obj[key] = value
+        raw_mutation = await self.execute_query(
+            CREATE_AUTOMATION_SIMULATION_MUTATION,
+            {"input": input_obj},
+        )
+        block = raw_mutation.get("createAutomationSimulation")
+        if not isinstance(block, dict):
+            raise ValueError(
+                "createAutomationSimulation response was missing or invalid."
+            )
+        raw_sid = block.get("simulationId")
+        if raw_sid is None or (isinstance(raw_sid, str) and not raw_sid.strip()):
+            raise ValueError("createAutomationSimulation returned no simulationId.")
+        simulation_id = str(raw_sid).strip()
+        raw_query = await self.execute_query(
+            AUTOMATION_SIMULATION_QUERY,
+            {"simulationId": simulation_id},
+        )
+        row = raw_query.get("automationSimulation")
+        if not isinstance(row, dict):
+            raise ValueError(
+                "automationSimulation query returned no data for the simulationId."
+            )
+        return SimulateAutomationServiceResult(
+            simulation_id=simulation_id,
+            automation_simulation=cast(AutomationSimulationRow, row),
+        )
 
     async def delete_automation(
         self, automation_id: str

--- a/src/pipefy_mcp/services/pipefy/client.py
+++ b/src/pipefy_mcp/services/pipefy/client.py
@@ -15,6 +15,7 @@ from pipefy_mcp.services.pipefy.automation_graphql_types import (
     AutomationRuleSummary,
     CreateAutomationMutationResult,
     DeleteAutomationServiceResult,
+    SimulateAutomationServiceResult,
     UpdateAutomationMutationResult,
 )
 from pipefy_mcp.services.pipefy.automation_service import AutomationService
@@ -559,6 +560,32 @@ class PipefyClient:
         """Update a traditional automation (optional ``extra_input`` uses UpdateAutomationInput field names)."""
         return await self._automation_service.update_automation(
             automation_id, **(extra_input or {})
+        )
+
+    async def simulate_automation(
+        self,
+        *,
+        pipe_id: str,
+        action_id: str,
+        sample_card_id: str,
+        event_id: str | None = None,
+        event_params: dict[str, Any] | None = None,
+        action_params: dict[str, Any] | None = None,
+        condition: dict[str, Any] | None = None,
+        name: str | None = None,
+        extra_input: dict[str, Any] | None = None,
+    ) -> SimulateAutomationServiceResult:
+        """Dry-run a traditional automation action against a sample card (simulation mutation + query)."""
+        return await self._automation_service.simulate_automation(
+            pipe_id=pipe_id,
+            action_id=action_id,
+            sample_card_id=sample_card_id,
+            event_id=event_id,
+            event_params=event_params,
+            action_params=action_params,
+            condition=condition,
+            name=name,
+            extra_input=extra_input,
         )
 
     async def delete_automation(

--- a/src/pipefy_mcp/services/pipefy/queries/automation_queries.py
+++ b/src/pipefy_mcp/services/pipefy/queries/automation_queries.py
@@ -20,6 +20,109 @@ GET_AUTOMATION_QUERY = gql(
                 id
                 name
             }
+            event_params {
+                fromPhaseId
+                inPhaseId
+                kindOfSla
+                to_phase_id
+                triggerAutomationId
+                triggerFieldIds
+                phase {
+                    id
+                    name
+                }
+            }
+            action_params {
+                aiParams {
+                    value
+                    fieldIds
+                    skillsIds
+                }
+                aiBehaviorParams {
+                    instruction
+                    providerId
+                    uuid
+                }
+                authenticationAddTo
+                authenticationKey
+                authenticationType
+                body
+                card_id
+                email_template_id
+                field_map {
+                    fieldId
+                    inputMode
+                    value
+                }
+                fields_map_order
+                hasAuthenticationValue
+                headers
+                httpMethod
+                oauth2ClientData {
+                    clientId
+                    grantType
+                    name
+                    ownerId
+                    ownerType
+                    scopes
+                    tokenUrl
+                    uuid
+                }
+                phase {
+                    id
+                    name
+                }
+                slaParams {
+                    timezone
+                    holidays {
+                        date
+                        description
+                        recurrence
+                    }
+                    monday {
+                        enabled
+                        endHour
+                        startHour
+                    }
+                    tuesday {
+                        enabled
+                        endHour
+                        startHour
+                    }
+                    wednesday {
+                        enabled
+                        endHour
+                        startHour
+                    }
+                    thursday {
+                        enabled
+                        endHour
+                        startHour
+                    }
+                    friday {
+                        enabled
+                        endHour
+                        startHour
+                    }
+                    saturday {
+                        enabled
+                        endHour
+                        startHour
+                    }
+                    sunday {
+                        enabled
+                        endHour
+                        startHour
+                    }
+                }
+                strategy
+                taskParams {
+                    recipients
+                    title
+                }
+                to_phase_id
+                url
+            }
         }
     }
     """

--- a/src/pipefy_mcp/services/pipefy/queries/automation_queries.py
+++ b/src/pipefy_mcp/services/pipefy/queries/automation_queries.py
@@ -102,7 +102,11 @@ CREATE_AUTOMATION_MUTATION = gql(
                 name
                 active
             }
-            errors
+            error_details {
+                object_name
+                object_key
+                messages
+            }
         }
     }
     """
@@ -117,7 +121,11 @@ UPDATE_AUTOMATION_MUTATION = gql(
                 name
                 active
             }
-            errors
+            error_details {
+                object_name
+                object_key
+                messages
+            }
         }
     }
     """

--- a/src/pipefy_mcp/services/pipefy/queries/automation_queries.py
+++ b/src/pipefy_mcp/services/pipefy/queries/automation_queries.py
@@ -141,8 +141,36 @@ DELETE_AUTOMATION_MUTATION = gql(
     """
 )
 
+CREATE_AUTOMATION_SIMULATION_MUTATION = gql(
+    """
+    mutation createAutomationSimulation($input: CreateAutomationSimulationInput!) {
+        createAutomationSimulation(input: $input) {
+            simulationId
+            clientMutationId
+        }
+    }
+    """
+)
+
+AUTOMATION_SIMULATION_QUERY = gql(
+    """
+    query automationSimulation($simulationId: ID!) {
+        automationSimulation(simulationId: $simulationId) {
+            status
+            details {
+                errorType
+                message
+            }
+            simulationResult
+        }
+    }
+    """
+)
+
 __all__ = [
+    "AUTOMATION_SIMULATION_QUERY",
     "CREATE_AUTOMATION_MUTATION",
+    "CREATE_AUTOMATION_SIMULATION_MUTATION",
     "DELETE_AUTOMATION_MUTATION",
     "GET_AUTOMATION_ACTIONS_QUERY",
     "GET_AUTOMATION_EVENTS_QUERY",

--- a/src/pipefy_mcp/tools/ai_agent_tools.py
+++ b/src/pipefy_mcp/tools/ai_agent_tools.py
@@ -263,7 +263,8 @@ class AiAgentTools:
             agent_uuid = create_result["agent_uuid"]
 
             resolved_behaviors = await resolve_field_slugs_to_numeric(
-                client, validated.behaviors
+                client,
+                [b.model_dump(by_alias=True) for b in validated.behaviors],
             )
             update_input = UpdateAiAgentInput(
                 uuid=agent_uuid,

--- a/src/pipefy_mcp/tools/automation_tool_helpers.py
+++ b/src/pipefy_mcp/tools/automation_tool_helpers.py
@@ -40,6 +40,13 @@ class AutomationMutationSuccessPayload(TypedDict):
     automation: dict[str, Any]
 
 
+class AutomationSimulationSuccessPayload(TypedDict):
+    success: Literal[True]
+    message: str
+    simulation_id: str
+    automation_simulation: dict[str, Any]
+
+
 class AutomationToolErrorPayload(TypedDict):
     success: Literal[False]
     error: str
@@ -65,6 +72,20 @@ def build_automation_mutation_success_payload(
         "success": True,
         "message": message,
         "automation": automation,
+    }
+
+
+def build_automation_simulation_success_payload(
+    simulation_id: str,
+    automation_simulation: dict[str, Any],
+) -> AutomationSimulationSuccessPayload:
+    """Success payload with full ``automationSimulation`` row and the mutation ``simulationId``."""
+
+    return {
+        "success": True,
+        "message": "Automation simulation completed.",
+        "simulation_id": simulation_id,
+        "automation_simulation": automation_simulation,
     }
 
 

--- a/src/pipefy_mcp/tools/automation_tools.py
+++ b/src/pipefy_mcp/tools/automation_tools.py
@@ -13,6 +13,7 @@ from pipefy_mcp.tools.automation_tool_helpers import (
     build_automation_error_payload,
     build_automation_mutation_success_payload,
     build_automation_read_success_payload,
+    build_automation_simulation_success_payload,
     handle_automation_tool_graphql_error,
 )
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
@@ -39,6 +40,16 @@ def _normalize_required_id(value: str | int) -> str | None:
     if isinstance(value, int):
         return str(value)
     return value.strip()
+
+
+def _normalize_simulation_action_id(value: str | int) -> str | None:
+    """Normalize simulation ``action_id`` (enum string such as ``generate_with_ai``, or positive int)."""
+    if isinstance(value, int):
+        return str(value) if value > 0 else None
+    if isinstance(value, str):
+        s = value.strip()
+        return s if s else None
+    return None
 
 
 class AutomationTools:
@@ -191,6 +202,104 @@ class AutomationTools:
             return build_automation_read_success_payload(
                 rows,
                 "Automation events catalog retrieved.",
+            )
+
+        @mcp.tool(
+            annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False),
+        )
+        async def simulate_automation(
+            ctx: Context,
+            pipe_id: str | int,
+            action_id: str | int,
+            sample_card_id: str | int,
+            event_id: str | int | None = None,
+            event_params: Any | None = None,
+            action_params: Any | None = None,
+            condition: Any | None = None,
+            name: str | None = None,
+            extra_input: Any | None = None,
+            debug: bool = False,
+        ) -> dict[str, Any]:
+            """Dry-run a traditional automation action against a real card (safe simulation, no live side effects).
+
+            Runs ``createAutomationSimulation`` and returns the **full** ``automationSimulation`` row in one
+            synchronous round-trip (mutation + follow-up query). Use this before enabling risky rules
+            (especially **AI / ``generate_with_ai``**) to validate behavior on a ``sample_card_id``.
+
+            **Pipe context:** ``pipe_id`` is forwarded as ``event_repo_id`` and ``action_repo_id`` on the
+            simulation input (Pipefy often returns ``INTERNAL_SERVER_ERROR`` if these are omitted). Override
+            via ``extra_input`` for cross-pipe setups. **Forward-compatible** ``action_id`` must be a **string**
+            (today's API includes ``generate_with_ai``; future enum values pass through as strings).
+
+            Args:
+                pipe_id: Pipe ID — default ``event_repo_id`` / ``action_repo_id`` for the simulation input.
+                action_id: Simulation action id (string, e.g. ``generate_with_ai``).
+                sample_card_id: Card id the simulation executes against.
+                event_id: Optional trigger event id when the scenario needs it.
+                event_params: Optional JSON object (trigger parameters).
+                action_params: Optional JSON object (action parameters).
+                condition: Optional JSON object (condition payload).
+                name: Optional simulation input name.
+                extra_input: Optional map of extra ``CreateAutomationSimulationInput`` fields (merged last).
+                debug: When True, append GraphQL codes and correlation_id to errors.
+            """
+            pid = _normalize_required_id(pipe_id)
+            sid = _normalize_required_id(sample_card_id)
+            aid = _normalize_simulation_action_id(action_id)
+            if pid is None or sid is None or aid is None:
+                return build_automation_error_payload(
+                    message=(
+                        "Invalid 'pipe_id', 'sample_card_id', or 'action_id': use non-empty "
+                        "strings or positive integers where applicable."
+                    ),
+                )
+            eid: str | None = None
+            if event_id is not None:
+                eid = _normalize_required_id(event_id)
+                if eid is None:
+                    return build_automation_error_payload(
+                        message=(
+                            "Invalid 'event_id': provide a non-empty string or "
+                            "positive integer when supplied."
+                        ),
+                    )
+            for arg_name, val in (
+                ("event_params", event_params),
+                ("action_params", action_params),
+                ("condition", condition),
+            ):
+                bad = mutation_error_if_not_optional_dict(val, arg_name=arg_name)
+                if bad is not None:
+                    return bad
+            bad = mutation_error_if_not_optional_dict(
+                extra_input, arg_name="extra_input"
+            )
+            if bad is not None:
+                return bad
+            if name is not None and (not isinstance(name, str) or not name.strip()):
+                return build_automation_error_payload(
+                    message="Invalid 'name': provide a non-empty string when supplied.",
+                )
+            try:
+                result = await client.simulate_automation(
+                    pipe_id=pid,
+                    action_id=aid,
+                    sample_card_id=sid,
+                    event_id=eid,
+                    event_params=event_params,
+                    action_params=action_params,
+                    condition=condition,
+                    name=name.strip() if isinstance(name, str) else None,
+                    extra_input=extra_input,
+                )
+            except Exception as exc:  # noqa: BLE001
+                return handle_automation_tool_graphql_error(exc, ctx, debug)
+            sim_row = result["automation_simulation"]
+            if not isinstance(sim_row, dict):
+                sim_row = {}
+            return build_automation_simulation_success_payload(
+                result["simulation_id"],
+                sim_row,
             )
 
         @mcp.tool(

--- a/src/pipefy_mcp/tools/automation_tools.py
+++ b/src/pipefy_mcp/tools/automation_tools.py
@@ -63,11 +63,17 @@ class AutomationTools:
         async def get_automation(
             ctx: Context, automation_id: str | int
         ) -> dict[str, Any]:
-            """Load one automation rule by ID (name, active flag, pipe, trigger, actions).
+            """Load one automation rule by ID, including trigger and action payloads.
 
-            Use this before ``update_automation`` to inspect the current configuration.
-            For new rules, discover trigger and action IDs via ``get_automation_events`` and
-            ``get_automation_actions`` on the target pipe, then call ``create_automation``.
+            Returns ``event_params`` and ``action_params`` (e.g. ``aiParams`` with
+            ``value`` / ``fieldIds`` / ``skillsIds``) for inspection, debugging, and parity
+            with ``simulate_automation`` / ``create_automation`` inputs. Use this before
+            ``update_automation`` to inspect the stored configuration; when cloning a rule,
+            copy these objects into the matching optional JSON args on create/update or
+            simulation.
+
+            For new rules, discover ``event_id`` / ``action_id`` via ``get_automation_events``
+            and ``get_automation_actions`` on the target pipe, then call ``create_automation``.
 
             Args:
                 automation_id: Automation rule ID.

--- a/tests/services/pipefy/test_automation_service.py
+++ b/tests/services/pipefy/test_automation_service.py
@@ -304,16 +304,39 @@ async def test_create_automation_transport_error(mock_settings):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_create_automation_raises_when_mutation_returns_errors(mock_settings):
+async def test_create_automation_raises_when_mutation_returns_error_details(
+    mock_settings,
+):
     payload = {
         "createAutomation": {
             "automation": None,
-            "errors": ["Invalid action for this event"],
+            "error_details": [
+                {
+                    "object_name": "Automation",
+                    "messages": ["Invalid action for this event"],
+                },
+            ],
         },
     }
     service = _make_service(mock_settings, payload)
     with pytest.raises(ValueError, match="Invalid action"):
         await service.create_automation("p1", "N", "e", "a")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_update_automation_raises_when_mutation_returns_error_details(
+    mock_settings,
+):
+    payload = {
+        "updateAutomation": {
+            "automation": None,
+            "error_details": [{"messages": ["Cannot rename inactive automation"]}],
+        },
+    }
+    service = _make_service(mock_settings, payload)
+    with pytest.raises(ValueError, match="Cannot rename"):
+        await service.update_automation("a7", name="x")
 
 
 @pytest.mark.unit

--- a/tests/services/pipefy/test_automation_service.py
+++ b/tests/services/pipefy/test_automation_service.py
@@ -51,6 +51,20 @@ async def test_get_automation_success(mock_settings):
         "disabledReason": None,
         "created_at": "2025-01-01",
         "event_repo": {"id": "p1", "name": "Pipe A"},
+        "event_params": {
+            "to_phase_id": "ph_dest",
+            "triggerFieldIds": ["f1", "f2"],
+            "phase": {"id": "ph1", "name": "Doing"},
+        },
+        "action_params": {
+            "aiParams": {
+                "value": "Summarize card",
+                "fieldIds": ["10"],
+                "skillsIds": ["20"],
+            },
+            "email_template_id": "tmpl-1",
+            "to_phase_id": "ph2",
+        },
     }
     service = _make_service(mock_settings, {"automation": automation})
     result = await service.get_automation("101")
@@ -61,6 +75,10 @@ async def test_get_automation_success(mock_settings):
     assert variables == {"id": 101}
     assert result["id"] == "a1"
     assert result["name"] == "Notify assignee"
+    assert result["event_params"]["to_phase_id"] == "ph_dest"
+    assert result["event_params"]["triggerFieldIds"] == ["f1", "f2"]
+    assert result["action_params"]["aiParams"]["value"] == "Summarize card"
+    assert result["action_params"]["aiParams"]["fieldIds"] == ["10"]
 
 
 @pytest.mark.unit

--- a/tests/services/pipefy/test_automation_service.py
+++ b/tests/services/pipefy/test_automation_service.py
@@ -7,7 +7,9 @@ from gql.transport.exceptions import TransportQueryError
 
 from pipefy_mcp.services.pipefy.automation_service import AutomationService
 from pipefy_mcp.services.pipefy.queries.automation_queries import (
+    AUTOMATION_SIMULATION_QUERY,
     CREATE_AUTOMATION_MUTATION,
+    CREATE_AUTOMATION_SIMULATION_MUTATION,
     DELETE_AUTOMATION_MUTATION,
     GET_AUTOMATION_ACTIONS_QUERY,
     GET_AUTOMATION_EVENTS_QUERY,
@@ -385,3 +387,110 @@ async def test_delete_automation_transport_error(mock_settings):
     )
     with pytest.raises(TransportQueryError):
         await service.delete_automation("z")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_simulate_automation_success(mock_settings):
+    mutation_payload = {
+        "createAutomationSimulation": {
+            "simulationId": "sim-99",
+            "clientMutationId": None,
+        },
+    }
+    query_payload = {
+        "automationSimulation": {
+            "status": "success",
+            "details": {"errorType": None, "message": "ok"},
+            "simulationResult": {"preview": True},
+        },
+    }
+    service = AutomationService(settings=mock_settings)
+    service.execute_query = AsyncMock(side_effect=[mutation_payload, query_payload])
+    result = await service.simulate_automation(
+        pipe_id="pipe-77",
+        action_id="generate_with_ai",
+        sample_card_id="card-1",
+        event_id="card_created",
+        event_params={"to_phase_id": "1"},
+        name="Trial",
+        extra_input={"active": True, "schedulerCron": "0 0 * * *"},
+    )
+
+    assert service.execute_query.await_count == 2
+    q1, v1 = service.execute_query.call_args_list[0][0]
+    q2, v2 = service.execute_query.call_args_list[1][0]
+    assert q1 is CREATE_AUTOMATION_SIMULATION_MUTATION
+    assert v1["input"]["action_id"] == "generate_with_ai"
+    assert v1["input"]["sampleCardId"] == "card-1"
+    assert v1["input"]["event_repo_id"] == "pipe-77"
+    assert v1["input"]["action_repo_id"] == "pipe-77"
+    assert v1["input"]["event_id"] == "card_created"
+    assert v1["input"]["event_params"] == {"to_phase_id": "1"}
+    assert v1["input"]["name"] == "Trial"
+    assert v1["input"]["active"] is True
+    assert v1["input"]["schedulerCron"] == "0 0 * * *"
+    assert q2 is AUTOMATION_SIMULATION_QUERY
+    assert v2 == {"simulationId": "sim-99"}
+    assert result["simulation_id"] == "sim-99"
+    assert result["automation_simulation"]["status"] == "success"
+    assert result["automation_simulation"]["simulationResult"] == {"preview": True}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_simulate_automation_extra_input_overrides_repo_ids(mock_settings):
+    mutation_payload = {
+        "createAutomationSimulation": {
+            "simulationId": "sim-override",
+            "clientMutationId": None,
+        },
+    }
+    query_payload = {
+        "automationSimulation": {
+            "status": "processing",
+            "details": None,
+            "simulationResult": None,
+        },
+    }
+    service = AutomationService(settings=mock_settings)
+    service.execute_query = AsyncMock(side_effect=[mutation_payload, query_payload])
+    await service.simulate_automation(
+        pipe_id="default-pipe",
+        action_id="generate_with_ai",
+        sample_card_id="c1",
+        extra_input={"event_repo_id": "ev-pipe", "action_repo_id": "act-pipe"},
+    )
+    _, v1 = service.execute_query.call_args_list[0][0]
+    assert v1["input"]["event_repo_id"] == "ev-pipe"
+    assert v1["input"]["action_repo_id"] == "act-pipe"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_simulate_automation_raises_when_no_simulation_id(mock_settings):
+    service = AutomationService(settings=mock_settings)
+    service.execute_query = AsyncMock(
+        return_value={"createAutomationSimulation": {"simulationId": None}},
+    )
+    with pytest.raises(ValueError, match="simulationId"):
+        await service.simulate_automation(
+            pipe_id="p1",
+            action_id="generate_with_ai",
+            sample_card_id="1",
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_simulate_automation_transport_error(mock_settings):
+    service = AutomationService(settings=mock_settings)
+    service.execute_query = AsyncMock(
+        side_effect=TransportQueryError("failed", errors=[{"message": "denied"}])
+    )
+    with pytest.raises(TransportQueryError):
+        await service.simulate_automation(
+            pipe_id="p1",
+            action_id="generate_with_ai",
+            sample_card_id="1",
+        )

--- a/tests/services/test_pipefy_facade.py
+++ b/tests/services/test_pipefy_facade.py
@@ -137,6 +137,9 @@ async def test_pipefy_client_facade_delegates_to_services_without_modifying_args
     automation_service.update_automation = AsyncMock(
         return_value={"ok": "update_automation"}
     )
+    automation_service.simulate_automation = AsyncMock(
+        return_value={"ok": "simulate_automation"}
+    )
     automation_service.delete_automation = AsyncMock(
         return_value={"ok": "delete_automation"}
     )
@@ -446,6 +449,24 @@ async def test_pipefy_client_facade_delegates_to_services_without_modifying_args
         "ok": "update_automation"
     }
     automation_service.update_automation.assert_awaited_once_with("a1", name="N")
+
+    assert await client.simulate_automation(
+        pipe_id="pipe-z",
+        action_id="generate_with_ai",
+        sample_card_id="c1",
+        event_id="card_created",
+    ) == {"ok": "simulate_automation"}
+    automation_service.simulate_automation.assert_awaited_once_with(
+        pipe_id="pipe-z",
+        action_id="generate_with_ai",
+        sample_card_id="c1",
+        event_id="card_created",
+        event_params=None,
+        action_params=None,
+        condition=None,
+        name=None,
+        extra_input=None,
+    )
 
     assert await client.delete_automation("rm") == {"ok": "delete_automation"}
     automation_service.delete_automation.assert_awaited_once_with("rm")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -131,6 +131,7 @@ async def test_register_tools(client_session):
         "search_tables",
         "send_email_with_template",
         "send_inbox_email",
+        "simulate_automation",
         "set_role",
         "set_table_record_field_value",
         "update_ai_agent",

--- a/tests/tools/test_automation_tools.py
+++ b/tests/tools/test_automation_tools.py
@@ -60,6 +60,10 @@ async def test_get_automation_success(
         "id": "a1",
         "name": "Rule",
         "active": True,
+        "event_params": {"kindOfSla": "due_date", "triggerFieldIds": ["99"]},
+        "action_params": {
+            "aiParams": {"value": "Run prompt", "fieldIds": ["1"], "skillsIds": []},
+        },
     }
 
     async with automation_session as session:
@@ -70,6 +74,8 @@ async def test_get_automation_success(
     payload = extract_payload(result)
     assert payload["success"] is True
     assert payload["data"] == mock_automation_client.get_automation.return_value
+    assert payload["data"]["event_params"]["kindOfSla"] == "due_date"
+    assert payload["data"]["action_params"]["aiParams"]["value"] == "Run prompt"
 
 
 @pytest.mark.anyio

--- a/tests/tools/test_automation_tools.py
+++ b/tests/tools/test_automation_tools.py
@@ -28,6 +28,7 @@ def mock_automation_client():
     client.get_automation_events = AsyncMock()
     client.create_automation = AsyncMock()
     client.update_automation = AsyncMock()
+    client.simulate_automation = AsyncMock()
     client.delete_automation = AsyncMock()
     return client
 
@@ -562,8 +563,99 @@ async def test_create_and_update_automation_tools_are_not_read_only(
     async with automation_session as session:
         listed = await session.list_tools()
     by_name = {t.name: t for t in listed.tools}
-    for name in ("create_automation", "update_automation"):
+    for name in ("create_automation", "update_automation", "simulate_automation"):
         ann = by_name[name].annotations
         assert ann is not None
         assert ann.readOnlyHint is False
         assert ann.destructiveHint is not True
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("automation_session", [None], indirect=True)
+async def test_simulate_automation_success(
+    automation_session, mock_automation_client, extract_payload
+):
+    mock_automation_client.simulate_automation.return_value = {
+        "simulation_id": "sim-1",
+        "automation_simulation": {
+            "status": "success",
+            "details": {"message": "done"},
+            "simulationResult": {"x": 1},
+        },
+    }
+
+    async with automation_session as session:
+        result = await session.call_tool(
+            "simulate_automation",
+            {
+                "pipe_id": "p1",
+                "action_id": "generate_with_ai",
+                "sample_card_id": "c9",
+                "event_id": "card_created",
+                "event_params": None,
+                "action_params": None,
+                "condition": None,
+                "name": None,
+                "extra_input": None,
+                "debug": False,
+            },
+        )
+
+    assert result.isError is False
+    mock_automation_client.simulate_automation.assert_awaited_once_with(
+        pipe_id="p1",
+        action_id="generate_with_ai",
+        sample_card_id="c9",
+        event_id="card_created",
+        event_params=None,
+        action_params=None,
+        condition=None,
+        name=None,
+        extra_input=None,
+    )
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    assert payload["simulation_id"] == "sim-1"
+    assert payload["automation_simulation"]["simulationResult"] == {"x": 1}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("automation_session", [None], indirect=True)
+async def test_simulate_automation_graphql_error(
+    automation_session, mock_automation_client, extract_payload
+):
+    mock_automation_client.simulate_automation.side_effect = TransportQueryError(
+        "failed", errors=[{"message": "bad simulation"}]
+    )
+
+    async with automation_session as session:
+        result = await session.call_tool(
+            "simulate_automation",
+            {
+                "pipe_id": "p1",
+                "action_id": "generate_with_ai",
+                "sample_card_id": "c1",
+            },
+        )
+
+    assert extract_payload(result)["success"] is False
+    assert "bad simulation" in extract_payload(result)["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("automation_session", [None], indirect=True)
+async def test_simulate_automation_rejects_invalid_pipe_id(
+    automation_session, mock_automation_client, extract_payload
+):
+    async with automation_session as session:
+        result = await session.call_tool(
+            "simulate_automation",
+            {
+                "pipe_id": "",
+                "action_id": "generate_with_ai",
+                "sample_card_id": "1",
+            },
+        )
+
+    mock_automation_client.simulate_automation.assert_not_called()
+    assert extract_payload(result)["success"] is False


### PR DESCRIPTION
## Summary
Atomic commits for automation hardening and tooling aligned with `pipe-full-toolset`:

- **fix(tools):** pass behavior dicts to `resolve_field_slugs_to_numeric`
- **fix(automations):** use `error_details` on create/update mutations
- **feat(automations):** `simulate_automation` MCP tool (`event_repo_id` / `action_repo_id` from `pipe_id`)
- **feat(automations):** expand `get_automation` query (`event_params`, `action_params`, TypedDicts)

## Testing
```bash
uv run ruff check src/ tests/
uv run pytest -m "not integration" -q
```
958 passed, 22 skipped (integration).

## Manual
Smoke `get_automation`, `simulate_automation`, create/update automations via Cursor MCP when possible.