### PR TITLE
fix(tools): member tools ID coercion and remove_member debug

### DIFF
--- a/src/pipefy_mcp/tools/member_tools.py
+++ b/src/pipefy_mcp/tools/member_tools.py
@@ -118,15 +118,26 @@ class MemberTools:
             if guard is not None:
                 return guard
 
+            await ctx.debug(
+                f"remove_member_from_pipe: calling mutation with "
+                f"pipe_id={pipe_id!r} (type={type(pipe_id).__name__}), "
+                f"user_ids={user_ids!r}"
+            )
             try:
                 raw = await client.remove_members_from_pipe(pipe_id, user_ids)
             except ValueError as exc:
                 return build_member_error_payload(message=str(exc))
             except Exception as exc:  # noqa: BLE001
+                await ctx.debug(
+                    f"remove_member_from_pipe: mutation failed — {type(exc).__name__}: {exc}"
+                )
                 return handle_member_tool_graphql_error(
                     exc, "Remove members from pipe failed.", debug=debug
                 )
 
+            await ctx.debug(
+                "remove_member_from_pipe: mutation succeeded, verifying removal"
+            )
             warning = await _verify_removal(client, pipe_id, user_ids)
             return build_member_success_payload(
                 message="Members removed from pipe.",

--- a/src/pipefy_mcp/tools/member_tools.py
+++ b/src/pipefy_mcp/tools/member_tools.py
@@ -27,7 +27,7 @@ class MemberTools:
             annotations=ToolAnnotations(readOnlyHint=False),
         )
         async def invite_members(
-            pipe_id: str,
+            pipe_id: str | int,
             members: list[dict[str, Any]],
             debug: bool = False,
         ) -> dict[str, Any]:
@@ -44,6 +44,7 @@ class MemberTools:
                 return build_member_error_payload(
                     message="Invalid 'pipe_id': provide a non-empty string or positive integer.",
                 )
+            pipe_id = str(pipe_id)
             if not isinstance(members, list) or not members:
                 return build_member_error_payload(
                     message="Invalid 'members': provide a non-empty list of dicts with 'email' and 'role_name'.",
@@ -137,8 +138,8 @@ class MemberTools:
             annotations=ToolAnnotations(readOnlyHint=False),
         )
         async def set_role(
-            pipe_id: str,
-            member_id: str,
+            pipe_id: str | int,
+            member_id: str | int,
             role_name: str,
             debug: bool = False,
         ) -> dict[str, Any]:
@@ -154,7 +155,9 @@ class MemberTools:
                 return build_member_error_payload(
                     message="Invalid 'pipe_id': provide a non-empty string or positive integer.",
                 )
-            if not isinstance(member_id, str) or not member_id.strip():
+            pipe_id = str(pipe_id)
+            member_id = str(member_id)
+            if not member_id.strip():
                 return build_member_error_payload(
                     message="Invalid 'member_id': provide a non-empty string.",
                 )


### PR DESCRIPTION
## Summary

- **fix(tools):** Accept `str | int` for `pipe_id` in `invite_members` and for `pipe_id` / `member_id` in `set_role`, normalizing to `str` before API calls (matches MCP clients that serialize numeric IDs as integers).
- **chore(tools):** Add `ctx.debug` traces around `remove_member_from_pipe` mutation (call, failure, success before verification) for easier troubleshooting in MCP clients.

## Testing

- `uv run ruff check src/ tests/`
- `uv run ruff format src/ tests/ --check`
- `uv run pytest -m "not integration" -q` (969 passed locally before this push)
- `uv run pytest tests/tools/test_member_tools.py` (15 passed after commits)

## Base branch

Targets `pipe-full-toolset` as requested.