### PR TITLE
fix: AI automation skillsIds and phase field disambiguation

### DIFF
--- a/src/pipefy_mcp/models/ai_automation.py
+++ b/src/pipefy_mcp/models/ai_automation.py
@@ -48,6 +48,10 @@ class CreateAiAutomationInput(BaseModel):
         min_length=1,
         description="Non-empty list of field internal IDs as strings",
     )
+    skills_ids: list[str] = Field(
+        default_factory=list,
+        description="AI skill IDs to attach. Defaults to empty (no skills).",
+    )
     condition: dict = Field(default_factory=lambda: copy.deepcopy(DEFAULT_CONDITION))
 
 
@@ -59,4 +63,5 @@ class UpdateAiAutomationInput(BaseModel):
     active: bool | None = None
     prompt: NonBlankStr | None = None
     field_ids: list[str] | None = Field(default=None, min_length=1)
+    skills_ids: list[str] | None = None
     condition: dict | None = None

--- a/src/pipefy_mcp/services/pipefy/ai_automation_service.py
+++ b/src/pipefy_mcp/services/pipefy/ai_automation_service.py
@@ -51,6 +51,7 @@ class AiAutomationService:
                 "aiParams": {
                     "value": automation_input.prompt,
                     "fieldIds": automation_input.field_ids,
+                    "skillsIds": automation_input.skills_ids,
                 }
             },
             "condition": automation_input.condition,
@@ -100,6 +101,8 @@ class AiAutomationService:
             ai_params["value"] = automation_input.prompt
         if automation_input.field_ids is not None:
             ai_params["fieldIds"] = automation_input.field_ids
+        if automation_input.skills_ids is not None:
+            ai_params["skillsIds"] = automation_input.skills_ids
         if ai_params:
             input_dict["action_params"] = {"aiParams": ai_params}
 

--- a/src/pipefy_mcp/services/pipefy/client.py
+++ b/src/pipefy_mcp/services/pipefy/client.py
@@ -145,9 +145,16 @@ class PipefyClient:
         """Update a phase field (see Pipefy `UpdatePhaseFieldInput`)."""
         return await self._pipe_config_service.update_phase_field(field_id, **attrs)
 
-    async def delete_phase_field(self, field_id: str | int) -> dict:
+    async def delete_phase_field(
+        self,
+        field_id: str | int,
+        *,
+        pipe_uuid: str | None = None,
+    ) -> dict:
         """Delete a phase field by ID (permanent)."""
-        return await self._pipe_config_service.delete_phase_field(field_id)
+        return await self._pipe_config_service.delete_phase_field(
+            field_id, pipe_uuid=pipe_uuid
+        )
 
     async def create_label(self, pipe_id: int, name: str, color: str) -> dict:
         """Create a label on a pipe."""

--- a/src/pipefy_mcp/services/pipefy/pipe_config_service.py
+++ b/src/pipefy_mcp/services/pipefy/pipe_config_service.py
@@ -143,15 +143,24 @@ class PipeConfigService(BasePipefyClient):
                 payload[key] = value
         return await self.execute_query(UPDATE_PHASE_FIELD_MUTATION, {"input": payload})
 
-    async def delete_phase_field(self, field_id: str | int) -> dict:
+    async def delete_phase_field(
+        self,
+        field_id: str | int,
+        *,
+        pipe_uuid: str | None = None,
+    ) -> dict:
         """Delete a phase field by ID (permanent).
 
         Args:
-            field_id: Phase field ID to delete (slug or numeric).
+            field_id: Phase field slug or uuid to delete.
+            pipe_uuid: Optional pipe UUID for disambiguation when the slug exists on multiple phases.
         """
+        input_obj: dict[str, Any] = {"id": field_id}
+        if pipe_uuid is not None:
+            input_obj["pipeUuid"] = pipe_uuid
         return await self.execute_query(
             DELETE_PHASE_FIELD_MUTATION,
-            {"input": {"id": field_id}},
+            {"input": input_obj},
         )
 
     async def create_label(

--- a/src/pipefy_mcp/services/pipefy/queries/pipe_config_queries.py
+++ b/src/pipefy_mcp/services/pipefy/queries/pipe_config_queries.py
@@ -100,6 +100,8 @@ CREATE_PHASE_FIELD_MUTATION = gql(
         createPhaseField(input: $input) {
             phase_field {
                 id
+                internal_id
+                uuid
                 label
                 type
             }

--- a/src/pipefy_mcp/tools/ai_automation_tools.py
+++ b/src/pipefy_mcp/tools/ai_automation_tools.py
@@ -35,6 +35,7 @@ class AiAutomationTools:
             pipe_id: str,
             prompt: str,
             field_ids: list[str],
+            skills_ids: list[str] | None = None,
             condition: dict | None = None,
         ) -> dict:
             """Create a simple AI automation that generates content with a prompt and writes the result to one or more card fields.
@@ -48,11 +49,17 @@ class AiAutomationTools:
                 pipe_id: Pipe ID where the automation runs.
                 prompt: AI prompt text that generates the content.
                 field_ids: List of field internal IDs to write the result to.
+                skills_ids: AI skill IDs to attach. Defaults to empty (no skills).
                 condition: Optional condition structure for the automation trigger.
             """
             ctx.debug(
                 f"create_ai_automation: name={name}, event_id={event_id}, pipe_id={pipe_id}"
             )
+            optional_fields: dict = {}
+            if skills_ids is not None:
+                optional_fields["skills_ids"] = skills_ids
+            if condition is not None:
+                optional_fields["condition"] = condition
             try:
                 validated = CreateAiAutomationInput(
                     name=name,
@@ -60,7 +67,7 @@ class AiAutomationTools:
                     pipe_id=pipe_id,
                     prompt=prompt,
                     field_ids=field_ids,
-                    **({"condition": condition} if condition is not None else {}),
+                    **optional_fields,
                 )
             except ValidationError as exc:
                 return build_ai_tool_error(str(exc))
@@ -85,6 +92,7 @@ class AiAutomationTools:
             active: bool | None = None,
             prompt: str | None = None,
             field_ids: list[str] | None = None,
+            skills_ids: list[str] | None = None,
             condition: dict | None = None,
         ) -> dict:
             """Update an existing AI automation's name, prompt, destination fields, or active state.
@@ -95,6 +103,7 @@ class AiAutomationTools:
                 active: Whether the automation is active (optional).
                 prompt: New AI prompt text (optional).
                 field_ids: New list of field internal IDs (optional).
+                skills_ids: New list of AI skill IDs (optional).
                 condition: New condition structure (optional).
             """
             ctx.debug(f"update_ai_automation: automation_id={automation_id}")
@@ -105,6 +114,7 @@ class AiAutomationTools:
                     active=active,
                     prompt=prompt,
                     field_ids=field_ids,
+                    skills_ids=skills_ids,
                     condition=condition,
                 )
             except ValidationError as exc:

--- a/src/pipefy_mcp/tools/pipe_config_tools.py
+++ b/src/pipefy_mcp/tools/pipe_config_tools.py
@@ -25,7 +25,7 @@ from pipefy_mcp.tools.pipe_config_tool_helpers import (
 from pipefy_mcp.tools.pipe_config_validators import valid_phase_field_id
 
 _CREATE_PHASE_FIELD_EXTRA_RESERVED = frozenset({"phase_id", "label", "type"})
-_UPDATE_PHASE_FIELD_EXTRA_RESERVED = frozenset({"id"})
+_UPDATE_PHASE_FIELD_EXTRA_RESERVED = frozenset({"id", "uuid"})
 _UPDATE_LABEL_EXTRA_RESERVED = frozenset({"id"})
 
 
@@ -444,27 +444,28 @@ class PipeConfigTools:
             phase_id: int,
             label: str,
             field_type: str,
+            options: list[str] | None = None,
+            description: str | None = None,
+            required: bool | None = None,
             extra_input: dict[str, Any] | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Create a custom field on a phase.
 
             ``field_type`` is passed through to Pipefy (use schema introspection on
-            ``CreatePhaseFieldInput`` to list valid types). Optional keys in
-            ``extra_input`` are merged into the mutation input (e.g. description,
-            required, options).
+            ``CreatePhaseFieldInput`` to list valid types).
 
-            **Select / radio / checklist fields:** pass ``options`` inside
-            ``extra_input`` (e.g. ``extra_input={"options": ["Alta", "Média",
-            "Baixa"]}``). If the API rejects options on creation, create the field
-            first and then call ``update_phase_field`` with the ``options`` list.
+            The response includes ``internal_id`` — use that numeric ID (not the slug
+            ``id``) for subsequent ``update_phase_field`` or ``delete_phase_field`` calls.
 
             Args:
                 phase_id: Phase that will receive the field.
                 label: Field label shown in the UI.
                 field_type: Pipefy field type string (API input field ``type``).
-                extra_input: Additional ``CreatePhaseFieldInput`` fields, if any
-                    (e.g. description, required, options).
+                options: Option values for select/radio/checklist fields (e.g. ["Alta", "Média", "Baixa"]).
+                description: Optional field description.
+                required: Whether the field is required.
+                extra_input: Additional ``CreatePhaseFieldInput`` fields, if any.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             if not isinstance(phase_id, int) or phase_id <= 0:
@@ -484,6 +485,12 @@ class PipeConfigTools:
                 for k, v in (extra_input or {}).items()
                 if k not in _CREATE_PHASE_FIELD_EXTRA_RESERVED
             }
+            if options is not None:
+                merged["options"] = options
+            if description is not None:
+                merged["description"] = description
+            if required is not None:
+                merged["required"] = required
             try:
                 raw = await client.create_phase_field(
                     phase_id,
@@ -507,23 +514,30 @@ class PipeConfigTools:
         )
         async def update_phase_field(
             field_id: str | int,
-            label: str | None = None,
+            label: str,
             description: str | None = None,
             required: bool | None = None,
             options: list[Any] | dict[str, Any] | None = None,
+            uuid: str | None = None,
             extra_input: dict[str, Any] | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Update a phase field.
 
-            Pass only fields to change. Use introspection on `UpdatePhaseFieldInput` for the full list.
+            Pass only fields to change (besides ``label`` which is always required by the API).
+
+            ``field_id`` is the field slug (e.g. ``"prioridade"``) returned by
+            ``create_phase_field`` or ``get_phase_fields``. When the same slug exists on
+            multiple phases, pass ``uuid`` to disambiguate (available from
+            ``create_phase_field`` and ``get_phase_fields``).
 
             Args:
-                field_id: Phase field ID (slug string from create/get_phase_fields, or positive integer).
-                label: New label, if changing.
+                field_id: Field slug (from create_phase_field or get_phase_fields).
+                label: Field label (required by the Pipefy API even if unchanged — pass the current value).
                 description: New description, if changing.
                 required: Whether the field is required, if changing.
-                options: Field options structure (API-specific), if changing.
+                options: Field options list (e.g. ["Alta", "Média", "Baixa"] for select fields).
+                uuid: Field UUID for disambiguation when the slug exists on multiple phases.
                 extra_input: Additional UpdatePhaseFieldInput fields, if any.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
@@ -534,23 +548,27 @@ class PipeConfigTools:
                         "or a positive integer."
                     ),
                 )
+            if not isinstance(label, str) or not label.strip():
+                return build_pipe_tool_error_payload(
+                    message=(
+                        "Invalid 'label': the Pipefy API requires label on every update "
+                        "(pass the current label if unchanged)."
+                    ),
+                )
             update_attrs: dict[str, Any] = {
                 k: v
                 for k, v in (extra_input or {}).items()
                 if k not in _UPDATE_PHASE_FIELD_EXTRA_RESERVED
             }
-            if label is not None:
-                update_attrs["label"] = label
+            update_attrs["label"] = label
             if description is not None:
                 update_attrs["description"] = description
             if required is not None:
                 update_attrs["required"] = required
             if options is not None:
                 update_attrs["options"] = options
-            if not update_attrs:
-                return build_pipe_tool_error_payload(
-                    message="Provide at least one attribute to update.",
-                )
+            if uuid is not None:
+                update_attrs["uuid"] = uuid
             fid = field_id.strip() if isinstance(field_id, str) else field_id
             try:
                 raw = await client.update_phase_field(fid, **update_attrs)
@@ -573,6 +591,7 @@ class PipeConfigTools:
             ctx: Context[ServerSession, None],
             field_id: str | int,
             confirm: bool = False,
+            pipe_uuid: str | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Delete a phase field permanently.
@@ -581,9 +600,14 @@ class PipeConfigTools:
             ``confirm=True`` after user approval. When the MCP client supports
             elicitation, the user is prompted interactively instead.
 
+            ``field_id`` is the field slug (e.g. ``"prioridade"``) or uuid.
+            When the slug is shared across phases, pass ``pipe_uuid`` to
+            disambiguate (available from ``get_pipe``).
+
             Args:
-                field_id: Phase field ID to delete (slug string or positive integer).
+                field_id: Field slug or uuid (from create_phase_field or get_phase_fields).
                 confirm: Set to True to execute the deletion (step 2).
+                pipe_uuid: Pipe UUID for disambiguation when the slug is not unique across phases.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             if not valid_phase_field_id(field_id):
@@ -604,7 +628,7 @@ class PipeConfigTools:
                 return guard
 
             try:
-                raw = await client.delete_phase_field(fid)
+                raw = await client.delete_phase_field(fid, pipe_uuid=pipe_uuid)
             except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
                     exc, "Delete phase field failed.", debug=debug

--- a/tests/models/test_ai_automation.py
+++ b/tests/models/test_ai_automation.py
@@ -34,6 +34,19 @@ def test_create_ai_automation_input_requires_name_event_id_pipe_id_prompt_field_
 
 
 @pytest.mark.unit
+def test_create_ai_automation_input_skills_ids_defaults_to_empty_list():
+    """CreateAiAutomationInput skills_ids defaults to empty list."""
+    inp = CreateAiAutomationInput(
+        name="My Automation",
+        event_id="card_created",
+        pipe_id="123",
+        prompt="Summarize",
+        field_ids=["133"],
+    )
+    assert inp.skills_ids == []
+
+
+@pytest.mark.unit
 def test_create_ai_automation_input_condition_defaults_to_placeholder():
     """CreateAiAutomationInput condition defaults to placeholder structure."""
     inp = CreateAiAutomationInput(

--- a/tests/services/pipefy/test_pipe_config_service.py
+++ b/tests/services/pipefy/test_pipe_config_service.py
@@ -201,7 +201,13 @@ async def test_create_phase_field_sends_type_and_optional_attrs(mock_settings):
         mock_settings,
         {
             "createPhaseField": {
-                "phase_field": {"id": "f1", "label": "Email", "type": "email"},
+                "phase_field": {
+                    "id": "f1",
+                    "internal_id": "99001",
+                    "uuid": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+                    "label": "Email",
+                    "type": "email",
+                },
             },
         },
     )
@@ -226,7 +232,13 @@ async def test_create_phase_field_sends_type_and_optional_attrs(mock_settings):
     }
     assert result == {
         "createPhaseField": {
-            "phase_field": {"id": "f1", "label": "Email", "type": "email"},
+            "phase_field": {
+                "id": "f1",
+                "internal_id": "99001",
+                "uuid": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+                "label": "Email",
+                "type": "email",
+            },
         },
     }
 
@@ -300,10 +312,28 @@ async def test_delete_phase_field_sends_delete_input(mock_settings):
 @pytest.mark.asyncio
 async def test_delete_phase_field_accepts_string_slug(mock_settings):
     service = _make_service(mock_settings, {"deletePhaseField": {"success": True}})
-    result = await service.delete_phase_field("detalhe_mcp")
+    result = await service.delete_phase_field("prioridade")
 
     _query, variables = service.execute_query.call_args[0]
-    assert variables == {"input": {"id": "detalhe_mcp"}}
+    assert variables == {"input": {"id": "prioridade"}}
+    assert result == {"deletePhaseField": {"success": True}}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_delete_phase_field_includes_pipe_uuid_when_provided(mock_settings):
+    service = _make_service(mock_settings, {"deletePhaseField": {"success": True}})
+    result = await service.delete_phase_field(
+        "prioridade", pipe_uuid="b3bba313-6b99-44dc-b17e-f192dc00bb21"
+    )
+
+    _query, variables = service.execute_query.call_args[0]
+    assert variables == {
+        "input": {
+            "id": "prioridade",
+            "pipeUuid": "b3bba313-6b99-44dc-b17e-f192dc00bb21",
+        },
+    }
     assert result == {"deletePhaseField": {"success": True}}
 
 

--- a/tests/services/test_ai_automation_service.py
+++ b/tests/services/test_ai_automation_service.py
@@ -52,9 +52,36 @@ async def test_create_automation_calls_execute_query_with_correct_variables():
     assert variables["action_repo_id"] == "303"
     assert variables["action_params"]["aiParams"]["value"] == "Summarize the card"
     assert variables["action_params"]["aiParams"]["fieldIds"] == ["133", "789"]
+    assert variables["action_params"]["aiParams"]["skillsIds"] == []
     assert result["automation_id"] == "456"
     assert "AI Automation created successfully" in result["message"]
     assert "456" in result["message"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_automation_sends_custom_skills_ids():
+    """create_automation forwards custom skills_ids in aiParams.skillsIds."""
+    mock_client = _create_mock_internal_api_client(
+        {"data": {"createAutomation": {"automation": {"id": "456"}}}}
+    )
+    service = AiAutomationService(client=mock_client)
+
+    inp = CreateAiAutomationInput(
+        name="With Skills",
+        event_id="card_created",
+        pipe_id="303",
+        prompt="Summarize",
+        field_ids=["1"],
+        skills_ids=["skill_a", "skill_b"],
+    )
+    await service.create_automation(inp)
+
+    variables = mock_client.execute_query.call_args[0][1]
+    assert variables["action_params"]["aiParams"]["skillsIds"] == [
+        "skill_a",
+        "skill_b",
+    ]
 
 
 @pytest.mark.unit
@@ -112,6 +139,25 @@ async def test_update_automation_calls_execute_query_with_correct_variables():
     assert variables["input"]["action_params"]["aiParams"]["fieldIds"] == ["133"]
     assert result["automation_id"] == "789"
     assert "AI Automation updated successfully" in result["message"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_update_automation_sends_skills_ids_when_provided():
+    """update_automation includes skillsIds in aiParams when skills_ids is set."""
+    mock_client = _create_mock_internal_api_client(
+        {"data": {"updateAutomation": {"automation": {"id": "789"}}}}
+    )
+    service = AiAutomationService(client=mock_client)
+
+    inp = UpdateAiAutomationInput(
+        automation_id="789",
+        skills_ids=["skill_x"],
+    )
+    await service.update_automation(inp)
+
+    variables = mock_client.execute_query.call_args[0][1]
+    assert variables["input"]["action_params"]["aiParams"]["skillsIds"] == ["skill_x"]
 
 
 @pytest.mark.unit

--- a/tests/services/test_pipefy_facade.py
+++ b/tests/services/test_pipefy_facade.py
@@ -248,7 +248,7 @@ async def test_pipefy_client_facade_delegates_to_services_without_modifying_args
     pipe_config_service.update_phase_field.assert_awaited_once_with(12, label="L")
 
     assert await client.delete_phase_field(13) == {"ok": "delete_phase_field"}
-    pipe_config_service.delete_phase_field.assert_awaited_once_with(13)
+    pipe_config_service.delete_phase_field.assert_awaited_once_with(13, pipe_uuid=None)
 
     assert await client.create_label(14, "Bug", "red") == {"ok": "create_label"}
     pipe_config_service.create_label.assert_awaited_once_with(14, "Bug", "red")

--- a/tests/tools/test_pipe_config_tools.py
+++ b/tests/tools/test_pipe_config_tools.py
@@ -434,7 +434,13 @@ async def test_create_phase_field_success(
 ):
     mock_pipe_config_client.create_phase_field.return_value = {
         "createPhaseField": {
-            "phase_field": {"id": "f1", "label": "Email", "type": "email"},
+            "phase_field": {
+                "id": "f1",
+                "internal_id": "99001",
+                "uuid": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+                "label": "Email",
+                "type": "email",
+            },
         },
     }
 
@@ -445,7 +451,7 @@ async def test_create_phase_field_success(
                 "phase_id": 1,
                 "label": "Email",
                 "field_type": "email",
-                "extra_input": {"description": "Contact"},
+                "description": "Contact",
             },
         )
 
@@ -454,6 +460,44 @@ async def test_create_phase_field_success(
         "Email",
         "email",
         description="Contact",
+    )
+    payload = extract_payload(result)
+    assert payload["success"] is True
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_create_phase_field_with_options(
+    pipe_config_session, mock_pipe_config_client, extract_payload
+):
+    mock_pipe_config_client.create_phase_field.return_value = {
+        "createPhaseField": {
+            "phase_field": {
+                "id": "prioridade",
+                "internal_id": "427957330",
+                "uuid": "c1d2e3f4-5678-9abc-def0-123456789abc",
+                "label": "Prioridade",
+                "type": "select",
+            },
+        },
+    }
+
+    async with pipe_config_session as session:
+        result = await session.call_tool(
+            "create_phase_field",
+            {
+                "phase_id": 1,
+                "label": "Prioridade",
+                "field_type": "select",
+                "options": ["Alta", "Média", "Baixa"],
+            },
+        )
+
+    mock_pipe_config_client.create_phase_field.assert_awaited_once_with(
+        1,
+        "Prioridade",
+        "select",
+        options=["Alta", "Média", "Baixa"],
     )
     assert extract_payload(result)["success"] is True
 
@@ -512,16 +556,51 @@ async def test_update_phase_field_success_with_string_slug(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
-async def test_update_phase_field_requires_at_least_one_attr(
+async def test_update_phase_field_with_uuid_for_disambiguation(
+    pipe_config_session, mock_pipe_config_client, extract_payload
+):
+    mock_pipe_config_client.update_phase_field.return_value = {
+        "updatePhaseField": {
+            "phase_field": {
+                "id": "prioridade",
+                "label": "Nível de Urgência",
+                "type": "select",
+            },
+        },
+    }
+
+    async with pipe_config_session as session:
+        result = await session.call_tool(
+            "update_phase_field",
+            {
+                "field_id": "prioridade",
+                "label": "Nível de Urgência",
+                "uuid": "a796cc44-6568-4bfb-9c09-2b903eb7bff2",
+            },
+        )
+
+    mock_pipe_config_client.update_phase_field.assert_awaited_once_with(
+        "prioridade",
+        label="Nível de Urgência",
+        uuid="a796cc44-6568-4bfb-9c09-2b903eb7bff2",
+    )
+    assert extract_payload(result)["success"] is True
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_update_phase_field_rejects_blank_label(
     pipe_config_session, mock_pipe_config_client, extract_payload
 ):
     async with pipe_config_session as session:
         result = await session.call_tool(
             "update_phase_field",
-            {"field_id": 9},
+            {"field_id": 9, "label": "   "},
         )
     mock_pipe_config_client.update_phase_field.assert_not_called()
-    assert extract_payload(result)["success"] is False
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "label" in payload["error"].lower()
 
 
 @pytest.mark.anyio
@@ -539,7 +618,9 @@ async def test_delete_phase_field_success(
             {"field_id": 100, "confirm": True},
         )
 
-    mock_pipe_config_client.delete_phase_field.assert_awaited_once_with(100)
+    mock_pipe_config_client.delete_phase_field.assert_awaited_once_with(
+        100, pipe_uuid=None
+    )
     assert extract_payload(result)["success"] is True
 
 
@@ -577,7 +658,7 @@ async def test_delete_phase_field_success_with_string_slug(
         )
 
     mock_pipe_config_client.delete_phase_field.assert_awaited_once_with(
-        "detalhe_mcp",
+        "detalhe_mcp", pipe_uuid=None
     )
     assert extract_payload(result)["success"] is True
 


### PR DESCRIPTION
## Summary

- **AI automation:** Send `skillsIds` in `aiParams` on create (default empty) and on update when provided. Fixes internal API errors when the field was omitted.
- **Phase fields:** `create_phase_field` passes `options` directly and returns `uuid`; `update_phase_field` accepts optional `uuid` to disambiguate when the slug collides across phases; `delete_phase_field` accepts optional `pipe_uuid` for the same reason.

## Commits

1. `fix(ai-automation): include skillsIds in aiParams for create/update`
2. `fix(tools): disambiguate phase fields by uuid and pipe_uuid`

## Testing

`uv run pytest` on affected unit tests (127 passed).