### PR TITLE
feat: attachment upload tools (card + table record)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MCP server for Pipefy
 
 <p align="center">
-  <strong>Open-source MCP for Pipefy: 112 tools across pipes, cards, tables, relations, reports, automations, AI agents and observability — built for your IDE, with pagination, introspection and safe deletes.</strong>
+  <strong>Open-source MCP for Pipefy: 114 tools across pipes, cards, tables, relations, reports, automations, AI agents and observability — built for your IDE, with pagination, introspection and safe deletes.</strong>
 </p>
 
 <p align="center">
@@ -32,7 +32,7 @@
 
 ## MCP tools
 
-**112 tools** across 9 categories. Each tool has a docstring consumed by LLM clients for routing — treat those as the source of truth for arguments.
+**114 tools** across 9 categories. Each tool has a docstring consumed by LLM clients for routing — treat those as the source of truth for arguments.
 
 **Shared conventions (many tools):**
 - **Pagination** — List endpoints accept `first` and `after`. Use `pageInfo.hasNextPage` and `pageInfo.endCursor` to fetch the next page.
@@ -43,8 +43,8 @@
 
 | Category | Tools | Description | Docs |
 |----------|:-----:|-------------|------|
-| **Pipes & cards** | 33 | Read, create, update, and delete pipes, phases, fields, labels, cards, and field conditions. | [Details](docs/tools/pipes-and-cards.md) |
-| **Database tables** | 17 | Tables, records (rows), schema columns (table fields), and org-wide table discovery. | [Details](docs/tools/database-tables.md) |
+| **Pipes & cards** | 34 | Read, create, update, and delete pipes, phases, fields, labels, cards, field conditions, and card attachment uploads. | [Details](docs/tools/pipes-and-cards.md) |
+| **Database tables** | 18 | Tables, records (rows), schema columns (table fields), org-wide table discovery, and table-record attachment uploads. | [Details](docs/tools/database-tables.md) |
 | **Relations** | 5 | Link pipes, tables, and cards across workflows. | [Details](docs/tools/relations.md) |
 | **Reports** | 16 | Pipe and organization reports: discovery, CRUD, and async exports. | [Details](docs/tools/reports.md) |
 | **Automations & AI** | 16 | Traditional automations (rules engine) and AI-powered automations and agents. | [Details](docs/tools/automations-and-ai.md) |
@@ -103,6 +103,9 @@ uv run pytest --cov=src/pipefy_mcp/services/pipefy --cov-report=term-missing
 
 # Integration tests (requires .env with PIPEFY_* OAuth settings)
 uv run pytest -m integration -v
+
+# Attachment upload live tests (optional IDs — see tests/tools/test_attachment_tools_live.py)
+# uv run pytest tests/tools/test_attachment_tools_live.py -m integration -v
 ```
 
 ### MCP Inspector

--- a/docs/tools/database-tables.md
+++ b/docs/tools/database-tables.md
@@ -1,6 +1,6 @@
 # Database Tables
 
-Tables, records (rows), and schema columns (table fields) for org Database Tables. **17 tools.**
+Tables, records (rows), and schema columns (table fields) for org Database Tables. **18 tools.**
 
 ## Cross-cutting patterns
 
@@ -13,5 +13,5 @@ Tables, records (rows), and schema columns (table fields) for org Database Table
 |--------|-------|-------|
 | **Read** | `get_table`, `get_tables`, `get_table_records`, `get_table_record`, `find_records` | |
 | **Table CRUD** | `create_table`, `update_table`, `delete_table` | `delete_table` uses preview + `confirm=true` (like `delete_pipe`). |
-| **Record CRUD** | `create_table_record`, `update_table_record`, `delete_table_record`, `set_table_record_field_value` | |
+| **Record CRUD** | `create_table_record`, `update_table_record`, `delete_table_record`, `set_table_record_field_value`, `upload_attachment_to_table_record` | `upload_attachment_to_table_record` runs presigned URL + S3 PUT + `setTableRecordFieldValue` for attachment columns. **One file per call** — to attach multiple files, call the tool once per file. Same inputs as card upload: one of `file_url` / `file_content_base64`. **`field_id` must be the field slug**, not the uuid. |
 | **Field CRUD** | `create_table_field`, `update_table_field`, `delete_table_field` | Schema columns; `delete_table_field` is destructive (confirm with the user). |

--- a/docs/tools/pipes-and-cards.md
+++ b/docs/tools/pipes-and-cards.md
@@ -1,6 +1,6 @@
 # Pipes & Cards
 
-Read, create, update, and delete pipes, phases, phase fields, labels, cards, and field conditions. **33 tools.**
+Read, create, update, and delete pipes, phases, phase fields, labels, cards, and field conditions. **34 tools.**
 
 ## Cross-cutting patterns
 
@@ -51,6 +51,7 @@ Read, create, update, and delete pipes, phases, phase fields, labels, cards, and
 | `update_card_field` | Single-field update (`updateCardField`). |
 | `update_card` | Metadata (title, assignees, labels, due date) and/or multiple custom fields via `field_updates`. |
 | `delete_card` | Two-step: default preview; `confirm=true` after explicit user confirmation. |
+| `upload_attachment_to_card` | Presigned URL + S3 PUT + `updateCardField` for **attachment** fields. **One file per call** — to attach multiple files, call the tool once per file. Exactly one of `file_url` or `file_content_base64`; optional `content_type` (inferred from `file_name` if omitted). **`field_id` must be the field slug** (e.g. `document_upload`), not the uuid — using the uuid returns `RESOURCE_NOT_FOUND`. |
 
 **Choosing card updates:** `update_card_field` = one field, full replacement. `update_card` + `field_updates` = several custom fields at once. `update_card` with attribute args = metadata (combinable with `field_updates`).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "gql[httpx]>=3.5.2",
+    "httpx>=0.27.0",
     "openpyxl>=3.1.5",
     "httpx-auth>=0.23.1",
     "mcp[cli]>=1.25.0",

--- a/src/pipefy_mcp/models/__init__.py
+++ b/src/pipefy_mcp/models/__init__.py
@@ -1,0 +1,15 @@
+"""Pipefy MCP Pydantic models (package exports)."""
+
+from __future__ import annotations
+
+from pipefy_mcp.models.attachment import (
+    UploadAttachmentToCardInput,
+    UploadAttachmentToTableRecordInput,
+    infer_content_type,
+)
+
+__all__ = [
+    "UploadAttachmentToCardInput",
+    "UploadAttachmentToTableRecordInput",
+    "infer_content_type",
+]

--- a/src/pipefy_mcp/models/attachment.py
+++ b/src/pipefy_mcp/models/attachment.py
@@ -1,0 +1,97 @@
+"""Pydantic models for attachment upload input validation."""
+
+from __future__ import annotations
+
+import mimetypes
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, model_validator
+
+APPLICATION_OCTET_STREAM = "application/octet-stream"
+
+# ``mimetypes`` maps ``.xyz`` to ``chemical/x-xyz`` on many systems; for generic uploads
+# we treat that as unknown binary content.
+_MIME_FALSE_POSITIVES_FOR_UPLOAD = frozenset({"chemical/x-xyz"})
+
+
+def infer_content_type(file_name: str) -> str:
+    """Infer a MIME type from ``file_name`` (typically the basename or path).
+
+    Uses :func:`mimetypes.guess_type`. Returns ``application/octet-stream`` when the type
+    is unknown or a known false positive for arbitrary ``.xyz`` files.
+
+    Args:
+        file_name: File name or path whose suffix is used for guessing.
+
+    Returns:
+        A MIME type string suitable for ``Content-Type``-style headers.
+    """
+    mime, _encoding = mimetypes.guess_type(file_name)
+    if mime is None or mime in _MIME_FALSE_POSITIVES_FOR_UPLOAD:
+        return APPLICATION_OCTET_STREAM
+    return mime
+
+
+def _source_nonempty(value: str | None) -> bool:
+    return bool(value and value.strip())
+
+
+def _raise_unless_exactly_one_file_source(
+    file_url: str | None,
+    file_content_base64: str | None,
+) -> None:
+    """Ensure exactly one of URL or base64 payload is non-empty.
+
+    Raises:
+        ValueError: When both or neither source is provided with non-empty content.
+    """
+    has_url = _source_nonempty(file_url)
+    has_b64 = _source_nonempty(file_content_base64)
+    if has_url and has_b64:
+        raise ValueError(
+            "Provide exactly one of file_url or file_content_base64, not both."
+        )
+    if not has_url and not has_b64:
+        raise ValueError(
+            "Provide exactly one of file_url or file_content_base64 (non-empty)."
+        )
+
+
+class UploadAttachmentToCardInput(BaseModel):
+    """Validated input for uploading an attachment to a card field."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    organization_id: str
+    card_id: int
+    field_id: str
+    file_name: str
+    file_url: str | None = None
+    file_content_base64: str | None = None
+    content_type: str | None = None
+
+    @model_validator(mode="after")
+    def exactly_one_file_source(self) -> Self:
+        """Require exactly one of ``file_url`` or ``file_content_base64`` with non-empty value."""
+        _raise_unless_exactly_one_file_source(self.file_url, self.file_content_base64)
+        return self
+
+
+class UploadAttachmentToTableRecordInput(BaseModel):
+    """Validated input for uploading an attachment to a table record field."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    organization_id: str
+    table_record_id: str
+    field_id: str
+    file_name: str
+    file_url: str | None = None
+    file_content_base64: str | None = None
+    content_type: str | None = None
+
+    @model_validator(mode="after")
+    def exactly_one_file_source(self) -> Self:
+        """Require exactly one of ``file_url`` or ``file_content_base64`` with non-empty value."""
+        _raise_unless_exactly_one_file_source(self.file_url, self.file_content_base64)
+        return self

--- a/src/pipefy_mcp/services/pipefy/__init__.py
+++ b/src/pipefy_mcp/services/pipefy/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from .ai_agent_service import AiAgentService
 from .ai_automation_service import AiAutomationService
+from .attachment_service import AttachmentService
 from .automation_service import AutomationService
 from .base_client import BasePipefyClient
 from .card_service import CardService
@@ -21,6 +22,7 @@ from .webhook_service import WebhookService
 __all__ = [
     "AiAgentService",
     "AiAutomationService",
+    "AttachmentService",
     "AutomationService",
     "BasePipefyClient",
     "CardService",

--- a/src/pipefy_mcp/services/pipefy/attachment_service.py
+++ b/src/pipefy_mcp/services/pipefy/attachment_service.py
@@ -1,0 +1,101 @@
+"""Presigned URL creation, storage path parsing, and S3 upload via HTTP PUT."""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import unquote, urlparse
+
+import httpx
+from httpx_auth import OAuth2ClientCredentials
+
+from pipefy_mcp.services.pipefy.base_client import BasePipefyClient
+from pipefy_mcp.services.pipefy.queries.attachment_queries import (
+    CREATE_PRESIGNED_URL_MUTATION,
+)
+from pipefy_mcp.settings import PipefySettings
+
+_BODY_SNIPPET_MAX_CHARS = 500
+
+
+class AttachmentService(BasePipefyClient):
+    """Create upload URLs and PUT file bytes to object storage."""
+
+    def __init__(
+        self,
+        settings: PipefySettings,
+        auth: OAuth2ClientCredentials | None = None,
+    ) -> None:
+        super().__init__(settings=settings, auth=auth)
+
+    async def create_presigned_url(
+        self,
+        organization_id: str,
+        file_name: str,
+        content_type: str | None = None,
+        content_length: int | None = None,
+    ) -> dict[str, Any]:
+        """Request a presigned upload URL from Pipefy.
+
+        Args:
+            organization_id: Organization ID.
+            file_name: Target file name for the upload.
+            content_type: Optional MIME type for the object.
+            content_length: Optional size in bytes.
+        """
+        payload = await self.execute_query(
+            CREATE_PRESIGNED_URL_MUTATION,
+            {
+                "organizationId": organization_id,
+                "fileName": file_name,
+                "contentType": content_type,
+                "contentLength": content_length,
+            },
+        )
+        node = payload.get("createPresignedUrl")
+        if not isinstance(node, dict):
+            return {"url": None, "download_url": None}
+        return {
+            "url": node.get("url"),
+            "download_url": node.get("downloadUrl"),
+        }
+
+    @staticmethod
+    def extract_storage_path(presigned_url: str) -> str:
+        """Return the object key path from a presigned URL (no host, query, or leading slash).
+
+        Args:
+            presigned_url: Full HTTPS URL including path and optional query string.
+
+        Raises:
+            ValueError: If the URL has no non-empty path.
+        """
+        parsed = urlparse(presigned_url)
+        path = unquote(parsed.path or "").lstrip("/")
+        if not path:
+            raise ValueError("Presigned URL has no object path.")
+        return path
+
+    async def upload_file_to_s3(
+        self,
+        presigned_url: str,
+        file_bytes: bytes,
+        content_type: str | None = None,
+    ) -> dict[str, Any]:
+        """PUT file bytes to the given presigned URL.
+
+        Args:
+            presigned_url: Destination URL (not echoed back on failure).
+            file_bytes: Raw file content.
+            content_type: Optional ``Content-Type`` header for the request.
+        """
+        headers: dict[str, str] = {}
+        if content_type is not None:
+            headers["Content-Type"] = content_type
+        async with httpx.AsyncClient() as client:
+            response = await client.put(
+                presigned_url, content=file_bytes, headers=headers
+            )
+        result: dict[str, Any] = {"status_code": response.status_code}
+        if response.status_code >= 400:
+            result["body_snippet"] = response.text[:_BODY_SNIPPET_MAX_CHARS]
+        return result

--- a/src/pipefy_mcp/services/pipefy/base_client.py
+++ b/src/pipefy_mcp/services/pipefy/base_client.py
@@ -72,6 +72,6 @@ class BasePipefyClient:
             timeout=Timeout(timeout=self.GRAPHQL_REQUEST_TIMEOUT_SECONDS),
         )
         async with Client(
-            transport=transport, fetch_schema_from_transport=True
+            transport=transport, fetch_schema_from_transport=False
         ) as session:
             return await session.execute(query, variable_values=variables)

--- a/src/pipefy_mcp/services/pipefy/client.py
+++ b/src/pipefy_mcp/services/pipefy/client.py
@@ -8,6 +8,7 @@ from httpx_auth import OAuth2ClientCredentials
 
 from pipefy_mcp.models.ai_agent import CreateAiAgentInput, UpdateAiAgentInput
 from pipefy_mcp.services.pipefy.ai_agent_service import AiAgentService
+from pipefy_mcp.services.pipefy.attachment_service import AttachmentService
 from pipefy_mcp.services.pipefy.automation_graphql_types import (
     AutomationActionRow,
     AutomationEventRow,
@@ -70,6 +71,7 @@ class PipefyClient:
         self._observability_service = ObservabilityService(settings=settings, auth=auth)
         self._report_service = ReportService(settings=settings, auth=auth)
         self._organization_service = OrganizationService(settings=settings, auth=auth)
+        self._attachment_service = AttachmentService(settings=settings, auth=auth)
         self._introspection_service = SchemaIntrospectionService(
             settings=settings, auth=auth
         )
@@ -957,6 +959,53 @@ class PipefyClient:
             organization_id: Numeric organization ID.
         """
         return await self._organization_service.get_organization(organization_id)
+
+    async def create_presigned_url(
+        self,
+        organization_id: str,
+        file_name: str,
+        content_type: str | None = None,
+        content_length: int | None = None,
+    ) -> dict[str, Any]:
+        """Request a presigned upload URL from Pipefy.
+
+        Args:
+            organization_id: Organization ID.
+            file_name: Target file name for the upload.
+            content_type: Optional MIME type for the object.
+            content_length: Optional size in bytes.
+        """
+        return await self._attachment_service.create_presigned_url(
+            organization_id,
+            file_name,
+            content_type=content_type,
+            content_length=content_length,
+        )
+
+    async def upload_file_to_s3(
+        self,
+        presigned_url: str,
+        file_bytes: bytes,
+        content_type: str | None = None,
+    ) -> dict[str, Any]:
+        """PUT file bytes to a presigned object storage URL.
+
+        Args:
+            presigned_url: Full presigned destination URL.
+            file_bytes: Raw file content.
+            content_type: Optional ``Content-Type`` header for the PUT.
+        """
+        return await self._attachment_service.upload_file_to_s3(
+            presigned_url, file_bytes, content_type=content_type
+        )
+
+    def extract_storage_path(self, presigned_url: str) -> str:
+        """Return the object key path embedded in a presigned URL (no host or query string).
+
+        Args:
+            presigned_url: Full HTTPS URL including path and optional query string.
+        """
+        return self._attachment_service.extract_storage_path(presigned_url)
 
     async def introspect_type(
         self, type_name: str, *, max_depth: int = 1

--- a/src/pipefy_mcp/services/pipefy/queries/attachment_queries.py
+++ b/src/pipefy_mcp/services/pipefy/queries/attachment_queries.py
@@ -1,0 +1,29 @@
+"""GraphQL mutations for Pipefy attachment uploads (presigned URLs)."""
+
+from __future__ import annotations
+
+from gql import gql
+
+CREATE_PRESIGNED_URL_MUTATION = gql(
+    """
+    mutation createPresignedUrl(
+        $organizationId: ID!,
+        $fileName: String!,
+        $contentType: String,
+        $contentLength: Int
+    ) {
+        createPresignedUrl(
+            input: {
+                organizationId: $organizationId,
+                fileName: $fileName,
+                contentType: $contentType,
+                contentLength: $contentLength
+            }
+        ) {
+            url
+            downloadUrl
+            clientMutationId
+        }
+    }
+    """
+)

--- a/src/pipefy_mcp/tools/attachment_tool_helpers.py
+++ b/src/pipefy_mcp/tools/attachment_tool_helpers.py
@@ -1,0 +1,146 @@
+"""Payload builders and error strings for attachment upload MCP tools."""
+
+from __future__ import annotations
+
+import binascii
+from typing import Any, Literal
+
+import httpx
+from pydantic import ValidationError
+
+from pipefy_mcp.tools.graphql_error_helpers import extract_error_strings
+
+UploadFlowStep = Literal[
+    "validation",
+    "file_download",
+    "presigned_url",
+    "s3_upload",
+    "field_update",
+]
+
+
+def build_upload_success_payload(
+    *,
+    download_url: str | None,
+    file_name: str,
+    content_type: str,
+    file_size: int,
+    field_id: str,
+    card_id: int | None = None,
+    table_record_id: str | None = None,
+) -> dict[str, Any]:
+    """Structured success payload (FR-8).
+
+    Args:
+        download_url: Permanent/signed download URL from Pipefy (may be None if API omits it).
+        file_name: File name used for the upload.
+        content_type: MIME type sent to storage.
+        file_size: Uploaded size in bytes.
+        field_id: Updated attachment field id.
+        card_id: Target card id (card uploads).
+        table_record_id: Target table record id (table uploads).
+    """
+    payload: dict[str, Any] = {
+        "success": True,
+        "download_url": download_url,
+        "file_name": file_name,
+        "content_type": content_type,
+        "file_size": file_size,
+        "field_id": field_id,
+    }
+    if card_id is not None:
+        payload["card_id"] = card_id
+    if table_record_id is not None:
+        payload["table_record_id"] = table_record_id
+    return payload
+
+
+def build_upload_error_payload(
+    *,
+    message: str,
+    step: UploadFlowStep,
+) -> dict[str, Any]:
+    """Structured failure payload for the upload flow.
+
+    Args:
+        message: Actionable reason for the caller.
+        step: Failed stage (``file_download``, ``presigned_url``, ``s3_upload``, ``field_update``).
+    """
+    return {
+        "success": False,
+        "error": message,
+        "message": message,
+        "step": step,
+    }
+
+
+def format_s3_upload_failure(upload_result: dict[str, Any]) -> str:
+    """Build an agent-facing message from ``AttachmentService.upload_file_to_s3`` output.
+
+    Args:
+        upload_result: Dict containing at least ``status_code``; may include ``body_snippet``.
+    """
+    code = upload_result.get("status_code")
+    snippet = upload_result.get("body_snippet")
+    base = f"S3 upload failed with HTTP status {code}."
+    if isinstance(snippet, str) and snippet.strip():
+        body = snippet.strip()[:300]
+        hint = ""
+        if "ExpiredToken" in snippet or "request has expired" in snippet.lower():
+            hint = (
+                " The presigned URL may have expired; call the upload tool again "
+                "to obtain a fresh URL."
+            )
+        elif "SignatureDoesNotMatch" in snippet:
+            hint = (
+                " The request body or headers may not match what was signed "
+                "(check content length and Content-Type)."
+            )
+        if hint:
+            return f"{base} Response snippet: {body}.{hint}"
+        return f"{base} Response snippet: {body}"
+    return f"{base} Check content type, size, and presigned URL validity."
+
+
+def map_upload_error_to_message(exc: BaseException, step: UploadFlowStep) -> str:
+    """Map an exception to a short, actionable message (FR-9).
+
+    Args:
+        exc: Failure from transport, GraphQL, or validation.
+        step: Current flow step where the error was observed (for context only).
+    """
+    if isinstance(exc, ValidationError):
+        parts: list[str] = []
+        for err in exc.errors():
+            loc = ".".join(str(x) for x in err.get("loc", ()))
+            msg = err.get("msg", "invalid")
+            if loc:
+                parts.append(f"{loc}: {msg}")
+            else:
+                parts.append(str(msg))
+        return "; ".join(parts) if parts else "Invalid input."
+    if isinstance(exc, binascii.Error):
+        return "Invalid file_content_base64: could not decode base64 data."
+    if isinstance(exc, httpx.HTTPStatusError):
+        if step == "file_download":
+            return (
+                f"Could not download file_url (HTTP {exc.response.status_code}). "
+                "Verify the URL is public or reachable from this server."
+            )
+        return (
+            f"HTTP error ({exc.response.status_code}) during request. "
+            "Retry or check network and URL."
+        )
+    if isinstance(exc, httpx.RequestError):
+        if step == "file_download":
+            return (
+                f"Network error while downloading file_url: {exc}. "
+                "Check connectivity and URL validity."
+            )
+        return f"Network error: {exc}"
+    if isinstance(exc, ValueError):
+        return str(exc)
+    msgs = extract_error_strings(exc)
+    if msgs:
+        return "; ".join(dict.fromkeys(msgs))
+    return f"{type(exc).__name__}: {exc}".strip()

--- a/src/pipefy_mcp/tools/attachment_tool_helpers.py
+++ b/src/pipefy_mcp/tools/attachment_tool_helpers.py
@@ -69,7 +69,6 @@ def build_upload_error_payload(
     return {
         "success": False,
         "error": message,
-        "message": message,
         "step": step,
     }
 

--- a/src/pipefy_mcp/tools/attachment_tools.py
+++ b/src/pipefy_mcp/tools/attachment_tools.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import base64
 import binascii
+import ipaddress
+import socket
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 from mcp.server.fastmcp import Context, FastMCP
@@ -26,22 +29,91 @@ from pipefy_mcp.tools.attachment_tool_helpers import (
 )
 
 _FILE_DOWNLOAD_TIMEOUT_SEC = 60.0
+_MAX_DOWNLOAD_SIZE_BYTES = 100 * 1024 * 1024  # 100 MiB
+
+_PRIVATE_NETWORKS = (
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fd00::/8"),
+    ipaddress.ip_network("fe80::/10"),
+)
+
+
+def _validate_url_safe(url: str) -> None:
+    """Reject URLs that target private/internal networks or non-HTTP schemes.
+
+    Raises:
+        ValueError: When the URL is unsafe for server-side fetch.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        msg = f"Only http and https URLs are allowed, got '{parsed.scheme}'."
+        raise ValueError(msg)
+
+    hostname = parsed.hostname
+    if not hostname:
+        msg = "URL has no hostname."
+        raise ValueError(msg)
+
+    try:
+        addr_info = socket.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as exc:
+        msg = f"Could not resolve hostname '{hostname}': {exc}"
+        raise ValueError(msg) from exc
+
+    for _, _, _, _, sockaddr in addr_info:
+        ip = ipaddress.ip_address(sockaddr[0])
+        for net in _PRIVATE_NETWORKS:
+            if ip in net:
+                msg = f"URL resolves to a private/internal address ({ip}). Request blocked."
+                raise ValueError(msg)
 
 
 async def _download_file_bytes(url: str) -> bytes:
-    """Fetch file body from an HTTP(S) URL.
+    """Fetch file body from an HTTP(S) URL with SSRF protection and size limit.
 
     Args:
-        url: Location to download.
+        url: Location to download. Must be http/https and resolve to a public IP.
+
+    Raises:
+        ValueError: When the URL targets a private network or exceeds size limit.
+        httpx.HTTPError: On transport/HTTP failures.
     """
+    _validate_url_safe(url)
+
     async with httpx.AsyncClient() as http:
-        response = await http.get(
+        async with http.stream(
+            "GET",
             url,
             follow_redirects=True,
             timeout=_FILE_DOWNLOAD_TIMEOUT_SEC,
-        )
-        response.raise_for_status()
-        return response.content
+        ) as response:
+            response.raise_for_status()
+
+            content_length = response.headers.get("content-length")
+            if content_length and int(content_length) > _MAX_DOWNLOAD_SIZE_BYTES:
+                msg = (
+                    f"File too large: Content-Length {content_length} bytes "
+                    f"exceeds the {_MAX_DOWNLOAD_SIZE_BYTES // (1024 * 1024)} MiB limit."
+                )
+                raise ValueError(msg)
+
+            chunks: list[bytes] = []
+            total = 0
+            async for chunk in response.aiter_bytes():
+                total += len(chunk)
+                if total > _MAX_DOWNLOAD_SIZE_BYTES:
+                    msg = (
+                        f"File too large: downloaded {total} bytes, "
+                        f"exceeding the {_MAX_DOWNLOAD_SIZE_BYTES // (1024 * 1024)} MiB limit."
+                    )
+                    raise ValueError(msg)
+                chunks.append(chunk)
+            return b"".join(chunks)
 
 
 def _decode_base64_file(payload: str) -> bytes:
@@ -62,32 +134,34 @@ class AttachmentTools:
 
     @staticmethod
     def register(mcp: FastMCP, client: PipefyClient) -> None:
-        async def _upload_to_card_flow(
+        async def _upload_flow(
             ctx: Context[ServerSession, None],
-            data: UploadAttachmentToCardInput,
+            *,
+            organization_id: str,
+            field_id: str,
+            file_name: str,
+            file_url: str | None,
+            file_content_base64: str | None,
+            content_type: str | None,
+            update_field_fn: Any,
+            debug_prefix: str,
+            success_extra: dict[str, Any],
         ) -> dict[str, Any]:
-            file_name = data.file_name
-            effective_type = data.content_type or infer_content_type(file_name)
+            """Shared orchestration: download/decode → presigned URL → S3 PUT → field update."""
+            effective_type = content_type or infer_content_type(file_name)
             await ctx.debug(
-                f"upload_attachment_to_card: card_id={data.card_id} field_id={data.field_id!r} "
+                f"{debug_prefix}: field_id={field_id!r} "
                 f"file_name={file_name!r} content_type={effective_type!r}"
             )
             try:
-                if data.file_url:
-                    await ctx.debug("upload_attachment_to_card: downloading file_url")
-                    file_bytes = await _download_file_bytes(data.file_url.strip())
+                if file_url:
+                    await ctx.debug(f"{debug_prefix}: downloading file_url")
+                    file_bytes = await _download_file_bytes(file_url.strip())
                 else:
-                    await ctx.debug(
-                        "upload_attachment_to_card: decoding base64 payload"
-                    )
-                    file_bytes = _decode_base64_file(data.file_content_base64 or "")
-            except httpx.HTTPError as exc:
-                await ctx.debug(f"upload_attachment_to_card: file source error {exc!r}")
-                return build_upload_error_payload(
-                    message=map_upload_error_to_message(exc, "file_download"),
-                    step="file_download",
-                )
-            except binascii.Error as exc:
+                    await ctx.debug(f"{debug_prefix}: decoding base64 payload")
+                    file_bytes = _decode_base64_file(file_content_base64 or "")
+            except (httpx.HTTPError, binascii.Error, ValueError) as exc:
+                await ctx.debug(f"{debug_prefix}: file source error {exc!r}")
                 return build_upload_error_payload(
                     message=map_upload_error_to_message(exc, "file_download"),
                     step="file_download",
@@ -95,17 +169,15 @@ class AttachmentTools:
 
             content_length = len(file_bytes)
             try:
-                await ctx.debug("upload_attachment_to_card: createPresignedUrl")
+                await ctx.debug(f"{debug_prefix}: createPresignedUrl")
                 presigned = await client.create_presigned_url(
-                    data.organization_id,
+                    organization_id,
                     file_name,
                     effective_type,
                     content_length,
                 )
             except Exception as exc:  # noqa: BLE001
-                await ctx.debug(
-                    f"upload_attachment_to_card: presigned URL failed {exc!r}"
-                )
+                await ctx.debug(f"{debug_prefix}: presigned URL failed {exc!r}")
                 return build_upload_error_payload(
                     message=map_upload_error_to_message(exc, "presigned_url"),
                     step="presigned_url",
@@ -122,7 +194,7 @@ class AttachmentTools:
                     step="presigned_url",
                 )
 
-            await ctx.debug("upload_attachment_to_card: S3 PUT")
+            await ctx.debug(f"{debug_prefix}: S3 PUT")
             put_result = await client.upload_file_to_s3(
                 upload_url.strip(),
                 file_bytes,
@@ -144,16 +216,10 @@ class AttachmentTools:
                 )
 
             try:
-                await ctx.debug("upload_attachment_to_card: updateCardField")
-                await client.update_card_field(
-                    data.card_id,
-                    data.field_id,
-                    [storage_path],
-                )
+                await ctx.debug(f"{debug_prefix}: field update")
+                await update_field_fn(storage_path)
             except Exception as exc:  # noqa: BLE001
-                await ctx.debug(
-                    f"upload_attachment_to_card: field update failed {exc!r}"
-                )
+                await ctx.debug(f"{debug_prefix}: field update failed {exc!r}")
                 return build_upload_error_payload(
                     message=map_upload_error_to_message(exc, "field_update"),
                     step="field_update",
@@ -164,104 +230,8 @@ class AttachmentTools:
                 file_name=file_name,
                 content_type=effective_type,
                 file_size=content_length,
-                field_id=data.field_id,
-                card_id=data.card_id,
-            )
-
-        async def _upload_to_table_flow(
-            ctx: Context[ServerSession, None],
-            data: UploadAttachmentToTableRecordInput,
-        ) -> dict[str, Any]:
-            file_name = data.file_name
-            effective_type = data.content_type or infer_content_type(file_name)
-            await ctx.debug(
-                f"upload_attachment_to_table_record: record_id={data.table_record_id!r} "
-                f"field_id={data.field_id!r} file_name={file_name!r}"
-            )
-            try:
-                if data.file_url:
-                    file_bytes = await _download_file_bytes(data.file_url.strip())
-                else:
-                    file_bytes = _decode_base64_file(data.file_content_base64 or "")
-            except httpx.HTTPError as exc:
-                return build_upload_error_payload(
-                    message=map_upload_error_to_message(exc, "file_download"),
-                    step="file_download",
-                )
-            except binascii.Error as exc:
-                return build_upload_error_payload(
-                    message=map_upload_error_to_message(exc, "file_download"),
-                    step="file_download",
-                )
-
-            content_length = len(file_bytes)
-            try:
-                await ctx.debug("upload_attachment_to_table_record: createPresignedUrl")
-                presigned = await client.create_presigned_url(
-                    data.organization_id,
-                    file_name,
-                    effective_type,
-                    content_length,
-                )
-            except Exception as exc:  # noqa: BLE001
-                return build_upload_error_payload(
-                    message=map_upload_error_to_message(exc, "presigned_url"),
-                    step="presigned_url",
-                )
-
-            upload_url = presigned.get("url")
-            download_url = presigned.get("download_url")
-            if not isinstance(upload_url, str) or not upload_url.strip():
-                return build_upload_error_payload(
-                    message=(
-                        "Pipefy did not return a presigned upload URL. "
-                        "Check organization_id and file_name, then retry."
-                    ),
-                    step="presigned_url",
-                )
-
-            put_result = await client.upload_file_to_s3(
-                upload_url.strip(),
-                file_bytes,
-                effective_type,
-            )
-            status = put_result.get("status_code", 0)
-            if not isinstance(status, int) or status >= 400:
-                return build_upload_error_payload(
-                    message=format_s3_upload_failure(put_result),
-                    step="s3_upload",
-                )
-
-            try:
-                storage_path = client.extract_storage_path(upload_url)
-            except ValueError as exc:
-                return build_upload_error_payload(
-                    message=str(exc),
-                    step="s3_upload",
-                )
-
-            try:
-                await ctx.debug(
-                    "upload_attachment_to_table_record: setTableRecordFieldValue"
-                )
-                await client.set_table_record_field_value(
-                    data.table_record_id,
-                    data.field_id,
-                    [storage_path],
-                )
-            except Exception as exc:  # noqa: BLE001
-                return build_upload_error_payload(
-                    message=map_upload_error_to_message(exc, "field_update"),
-                    step="field_update",
-                )
-
-            return build_upload_success_payload(
-                download_url=download_url if isinstance(download_url, str) else None,
-                file_name=file_name,
-                content_type=effective_type,
-                file_size=content_length,
-                field_id=data.field_id,
-                table_record_id=data.table_record_id,
+                field_id=field_id,
+                **success_extra,
             )
 
         @mcp.tool(
@@ -285,11 +255,11 @@ class AttachmentTools:
             ``content_type`` is omitted, it is inferred from ``file_name``.
 
             Args:
-                organization_id: Pipefy organization id (string).
+                organization_id: Pipefy organization id. Use ``get_organization`` or ``get_pipe`` to find it.
                 card_id: Target card id.
                 field_id: Attachment field slug (e.g. "document_upload"), not the uuid.
                 file_name: File name including extension (used for storage and MIME guess).
-                file_url: Public or reachable URL to download the file bytes.
+                file_url: Public or reachable URL to download the file bytes (max 100 MiB).
                 file_content_base64: Raw file bytes encoded as standard base64.
                 content_type: Optional MIME type; sent with the S3 upload and presigned request.
             """
@@ -308,7 +278,24 @@ class AttachmentTools:
                     message=map_upload_error_to_message(exc, "validation"),
                     step="validation",
                 )
-            return await _upload_to_card_flow(ctx, data)
+
+            async def _update_card(path: str) -> Any:
+                return await client.update_card_field(
+                    data.card_id, data.field_id, [path]
+                )
+
+            return await _upload_flow(
+                ctx,
+                organization_id=data.organization_id,
+                field_id=data.field_id,
+                file_name=data.file_name,
+                file_url=data.file_url,
+                file_content_base64=data.file_content_base64,
+                content_type=data.content_type,
+                update_field_fn=_update_card,
+                debug_prefix="upload_attachment_to_card",
+                success_extra={"card_id": data.card_id},
+            )
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
@@ -331,11 +318,11 @@ class AttachmentTools:
             omitted, it is inferred from ``file_name``.
 
             Args:
-                organization_id: Pipefy organization id (string).
+                organization_id: Pipefy organization id. Use ``get_organization`` or ``get_pipe`` to find it.
                 table_record_id: Database table record id.
                 field_id: Attachment field slug on the table record (e.g. "document_upload"), not the uuid.
                 file_name: File name including extension.
-                file_url: URL to download the file from.
+                file_url: URL to download the file from (max 100 MiB).
                 file_content_base64: Base64-encoded file bytes.
                 content_type: Optional MIME type for storage.
             """
@@ -354,4 +341,21 @@ class AttachmentTools:
                     message=map_upload_error_to_message(exc, "validation"),
                     step="validation",
                 )
-            return await _upload_to_table_flow(ctx, data)
+
+            async def _update_record(path: str) -> Any:
+                return await client.set_table_record_field_value(
+                    data.table_record_id, data.field_id, [path]
+                )
+
+            return await _upload_flow(
+                ctx,
+                organization_id=data.organization_id,
+                field_id=data.field_id,
+                file_name=data.file_name,
+                file_url=data.file_url,
+                file_content_base64=data.file_content_base64,
+                content_type=data.content_type,
+                update_field_fn=_update_record,
+                debug_prefix="upload_attachment_to_table_record",
+                success_extra={"table_record_id": data.table_record_id},
+            )

--- a/src/pipefy_mcp/tools/attachment_tools.py
+++ b/src/pipefy_mcp/tools/attachment_tools.py
@@ -1,0 +1,357 @@
+"""MCP tools to upload attachments to card or table record fields."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+from typing import Any
+
+import httpx
+from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.session import ServerSession
+from mcp.types import ToolAnnotations
+from pydantic import ValidationError
+
+from pipefy_mcp.models.attachment import (
+    UploadAttachmentToCardInput,
+    UploadAttachmentToTableRecordInput,
+    infer_content_type,
+)
+from pipefy_mcp.services.pipefy import PipefyClient
+from pipefy_mcp.tools.attachment_tool_helpers import (
+    build_upload_error_payload,
+    build_upload_success_payload,
+    format_s3_upload_failure,
+    map_upload_error_to_message,
+)
+
+_FILE_DOWNLOAD_TIMEOUT_SEC = 60.0
+
+
+async def _download_file_bytes(url: str) -> bytes:
+    """Fetch file body from an HTTP(S) URL.
+
+    Args:
+        url: Location to download.
+    """
+    async with httpx.AsyncClient() as http:
+        response = await http.get(
+            url,
+            follow_redirects=True,
+            timeout=_FILE_DOWNLOAD_TIMEOUT_SEC,
+        )
+        response.raise_for_status()
+        return response.content
+
+
+def _decode_base64_file(payload: str) -> bytes:
+    """Decode base64 file content.
+
+    Args:
+        payload: Standard base64 text (whitespace ignored).
+
+    Raises:
+        binascii.Error: When padding or alphabet is invalid.
+    """
+    cleaned = "".join(payload.split())
+    return base64.b64decode(cleaned, validate=True)
+
+
+class AttachmentTools:
+    """MCP tools for orchestrated attachment uploads (presigned URL, S3 PUT, field update)."""
+
+    @staticmethod
+    def register(mcp: FastMCP, client: PipefyClient) -> None:
+        async def _upload_to_card_flow(
+            ctx: Context[ServerSession, None],
+            data: UploadAttachmentToCardInput,
+        ) -> dict[str, Any]:
+            file_name = data.file_name
+            effective_type = data.content_type or infer_content_type(file_name)
+            await ctx.debug(
+                f"upload_attachment_to_card: card_id={data.card_id} field_id={data.field_id!r} "
+                f"file_name={file_name!r} content_type={effective_type!r}"
+            )
+            try:
+                if data.file_url:
+                    await ctx.debug("upload_attachment_to_card: downloading file_url")
+                    file_bytes = await _download_file_bytes(data.file_url.strip())
+                else:
+                    await ctx.debug(
+                        "upload_attachment_to_card: decoding base64 payload"
+                    )
+                    file_bytes = _decode_base64_file(data.file_content_base64 or "")
+            except httpx.HTTPError as exc:
+                await ctx.debug(f"upload_attachment_to_card: file source error {exc!r}")
+                return build_upload_error_payload(
+                    message=map_upload_error_to_message(exc, "file_download"),
+                    step="file_download",
+                )
+            except binascii.Error as exc:
+                return build_upload_error_payload(
+                    message=map_upload_error_to_message(exc, "file_download"),
+                    step="file_download",
+                )
+
+            content_length = len(file_bytes)
+            try:
+                await ctx.debug("upload_attachment_to_card: createPresignedUrl")
+                presigned = await client.create_presigned_url(
+                    data.organization_id,
+                    file_name,
+                    effective_type,
+                    content_length,
+                )
+            except Exception as exc:  # noqa: BLE001
+                await ctx.debug(
+                    f"upload_attachment_to_card: presigned URL failed {exc!r}"
+                )
+                return build_upload_error_payload(
+                    message=map_upload_error_to_message(exc, "presigned_url"),
+                    step="presigned_url",
+                )
+
+            upload_url = presigned.get("url")
+            download_url = presigned.get("download_url")
+            if not isinstance(upload_url, str) or not upload_url.strip():
+                return build_upload_error_payload(
+                    message=(
+                        "Pipefy did not return a presigned upload URL. "
+                        "Check organization_id and file_name, then retry."
+                    ),
+                    step="presigned_url",
+                )
+
+            await ctx.debug("upload_attachment_to_card: S3 PUT")
+            put_result = await client.upload_file_to_s3(
+                upload_url.strip(),
+                file_bytes,
+                effective_type,
+            )
+            status = put_result.get("status_code", 0)
+            if not isinstance(status, int) or status >= 400:
+                return build_upload_error_payload(
+                    message=format_s3_upload_failure(put_result),
+                    step="s3_upload",
+                )
+
+            try:
+                storage_path = client.extract_storage_path(upload_url)
+            except ValueError as exc:
+                return build_upload_error_payload(
+                    message=str(exc),
+                    step="s3_upload",
+                )
+
+            try:
+                await ctx.debug("upload_attachment_to_card: updateCardField")
+                await client.update_card_field(
+                    data.card_id,
+                    data.field_id,
+                    [storage_path],
+                )
+            except Exception as exc:  # noqa: BLE001
+                await ctx.debug(
+                    f"upload_attachment_to_card: field update failed {exc!r}"
+                )
+                return build_upload_error_payload(
+                    message=map_upload_error_to_message(exc, "field_update"),
+                    step="field_update",
+                )
+
+            return build_upload_success_payload(
+                download_url=download_url if isinstance(download_url, str) else None,
+                file_name=file_name,
+                content_type=effective_type,
+                file_size=content_length,
+                field_id=data.field_id,
+                card_id=data.card_id,
+            )
+
+        async def _upload_to_table_flow(
+            ctx: Context[ServerSession, None],
+            data: UploadAttachmentToTableRecordInput,
+        ) -> dict[str, Any]:
+            file_name = data.file_name
+            effective_type = data.content_type or infer_content_type(file_name)
+            await ctx.debug(
+                f"upload_attachment_to_table_record: record_id={data.table_record_id!r} "
+                f"field_id={data.field_id!r} file_name={file_name!r}"
+            )
+            try:
+                if data.file_url:
+                    file_bytes = await _download_file_bytes(data.file_url.strip())
+                else:
+                    file_bytes = _decode_base64_file(data.file_content_base64 or "")
+            except httpx.HTTPError as exc:
+                return build_upload_error_payload(
+                    message=map_upload_error_to_message(exc, "file_download"),
+                    step="file_download",
+                )
+            except binascii.Error as exc:
+                return build_upload_error_payload(
+                    message=map_upload_error_to_message(exc, "file_download"),
+                    step="file_download",
+                )
+
+            content_length = len(file_bytes)
+            try:
+                await ctx.debug("upload_attachment_to_table_record: createPresignedUrl")
+                presigned = await client.create_presigned_url(
+                    data.organization_id,
+                    file_name,
+                    effective_type,
+                    content_length,
+                )
+            except Exception as exc:  # noqa: BLE001
+                return build_upload_error_payload(
+                    message=map_upload_error_to_message(exc, "presigned_url"),
+                    step="presigned_url",
+                )
+
+            upload_url = presigned.get("url")
+            download_url = presigned.get("download_url")
+            if not isinstance(upload_url, str) or not upload_url.strip():
+                return build_upload_error_payload(
+                    message=(
+                        "Pipefy did not return a presigned upload URL. "
+                        "Check organization_id and file_name, then retry."
+                    ),
+                    step="presigned_url",
+                )
+
+            put_result = await client.upload_file_to_s3(
+                upload_url.strip(),
+                file_bytes,
+                effective_type,
+            )
+            status = put_result.get("status_code", 0)
+            if not isinstance(status, int) or status >= 400:
+                return build_upload_error_payload(
+                    message=format_s3_upload_failure(put_result),
+                    step="s3_upload",
+                )
+
+            try:
+                storage_path = client.extract_storage_path(upload_url)
+            except ValueError as exc:
+                return build_upload_error_payload(
+                    message=str(exc),
+                    step="s3_upload",
+                )
+
+            try:
+                await ctx.debug(
+                    "upload_attachment_to_table_record: setTableRecordFieldValue"
+                )
+                await client.set_table_record_field_value(
+                    data.table_record_id,
+                    data.field_id,
+                    [storage_path],
+                )
+            except Exception as exc:  # noqa: BLE001
+                return build_upload_error_payload(
+                    message=map_upload_error_to_message(exc, "field_update"),
+                    step="field_update",
+                )
+
+            return build_upload_success_payload(
+                download_url=download_url if isinstance(download_url, str) else None,
+                file_name=file_name,
+                content_type=effective_type,
+                file_size=content_length,
+                field_id=data.field_id,
+                table_record_id=data.table_record_id,
+            )
+
+        @mcp.tool(
+            annotations=ToolAnnotations(readOnlyHint=False),
+        )
+        async def upload_attachment_to_card(
+            ctx: Context[ServerSession, None],
+            organization_id: str,
+            card_id: int,
+            field_id: str,
+            file_name: str,
+            file_url: str | None = None,
+            file_content_base64: str | None = None,
+            content_type: str | None = None,
+        ) -> dict[str, Any]:
+            """Upload one file to a card attachment field (presigned URL, S3 PUT, then updateCardField).
+
+            Handles one file per call. To attach multiple files, call this tool once per file.
+
+            Provide exactly one of ``file_url`` (HTTP download) or ``file_content_base64``. If
+            ``content_type`` is omitted, it is inferred from ``file_name``.
+
+            Args:
+                organization_id: Pipefy organization id (string).
+                card_id: Target card id.
+                field_id: Attachment field slug (e.g. "document_upload"), not the uuid.
+                file_name: File name including extension (used for storage and MIME guess).
+                file_url: Public or reachable URL to download the file bytes.
+                file_content_base64: Raw file bytes encoded as standard base64.
+                content_type: Optional MIME type; sent with the S3 upload and presigned request.
+            """
+            try:
+                data = UploadAttachmentToCardInput(
+                    organization_id=organization_id,
+                    card_id=card_id,
+                    field_id=field_id,
+                    file_name=file_name,
+                    file_url=file_url,
+                    file_content_base64=file_content_base64,
+                    content_type=content_type,
+                )
+            except ValidationError as exc:
+                return build_upload_error_payload(
+                    message=map_upload_error_to_message(exc, "validation"),
+                    step="validation",
+                )
+            return await _upload_to_card_flow(ctx, data)
+
+        @mcp.tool(
+            annotations=ToolAnnotations(readOnlyHint=False),
+        )
+        async def upload_attachment_to_table_record(
+            ctx: Context[ServerSession, None],
+            organization_id: str,
+            table_record_id: str,
+            field_id: str,
+            file_name: str,
+            file_url: str | None = None,
+            file_content_base64: str | None = None,
+            content_type: str | None = None,
+        ) -> dict[str, Any]:
+            """Upload one file to a table record attachment field (presigned URL, S3 PUT, setTableRecordFieldValue).
+
+            Handles one file per call. To attach multiple files, call this tool once per file.
+
+            Provide exactly one of ``file_url`` or ``file_content_base64``. If ``content_type`` is
+            omitted, it is inferred from ``file_name``.
+
+            Args:
+                organization_id: Pipefy organization id (string).
+                table_record_id: Database table record id.
+                field_id: Attachment field slug on the table record (e.g. "document_upload"), not the uuid.
+                file_name: File name including extension.
+                file_url: URL to download the file from.
+                file_content_base64: Base64-encoded file bytes.
+                content_type: Optional MIME type for storage.
+            """
+            try:
+                data = UploadAttachmentToTableRecordInput(
+                    organization_id=organization_id,
+                    table_record_id=table_record_id,
+                    field_id=field_id,
+                    file_name=file_name,
+                    file_url=file_url,
+                    file_content_base64=file_content_base64,
+                    content_type=content_type,
+                )
+            except ValidationError as exc:
+                return build_upload_error_payload(
+                    message=map_upload_error_to_message(exc, "validation"),
+                    step="validation",
+                )
+            return await _upload_to_table_flow(ctx, data)

--- a/src/pipefy_mcp/tools/registry.py
+++ b/src/pipefy_mcp/tools/registry.py
@@ -5,6 +5,7 @@ from mcp.server.fastmcp import FastMCP
 from pipefy_mcp.core.container import ServicesContainer
 from pipefy_mcp.tools.ai_agent_tools import AiAgentTools
 from pipefy_mcp.tools.ai_automation_tools import AiAutomationTools
+from pipefy_mcp.tools.attachment_tools import AttachmentTools
 from pipefy_mcp.tools.automation_tools import AutomationTools
 from pipefy_mcp.tools.field_condition_tools import FieldConditionTools
 from pipefy_mcp.tools.introspection_tools import IntrospectionTools
@@ -37,6 +38,7 @@ class ToolRegistry:
         TableTools.register(self.mcp, self.services_container.pipefy_client)
         RelationTools.register(self.mcp, self.services_container.pipefy_client)
         ReportTools.register(self.mcp, self.services_container.pipefy_client)
+        AttachmentTools.register(self.mcp, self.services_container.pipefy_client)
         MemberTools.register(self.mcp, self.services_container.pipefy_client)
         WebhookTools.register(self.mcp, self.services_container.pipefy_client)
         AutomationTools.register(self.mcp, self.services_container.pipefy_client)

--- a/tests/models/test_attachment.py
+++ b/tests/models/test_attachment.py
@@ -1,0 +1,196 @@
+"""Tests for attachment upload Pydantic models."""
+
+import pytest
+from pydantic import ValidationError
+
+from pipefy_mcp.models.attachment import (
+    UploadAttachmentToCardInput,
+    UploadAttachmentToTableRecordInput,
+    infer_content_type,
+)
+
+
+def _base_kwargs():
+    return {
+        "organization_id": "org-1",
+        "field_id": "field_abc",
+        "file_name": "doc.pdf",
+    }
+
+
+@pytest.mark.unit
+def test_upload_attachment_to_card_accepts_file_url():
+    data = UploadAttachmentToCardInput(
+        **_base_kwargs(),
+        card_id=42,
+        file_url="https://example.com/f.pdf",
+        file_content_base64=None,
+    )
+    assert data.file_url == "https://example.com/f.pdf"
+    assert data.file_content_base64 is None
+
+
+@pytest.mark.unit
+def test_upload_attachment_to_card_accepts_base64():
+    data = UploadAttachmentToCardInput(
+        **_base_kwargs(),
+        card_id=1,
+        file_url=None,
+        file_content_base64="YWFh",
+    )
+    assert data.file_url is None
+    assert data.file_content_base64 == "YWFh"
+
+
+@pytest.mark.unit
+def test_upload_attachment_to_card_rejects_both_sources():
+    with pytest.raises(ValueError, match="not both"):
+        UploadAttachmentToCardInput(
+            **_base_kwargs(),
+            card_id=1,
+            file_url="https://example.com/a",
+            file_content_base64="YWFh",
+        )
+
+
+@pytest.mark.unit
+def test_upload_attachment_to_card_rejects_neither_source():
+    with pytest.raises(ValueError, match="exactly one"):
+        UploadAttachmentToCardInput(
+            **_base_kwargs(),
+            card_id=1,
+            file_url=None,
+            file_content_base64=None,
+        )
+
+
+@pytest.mark.unit
+def test_upload_attachment_to_card_rejects_both_empty_strings():
+    with pytest.raises(ValueError, match="exactly one"):
+        UploadAttachmentToCardInput(
+            **_base_kwargs(),
+            card_id=1,
+            file_url="   ",
+            file_content_base64="",
+        )
+
+
+@pytest.mark.unit
+def test_upload_attachment_to_card_missing_required_field():
+    with pytest.raises(ValidationError):
+        UploadAttachmentToCardInput(
+            organization_id="o",
+            card_id=1,
+            field_id="f",
+            # file_name missing
+            file_url="https://x",
+        )
+
+
+@pytest.mark.unit
+def test_upload_attachment_to_card_content_type_optional_none():
+    data = UploadAttachmentToCardInput(
+        **_base_kwargs(),
+        card_id=1,
+        file_url="https://example.com/x",
+        content_type=None,
+    )
+    assert data.content_type is None
+
+
+@pytest.mark.unit
+def test_upload_attachment_to_table_record_uses_table_record_id_not_card_id():
+    data = UploadAttachmentToTableRecordInput(
+        organization_id="org-1",
+        table_record_id="tr-999",
+        field_id="f",
+        file_name="n.csv",
+        file_url="https://example.com/x",
+    )
+    assert data.table_record_id == "tr-999"
+    assert not hasattr(data, "card_id")
+
+
+@pytest.mark.unit
+def test_upload_attachment_to_table_record_accepts_base64():
+    data = UploadAttachmentToTableRecordInput(
+        organization_id="o",
+        table_record_id="tr-1",
+        field_id="f",
+        file_name="n.bin",
+        file_content_base64="QQ==",
+    )
+    assert data.file_content_base64 == "QQ=="
+
+
+@pytest.mark.unit
+def test_upload_attachment_to_table_record_rejects_both_sources():
+    with pytest.raises(ValueError, match="not both"):
+        UploadAttachmentToTableRecordInput(
+            organization_id="o",
+            table_record_id="tr-1",
+            field_id="f",
+            file_name="n",
+            file_url="https://a",
+            file_content_base64="YQ==",
+        )
+
+
+@pytest.mark.unit
+def test_upload_attachment_to_table_record_rejects_neither_source():
+    with pytest.raises(ValueError, match="exactly one"):
+        UploadAttachmentToTableRecordInput(
+            organization_id="o",
+            table_record_id="tr-1",
+            field_id="f",
+            file_name="n",
+        )
+
+
+@pytest.mark.unit
+def test_upload_attachment_to_table_record_missing_required_field():
+    with pytest.raises(ValidationError):
+        UploadAttachmentToTableRecordInput(
+            organization_id="o",
+            # table_record_id missing
+            field_id="f",
+            file_name="n",
+            file_url="https://x",
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "file_name,expected",
+    [
+        ("report.pdf", "application/pdf"),
+        ("data.csv", "text/csv"),
+        ("img.png", "image/png"),
+        ("photo.jpg", "image/jpeg"),
+        (
+            "letter.docx",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        ),
+        ("unknown.xyz", "application/octet-stream"),
+        ("noextension", "application/octet-stream"),
+    ],
+)
+def test_infer_content_type(file_name, expected):
+    assert infer_content_type(file_name) == expected
+
+
+@pytest.mark.unit
+def test_models_exported_from_package():
+    from pipefy_mcp.models import (
+        UploadAttachmentToCardInput as CardFromPkg,
+    )
+    from pipefy_mcp.models import (
+        UploadAttachmentToTableRecordInput as TableFromPkg,
+    )
+    from pipefy_mcp.models import (
+        infer_content_type as infer_from_pkg,
+    )
+
+    assert CardFromPkg is UploadAttachmentToCardInput
+    assert TableFromPkg is UploadAttachmentToTableRecordInput
+    assert infer_from_pkg is infer_content_type

--- a/tests/services/pipefy/test_schema_introspection_integration.py
+++ b/tests/services/pipefy/test_schema_introspection_integration.py
@@ -129,8 +129,9 @@ async def test_live_execute_invalid_field_surfaces_errors_payload(live_svc):
     )
     assert "errors" in data
     assert any(
-        "thisFieldDoesNotExistOnQuery" in (e.get("message") or "").lower()
+        "thisfielddoesnotexistonquery" in (e.get("message") or "").lower()
         or "cannot query field" in (e.get("message") or "").lower()
+        or "doesn't exist" in (e.get("message") or "").lower()
         for e in data["errors"]
         if isinstance(e, dict)
     )

--- a/tests/services/test_attachment_service.py
+++ b/tests/services/test_attachment_service.py
@@ -1,0 +1,276 @@
+"""Unit tests for AttachmentService and attachment GraphQL constants."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from graphql import print_ast
+
+from pipefy_mcp.services.pipefy.attachment_service import AttachmentService
+from pipefy_mcp.services.pipefy.client import PipefyClient
+from pipefy_mcp.services.pipefy.queries.attachment_queries import (
+    CREATE_PRESIGNED_URL_MUTATION,
+)
+from pipefy_mcp.settings import PipefySettings
+
+
+@pytest.fixture
+def mock_settings():
+    return PipefySettings(
+        graphql_url="https://api.pipefy.com/graphql",
+        oauth_url="https://auth.pipefy.com/oauth/token",
+        oauth_client="client_id",
+        oauth_secret="client_secret",
+    )
+
+
+def _make_service(mock_settings, return_value):
+    service = AttachmentService(settings=mock_settings)
+    service.execute_query = AsyncMock(return_value=return_value)
+    return service
+
+
+@pytest.mark.unit
+def test_create_presigned_url_mutation_document_shape():
+    doc = print_ast(CREATE_PRESIGNED_URL_MUTATION)
+    lowered = doc.lower()
+    stripped_lines = {ln.strip() for ln in doc.splitlines()}
+    assert "createpresignedurl" in lowered
+    assert "url" in stripped_lines
+    assert "downloadUrl" in stripped_lines
+    assert "clientMutationId" in stripped_lines
+    assert "$organizationId" in doc
+    assert "$fileName" in doc
+    assert "$contentType" in doc
+    assert "$contentLength" in doc
+
+
+@pytest.mark.unit
+def test_extract_storage_path_standard_presigned_url():
+    url = (
+        "https://pipefy-uploads.s3.amazonaws.com/orgs/550e8400-e29b-41d4-a716-446655440000/"
+        "uploads/660e8400-e29b-41d4-a716-446655440001/report.pdf"
+        "?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=test"
+    )
+    expected = (
+        "orgs/550e8400-e29b-41d4-a716-446655440000/"
+        "uploads/660e8400-e29b-41d4-a716-446655440001/report.pdf"
+    )
+    assert AttachmentService.extract_storage_path(url) == expected
+
+
+@pytest.mark.unit
+def test_extract_storage_path_special_characters_in_filename():
+    url = (
+        "https://bucket.s3.us-east-1.amazonaws.com/orgs/u1/uploads/u2/"
+        "my%20file%20%C3%A9t%C3%A9.txt?signature=abc"
+    )
+    assert (
+        AttachmentService.extract_storage_path(url)
+        == "orgs/u1/uploads/u2/my file été.txt"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "bad_url",
+    [
+        "https://example.com",
+        "https://example.com/",
+        "https://example.com/?q=1",
+    ],
+)
+def test_extract_storage_path_empty_path_raises(bad_url):
+    with pytest.raises(ValueError, match="no object path"):
+        AttachmentService.extract_storage_path(bad_url)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_presigned_url_success(mock_settings):
+    payload = {
+        "createPresignedUrl": {
+            "url": "https://s3.example.com/put?sig=1",
+            "downloadUrl": "https://app.pipefy.com/files/dl/xyz",
+            "clientMutationId": "cm1",
+        }
+    }
+    service = _make_service(mock_settings, payload)
+    result = await service.create_presigned_url("42", "doc.pdf")
+
+    service.execute_query.assert_awaited_once()
+    query, variables = service.execute_query.call_args[0]
+    assert query is CREATE_PRESIGNED_URL_MUTATION
+    assert variables["organizationId"] == "42"
+    assert variables["fileName"] == "doc.pdf"
+    assert variables["contentType"] is None
+    assert variables["contentLength"] is None
+    assert result["url"] == "https://s3.example.com/put?sig=1"
+    assert result["download_url"] == "https://app.pipefy.com/files/dl/xyz"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_presigned_url_with_optional_fields(mock_settings):
+    payload = {
+        "createPresignedUrl": {
+            "url": "https://s3.example.com/put",
+            "downloadUrl": "https://dl",
+            "clientMutationId": None,
+        }
+    }
+    service = _make_service(mock_settings, payload)
+    await service.create_presigned_url(
+        "99",
+        "a.bin",
+        content_type="application/octet-stream",
+        content_length=1024,
+    )
+    variables = service.execute_query.call_args[0][1]
+    assert variables["organizationId"] == "99"
+    assert variables["fileName"] == "a.bin"
+    assert variables["contentType"] == "application/octet-stream"
+    assert variables["contentLength"] == 1024
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_upload_file_to_s3_success(mock_settings):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = ""
+    mock_inner = MagicMock()
+    mock_inner.put = AsyncMock(return_value=mock_response)
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_inner)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+    service = AttachmentService(settings=mock_settings)
+    with patch("httpx.AsyncClient", return_value=mock_cm):
+        result = await service.upload_file_to_s3(
+            "https://s3.example.com/presigned",
+            b"hello",
+            content_type=None,
+        )
+
+    assert result == {"status_code": 200}
+    mock_inner.put.assert_awaited_once()
+    call_kw = mock_inner.put.call_args.kwargs
+    assert call_kw["content"] == b"hello"
+    assert call_kw["headers"] == {}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_upload_file_to_s3_forbidden_includes_body_snippet(mock_settings):
+    mock_response = MagicMock()
+    mock_response.status_code = 403
+    mock_response.text = "<?xml version='1.0'?><Error><Code>AccessDenied</Code></Error>"
+    mock_inner = MagicMock()
+    mock_inner.put = AsyncMock(return_value=mock_response)
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_inner)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+    service = AttachmentService(settings=mock_settings)
+    with patch("httpx.AsyncClient", return_value=mock_cm):
+        result = await service.upload_file_to_s3(
+            "https://s3.example.com/presigned",
+            b"x",
+            content_type=None,
+        )
+
+    assert result["status_code"] == 403
+    assert "body_snippet" in result
+    assert "AccessDenied" in result["body_snippet"]
+    assert "presigned" not in result["body_snippet"].lower()
+    assert "https://" not in result["body_snippet"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_upload_file_to_s3_sets_content_type_header(mock_settings):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = ""
+    mock_inner = MagicMock()
+    mock_inner.put = AsyncMock(return_value=mock_response)
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_inner)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+    service = AttachmentService(settings=mock_settings)
+    with patch("httpx.AsyncClient", return_value=mock_cm):
+        await service.upload_file_to_s3(
+            "https://s3.example.com/presigned",
+            b"%PDF",
+            content_type="application/pdf",
+        )
+
+    call_kw = mock_inner.put.call_args.kwargs
+    assert call_kw["headers"] == {"Content-Type": "application/pdf"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_pipefy_client_create_presigned_url_delegates_to_attachment_service():
+    attachment = AsyncMock()
+    attachment.create_presigned_url = AsyncMock(
+        return_value={"url": "https://s3/u", "download_url": "https://app/dl"}
+    )
+    client = PipefyClient.__new__(PipefyClient)
+    client._attachment_service = attachment
+
+    result = await client.create_presigned_url(
+        "302398434",
+        "doc.pdf",
+        content_type="application/pdf",
+        content_length=128,
+    )
+
+    attachment.create_presigned_url.assert_awaited_once_with(
+        "302398434",
+        "doc.pdf",
+        content_type="application/pdf",
+        content_length=128,
+    )
+    assert result == {"url": "https://s3/u", "download_url": "https://app/dl"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_pipefy_client_upload_file_to_s3_delegates_to_attachment_service():
+    attachment = AsyncMock()
+    attachment.upload_file_to_s3 = AsyncMock(return_value={"status_code": 200})
+    client = PipefyClient.__new__(PipefyClient)
+    client._attachment_service = attachment
+
+    result = await client.upload_file_to_s3(
+        "https://s3/presigned",
+        b"bytes",
+        content_type="text/plain",
+    )
+
+    attachment.upload_file_to_s3.assert_awaited_once_with(
+        "https://s3/presigned",
+        b"bytes",
+        content_type="text/plain",
+    )
+    assert result == {"status_code": 200}
+
+
+@pytest.mark.unit
+def test_pipefy_client_extract_storage_path_delegates_to_attachment_service():
+    attachment = MagicMock()
+    attachment.extract_storage_path = MagicMock(
+        return_value="orgs/o/uploads/u/file.pdf",
+    )
+    client = PipefyClient.__new__(PipefyClient)
+    client._attachment_service = attachment
+
+    assert (
+        client.extract_storage_path("https://bucket/file.pdf?x=1")
+        == "orgs/o/uploads/u/file.pdf"
+    )
+    attachment.extract_storage_path.assert_called_once_with(
+        "https://bucket/file.pdf?x=1",
+    )

--- a/tests/services/test_pipefy_facade.py
+++ b/tests/services/test_pipefy_facade.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from pipefy_mcp.services.pipefy.ai_agent_service import AiAgentService
+from pipefy_mcp.services.pipefy.attachment_service import AttachmentService
 from pipefy_mcp.services.pipefy.automation_service import AutomationService
 from pipefy_mcp.services.pipefy.card_service import CardService
 from pipefy_mcp.services.pipefy.client import PipefyClient
@@ -504,6 +505,7 @@ def test_pipefy_client_creates_services_with_shared_auth():
     assert isinstance(client._relation_service, RelationService)
     assert isinstance(client._automation_service, AutomationService)
     assert isinstance(client._ai_agent_service, AiAgentService)
+    assert isinstance(client._attachment_service, AttachmentService)
     assert isinstance(client._introspection_service, SchemaIntrospectionService)
     assert client._pipe_service._auth is not None, (
         "PipeService should have an auth instance"
@@ -536,6 +538,7 @@ def test_pipefy_client_creates_services_with_shared_auth():
     assert client._pipe_service._auth is client._relation_service._auth
     assert client._pipe_service._auth is client._automation_service._auth
     assert client._pipe_service._auth is client._introspection_service._auth
+    assert client._pipe_service._auth is client._attachment_service._auth
 
 
 @pytest.mark.unit

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -151,6 +151,8 @@ async def test_register_tools(client_session):
         "update_table",
         "update_table_field",
         "update_table_record",
+        "upload_attachment_to_card",
+        "upload_attachment_to_table_record",
         "validate_ai_agent_behaviors",
     ]
 

--- a/tests/tools/test_attachment_tool_helpers.py
+++ b/tests/tools/test_attachment_tool_helpers.py
@@ -58,7 +58,6 @@ def test_build_upload_error_payload_shape():
     assert out == {
         "success": False,
         "error": "failed",
-        "message": "failed",
         "step": "s3_upload",
     }
 

--- a/tests/tools/test_attachment_tool_helpers.py
+++ b/tests/tools/test_attachment_tool_helpers.py
@@ -1,0 +1,150 @@
+"""Unit tests for attachment_tool_helpers."""
+
+import binascii
+
+import httpx
+import pytest
+from gql.transport.exceptions import TransportQueryError
+from pydantic import ValidationError
+
+from pipefy_mcp.models.attachment import UploadAttachmentToCardInput
+from pipefy_mcp.tools.attachment_tool_helpers import (
+    build_upload_error_payload,
+    build_upload_success_payload,
+    format_s3_upload_failure,
+    map_upload_error_to_message,
+)
+
+
+@pytest.mark.unit
+def test_build_upload_success_payload_card():
+    out = build_upload_success_payload(
+        download_url="https://app.pipefy.com/storage/v1/signed/x",
+        file_name="doc.pdf",
+        content_type="application/pdf",
+        file_size=12,
+        field_id="f1",
+        card_id=99,
+    )
+    assert out["success"] is True
+    assert out["download_url"] == "https://app.pipefy.com/storage/v1/signed/x"
+    assert out["file_name"] == "doc.pdf"
+    assert out["content_type"] == "application/pdf"
+    assert out["file_size"] == 12
+    assert out["field_id"] == "f1"
+    assert out["card_id"] == 99
+    assert "table_record_id" not in out
+
+
+@pytest.mark.unit
+def test_build_upload_success_payload_table():
+    out = build_upload_success_payload(
+        download_url=None,
+        file_name="a.csv",
+        content_type="text/csv",
+        file_size=3,
+        field_id="tf",
+        table_record_id="401",
+    )
+    assert out["success"] is True
+    assert out["download_url"] is None
+    assert out["table_record_id"] == "401"
+    assert "card_id" not in out
+
+
+@pytest.mark.unit
+def test_build_upload_error_payload_shape():
+    out = build_upload_error_payload(message="failed", step="s3_upload")
+    assert out == {
+        "success": False,
+        "error": "failed",
+        "message": "failed",
+        "step": "s3_upload",
+    }
+
+
+@pytest.mark.unit
+def test_format_s3_upload_failure_with_snippet():
+    msg = format_s3_upload_failure(
+        {"status_code": 403, "body_snippet": "<Error>Access</Error>"}
+    )
+    assert "403" in msg
+    assert "Access" in msg
+
+
+@pytest.mark.unit
+def test_format_s3_upload_failure_without_snippet():
+    msg = format_s3_upload_failure({"status_code": 500})
+    assert "500" in msg
+
+
+@pytest.mark.unit
+def test_format_s3_upload_failure_expired_token_hint():
+    msg = format_s3_upload_failure(
+        {
+            "status_code": 403,
+            "body_snippet": "<Code>AccessDenied</Code><Message>Request has expired</Message>",
+        }
+    )
+    assert "403" in msg
+    assert "expired" in msg.lower()
+
+
+@pytest.mark.unit
+def test_format_s3_upload_failure_signature_mismatch_hint():
+    msg = format_s3_upload_failure(
+        {"status_code": 403, "body_snippet": "<Code>SignatureDoesNotMatch</Code>"}
+    )
+    assert "403" in msg
+    assert "signed" in msg.lower() or "SignatureDoesNotMatch" in msg
+
+
+@pytest.mark.unit
+def test_map_upload_error_validation_error():
+    with pytest.raises(ValidationError) as exc_info:
+        UploadAttachmentToCardInput(
+            organization_id="1",
+            card_id=1,
+            field_id="f",
+            file_name="x",
+            file_url="http://a",
+            file_content_base64="Ym9sZAo=",
+        )
+    text = map_upload_error_to_message(exc_info.value, "validation")
+    assert "file_url" in text or "file_content_base64" in text
+
+
+@pytest.mark.unit
+def test_map_upload_error_binascii():
+    exc = binascii.Error("incorrect padding")
+    text = map_upload_error_to_message(exc, "file_download")
+    assert "base64" in text.lower()
+
+
+@pytest.mark.unit
+def test_map_upload_error_http_status_file_download():
+    req = httpx.Request("GET", "https://example.com/f")
+    resp = httpx.Response(404, request=req)
+    exc = httpx.HTTPStatusError("x", request=req, response=resp)
+    text = map_upload_error_to_message(exc, "file_download")
+    assert "404" in text
+    assert "file_url" in text
+
+
+@pytest.mark.unit
+def test_map_upload_error_transport_query():
+    exc = TransportQueryError("q", errors=[{"message": "not allowed"}])
+    text = map_upload_error_to_message(exc, "field_update")
+    assert "not allowed" in text
+
+
+@pytest.mark.unit
+def test_map_upload_error_value_error():
+    text = map_upload_error_to_message(ValueError("bad path"), "presigned_url")
+    assert text == "bad path"
+
+
+@pytest.mark.unit
+def test_map_upload_error_generic():
+    text = map_upload_error_to_message(RuntimeError("boom"), "presigned_url")
+    assert "boom" in text

--- a/tests/tools/test_attachment_tools.py
+++ b/tests/tools/test_attachment_tools.py
@@ -1,0 +1,383 @@
+"""Tests for attachment MCP tools (mocked PipefyClient)."""
+
+import base64
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from gql.transport.exceptions import TransportQueryError
+from mcp.server.fastmcp import FastMCP
+from mcp.shared.memory import (
+    create_connected_server_and_client_session as create_client_session,
+)
+
+from pipefy_mcp.services.pipefy import PipefyClient
+from pipefy_mcp.tools.attachment_tools import AttachmentTools
+
+PRESIGNED_PUT_URL = (
+    "https://s3.example.com/orgs/o/u/f/report.pdf"
+    "?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=abc"
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture
+def mock_attachment_client():
+    client = MagicMock(PipefyClient)
+    client.create_presigned_url = AsyncMock(
+        return_value={
+            "url": PRESIGNED_PUT_URL,
+            "download_url": "https://app.pipefy.com/storage/v1/signed/z",
+        }
+    )
+    client.upload_file_to_s3 = AsyncMock(return_value={"status_code": 200})
+    client.extract_storage_path = MagicMock(return_value="orgs/o/u/f/report.pdf")
+    client.update_card_field = AsyncMock(return_value={"ok": True})
+    client.set_table_record_field_value = AsyncMock(return_value={"ok": True})
+    return client
+
+
+@pytest.fixture
+def attachment_mcp_server(mock_attachment_client):
+    mcp = FastMCP("Attachment Tools Test")
+    AttachmentTools.register(mcp, mock_attachment_client)
+    return mcp
+
+
+@pytest.fixture
+def attachment_session(attachment_mcp_server):
+    return create_client_session(
+        attachment_mcp_server,
+        read_timeout_seconds=timedelta(seconds=10),
+        raise_exceptions=True,
+    )
+
+
+def _httpx_download_cm_mock(content=b"hello-bytes"):
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.content = content
+    mock_inner = MagicMock()
+    mock_inner.get = AsyncMock(return_value=mock_response)
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_inner)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+    return mock_cm
+
+
+@pytest.mark.anyio
+async def test_upload_attachment_to_card_file_url_success(
+    attachment_session,
+    mock_attachment_client,
+    extract_payload,
+):
+    mock_cm = _httpx_download_cm_mock()
+    with patch(
+        "pipefy_mcp.tools.attachment_tools.httpx.AsyncClient", return_value=mock_cm
+    ):
+        async with attachment_session as session:
+            result = await session.call_tool(
+                "upload_attachment_to_card",
+                {
+                    "organization_id": "42",
+                    "card_id": 7,
+                    "field_id": "field-uuid",
+                    "file_name": "report.pdf",
+                    "file_url": "https://files.example.com/report.pdf",
+                },
+            )
+
+    assert result.isError is False
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    assert payload["card_id"] == 7
+    assert payload["field_id"] == "field-uuid"
+    assert payload["file_name"] == "report.pdf"
+    assert payload["content_type"] == "application/pdf"
+    assert payload["file_size"] == len(b"hello-bytes")
+    assert "download_url" in payload
+
+    mock_attachment_client.create_presigned_url.assert_awaited_once_with(
+        "42",
+        "report.pdf",
+        "application/pdf",
+        len(b"hello-bytes"),
+    )
+    mock_attachment_client.upload_file_to_s3.assert_awaited_once()
+    mock_attachment_client.update_card_field.assert_awaited_once_with(
+        7,
+        "field-uuid",
+        ["orgs/o/u/f/report.pdf"],
+    )
+
+
+@pytest.mark.anyio
+async def test_upload_attachment_to_card_base64_success(
+    attachment_session,
+    mock_attachment_client,
+    extract_payload,
+):
+    raw = b"hello"
+    b64 = base64.b64encode(raw).decode("ascii")
+
+    async with attachment_session as session:
+        result = await session.call_tool(
+            "upload_attachment_to_card",
+            {
+                "organization_id": "42",
+                "card_id": 7,
+                "field_id": "f1",
+                "file_name": "note.txt",
+                "file_content_base64": b64,
+            },
+        )
+
+    assert result.isError is False
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    assert payload["file_size"] == 5
+    mock_attachment_client.create_presigned_url.assert_awaited_once_with(
+        "42",
+        "note.txt",
+        "text/plain",
+        5,
+    )
+
+
+@pytest.mark.anyio
+async def test_upload_attachment_to_card_presigned_url_missing(
+    attachment_session,
+    mock_attachment_client,
+    extract_payload,
+):
+    mock_attachment_client.create_presigned_url = AsyncMock(
+        return_value={"url": None, "download_url": None}
+    )
+    async with attachment_session as session:
+        result = await session.call_tool(
+            "upload_attachment_to_card",
+            {
+                "organization_id": "42",
+                "card_id": 1,
+                "field_id": "f",
+                "file_name": "a.bin",
+                "file_content_base64": "YWIj",
+            },
+        )
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert payload["step"] == "presigned_url"
+    mock_attachment_client.upload_file_to_s3.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_upload_attachment_to_card_presigned_graphql_error(
+    attachment_session,
+    mock_attachment_client,
+    extract_payload,
+):
+    mock_attachment_client.create_presigned_url = AsyncMock(
+        side_effect=TransportQueryError("x", errors=[{"message": "org denied"}])
+    )
+    async with attachment_session as session:
+        result = await session.call_tool(
+            "upload_attachment_to_card",
+            {
+                "organization_id": "42",
+                "card_id": 1,
+                "field_id": "f",
+                "file_name": "a.bin",
+                "file_content_base64": "YWIj",
+            },
+        )
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert payload["step"] == "presigned_url"
+    assert "denied" in payload["error"]
+
+
+@pytest.mark.anyio
+async def test_upload_attachment_to_card_s3_failure(
+    attachment_session,
+    mock_attachment_client,
+    extract_payload,
+):
+    mock_attachment_client.upload_file_to_s3 = AsyncMock(
+        return_value={"status_code": 403, "body_snippet": "<Error/>"}
+    )
+    async with attachment_session as session:
+        result = await session.call_tool(
+            "upload_attachment_to_card",
+            {
+                "organization_id": "42",
+                "card_id": 1,
+                "field_id": "f",
+                "file_name": "a.bin",
+                "file_content_base64": "YWIj",
+            },
+        )
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert payload["step"] == "s3_upload"
+    mock_attachment_client.update_card_field.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_upload_attachment_to_card_field_update_failure(
+    attachment_session,
+    mock_attachment_client,
+    extract_payload,
+):
+    mock_attachment_client.update_card_field = AsyncMock(
+        side_effect=TransportQueryError(
+            "x", errors=[{"message": "field must be attachment"}]
+        )
+    )
+    async with attachment_session as session:
+        result = await session.call_tool(
+            "upload_attachment_to_card",
+            {
+                "organization_id": "42",
+                "card_id": 1,
+                "field_id": "f",
+                "file_name": "a.bin",
+                "file_content_base64": "YWIj",
+            },
+        )
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert payload["step"] == "field_update"
+    assert "attachment" in payload["error"]
+
+
+@pytest.mark.anyio
+async def test_upload_attachment_to_card_validation_both_sources(
+    attachment_session,
+    mock_attachment_client,
+    extract_payload,
+):
+    async with attachment_session as session:
+        result = await session.call_tool(
+            "upload_attachment_to_card",
+            {
+                "organization_id": "42",
+                "card_id": 1,
+                "field_id": "f",
+                "file_name": "a.bin",
+                "file_url": "https://x",
+                "file_content_base64": base64.b64encode(b"x").decode("ascii"),
+            },
+        )
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert payload["step"] == "validation"
+    mock_attachment_client.create_presigned_url.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_upload_attachment_to_table_record_file_url_success(
+    attachment_session,
+    mock_attachment_client,
+    extract_payload,
+):
+    mock_cm = _httpx_download_cm_mock(b"tbl")
+    with patch(
+        "pipefy_mcp.tools.attachment_tools.httpx.AsyncClient", return_value=mock_cm
+    ):
+        async with attachment_session as session:
+            result = await session.call_tool(
+                "upload_attachment_to_table_record",
+                {
+                    "organization_id": "42",
+                    "table_record_id": "999",
+                    "field_id": "tf",
+                    "file_name": "data.csv",
+                    "file_url": "https://files.example.com/data.csv",
+                },
+            )
+
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    assert payload["table_record_id"] == "999"
+    assert payload["content_type"] == "text/csv"
+    mock_attachment_client.set_table_record_field_value.assert_awaited_once_with(
+        "999",
+        "tf",
+        ["orgs/o/u/f/report.pdf"],
+    )
+
+
+@pytest.mark.anyio
+async def test_upload_attachment_to_table_record_base64_and_presigned_error(
+    attachment_session,
+    mock_attachment_client,
+    extract_payload,
+):
+    mock_attachment_client.create_presigned_url = AsyncMock(
+        return_value={"url": "", "download_url": None}
+    )
+    async with attachment_session as session:
+        result = await session.call_tool(
+            "upload_attachment_to_table_record",
+            {
+                "organization_id": "42",
+                "table_record_id": "r1",
+                "field_id": "tf",
+                "file_name": "x.bin",
+                "file_content_base64": "QQ==",
+            },
+        )
+    payload = extract_payload(result)
+    assert payload["step"] == "presigned_url"
+
+
+@pytest.mark.anyio
+async def test_upload_attachment_to_table_record_s3_failure(
+    attachment_session,
+    mock_attachment_client,
+    extract_payload,
+):
+    mock_attachment_client.upload_file_to_s3 = AsyncMock(
+        return_value={"status_code": 500}
+    )
+    async with attachment_session as session:
+        result = await session.call_tool(
+            "upload_attachment_to_table_record",
+            {
+                "organization_id": "42",
+                "table_record_id": "r1",
+                "field_id": "tf",
+                "file_name": "x.bin",
+                "file_content_base64": "QQ==",
+            },
+        )
+    payload = extract_payload(result)
+    assert payload["step"] == "s3_upload"
+
+
+@pytest.mark.anyio
+async def test_upload_attachment_to_table_field_update_failure(
+    attachment_session,
+    mock_attachment_client,
+    extract_payload,
+):
+    mock_attachment_client.set_table_record_field_value = AsyncMock(
+        side_effect=TransportQueryError("e", errors=[{"message": "invalid field"}])
+    )
+    async with attachment_session as session:
+        result = await session.call_tool(
+            "upload_attachment_to_table_record",
+            {
+                "organization_id": "42",
+                "table_record_id": "r1",
+                "field_id": "tf",
+                "file_name": "x.bin",
+                "file_content_base64": "QQ==",
+            },
+        )
+    payload = extract_payload(result)
+    assert payload["step"] == "field_update"

--- a/tests/tools/test_attachment_tools.py
+++ b/tests/tools/test_attachment_tools.py
@@ -12,12 +12,18 @@ from mcp.shared.memory import (
 )
 
 from pipefy_mcp.services.pipefy import PipefyClient
-from pipefy_mcp.tools.attachment_tools import AttachmentTools
+from pipefy_mcp.tools.attachment_tools import (
+    AttachmentTools,
+    _validate_url_safe,
+)
 
 PRESIGNED_PUT_URL = (
     "https://s3.example.com/orgs/o/u/f/report.pdf"
     "?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=abc"
 )
+
+# Patch target for SSRF validation (bypassed in tool-level tests that use mocked httpx)
+_VALIDATE_PATCH = "pipefy_mcp.tools.attachment_tools._validate_url_safe"
 
 
 @pytest.fixture
@@ -57,16 +63,90 @@ def attachment_session(attachment_mcp_server):
     )
 
 
-def _httpx_download_cm_mock(content=b"hello-bytes"):
+def _httpx_stream_cm_mock(content=b"hello-bytes", headers=None):
+    """Build a mock that mimics httpx streaming (AsyncClient → stream → aiter_bytes)."""
     mock_response = MagicMock()
     mock_response.raise_for_status = MagicMock()
-    mock_response.content = content
+    mock_response.headers = headers or {}
+
+    async def _aiter_bytes():
+        yield content
+
+    mock_response.aiter_bytes = _aiter_bytes
+
+    stream_cm = MagicMock()
+    stream_cm.__aenter__ = AsyncMock(return_value=mock_response)
+    stream_cm.__aexit__ = AsyncMock(return_value=False)
+
     mock_inner = MagicMock()
-    mock_inner.get = AsyncMock(return_value=mock_response)
+    mock_inner.stream = MagicMock(return_value=stream_cm)
+
     mock_cm = MagicMock()
     mock_cm.__aenter__ = AsyncMock(return_value=mock_inner)
     mock_cm.__aexit__ = AsyncMock(return_value=False)
     return mock_cm
+
+
+# ---------------------------------------------------------------------------
+# _validate_url_safe unit tests (RF-01: SSRF protection)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateUrlSafe:
+    def test_rejects_file_scheme(self):
+        with pytest.raises(ValueError, match="Only http and https"):
+            _validate_url_safe("file:///etc/passwd")
+
+    def test_rejects_ftp_scheme(self):
+        with pytest.raises(ValueError, match="Only http and https"):
+            _validate_url_safe("ftp://internal/data")
+
+    def test_rejects_no_hostname(self):
+        with pytest.raises(ValueError, match="no hostname"):
+            _validate_url_safe("https://")
+
+    @patch("pipefy_mcp.tools.attachment_tools.socket.getaddrinfo")
+    def test_rejects_localhost(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("127.0.0.1", 0))]
+        with pytest.raises(ValueError, match="private/internal"):
+            _validate_url_safe("https://localhost/secret")
+
+    @patch("pipefy_mcp.tools.attachment_tools.socket.getaddrinfo")
+    def test_rejects_metadata_endpoint(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (None, None, None, None, ("169.254.169.254", 0))
+        ]
+        with pytest.raises(ValueError, match="private/internal"):
+            _validate_url_safe("http://169.254.169.254/latest/meta-data/")
+
+    @patch("pipefy_mcp.tools.attachment_tools.socket.getaddrinfo")
+    def test_rejects_private_10_range(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("10.0.0.1", 0))]
+        with pytest.raises(ValueError, match="private/internal"):
+            _validate_url_safe("https://internal.corp/file.pdf")
+
+    @patch("pipefy_mcp.tools.attachment_tools.socket.getaddrinfo")
+    def test_rejects_private_172_range(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("172.16.0.1", 0))]
+        with pytest.raises(ValueError, match="private/internal"):
+            _validate_url_safe("https://internal.corp/file.pdf")
+
+    @patch("pipefy_mcp.tools.attachment_tools.socket.getaddrinfo")
+    def test_rejects_private_192_range(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("192.168.1.1", 0))]
+        with pytest.raises(ValueError, match="private/internal"):
+            _validate_url_safe("https://home.lan/file.pdf")
+
+    @patch("pipefy_mcp.tools.attachment_tools.socket.getaddrinfo")
+    def test_rejects_ipv6_loopback(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("::1", 0, 0, 0))]
+        with pytest.raises(ValueError, match="private/internal"):
+            _validate_url_safe("https://[::1]/file.pdf")
+
+    @patch("pipefy_mcp.tools.attachment_tools.socket.getaddrinfo")
+    def test_accepts_public_ip(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
+        _validate_url_safe("https://example.com/file.pdf")  # should not raise
 
 
 @pytest.mark.anyio
@@ -75,9 +155,12 @@ async def test_upload_attachment_to_card_file_url_success(
     mock_attachment_client,
     extract_payload,
 ):
-    mock_cm = _httpx_download_cm_mock()
-    with patch(
-        "pipefy_mcp.tools.attachment_tools.httpx.AsyncClient", return_value=mock_cm
+    mock_cm = _httpx_stream_cm_mock()
+    with (
+        patch(
+            "pipefy_mcp.tools.attachment_tools.httpx.AsyncClient", return_value=mock_cm
+        ),
+        patch(_VALIDATE_PATCH),
     ):
         async with attachment_session as session:
             result = await session.call_tool(
@@ -284,9 +367,12 @@ async def test_upload_attachment_to_table_record_file_url_success(
     mock_attachment_client,
     extract_payload,
 ):
-    mock_cm = _httpx_download_cm_mock(b"tbl")
-    with patch(
-        "pipefy_mcp.tools.attachment_tools.httpx.AsyncClient", return_value=mock_cm
+    mock_cm = _httpx_stream_cm_mock(b"tbl")
+    with (
+        patch(
+            "pipefy_mcp.tools.attachment_tools.httpx.AsyncClient", return_value=mock_cm
+        ),
+        patch(_VALIDATE_PATCH),
     ):
         async with attachment_session as session:
             result = await session.call_tool(
@@ -381,3 +467,106 @@ async def test_upload_attachment_to_table_field_update_failure(
         )
     payload = extract_payload(result)
     assert payload["step"] == "field_update"
+
+
+# ---------------------------------------------------------------------------
+# RF-01: SSRF rejection at tool level
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_upload_attachment_to_card_rejects_ssrf_url(
+    attachment_session,
+    mock_attachment_client,
+    extract_payload,
+):
+    """Private IP URL should fail at file_download step, never reaching presigned URL."""
+    with patch(
+        "pipefy_mcp.tools.attachment_tools.socket.getaddrinfo",
+        return_value=[(None, None, None, None, ("169.254.169.254", 0))],
+    ):
+        async with attachment_session as session:
+            result = await session.call_tool(
+                "upload_attachment_to_card",
+                {
+                    "organization_id": "42",
+                    "card_id": 1,
+                    "field_id": "f",
+                    "file_name": "secret.txt",
+                    "file_url": "http://169.254.169.254/latest/meta-data/",
+                },
+            )
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert payload["step"] == "file_download"
+    assert (
+        "private" in payload["error"].lower() or "internal" in payload["error"].lower()
+    )
+    mock_attachment_client.create_presigned_url.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_upload_attachment_to_card_rejects_file_scheme(
+    attachment_session,
+    mock_attachment_client,
+    extract_payload,
+):
+    async with attachment_session as session:
+        result = await session.call_tool(
+            "upload_attachment_to_card",
+            {
+                "organization_id": "42",
+                "card_id": 1,
+                "field_id": "f",
+                "file_name": "passwd.txt",
+                "file_url": "file:///etc/passwd",
+            },
+        )
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert payload["step"] == "file_download"
+    assert "http" in payload["error"].lower()
+    mock_attachment_client.create_presigned_url.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# RF-02: File size limit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_upload_attachment_to_card_rejects_oversized_content_length(
+    attachment_session,
+    mock_attachment_client,
+    extract_payload,
+):
+    """Content-Length header exceeding limit should fail before downloading body."""
+    oversized = str(200 * 1024 * 1024)  # 200 MiB
+    mock_cm = _httpx_stream_cm_mock(
+        content=b"small",
+        headers={"content-length": oversized},
+    )
+    with (
+        patch(
+            "pipefy_mcp.tools.attachment_tools.httpx.AsyncClient", return_value=mock_cm
+        ),
+        patch(_VALIDATE_PATCH),
+    ):
+        async with attachment_session as session:
+            result = await session.call_tool(
+                "upload_attachment_to_card",
+                {
+                    "organization_id": "42",
+                    "card_id": 1,
+                    "field_id": "f",
+                    "file_name": "huge.bin",
+                    "file_url": "https://files.example.com/huge.bin",
+                },
+            )
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert payload["step"] == "file_download"
+    assert (
+        "too large" in payload["error"].lower() or "limit" in payload["error"].lower()
+    )
+    mock_attachment_client.create_presigned_url.assert_not_called()

--- a/tests/tools/test_attachment_tools_live.py
+++ b/tests/tools/test_attachment_tools_live.py
@@ -1,0 +1,362 @@
+"""Live attachment upload flows (real Pipefy + S3).
+
+Skips when ``PIPEFY_*`` OAuth is missing or when optional org/card/record env
+IDs are unset. Use a disposable sandbox card/record and attachment fields.
+
+Run card + table end-to-end (requires all IDs for each test):
+    uv run pytest tests/tools/test_attachment_tools_live.py -m integration -v
+
+Run S3 error matrix subset (requires org only + live test flag):
+    PIPE_ATTACHMENT_LIVE_S3_MATRIX=1 \\
+    uv run pytest tests/tools/test_attachment_tools_live.py -m integration -k s3_put -v
+
+Optional long-run expired-URL check (waits for ``PIPE_ATTACHMENT_S3_EXPIRY_WAIT_SECONDS``):
+    PIPE_ATTACHMENT_LIVE_S3_MATRIX=1 PIPE_ATTACHMENT_S3_EXPIRY_WAIT_SECONDS=310 \\
+    uv run pytest tests/tools/test_attachment_tools_live.py -m integration -k expired -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import os
+import uuid
+from datetime import timedelta
+from unittest.mock import patch
+
+import httpx
+import pytest
+from mcp.server.fastmcp import FastMCP
+from mcp.shared.memory import (
+    create_connected_server_and_client_session as create_client_session,
+)
+
+from pipefy_mcp.server import mcp as mcp_server
+from pipefy_mcp.services.pipefy import PipefyClient
+from pipefy_mcp.settings import settings
+from pipefy_mcp.tools.attachment_tools import AttachmentTools
+
+
+def _pipefy_live_configured() -> bool:
+    p = settings.pipefy
+    return bool(
+        p.graphql_url
+        and str(p.graphql_url).startswith(("http://", "https://"))
+        and p.oauth_url
+        and str(p.oauth_url).startswith(("http://", "https://"))
+        and p.oauth_client
+        and p.oauth_secret
+    )
+
+
+def _require_live_creds() -> None:
+    if not _pipefy_live_configured():
+        pytest.skip(
+            "Pipefy credentials not configured (PIPEFY_GRAPHQL_URL + OAuth in .env)"
+        )
+
+
+def _card_upload_env():
+    org = os.environ.get("PIPE_ATTACHMENT_LIVE_ORG_ID")
+    card_raw = os.environ.get("PIPE_ATTACHMENT_LIVE_CARD_ID")
+    field = os.environ.get("PIPE_ATTACHMENT_LIVE_CARD_FIELD_ID")
+    if not (org and card_raw and field):
+        return None
+    return org.strip(), int(card_raw), field.strip()
+
+
+def _table_upload_env():
+    org = os.environ.get("PIPE_ATTACHMENT_LIVE_ORG_ID")
+    rec = os.environ.get("PIPE_ATTACHMENT_LIVE_TABLE_RECORD_ID")
+    field = os.environ.get("PIPE_ATTACHMENT_LIVE_TABLE_FIELD_ID")
+    if not (org and rec and field):
+        return None
+    return org.strip(), rec.strip(), field.strip()
+
+
+def _find_named_field_value(fields, field_id: str):
+    for row in fields or []:
+        if str(row.get("name")) == str(field_id):
+            return row.get("value")
+    return None
+
+
+def _assert_field_shows_upload(value, file_name: str) -> None:
+    text = value if isinstance(value, str) else repr(value)
+    assert text, "field value empty after upload"
+    ok = file_name in text or "orgs/" in text
+    assert ok, f"attachment field value did not reference file/path: {text!r}"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture
+def live_pipefy_client():
+    _require_live_creds()
+    return PipefyClient(settings=settings.pipefy)
+
+
+@pytest.fixture
+def live_attachment_mcp(live_pipefy_client):
+    mcp = FastMCP("Attachment tools live")
+    AttachmentTools.register(mcp, live_pipefy_client)
+    return mcp
+
+
+@pytest.mark.integration
+@pytest.mark.anyio
+async def test_live_upload_attachment_to_card_end_to_end(
+    live_attachment_mcp,
+    extract_payload,
+):
+    """Full MCP flow: presigned URL, S3 PUT, updateCardField, read-back on card."""
+    _require_live_creds()
+    env = _card_upload_env()
+    if not env:
+        pytest.skip(
+            "Set PIPE_ATTACHMENT_LIVE_ORG_ID, PIPE_ATTACHMENT_LIVE_CARD_ID, "
+            "and PIPE_ATTACHMENT_LIVE_CARD_FIELD_ID (attachment field uuid)"
+        )
+    org_id, card_id, field_id = env
+    unique = uuid.uuid4().hex[:12]
+    file_name = f"mcp-live-{unique}.txt"
+    body = f"pipefy-mcp live attachment {unique}\n".encode()
+    b64 = base64.standard_b64encode(body).decode("ascii")
+
+    async with create_client_session(
+        live_attachment_mcp,
+        read_timeout_seconds=timedelta(seconds=120),
+        raise_exceptions=True,
+    ) as session:
+        result = await session.call_tool(
+            "upload_attachment_to_card",
+            {
+                "organization_id": org_id,
+                "card_id": card_id,
+                "field_id": field_id,
+                "file_name": file_name,
+                "file_content_base64": b64,
+                "content_type": "text/plain",
+            },
+        )
+    assert result.isError is False
+    payload = extract_payload(result)
+    assert payload.get("success") is True
+    assert payload.get("file_name") == file_name
+    assert payload.get("field_id") == field_id
+    assert payload.get("card_id") == card_id
+
+    client = PipefyClient(settings=settings.pipefy)
+    data = await client.get_card(card_id, include_fields=True)
+    card = data.get("card") or {}
+    value = _find_named_field_value(card.get("fields"), field_id)
+    _assert_field_shows_upload(value, file_name)
+
+
+@pytest.mark.integration
+@pytest.mark.anyio
+async def test_live_upload_attachment_to_table_record_end_to_end(
+    live_attachment_mcp,
+    extract_payload,
+):
+    """Full MCP path for table records: setTableRecordFieldValue + read-back."""
+    _require_live_creds()
+    env = _table_upload_env()
+    if not env:
+        pytest.skip(
+            "Set PIPE_ATTACHMENT_LIVE_ORG_ID, PIPE_ATTACHMENT_LIVE_TABLE_RECORD_ID, "
+            "and PIPE_ATTACHMENT_LIVE_TABLE_FIELD_ID"
+        )
+    org_id, record_id, field_id = env
+    unique = uuid.uuid4().hex[:12]
+    file_name = f"mcp-live-table-{unique}.txt"
+    body = f"pipefy-mcp table live {unique}\n".encode()
+    b64 = base64.standard_b64encode(body).decode("ascii")
+
+    async with create_client_session(
+        live_attachment_mcp,
+        read_timeout_seconds=timedelta(seconds=120),
+        raise_exceptions=True,
+    ) as session:
+        result = await session.call_tool(
+            "upload_attachment_to_table_record",
+            {
+                "organization_id": org_id,
+                "table_record_id": record_id,
+                "field_id": field_id,
+                "file_name": file_name,
+                "file_content_base64": b64,
+                "content_type": "text/plain",
+            },
+        )
+    assert result.isError is False
+    payload = extract_payload(result)
+    assert payload.get("success") is True
+    assert payload.get("table_record_id") == record_id
+
+    client = PipefyClient(settings=settings.pipefy)
+    data = await client.get_table_record(record_id)
+    rec = data.get("table_record") or {}
+    value = _find_named_field_value(rec.get("record_fields"), field_id)
+    _assert_field_shows_upload(value, file_name)
+
+
+@pytest.mark.integration
+@pytest.mark.anyio
+async def test_live_pipeclaw_mcp_upload_attachment_to_card(extract_payload):
+    """Registers AttachmentTools via the production app (ToolRegistry wiring)."""
+    _require_live_creds()
+    env = _card_upload_env()
+    if not env:
+        pytest.skip(
+            "Set PIPE_ATTACHMENT_LIVE_ORG_ID, PIPE_ATTACHMENT_LIVE_CARD_ID, "
+            "PIPE_ATTACHMENT_LIVE_CARD_FIELD_ID"
+        )
+    org_id, card_id, field_id = env
+    unique = uuid.uuid4().hex[:12]
+    file_name = f"mcp-app-live-{unique}.txt"
+    body = f"app-registry {unique}\n".encode()
+    b64 = base64.standard_b64encode(body).decode("ascii")
+
+    with patch("pipefy_mcp.server.settings", settings):
+        async with create_client_session(
+            mcp_server,
+            read_timeout_seconds=timedelta(seconds=120),
+            raise_exceptions=True,
+        ) as session:
+            result = await session.call_tool(
+                "upload_attachment_to_card",
+                {
+                    "organization_id": org_id,
+                    "card_id": card_id,
+                    "field_id": field_id,
+                    "file_name": file_name,
+                    "file_content_base64": b64,
+                },
+            )
+    assert result.isError is False
+    payload = extract_payload(result)
+    assert payload.get("success") is True
+
+
+def _s3_matrix_enabled() -> bool:
+    return os.environ.get("PIPE_ATTACHMENT_LIVE_S3_MATRIX", "").strip() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.anyio
+async def test_live_s3_put_mismatched_content_length():
+    """PUT body size must match ``contentLength`` given to createPresignedUrl."""
+    _require_live_creds()
+    org = os.environ.get("PIPE_ATTACHMENT_LIVE_ORG_ID")
+    if not org:
+        pytest.skip("Set PIPE_ATTACHMENT_LIVE_ORG_ID")
+    if not _s3_matrix_enabled():
+        pytest.skip("Set PIPE_ATTACHMENT_LIVE_S3_MATRIX=1 to run S3 PUT matrix tests")
+
+    client = PipefyClient(settings=settings.pipefy)
+    file_name = f"s3-mismatch-{uuid.uuid4().hex[:10]}.bin"
+    signed_len = 200
+    presigned = await client.create_presigned_url(
+        organization_id=org,
+        file_name=file_name,
+        content_type="application/octet-stream",
+        content_length=signed_len,
+    )
+    url = presigned.get("url")
+    assert isinstance(url, str) and url.strip(), "no presigned url"
+
+    wrong_body = b"x" * 3
+    result = await client.upload_file_to_s3(
+        presigned_url=url.strip(),
+        file_bytes=wrong_body,
+        content_type="application/octet-stream",
+    )
+    code = result.get("status_code", 0)
+    if code < 400:
+        pytest.skip(
+            "Presigned URL did not reject mismatched contentLength in this environment; "
+            "VD-6 still documents the usual AWS 4xx behavior."
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.anyio
+async def test_live_s3_put_expired_presigned_url():
+    """After X-Amz-Expires, PUT should fail (403 typical). Long wait — opt-in."""
+    _require_live_creds()
+    org = os.environ.get("PIPE_ATTACHMENT_LIVE_ORG_ID")
+    if not org:
+        pytest.skip("Set PIPE_ATTACHMENT_LIVE_ORG_ID")
+    if not _s3_matrix_enabled():
+        pytest.skip("Set PIPE_ATTACHMENT_LIVE_S3_MATRIX=1 for S3 matrix tests")
+
+    wait_raw = os.environ.get("PIPE_ATTACHMENT_S3_EXPIRY_WAIT_SECONDS", "").strip()
+    if not wait_raw:
+        pytest.skip(
+            "Set PIPE_ATTACHMENT_S3_EXPIRY_WAIT_SECONDS "
+            "(e.g. 310) to wait past presigned expiry"
+        )
+    wait_sec = int(wait_raw)
+
+    client = PipefyClient(settings=settings.pipefy)
+    file_name = f"s3-expiry-{uuid.uuid4().hex[:10]}.txt"
+    presigned = await client.create_presigned_url(
+        organization_id=org,
+        file_name=file_name,
+        content_type="text/plain",
+        content_length=4,
+    )
+    url = presigned.get("url")
+    assert isinstance(url, str) and url.strip()
+
+    await asyncio.sleep(wait_sec)
+    result = await client.upload_file_to_s3(
+        presigned_url=url.strip(),
+        file_bytes=b"abcd",
+        content_type="text/plain",
+    )
+    code = result.get("status_code", 0)
+    if code < 400:
+        pytest.skip(
+            "PUT still succeeded after wait; increase PIPE_ATTACHMENT_S3_EXPIRY_WAIT_SECONDS "
+            "past X-Amz-Expires or confirm clock skew."
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.anyio
+async def test_live_s3_put_omits_content_type_when_signed():
+    """If Content-Type is signed, omitting it on PUT should fail."""
+    _require_live_creds()
+    org = os.environ.get("PIPE_ATTACHMENT_LIVE_ORG_ID")
+    if not org:
+        pytest.skip("Set PIPE_ATTACHMENT_LIVE_ORG_ID")
+    if not _s3_matrix_enabled():
+        pytest.skip("Set PIPE_ATTACHMENT_LIVE_S3_MATRIX=1 for S3 matrix tests")
+
+    client = PipefyClient(settings=settings.pipefy)
+    file_name = f"s3-no-ctype-{uuid.uuid4().hex[:10]}.txt"
+    body = b"abcd"
+    presigned = await client.create_presigned_url(
+        organization_id=org,
+        file_name=file_name,
+        content_type="text/plain",
+        content_length=len(body),
+    )
+    url = presigned.get("url")
+    assert isinstance(url, str) and url.strip()
+
+    async with httpx.AsyncClient() as http:
+        response = await http.put(url.strip(), content=body)
+    if response.status_code < 400:
+        pytest.skip(
+            "Upload succeeded without Content-Type; signature may not bind it in this environment."
+        )

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -25,6 +25,7 @@ class TestToolRegistry:
     @patch("pipefy_mcp.tools.registry.AutomationTools.register")
     @patch("pipefy_mcp.tools.registry.WebhookTools.register")
     @patch("pipefy_mcp.tools.registry.MemberTools.register")
+    @patch("pipefy_mcp.tools.registry.AttachmentTools.register")
     @patch("pipefy_mcp.tools.registry.ReportTools.register")
     @patch("pipefy_mcp.tools.registry.RelationTools.register")
     @patch("pipefy_mcp.tools.registry.TableTools.register")
@@ -39,6 +40,7 @@ class TestToolRegistry:
         mock_table_tools_register,
         mock_relation_tools_register,
         mock_report_tools_register,
+        mock_attachment_tools_register,
         mock_member_tools_register,
         mock_webhook_tools_register,
         mock_automation_tools_register,
@@ -62,6 +64,7 @@ class TestToolRegistry:
         mock_table_tools_register.assert_called_once_with(mock_mcp, mock_client)
         mock_relation_tools_register.assert_called_once_with(mock_mcp, mock_client)
         mock_report_tools_register.assert_called_once_with(mock_mcp, mock_client)
+        mock_attachment_tools_register.assert_called_once_with(mock_mcp, mock_client)
         mock_member_tools_register.assert_called_once_with(mock_mcp, mock_client)
         mock_webhook_tools_register.assert_called_once_with(mock_mcp, mock_client)
         mock_automation_tools_register.assert_called_once_with(mock_mcp, mock_client)
@@ -91,6 +94,7 @@ class TestToolRegistry:
     @patch("pipefy_mcp.tools.registry.AutomationTools.register")
     @patch("pipefy_mcp.tools.registry.WebhookTools.register")
     @patch("pipefy_mcp.tools.registry.MemberTools.register")
+    @patch("pipefy_mcp.tools.registry.AttachmentTools.register")
     @patch("pipefy_mcp.tools.registry.ReportTools.register")
     @patch("pipefy_mcp.tools.registry.RelationTools.register")
     @patch("pipefy_mcp.tools.registry.TableTools.register")
@@ -105,6 +109,7 @@ class TestToolRegistry:
         mock_table_tools_register,
         mock_relation_tools_register,
         mock_report_tools_register,
+        mock_attachment_tools_register,
         mock_member_tools_register,
         mock_webhook_tools_register,
         mock_automation_tools_register,
@@ -131,6 +136,7 @@ class TestToolRegistry:
         mock_table_tools_register.assert_called_once_with(mock_mcp, mock_client)
         mock_relation_tools_register.assert_called_once_with(mock_mcp, mock_client)
         mock_report_tools_register.assert_called_once_with(mock_mcp, mock_client)
+        mock_attachment_tools_register.assert_called_once_with(mock_mcp, mock_client)
         mock_member_tools_register.assert_called_once_with(mock_mcp, mock_client)
         mock_webhook_tools_register.assert_called_once_with(mock_mcp, mock_client)
         mock_automation_tools_register.assert_called_once_with(mock_mcp, mock_client)

--- a/uv.lock
+++ b/uv.lock
@@ -693,6 +693,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "gql", extra = ["httpx"] },
+    { name = "httpx" },
     { name = "httpx-auth" },
     { name = "mcp", extra = ["cli"] },
     { name = "openpyxl" },
@@ -715,6 +716,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "gql", extras = ["httpx"], specifier = ">=3.5.2" },
+    { name = "httpx", specifier = ">=0.27.0" },
     { name = "httpx-auth", specifier = ">=0.23.1" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.25.0" },
     { name = "openpyxl", specifier = ">=3.1.5" },


### PR DESCRIPTION
## Summary
Adds orchestrated attachment upload via Pipefy presigned URLs, S3 PUT, and field updates:
- `upload_attachment_to_card` — `updateCardField` with storage path array
- `upload_attachment_to_table_record` — `setTableRecordFieldValue`

Also includes `AttachmentService`, Pydantic inputs, SSRF-safe `file_url` download (public IPs only, 100 MiB cap, streamed read), optional live integration tests, docs/tool count updates (114 tools), and `fetch_schema_from_transport=False` on gql clients to avoid per-request schema fetch.

## Testing
- `uv run pytest -m "not integration" -v` — all unit tests pass
- Optional: `uv run pytest -m integration` with `PIPEFY_*` and attachment env vars (see `tests/tools/test_attachment_tools_live.py`)

## Notes
- `field_id` for attachment fields is the **slug** (e.g. from `get_phase_fields`), not the uuid, for `updateCardField` compatibility.
