### PR TITLE
fix(tools): int user_ids/pipe_id in remove_member_from_pipe

### DIFF
--- a/src/pipefy_mcp/tools/member_tools.py
+++ b/src/pipefy_mcp/tools/member_tools.py
@@ -76,8 +76,8 @@ class MemberTools:
         )
         async def remove_member_from_pipe(
             ctx: Context[ServerSession, None],
-            pipe_id: str,
-            user_ids: list[str],
+            pipe_id: str | int,
+            user_ids: list[str | int],
             confirm: bool = False,
             debug: bool = False,
         ) -> dict[str, Any]:
@@ -97,11 +97,14 @@ class MemberTools:
                 return build_member_error_payload(
                     message="Invalid 'pipe_id': provide a non-empty string or positive integer.",
                 )
+            pipe_id = str(pipe_id)
             if not isinstance(user_ids, list) or not user_ids:
                 return build_member_error_payload(
                     message="Invalid 'user_ids': provide a non-empty list of user IDs.",
                 )
-            if not all(isinstance(uid, str) and uid.strip() for uid in user_ids):
+            # Agents may re-serialize numeric IDs as ints on the confirm call
+            user_ids = [str(uid) for uid in user_ids]
+            if not all(uid.strip() for uid in user_ids):
                 return build_member_error_payload(
                     message="Invalid 'user_ids': each ID must be a non-empty string.",
                 )

--- a/tests/tools/test_member_tools.py
+++ b/tests/tools/test_member_tools.py
@@ -321,6 +321,30 @@ async def test_remove_member_returns_success_when_verification_fails(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("member_session", [None], indirect=True)
+async def test_remove_member_coerces_int_user_ids_to_str(
+    member_session, mock_member_client, extract_payload
+):
+    """Agent may re-serialize user_ids as ints on the confirm call."""
+    mock_member_client.remove_members_from_pipe.return_value = {
+        "removeMembersFromPipe": {"success": True}
+    }
+    mock_member_client.get_pipe_members.return_value = {"pipe": {"members": []}}
+
+    async with member_session as session:
+        result = await session.call_tool(
+            "remove_member_from_pipe",
+            {"pipe_id": "100", "user_ids": [307516938], "confirm": True},
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    mock_member_client.remove_members_from_pipe.assert_awaited_once_with(
+        "100", ["307516938"]
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("member_session", [None], indirect=True)
 async def test_remove_member_from_pipe_graphql_error(
     member_session, mock_member_client, extract_payload
 ):


### PR DESCRIPTION
## Summary

Normalizes `pipe_id` and `user_ids` to strings in `remove_member_from_pipe`, so MCP clients that re-serialize numeric IDs as `int` on the confirm step still pass validation and call the member service correctly.

## Testing

`uv run pytest tests/tools/test_member_tools.py -q` — 15 passed.