### PR TITLE
feat(members): warn when pipe removal leaves members visible

### DIFF
--- a/src/pipefy_mcp/tools/member_tool_helpers.py
+++ b/src/pipefy_mcp/tools/member_tool_helpers.py
@@ -20,21 +20,31 @@ class MemberMutationSuccessPayload(TypedDict):
     result: dict[str, Any]
 
 
+class MemberMutationWarningPayload(TypedDict):
+    success: Literal[True]
+    message: str
+    warning: str
+    result: dict[str, Any]
+
+
 def build_member_success_payload(
     *,
     message: str,
     data: dict[str, Any],
-) -> MemberMutationSuccessPayload:
+    warning: str | None = None,
+) -> MemberMutationSuccessPayload | MemberMutationWarningPayload:
     """``success``, ``message``, and mutation ``result``.
 
     Args:
         message: Short summary for the client.
         data: Raw mutation payload (stored as ``result``).
+        warning: Optional warning appended when the operation succeeded
+            but post-verification detected an anomaly.
     """
-    return cast(
-        MemberMutationSuccessPayload,
-        {"success": True, "message": message, "result": data},
-    )
+    payload: dict[str, Any] = {"success": True, "message": message, "result": data}
+    if warning is not None:
+        payload["warning"] = warning
+    return cast(MemberMutationSuccessPayload, payload)
 
 
 def build_member_error_payload(*, message: str) -> dict[str, Any]:

--- a/src/pipefy_mcp/tools/member_tools.py
+++ b/src/pipefy_mcp/tools/member_tools.py
@@ -122,9 +122,12 @@ class MemberTools:
                 return handle_member_tool_graphql_error(
                     exc, "Remove members from pipe failed.", debug=debug
                 )
+
+            warning = await _verify_removal(client, pipe_id, user_ids)
             return build_member_success_payload(
                 message="Members removed from pipe.",
                 data=raw,
+                warning=warning,
             )
 
         @mcp.tool(
@@ -168,3 +171,45 @@ class MemberTools:
                 message="Role updated.",
                 data=raw,
             )
+
+
+async def _verify_removal(
+    client: PipefyClient,
+    pipe_id: str,
+    user_ids: list[str],
+) -> str | None:
+    """Check whether removed members are actually gone from the pipe.
+
+    Returns a warning string when any requested user IDs are still present,
+    or ``None`` when all were successfully removed.  Silently returns
+    ``None`` on non-numeric ``pipe_id`` (verification requires ``int``)
+    or if the verification query itself fails.
+    """
+    pipe_id_str = str(pipe_id).strip()
+    if not pipe_id_str.isdigit():
+        return None
+
+    try:
+        members_data = await client.get_pipe_members(int(pipe_id_str))
+    except Exception:  # noqa: BLE001
+        return None
+
+    members = (members_data.get("pipe") or {}).get("members", [])
+    remaining_ids: set[str] = set()
+    for m in members:
+        user = m.get("user") if isinstance(m.get("user"), dict) else {}
+        if user.get("id"):
+            remaining_ids.add(str(user["id"]))
+        if user.get("uuid"):
+            remaining_ids.add(str(user["uuid"]))
+
+    requested = {str(uid) for uid in user_ids}
+    still_present = requested & remaining_ids
+    if not still_present:
+        return None
+
+    ids_str = ", ".join(sorted(still_present))
+    return (
+        f"API returned success but member(s) [{ids_str}] are still present in the pipe. "
+        "They may have org-level permissions that override pipe-level removal."
+    )

--- a/tests/tools/test_member_tools.py
+++ b/tests/tools/test_member_tools.py
@@ -24,6 +24,7 @@ def mock_member_client():
     client = MagicMock(PipefyClient)
     client.invite_members = AsyncMock()
     client.remove_members_from_pipe = AsyncMock()
+    client.get_pipe_members = AsyncMock()
     client.set_role = AsyncMock()
     return client
 
@@ -155,7 +156,130 @@ async def test_remove_member_from_pipe_value_error_from_client(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("member_session", [None], indirect=True)
-async def test_remove_member_from_pipe_success(
+async def test_remove_member_verified_all_removed(
+    member_session, mock_member_client, extract_payload
+):
+    mock_member_client.remove_members_from_pipe.return_value = {
+        "removeMembersFromPipe": {"success": True}
+    }
+    mock_member_client.get_pipe_members.return_value = {
+        "pipe": {
+            "members": [
+                {
+                    "user": {
+                        "id": "99",
+                        "uuid": "uuid-99",
+                        "name": "Other",
+                        "email": "other@x.com",
+                    },
+                    "role_name": "member",
+                },
+            ]
+        }
+    }
+
+    async with member_session as session:
+        result = await session.call_tool(
+            "remove_member_from_pipe",
+            {"pipe_id": "100", "user_ids": ["user-1", "user-2"], "confirm": True},
+        )
+
+    assert result.isError is False
+    mock_member_client.remove_members_from_pipe.assert_awaited_once_with(
+        "100", ["user-1", "user-2"]
+    )
+    mock_member_client.get_pipe_members.assert_awaited_once_with(100)
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    assert "warning" not in payload
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("member_session", [None], indirect=True)
+async def test_remove_member_warns_when_member_still_present(
+    member_session, mock_member_client, extract_payload
+):
+    mock_member_client.remove_members_from_pipe.return_value = {
+        "removeMembersFromPipe": {"success": True}
+    }
+    mock_member_client.get_pipe_members.return_value = {
+        "pipe": {
+            "members": [
+                {
+                    "user": {
+                        "id": "160654",
+                        "uuid": "uuid-160654",
+                        "name": "Rodrigo",
+                        "email": "rodrigo@x.com",
+                    },
+                    "role_name": "admin",
+                },
+                {
+                    "user": {
+                        "id": "99",
+                        "uuid": "uuid-99",
+                        "name": "Other",
+                        "email": "other@x.com",
+                    },
+                    "role_name": "member",
+                },
+            ]
+        }
+    }
+
+    async with member_session as session:
+        result = await session.call_tool(
+            "remove_member_from_pipe",
+            {"pipe_id": "100", "user_ids": ["160654"], "confirm": True},
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    assert "warning" in payload
+    assert "160654" in payload["warning"]
+    assert "org-level" in payload["warning"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("member_session", [None], indirect=True)
+async def test_remove_member_warns_when_uuid_still_present(
+    member_session, mock_member_client, extract_payload
+):
+    """Verification matches user UUIDs too, not just numeric IDs."""
+    mock_member_client.remove_members_from_pipe.return_value = {
+        "removeMembersFromPipe": {"success": True}
+    }
+    mock_member_client.get_pipe_members.return_value = {
+        "pipe": {
+            "members": [
+                {
+                    "user": {
+                        "id": "160654",
+                        "uuid": "abc-def-123",
+                        "name": "Rodrigo",
+                        "email": "rodrigo@x.com",
+                    },
+                    "role_name": "admin",
+                },
+            ]
+        }
+    }
+
+    async with member_session as session:
+        result = await session.call_tool(
+            "remove_member_from_pipe",
+            {"pipe_id": "100", "user_ids": ["abc-def-123"], "confirm": True},
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    assert "warning" in payload
+    assert "abc-def-123" in payload["warning"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("member_session", [None], indirect=True)
+async def test_remove_member_skips_verification_for_non_numeric_pipe_id(
     member_session, mock_member_client, extract_payload
 ):
     mock_member_client.remove_members_from_pipe.return_value = {
@@ -165,16 +289,34 @@ async def test_remove_member_from_pipe_success(
     async with member_session as session:
         result = await session.call_tool(
             "remove_member_from_pipe",
-            {"pipe_id": "pipe-1", "user_ids": ["user-1", "user-2"], "confirm": True},
+            {"pipe_id": "pipe-1", "user_ids": ["user-1"], "confirm": True},
         )
 
-    assert result.isError is False
-    mock_member_client.remove_members_from_pipe.assert_awaited_once_with(
-        "pipe-1", ["user-1", "user-2"]
-    )
+    mock_member_client.get_pipe_members.assert_not_awaited()
     payload = extract_payload(result)
     assert payload["success"] is True
-    assert payload["result"]["removeMembersFromPipe"]["success"] is True
+    assert "warning" not in payload
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("member_session", [None], indirect=True)
+async def test_remove_member_returns_success_when_verification_fails(
+    member_session, mock_member_client, extract_payload
+):
+    """If get_pipe_members raises, don't fail the whole operation."""
+    mock_member_client.remove_members_from_pipe.return_value = {
+        "removeMembersFromPipe": {"success": True}
+    }
+    mock_member_client.get_pipe_members.side_effect = Exception("network error")
+
+    async with member_session as session:
+        result = await session.call_tool(
+            "remove_member_from_pipe",
+            {"pipe_id": "100", "user_ids": ["user-1"], "confirm": True},
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is True
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

After `remove_member_from_pipe` succeeds, the tool re-fetches pipe members. If any requested user IDs still appear (e.g. org-level access), the response stays `success: true` but includes a **`warning`** explaining the situation.

## Commits

1. `feat(members): add optional warning to member success payload`
2. `feat(tools): verify remove_member_from_pipe and warn if users remain`

## Testing

- `uv run pytest tests/tools/test_member_tools.py` — 14 passed
- `uv run ruff check` on touched files — clean