### PR TITLE
fix: coerce numeric Pipefy IDs to strings for MCP tools

### DIFF
--- a/src/pipefy_mcp/models/__init__.py
+++ b/src/pipefy_mcp/models/__init__.py
@@ -7,8 +7,10 @@ from pipefy_mcp.models.attachment import (
     UploadAttachmentToTableRecordInput,
     infer_content_type,
 )
+from pipefy_mcp.models.validators import PipefyId
 
 __all__ = [
+    "PipefyId",
     "UploadAttachmentToCardInput",
     "UploadAttachmentToTableRecordInput",
     "infer_content_type",

--- a/src/pipefy_mcp/models/attachment.py
+++ b/src/pipefy_mcp/models/attachment.py
@@ -7,6 +7,8 @@ from typing import Self
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
+from pipefy_mcp.models.validators import PipefyId
+
 APPLICATION_OCTET_STREAM = "application/octet-stream"
 
 # ``mimetypes`` maps ``.xyz`` to ``chemical/x-xyz`` on many systems; for generic uploads
@@ -62,9 +64,9 @@ class UploadAttachmentToCardInput(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    organization_id: str
+    organization_id: PipefyId
     card_id: int
-    field_id: str
+    field_id: PipefyId
     file_name: str
     file_url: str | None = None
     file_content_base64: str | None = None
@@ -82,9 +84,9 @@ class UploadAttachmentToTableRecordInput(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    organization_id: str
-    table_record_id: str
-    field_id: str
+    organization_id: PipefyId
+    table_record_id: PipefyId
+    field_id: PipefyId
     file_name: str
     file_url: str | None = None
     file_content_base64: str | None = None

--- a/src/pipefy_mcp/models/validators.py
+++ b/src/pipefy_mcp/models/validators.py
@@ -11,3 +11,26 @@ NonBlankStr = Annotated[
     BeforeValidator(str.strip),
     Field(min_length=1, description="Non-empty string after stripping whitespace"),
 ]
+
+
+def _coerce_id_to_str(v: object) -> object:
+    """Coerce numeric values to string for ID fields.
+
+    Why: mcporter CLI infers unquoted numeric values as int, but Pipefy IDs
+    are always strings in the GraphQL API.  ``bool`` is excluded because
+    ``isinstance(True, int)`` is ``True`` in Python and coercing ``True`` →
+    ``"1"`` would silently hide a caller bug.
+    """
+    if isinstance(v, bool):
+        return v
+    if isinstance(v, (int, float)):
+        return str(int(v))
+    return v
+
+
+PipefyId = Annotated[str, BeforeValidator(_coerce_id_to_str)]
+"""String ID that accepts numeric input and coerces it to ``str``.
+
+Mitigates clients (e.g. mcporter) that send ``25901`` instead of ``"25901"``
+for ID parameters.
+"""

--- a/src/pipefy_mcp/tools/ai_automation_tools.py
+++ b/src/pipefy_mcp/tools/ai_automation_tools.py
@@ -10,6 +10,7 @@ from pipefy_mcp.models.ai_automation import (
     CreateAiAutomationInput,
     UpdateAiAutomationInput,
 )
+from pipefy_mcp.models.validators import PipefyId
 from pipefy_mcp.services.pipefy.ai_automation_service import AiAutomationService
 from pipefy_mcp.tools.ai_tool_helpers import (
     build_ai_tool_error,
@@ -31,8 +32,8 @@ class AiAutomationTools:
         async def create_ai_automation(
             ctx: Context,
             name: str,
-            event_id: str,
-            pipe_id: str,
+            event_id: PipefyId,
+            pipe_id: PipefyId,
             prompt: str,
             field_ids: list[str],
             skills_ids: list[str] | None = None,
@@ -87,7 +88,7 @@ class AiAutomationTools:
         )
         async def update_ai_automation(
             ctx: Context,
-            automation_id: str,
+            automation_id: PipefyId,
             name: str | None = None,
             active: bool | None = None,
             prompt: str | None = None,

--- a/src/pipefy_mcp/tools/attachment_tools.py
+++ b/src/pipefy_mcp/tools/attachment_tools.py
@@ -20,6 +20,7 @@ from pipefy_mcp.models.attachment import (
     UploadAttachmentToTableRecordInput,
     infer_content_type,
 )
+from pipefy_mcp.models.validators import PipefyId
 from pipefy_mcp.services.pipefy import PipefyClient
 from pipefy_mcp.tools.attachment_tool_helpers import (
     build_upload_error_payload,
@@ -239,9 +240,9 @@ class AttachmentTools:
         )
         async def upload_attachment_to_card(
             ctx: Context[ServerSession, None],
-            organization_id: str,
+            organization_id: PipefyId,
             card_id: int,
-            field_id: str,
+            field_id: PipefyId,
             file_name: str,
             file_url: str | None = None,
             file_content_base64: str | None = None,
@@ -302,9 +303,9 @@ class AttachmentTools:
         )
         async def upload_attachment_to_table_record(
             ctx: Context[ServerSession, None],
-            organization_id: str,
-            table_record_id: str,
-            field_id: str,
+            organization_id: PipefyId,
+            table_record_id: PipefyId,
+            field_id: PipefyId,
             file_name: str,
             file_url: str | None = None,
             file_content_base64: str | None = None,

--- a/src/pipefy_mcp/tools/observability_tools.py
+++ b/src/pipefy_mcp/tools/observability_tools.py
@@ -7,6 +7,7 @@ from typing import Any
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
+from pipefy_mcp.models.validators import PipefyId
 from pipefy_mcp.services.pipefy import PipefyClient
 from pipefy_mcp.tools.observability_tool_helpers import (
     build_observability_error_payload,
@@ -113,7 +114,7 @@ class ObservabilityTools:
             annotations=ToolAnnotations(readOnlyHint=True),
         )
         async def get_automation_logs(
-            automation_id: str,
+            automation_id: PipefyId,
             first: int = 30,
             after: str | None = None,
             status: str | None = None,
@@ -130,7 +131,7 @@ class ObservabilityTools:
                 search_term: Free-text search within logs.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
-            if not automation_id or not isinstance(automation_id, str):
+            if not automation_id:
                 return build_observability_error_payload(
                     message="Invalid 'automation_id': provide a non-empty string.",
                 )
@@ -158,7 +159,7 @@ class ObservabilityTools:
             annotations=ToolAnnotations(readOnlyHint=True),
         )
         async def get_automation_logs_by_repo(
-            repo_id: str,
+            repo_id: PipefyId,
             first: int = 30,
             after: str | None = None,
             status: str | None = None,
@@ -175,7 +176,7 @@ class ObservabilityTools:
                 search_term: Free-text search within logs.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
-            if not repo_id or not isinstance(repo_id, str):
+            if not repo_id:
                 return build_observability_error_payload(
                     message="Invalid 'repo_id': provide a non-empty string.",
                 )
@@ -371,7 +372,7 @@ class ObservabilityTools:
             annotations=ToolAnnotations(readOnlyHint=True),
         )
         async def get_automation_jobs_export(
-            export_id: str,
+            export_id: PipefyId,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Poll an automation jobs export by id. Returns `status` (`created`, `processing`, `finished`, `failed`) and `fileUrl` when the API provides a signed download link (often after `finished`). Use after `export_automation_jobs`; repeat until `finished` or `failed`. The tool does not download the file — use `fileUrl` over HTTP if needed.
@@ -380,7 +381,7 @@ class ObservabilityTools:
                 export_id: Export id from `export_automation_jobs` result (`automationJobsExport.id`).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
-            if not export_id or not isinstance(export_id, str):
+            if not export_id:
                 return build_observability_error_payload(
                     message="Invalid 'export_id': provide a non-empty string.",
                 )
@@ -398,7 +399,7 @@ class ObservabilityTools:
             annotations=ToolAnnotations(readOnlyHint=True),
         )
         async def get_automation_jobs_export_csv(
-            export_id: str,
+            export_id: PipefyId,
             max_output_chars: int = _DEFAULT_CSV_CHARS,
             max_download_bytes: int = _DEFAULT_EXPORT_DOWNLOAD_BYTES,
             debug: bool = False,
@@ -411,7 +412,7 @@ class ObservabilityTools:
                 max_download_bytes: Max xlsx size to download (4 KiB–80 MiB); default 50 MiB.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
-            if not export_id or not isinstance(export_id, str):
+            if not export_id:
                 return build_observability_error_payload(
                     message="Invalid 'export_id': provide a non-empty string.",
                 )

--- a/src/pipefy_mcp/tools/organization_tools.py
+++ b/src/pipefy_mcp/tools/organization_tools.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
+from pipefy_mcp.models.validators import PipefyId
 from pipefy_mcp.services.pipefy import PipefyClient
 from pipefy_mcp.tools.introspection_tool_helpers import (
     build_error_payload,
@@ -22,7 +23,7 @@ class OrganizationTools:
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
         )
-        async def get_organization(organization_id: str) -> dict:
+        async def get_organization(organization_id: PipefyId) -> dict:
             """Fetch Pipefy organization details by ID.
 
             Returns id, uuid, name, plan, role, members count, pipes count,

--- a/src/pipefy_mcp/tools/report_tools.py
+++ b/src/pipefy_mcp/tools/report_tools.py
@@ -8,6 +8,7 @@ from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
 from mcp.types import ToolAnnotations
 
+from pipefy_mcp.models.validators import PipefyId
 from pipefy_mcp.services.pipefy import PipefyClient
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.report_tool_helpers import (
@@ -19,9 +20,7 @@ from pipefy_mcp.tools.report_tool_helpers import (
 
 
 def _blank_field_error(value: str, field: str) -> dict[str, Any] | None:
-    """Return an error payload when ``value`` is missing or blank."""
-    if not isinstance(value, str):
-        return build_report_error_payload(message=f"'{field}' must be a string.")
+    """Return an error payload when ``value`` is blank."""
     if not value.strip():
         return build_report_error_payload(message=f"'{field}' must be non-empty.")
     return None
@@ -40,7 +39,7 @@ class ReportTools:
             first: int = 30,
             after: str | None = None,
             search: str | None = None,
-            report_id: str | None = None,
+            report_id: PipefyId | None = None,
             order: dict | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
@@ -138,7 +137,7 @@ class ReportTools:
             annotations=ToolAnnotations(readOnlyHint=True),
         )
         async def get_organization_report(
-            report_id: str,
+            report_id: PipefyId,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Get a single organization report by ID.
@@ -165,7 +164,7 @@ class ReportTools:
             annotations=ToolAnnotations(readOnlyHint=True),
         )
         async def get_organization_reports(
-            organization_id: str,
+            organization_id: PipefyId,
             first: int = 30,
             after: str | None = None,
             debug: bool = False,
@@ -202,7 +201,7 @@ class ReportTools:
             annotations=ToolAnnotations(readOnlyHint=True),
         )
         async def get_pipe_report_export(
-            export_id: str,
+            export_id: PipefyId,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Check the status of a pipe report export. Poll this after calling `export_pipe_report`. States: processing -> done (with fileURL) -> failed.
@@ -229,7 +228,7 @@ class ReportTools:
             annotations=ToolAnnotations(readOnlyHint=True),
         )
         async def get_organization_report_export(
-            export_id: str,
+            export_id: PipefyId,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Check the status of an org report export. Poll this after calling `export_organization_report`.
@@ -256,7 +255,7 @@ class ReportTools:
             annotations=ToolAnnotations(readOnlyHint=False),
         )
         async def create_pipe_report(
-            pipe_id: str,
+            pipe_id: PipefyId,
             name: str,
             fields: list[str] | None = None,
             filter: dict | None = None,
@@ -296,7 +295,7 @@ class ReportTools:
             annotations=ToolAnnotations(readOnlyHint=False),
         )
         async def update_pipe_report(
-            report_id: str,
+            report_id: PipefyId,
             name: str | None = None,
             color: str | None = None,
             fields: list[str] | None = None,
@@ -347,7 +346,7 @@ class ReportTools:
         )
         async def delete_pipe_report(
             ctx: Context[ServerSession, None],
-            report_id: str,
+            report_id: PipefyId,
             confirm: bool = False,
             debug: bool = False,
         ) -> dict[str, Any]:
@@ -389,7 +388,7 @@ class ReportTools:
             annotations=ToolAnnotations(readOnlyHint=False),
         )
         async def create_organization_report(
-            organization_id: str,
+            organization_id: PipefyId,
             name: str,
             pipe_ids: list[str],
             fields: list[str] | None = None,
@@ -433,7 +432,7 @@ class ReportTools:
             annotations=ToolAnnotations(readOnlyHint=False),
         )
         async def update_organization_report(
-            report_id: str,
+            report_id: PipefyId,
             name: str | None = None,
             color: str | None = None,
             fields: list[str] | None = None,
@@ -481,7 +480,7 @@ class ReportTools:
         )
         async def delete_organization_report(
             ctx: Context[ServerSession, None],
-            report_id: str,
+            report_id: PipefyId,
             confirm: bool = False,
             debug: bool = False,
         ) -> dict[str, Any]:
@@ -523,8 +522,8 @@ class ReportTools:
             annotations=ToolAnnotations(readOnlyHint=False),
         )
         async def export_pipe_report(
-            pipe_id: str,
-            pipe_report_id: str,
+            pipe_id: PipefyId,
+            pipe_report_id: PipefyId,
             sort_by: dict | None = None,
             filter: dict | None = None,
             columns: list[str] | None = None,

--- a/src/pipefy_mcp/tools/webhook_tools.py
+++ b/src/pipefy_mcp/tools/webhook_tools.py
@@ -8,6 +8,7 @@ from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
 from mcp.types import ToolAnnotations
 
+from pipefy_mcp.models.validators import PipefyId
 from pipefy_mcp.services.pipefy import PipefyClient
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.validation_helpers import (
@@ -30,7 +31,7 @@ class WebhookTools:
             annotations=ToolAnnotations(readOnlyHint=True),
         )
         async def get_email_templates(
-            repo_id: str,
+            repo_id: PipefyId,
             filter_by_name: str | None = None,
             first: int = 50,
             debug: bool = False,
@@ -69,7 +70,7 @@ class WebhookTools:
             annotations=ToolAnnotations(readOnlyHint=True),
         )
         async def get_card_inbox_emails(
-            card_id: str,
+            card_id: PipefyId,
             email_type: str | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
@@ -113,7 +114,7 @@ class WebhookTools:
             annotations=ToolAnnotations(readOnlyHint=False),
         )
         async def send_inbox_email(
-            card_id: str,
+            card_id: PipefyId,
             to: list[str],
             subject: str,
             body: str,
@@ -185,8 +186,8 @@ class WebhookTools:
             annotations=ToolAnnotations(readOnlyHint=False),
         )
         async def send_email_with_template(
-            card_id: str,
-            email_template_id: str,
+            card_id: PipefyId,
+            email_template_id: PipefyId,
             to: list[str] | None = None,
             from_: str | None = None,
             extra_input: dict[str, Any] | None = None,
@@ -210,7 +211,7 @@ class WebhookTools:
                 return build_webhook_error_payload(
                     message="Invalid 'card_id': provide a non-empty string or positive integer.",
                 )
-            if not isinstance(email_template_id, str) or not email_template_id.strip():
+            if not email_template_id.strip():
                 return build_webhook_error_payload(
                     message="Invalid 'email_template_id': provide a non-empty string.",
                 )
@@ -249,7 +250,7 @@ class WebhookTools:
             annotations=ToolAnnotations(readOnlyHint=False),
         )
         async def create_webhook(
-            pipe_id: str,
+            pipe_id: PipefyId,
             url: str,
             actions: list[str],
             extra_input: dict[str, Any] | None = None,
@@ -314,7 +315,7 @@ class WebhookTools:
         )
         async def delete_webhook(
             ctx: Context[ServerSession, None],
-            webhook_id: str,
+            webhook_id: PipefyId,
             confirm: bool = False,
             debug: bool = False,
         ) -> dict[str, Any]:

--- a/tests/models/test_attachment.py
+++ b/tests/models/test_attachment.py
@@ -180,6 +180,44 @@ def test_infer_content_type(file_name, expected):
 
 
 @pytest.mark.unit
+def test_upload_attachment_to_card_coerces_int_organization_id():
+    data = UploadAttachmentToCardInput(
+        organization_id=12345,
+        card_id=42,
+        field_id="field_abc",
+        file_name="doc.pdf",
+        file_url="https://example.com/f.pdf",
+    )
+    assert data.organization_id == "12345"
+
+
+@pytest.mark.unit
+def test_upload_attachment_to_card_coerces_int_field_id():
+    data = UploadAttachmentToCardInput(
+        organization_id="org-1",
+        card_id=42,
+        field_id=999,
+        file_name="doc.pdf",
+        file_url="https://example.com/f.pdf",
+    )
+    assert data.field_id == "999"
+
+
+@pytest.mark.unit
+def test_upload_attachment_to_table_record_coerces_int_ids():
+    data = UploadAttachmentToTableRecordInput(
+        organization_id=100,
+        table_record_id=200,
+        field_id=300,
+        file_name="n.csv",
+        file_url="https://example.com/x",
+    )
+    assert data.organization_id == "100"
+    assert data.table_record_id == "200"
+    assert data.field_id == "300"
+
+
+@pytest.mark.unit
 def test_models_exported_from_package():
     from pipefy_mcp.models import (
         UploadAttachmentToCardInput as CardFromPkg,

--- a/tests/models/test_validators.py
+++ b/tests/models/test_validators.py
@@ -1,0 +1,49 @@
+"""Tests for shared Pydantic validators and annotated types."""
+
+import pytest
+from pydantic import BaseModel
+
+from pipefy_mcp.models.validators import PipefyId
+
+
+class _IdModel(BaseModel):
+    some_id: PipefyId
+
+
+@pytest.mark.unit
+class TestPipefyId:
+    def test_accepts_string(self):
+        m = _IdModel(some_id="25901")
+        assert m.some_id == "25901"
+
+    def test_coerces_int(self):
+        m = _IdModel(some_id=25901)
+        assert m.some_id == "25901"
+
+    def test_coerces_float(self):
+        m = _IdModel(some_id=25901.0)
+        assert m.some_id == "25901"
+
+    def test_coerces_float_truncates_decimal(self):
+        m = _IdModel(some_id=25901.9)
+        assert m.some_id == "25901"
+
+    def test_preserves_non_numeric_string(self):
+        m = _IdModel(some_id="abc-def")
+        assert m.some_id == "abc-def"
+
+    def test_preserves_empty_string(self):
+        m = _IdModel(some_id="")
+        assert m.some_id == ""
+
+    def test_rejects_none(self):
+        with pytest.raises(Exception):
+            _IdModel(some_id=None)
+
+    def test_rejects_bool_true(self):
+        with pytest.raises(Exception):
+            _IdModel(some_id=True)
+
+    def test_rejects_bool_false(self):
+        with pytest.raises(Exception):
+            _IdModel(some_id=False)

--- a/tests/services/pipefy/test_automation_service.py
+++ b/tests/services/pipefy/test_automation_service.py
@@ -5,7 +5,10 @@ from unittest.mock import AsyncMock
 import pytest
 from gql.transport.exceptions import TransportQueryError
 
-from pipefy_mcp.services.pipefy.automation_service import AutomationService
+from pipefy_mcp.services.pipefy.automation_service import (
+    AutomationService,
+    _format_automation_error_details,
+)
 from pipefy_mcp.services.pipefy.queries.automation_queries import (
     AUTOMATION_SIMULATION_QUERY,
     CREATE_AUTOMATION_MUTATION,
@@ -20,6 +23,82 @@ from pipefy_mcp.services.pipefy.queries.automation_queries import (
     UPDATE_AUTOMATION_MUTATION,
 )
 from pipefy_mcp.settings import PipefySettings
+
+## ---------------------------------------------------------------------------
+## _format_automation_error_details edge cases
+## ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFormatAutomationErrorDetails:
+    def test_none_returns_empty(self):
+        assert _format_automation_error_details(None) == ""
+
+    def test_string_passthrough(self):
+        assert _format_automation_error_details("some error") == "some error"
+
+    def test_dict_with_messages_list(self):
+        result = _format_automation_error_details({"messages": ["a", "b"]})
+        assert result == "a; b"
+
+    def test_dict_without_messages_falls_back_to_str(self):
+        result = _format_automation_error_details({"code": 42})
+        assert "42" in result
+
+    def test_list_of_strings(self):
+        result = _format_automation_error_details(["error one", "error two"])
+        assert result == "error one; error two"
+
+    def test_list_of_dicts_with_object_name_and_key(self):
+        result = _format_automation_error_details(
+            [
+                {
+                    "object_name": "Automation",
+                    "object_key": "a1",
+                    "messages": ["bad field"],
+                }
+            ]
+        )
+        assert result == "Automation (a1): bad field"
+
+    def test_list_of_dicts_with_object_name_only(self):
+        result = _format_automation_error_details(
+            [{"object_name": "Rule", "messages": ["invalid"]}]
+        )
+        assert result == "Rule: invalid"
+
+    def test_list_of_dicts_with_object_key_only(self):
+        result = _format_automation_error_details(
+            [{"object_key": "k1", "messages": ["whoops"]}]
+        )
+        assert result == "k1: whoops"
+
+    def test_list_of_dicts_with_single_message_field(self):
+        result = _format_automation_error_details([{"message": "single error"}])
+        assert result == "single error"
+
+    def test_list_skips_non_dict_non_string_items(self):
+        result = _format_automation_error_details([42, None, "hello"])
+        assert result == "hello"
+
+    def test_list_skips_dicts_without_messages(self):
+        result = _format_automation_error_details([{"code": 1}])
+        assert result == ""
+
+    def test_unknown_type_returns_str(self):
+        result = _format_automation_error_details(12345)
+        assert result == "12345"
+
+    def test_list_filters_empty_strings_in_messages(self):
+        result = _format_automation_error_details(
+            [{"messages": ["", "real error", ""]}]
+        )
+        assert result == "real error"
+
+
+## ---------------------------------------------------------------------------
+## Service tests
+## ---------------------------------------------------------------------------
 
 
 @pytest.fixture
@@ -155,6 +234,58 @@ async def test_get_automations_organization_only_omits_repo_id(mock_settings):
     assert query is GET_AUTOMATIONS_BY_ORG_QUERY
     assert variables == {"organizationId": 201}
     assert result == rows
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_automations_pipe_only_org_not_found_returns_empty(mock_settings):
+    """When pipe_id is given but org lookup returns no organizationId, return empty."""
+    service = AutomationService(settings=mock_settings)
+    service.execute_query = AsyncMock(return_value={"pipe": {"organizationId": None}})
+    result = await service.get_automations(pipe_id="100")
+    assert result == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_automations_pipe_only_pipe_missing_returns_empty(mock_settings):
+    """When pipe lookup returns no pipe key at all, return empty."""
+    service = AutomationService(settings=mock_settings)
+    service.execute_query = AsyncMock(return_value={"pipe": None})
+    result = await service.get_automations(pipe_id="100")
+    assert result == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_automations_null_nodes_returns_empty(mock_settings):
+    service = _make_service(mock_settings, {"automations": {"nodes": None}})
+    result = await service.get_automations(organization_id="1")
+    assert result == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_automations_null_connection_returns_empty(mock_settings):
+    service = _make_service(mock_settings, {"automations": None})
+    result = await service.get_automations(organization_id="1")
+    assert result == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_automation_actions_null_returns_empty(mock_settings):
+    service = _make_service(mock_settings, {"automationActions": None})
+    result = await service.get_automation_actions("100")
+    assert result == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_automation_events_null_returns_empty(mock_settings):
+    service = _make_service(mock_settings, {"automationEvents": None})
+    result = await service.get_automation_events("100")
+    assert result == []
 
 
 @pytest.mark.unit

--- a/tests/services/pipefy/test_observability_export_csv.py
+++ b/tests/services/pipefy/test_observability_export_csv.py
@@ -1,11 +1,14 @@
 """Unit tests for observability export CSV helpers."""
 
 import io
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from openpyxl import Workbook
 
 from pipefy_mcp.services.pipefy.observability_export_csv import (
+    download_bytes,
     is_allowed_pipefy_export_download_url,
     xlsx_first_sheet_to_csv_limited,
 )
@@ -67,3 +70,91 @@ def test_xlsx_csv_truncated_by_char_cap():
 def test_xlsx_first_sheet_rejects_zero_max_chars():
     with pytest.raises(ValueError, match="at least 1"):
         xlsx_first_sheet_to_csv_limited(b"", max_output_chars=0)
+
+
+# --- download_bytes tests (lines 93-123) ---
+
+
+@pytest.mark.asyncio
+async def test_download_bytes_rejects_http_scheme():
+    with pytest.raises(ValueError, match="not an allowed Pipefy https URL"):
+        await download_bytes("http://app.pipefy.com/export.xlsx", max_bytes=1024)
+
+
+@pytest.mark.asyncio
+async def test_download_bytes_rejects_non_pipefy_domain():
+    with pytest.raises(ValueError, match="not an allowed Pipefy https URL"):
+        await download_bytes("https://evil.com/export.xlsx", max_bytes=1024)
+
+
+@pytest.mark.asyncio
+async def test_download_bytes_rejects_content_length_exceeding_max():
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.headers = {"content-length": "5000"}
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=False)
+
+    mock_client = AsyncMock()
+    mock_client.stream = MagicMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "pipefy_mcp.services.pipefy.observability_export_csv.httpx.AsyncClient",
+        return_value=mock_client,
+    ):
+        with pytest.raises(ValueError, match="exceeds max_download_bytes"):
+            await download_bytes("https://app.pipefy.com/export.xlsx", max_bytes=1024)
+
+
+@pytest.mark.asyncio
+async def test_download_bytes_rejects_streaming_body_exceeding_max():
+    async def fake_aiter_bytes():
+        yield b"a" * 600
+        yield b"b" * 600
+
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.headers = {}
+    mock_response.aiter_bytes = fake_aiter_bytes
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=False)
+
+    mock_client = AsyncMock()
+    mock_client.stream = MagicMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "pipefy_mcp.services.pipefy.observability_export_csv.httpx.AsyncClient",
+        return_value=mock_client,
+    ):
+        with pytest.raises(ValueError, match="exceeds max_download_bytes"):
+            await download_bytes("https://app.pipefy.com/export.xlsx", max_bytes=1000)
+
+
+@pytest.mark.asyncio
+async def test_download_bytes_propagates_httpx_errors():
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError(
+            "Server Error",
+            request=httpx.Request("GET", "https://app.pipefy.com/x"),
+            response=httpx.Response(500),
+        )
+    )
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=False)
+
+    mock_client = AsyncMock()
+    mock_client.stream = MagicMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "pipefy_mcp.services.pipefy.observability_export_csv.httpx.AsyncClient",
+        return_value=mock_client,
+    ):
+        with pytest.raises(httpx.HTTPStatusError):
+            await download_bytes("https://app.pipefy.com/export.xlsx", max_bytes=1024)

--- a/tests/tools/test_ai_agent_tools.py
+++ b/tests/tools/test_ai_agent_tools.py
@@ -1,5 +1,6 @@
 """Tests for AI Agent MCP tools."""
 
+import asyncio
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock
 
@@ -987,6 +988,605 @@ class TestDeleteAiAgent:
         assert delete_tool.annotations is not None
         assert delete_tool.annotations.destructiveHint is True
         assert delete_tool.annotations.readOnlyHint is False
+
+
+@pytest.mark.anyio
+class TestGetAiAgentGraphqlError:
+    """Cover get_ai_agent GraphQL error path (line 410)."""
+
+    async def test_runtime_error_returns_error_payload(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.get_ai_agent.side_effect = RuntimeError("server down")
+        async with client_session as session:
+            result = await session.call_tool("get_ai_agent", {"uuid": "agent-1"})
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "server down" in payload["error"]
+
+
+@pytest.mark.anyio
+class TestGetAiAgentsErrorPaths:
+    """Cover get_ai_agents empty-list and GraphQL error paths."""
+
+    async def test_empty_list_returns_success_with_empty_agents(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.get_ai_agents.return_value = []
+        async with client_session as session:
+            result = await session.call_tool(
+                "get_ai_agents", {"repo_uuid": "pipe-uuid"}
+            )
+        payload = extract_payload(result)
+        assert payload["success"] is True
+        assert payload["agents"] == []
+
+    async def test_runtime_error_returns_error_payload(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.get_ai_agents.side_effect = RuntimeError("boom")
+        async with client_session as session:
+            result = await session.call_tool(
+                "get_ai_agents", {"repo_uuid": "pipe-uuid"}
+            )
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "boom" in payload["error"]
+
+
+@pytest.mark.anyio
+class TestToggleAiAgentStatusErrorPaths:
+    """Cover blank uuid path (line 373)."""
+
+    async def test_blank_uuid_returns_error(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        async with client_session as session:
+            result = await session.call_tool(
+                "toggle_ai_agent_status", {"uuid": "   ", "active": True}
+            )
+        mock_pipefy_client.toggle_ai_agent_status.assert_not_called()
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "blank" in payload["error"].lower()
+
+
+@pytest.mark.anyio
+class TestDeleteAiAgentConfirmationGuard:
+    """Cover confirmation guard early return (line 461)."""
+
+    async def test_no_confirm_returns_requires_confirmation(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        async with client_session as session:
+            result = await session.call_tool(
+                "delete_ai_agent", {"uuid": "agent-uuid", "confirm": False}
+            )
+        mock_pipefy_client.delete_ai_agent.assert_not_called()
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert payload.get("requires_confirmation") is True
+
+    async def test_runtime_error_returns_error_payload(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.delete_ai_agent.side_effect = RuntimeError("network")
+        async with client_session as session:
+            result = await session.call_tool(
+                "delete_ai_agent", {"uuid": "agent-uuid", "confirm": True}
+            )
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "network" in payload["error"]
+
+
+@pytest.mark.anyio
+class TestCreateAiAgentBlankInstruction:
+    """Cover blank instruction guard (line 246)."""
+
+    async def test_blank_instruction_returns_error(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_ai_agent",
+                {
+                    "name": "Agent",
+                    "repo_uuid": "repo-1",
+                    "instruction": "   ",
+                    "behaviors": [minimal_behavior_dict(name="B1")],
+                },
+            )
+        mock_pipefy_client.create_ai_agent.assert_not_called()
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "instruction" in payload["error"]
+
+
+@pytest.mark.anyio
+class TestUpdateAiAgentBlankFields:
+    """Cover blank name (line 325) and blank repo_uuid (line 327) guards."""
+
+    async def test_blank_name_returns_error(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        async with client_session as session:
+            result = await session.call_tool(
+                "update_ai_agent",
+                {
+                    "uuid": "agent-uuid",
+                    "name": "  ",
+                    "repo_uuid": "repo-1",
+                    "instruction": "Do things",
+                    "behaviors": [minimal_behavior_dict(name="B1")],
+                },
+            )
+        mock_pipefy_client.update_ai_agent.assert_not_called()
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "name" in payload["error"]
+
+    async def test_blank_repo_uuid_returns_error(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        async with client_session as session:
+            result = await session.call_tool(
+                "update_ai_agent",
+                {
+                    "uuid": "agent-uuid",
+                    "name": "Agent",
+                    "repo_uuid": "  ",
+                    "instruction": "Do things",
+                    "behaviors": [minimal_behavior_dict(name="B1")],
+                },
+            )
+        mock_pipefy_client.update_ai_agent.assert_not_called()
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "repo_uuid" in payload["error"]
+
+
+@pytest.mark.anyio
+class TestValidateAiAgentBehaviorsErrorPaths:
+    """Cover pipe fetch timeout, pipe fetch error, blank pipe_id, pydantic validation,
+    start_form_fields, relations child/parent, target pipe fetch, and cross-pipe fields."""
+
+    async def test_blank_pipe_id_returns_error(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_agent_behaviors",
+                {"pipe_id": "  ", "behaviors": [minimal_behavior_dict()]},
+            )
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "blank" in payload["error"].lower()
+
+    async def test_pydantic_validation_failure(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        """Invalid behavior dict fails BehaviorInput validation (lines 523-524)."""
+        bad_behavior = {"name": "X"}  # missing required fields
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_agent_behaviors",
+                {"pipe_id": "1", "behaviors": [bad_behavior]},
+            )
+        payload = extract_payload(result)
+        assert payload["success"] is True
+        assert payload["valid"] is False
+        assert len(payload["problems"]) > 0
+
+    async def test_pipe_fetch_timeout(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        """Timeout during get_pipe raises error (lines 538-541)."""
+        mock_pipefy_client.get_pipe.side_effect = asyncio.TimeoutError()
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_agent_behaviors",
+                {"pipe_id": "123", "behaviors": [minimal_behavior_dict()]},
+            )
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "timed out" in payload["error"].lower()
+
+    async def test_pipe_fetch_generic_error(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        """Generic error during get_pipe (lines 542-543)."""
+        mock_pipefy_client.get_pipe.side_effect = RuntimeError("db down")
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_agent_behaviors",
+                {"pipe_id": "123", "behaviors": [minimal_behavior_dict()]},
+            )
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "db down" in payload["error"]
+
+    async def test_start_form_fields_collected(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        """Start form fields are included in validation (lines 559-561)."""
+        mock_pipefy_client.get_pipe.return_value = {
+            "pipe": {
+                "phases": [{"id": "ph-1", "fields": []}],
+                "start_form_fields": [{"id": "sf-1"}],
+            }
+        }
+        mock_pipefy_client.get_pipe_relations.return_value = {
+            "children": [],
+            "parents": [],
+        }
+        behavior = _behavior_update_card_on_pipe(pipe_id="1", field_id="sf-1")
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_agent_behaviors",
+                {"pipe_id": "1", "behaviors": [behavior]},
+            )
+        payload = extract_payload(result)
+        assert payload["success"] is True
+        assert payload["valid"] is True
+        assert payload["problems"] == []
+
+    async def test_relations_children_and_parents_collected(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        """Child and parent relations are collected (lines 572-578).
+
+        When pipeId targets a related pipe, no 'not a related pipe' problem appears.
+        We mock the target pipe fetch so cross-pipe field checks also pass.
+        """
+        mock_pipefy_client.get_pipe.side_effect = [
+            _pipe_graph_with_field(),
+            {
+                "pipe": {
+                    "phases": [{"id": "tp-1", "fields": [{"id": "f1"}]}],
+                    "start_form_fields": [],
+                }
+            },
+        ]
+        mock_pipefy_client.get_pipe_relations.return_value = {
+            "children": [{"child": {"id": "200"}}],
+            "parents": [{"parent": {"id": "300"}}],
+        }
+        behavior = {
+            "name": "Connected",
+            "event_id": "card_created",
+            "actionParams": {
+                "aiBehaviorParams": {
+                    "instruction": "go",
+                    "actionsAttributes": [
+                        {
+                            "name": "cc",
+                            "actionType": "create_connected_card",
+                            "metadata": {
+                                "pipeId": "200",
+                                "fieldsAttributes": [
+                                    {
+                                        "fieldId": "f1",
+                                        "inputMode": "fill_with_ai",
+                                        "value": "",
+                                    }
+                                ],
+                            },
+                        },
+                    ],
+                }
+            },
+        }
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_agent_behaviors",
+                {"pipe_id": "1", "behaviors": [behavior]},
+            )
+        payload = extract_payload(result)
+        assert payload["success"] is True
+        assert payload["valid"] is True
+        assert payload["problems"] == []
+
+    async def test_target_pipe_fetch_for_cross_pipe_fields(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        """Cross-pipe target pipe is fetched and fields validated (lines 604-631)."""
+        mock_pipefy_client.get_pipe.side_effect = [
+            _pipe_graph_with_field(),
+            {
+                "pipe": {
+                    "phases": [{"id": "tp-1", "fields": [{"id": "tf-1"}]}],
+                    "start_form_fields": [{"id": "tf-2"}],
+                }
+            },
+        ]
+        mock_pipefy_client.get_pipe_relations.return_value = {
+            "children": [{"child": {"id": "999"}}],
+            "parents": [],
+        }
+        behavior = {
+            "name": "Cross",
+            "event_id": "card_created",
+            "actionParams": {
+                "aiBehaviorParams": {
+                    "instruction": "go",
+                    "actionsAttributes": [
+                        {
+                            "name": "cc",
+                            "actionType": "create_connected_card",
+                            "metadata": {
+                                "pipeId": "999",
+                                "fieldsAttributes": [
+                                    {
+                                        "fieldId": "tf-1",
+                                        "inputMode": "fill_with_ai",
+                                        "value": "",
+                                    }
+                                ],
+                            },
+                        },
+                    ],
+                }
+            },
+        }
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_agent_behaviors",
+                {"pipe_id": "1", "behaviors": [behavior]},
+            )
+        payload = extract_payload(result)
+        assert payload["success"] is True
+        # Field tf-1 exists on target pipe, so valid
+        assert payload["valid"] is True
+
+    async def test_target_pipe_fetch_failure_adds_warning(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        """Failure to fetch target pipe adds a warning (lines 627-634)."""
+        mock_pipefy_client.get_pipe.side_effect = [
+            _pipe_graph_with_field(),
+            RuntimeError("target pipe fetch failed"),
+        ]
+        mock_pipefy_client.get_pipe_relations.return_value = {
+            "children": [{"child": {"id": "999"}}],
+            "parents": [],
+        }
+        behavior = {
+            "name": "Cross",
+            "event_id": "card_created",
+            "actionParams": {
+                "aiBehaviorParams": {
+                    "instruction": "go",
+                    "actionsAttributes": [
+                        {
+                            "name": "cc",
+                            "actionType": "create_connected_card",
+                            "metadata": {
+                                "pipeId": "999",
+                                "fieldsAttributes": [
+                                    {
+                                        "fieldId": "some-field",
+                                        "inputMode": "fill_with_ai",
+                                        "value": "",
+                                    }
+                                ],
+                            },
+                        },
+                    ],
+                }
+            },
+        }
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_agent_behaviors",
+                {"pipe_id": "1", "behaviors": [behavior]},
+            )
+        payload = extract_payload(result)
+        assert payload["success"] is True
+        assert any("999" in w for w in payload["warnings"])
+
+
+@pytest.mark.anyio
+class TestEnrichWithValidation:
+    """Cover _enrich_with_validation internal paths via update_ai_agent error flow."""
+
+    async def test_record_not_saved_no_pipe_id_in_behaviors(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        """When behaviors have no pipeId, enrichment skips validation (line 97)."""
+        mock_pipefy_client.update_ai_agent.side_effect = TransportQueryError(
+            "RECORD_NOT_SAVED", errors=[{"message": "RECORD_NOT_SAVED"}]
+        )
+        behavior_no_pipe = {
+            "name": "Move",
+            "event_id": "card_created",
+            "actionParams": {
+                "aiBehaviorParams": {
+                    "instruction": "go",
+                    "actionsAttributes": [
+                        {
+                            "name": "m",
+                            "actionType": "move_card",
+                            "metadata": {"destinationPhaseId": "ph-1"},
+                        },
+                    ],
+                }
+            },
+        }
+        async with client_session as session:
+            result = await session.call_tool(
+                "update_ai_agent",
+                {
+                    "uuid": "agent-uuid",
+                    "name": "Agent",
+                    "repo_uuid": "repo-1",
+                    "instruction": "Do things",
+                    "behaviors": [behavior_no_pipe],
+                },
+            )
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "RECORD_NOT_SAVED" in payload["error"]
+        # No pipe_id found, so no validation suffix
+        mock_pipefy_client.get_pipe.assert_not_called()
+
+    async def test_record_not_saved_enrichment_exception_falls_back(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        """When pipe fetch fails during enrichment, falls back (lines 152-153)."""
+        mock_pipefy_client.update_ai_agent.side_effect = TransportQueryError(
+            "RECORD_NOT_SAVED", errors=[{"message": "RECORD_NOT_SAVED"}]
+        )
+        mock_pipefy_client.get_pipe.side_effect = RuntimeError("unreachable")
+        behavior = _behavior_update_card_on_pipe(
+            pipe_id="306996636", field_id="425829426"
+        )
+        async with client_session as session:
+            result = await session.call_tool(
+                "update_ai_agent",
+                {
+                    "uuid": "agent-uuid",
+                    "name": "Agent",
+                    "repo_uuid": "repo-1",
+                    "instruction": "Do things",
+                    "behaviors": [behavior],
+                },
+            )
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "RECORD_NOT_SAVED" in payload["error"]
+        # Falls back to standard enrichment, no validation suffix
+        assert "Validation found problems" not in payload["error"]
+        assert "pipe-specific restriction" not in payload["error"]
+
+    async def test_record_not_saved_with_start_form_fields_and_relations(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        """Enrichment collects start_form_fields and parent relations (lines 114-116, 126-134)."""
+        mock_pipefy_client.update_ai_agent.side_effect = TransportQueryError(
+            "RECORD_NOT_SAVED", errors=[{"message": "RECORD_NOT_SAVED"}]
+        )
+        mock_pipefy_client.get_pipe.return_value = {
+            "pipe": {
+                "phases": [{"id": "ph-1", "fields": []}],
+                "start_form_fields": [{"id": "sf-100"}],
+            }
+        }
+        mock_pipefy_client.get_pipe_relations.return_value = {
+            "children": [{"child": {"id": "child-1"}}],
+            "parents": [{"parent": {"id": "parent-1"}}],
+        }
+        behavior = _behavior_update_card_on_pipe(pipe_id="306996636", field_id="sf-100")
+        async with client_session as session:
+            result = await session.call_tool(
+                "update_ai_agent",
+                {
+                    "uuid": "agent-uuid",
+                    "name": "Agent",
+                    "repo_uuid": "repo-1",
+                    "instruction": "Do things",
+                    "behaviors": [behavior],
+                },
+            )
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "RECORD_NOT_SAVED" in payload["error"]
+        # sf-100 is valid (in start_form_fields), so payload should pass validation
+        assert "pipe-specific restriction" in payload["error"]
+
+    async def test_record_not_saved_relations_fetch_fails_still_validates(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        """When relations fetch fails in enrichment, validation still runs (lines 133-134)."""
+        mock_pipefy_client.update_ai_agent.side_effect = TransportQueryError(
+            "RECORD_NOT_SAVED", errors=[{"message": "RECORD_NOT_SAVED"}]
+        )
+        mock_pipefy_client.get_pipe.return_value = _pipe_graph_with_field(
+            field_id="425829426", phase_id="ph-1"
+        )
+        mock_pipefy_client.get_pipe_relations.side_effect = RuntimeError("no relations")
+        behavior = _behavior_update_card_on_pipe(
+            pipe_id="306996636", field_id="425829426"
+        )
+        async with client_session as session:
+            result = await session.call_tool(
+                "update_ai_agent",
+                {
+                    "uuid": "agent-uuid",
+                    "name": "Agent",
+                    "repo_uuid": "repo-1",
+                    "instruction": "Do things",
+                    "behaviors": [behavior],
+                },
+            )
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "RECORD_NOT_SAVED" in payload["error"]
+        # Field is valid, relations failed, still validates with related_pipe_ids=None
+        assert "pipe-specific restriction" in payload["error"]
 
 
 @pytest.mark.anyio

--- a/tests/tools/test_ai_automation_tools.py
+++ b/tests/tools/test_ai_automation_tools.py
@@ -169,3 +169,62 @@ class TestUpdateAiAutomation:
         payload = extract_payload(result)
         assert payload["success"] is False
         assert "error" in payload
+
+
+## ---------------------------------------------------------------------------
+## PipefyId coercion: int → str through MCP transport (mcporter mitigation)
+## ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+class TestPipefyIdCoercion:
+    async def test_create_ai_automation_coerces_int_pipe_id_and_event_id(
+        self,
+        client_session,
+        mock_ai_automation_service,
+        extract_payload,
+    ):
+        mock_ai_automation_service.create_automation.return_value = {
+            "automation_id": "456",
+            "message": "AI Automation created successfully. ID: 456",
+        }
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_ai_automation",
+                {
+                    "name": "Coerce Test",
+                    "event_id": 101,
+                    "pipe_id": 303,
+                    "prompt": "Summarize",
+                    "field_ids": ["f1"],
+                },
+            )
+        assert result.isError is False
+        payload = extract_payload(result)
+        assert payload["success"] is True
+
+        validated_input = mock_ai_automation_service.create_automation.call_args[0][0]
+        assert validated_input.pipe_id == "303"
+        assert validated_input.event_id == "101"
+
+    async def test_update_ai_automation_coerces_int_automation_id(
+        self,
+        client_session,
+        mock_ai_automation_service,
+        extract_payload,
+    ):
+        mock_ai_automation_service.update_automation.return_value = {
+            "automation_id": "789",
+            "message": "AI Automation updated successfully. ID: 789",
+        }
+        async with client_session as session:
+            result = await session.call_tool(
+                "update_ai_automation",
+                {"automation_id": 789, "name": "Updated"},
+            )
+        assert result.isError is False
+        payload = extract_payload(result)
+        assert payload["success"] is True
+
+        validated_input = mock_ai_automation_service.update_automation.call_args[0][0]
+        assert validated_input.automation_id == "789"

--- a/tests/tools/test_attachment_tools.py
+++ b/tests/tools/test_attachment_tools.py
@@ -570,3 +570,72 @@ async def test_upload_attachment_to_card_rejects_oversized_content_length(
         "too large" in payload["error"].lower() or "limit" in payload["error"].lower()
     )
     mock_attachment_client.create_presigned_url.assert_not_called()
+
+
+## ---------------------------------------------------------------------------
+## PipefyId coercion: int → str through MCP transport (mcporter mitigation)
+## ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_upload_attachment_to_card_coerces_int_ids(
+    attachment_session,
+    mock_attachment_client,
+    extract_payload,
+):
+    raw = b"hello"
+    b64 = base64.b64encode(raw).decode("ascii")
+
+    async with attachment_session as session:
+        result = await session.call_tool(
+            "upload_attachment_to_card",
+            {
+                "organization_id": 42,
+                "card_id": 7,
+                "field_id": 999,
+                "file_name": "note.txt",
+                "file_content_base64": b64,
+            },
+        )
+
+    assert result.isError is False
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    mock_attachment_client.create_presigned_url.assert_awaited_once_with(
+        "42", "note.txt", "text/plain", 5
+    )
+    mock_attachment_client.update_card_field.assert_awaited_once_with(
+        7, "999", ["orgs/o/u/f/report.pdf"]
+    )
+
+
+@pytest.mark.anyio
+async def test_upload_attachment_to_table_record_coerces_int_ids(
+    attachment_session,
+    mock_attachment_client,
+    extract_payload,
+):
+    raw = b"hello"
+    b64 = base64.b64encode(raw).decode("ascii")
+
+    async with attachment_session as session:
+        result = await session.call_tool(
+            "upload_attachment_to_table_record",
+            {
+                "organization_id": 42,
+                "table_record_id": 200,
+                "field_id": 300,
+                "file_name": "data.csv",
+                "file_content_base64": b64,
+            },
+        )
+
+    assert result.isError is False
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    mock_attachment_client.create_presigned_url.assert_awaited_once_with(
+        "42", "data.csv", "text/csv", 5
+    )
+    mock_attachment_client.set_table_record_field_value.assert_awaited_once_with(
+        "200", "300", ["orgs/o/u/f/report.pdf"]
+    )

--- a/tests/tools/test_observability_tools.py
+++ b/tests/tools/test_observability_tools.py
@@ -488,6 +488,86 @@ async def test_get_automation_jobs_export_rejects_empty_export_id(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("observability_session", [None], indirect=True)
+async def test_get_automation_jobs_export_coerces_int_export_id(
+    observability_session, mock_observability_client, extract_payload
+):
+    """mcporter CLI sends numeric IDs as int; PipefyId must coerce to str."""
+    mock_observability_client.get_automation_jobs_export.return_value = {
+        "automationJobsExport": {
+            "id": "25901",
+            "status": "finished",
+            "fileUrl": "https://app.pipefy.com/storage/signed/export.xlsx",
+        }
+    }
+
+    async with observability_session as session:
+        result = await session.call_tool(
+            "get_automation_jobs_export",
+            {"export_id": 25901},
+        )
+
+    assert result.isError is False
+    mock_observability_client.get_automation_jobs_export.assert_awaited_once_with(
+        "25901"
+    )
+    payload = extract_payload(result)
+    assert payload["success"] is True
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+async def test_get_automation_jobs_export_csv_coerces_int_export_id(
+    observability_session, mock_observability_client, extract_payload
+):
+    """mcporter CLI sends numeric IDs as int; PipefyId must coerce to str."""
+    mock_observability_client.get_automation_jobs_export_csv.return_value = {
+        "export_id": "25901",
+        "status": "finished",
+        "csv_text": "col1,col2\na,b\n",
+    }
+
+    async with observability_session as session:
+        result = await session.call_tool(
+            "get_automation_jobs_export_csv",
+            {"export_id": 25901},
+        )
+
+    assert result.isError is False
+    mock_observability_client.get_automation_jobs_export_csv.assert_awaited_once_with(
+        "25901",
+        max_output_chars=400_000,
+        max_download_bytes=50 * 1024 * 1024,
+    )
+    payload = extract_payload(result)
+    assert payload["success"] is True
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+async def test_get_automation_logs_coerces_int_automation_id(
+    observability_session, mock_observability_client, extract_payload
+):
+    mock_observability_client.get_automation_logs.return_value = {
+        "automationExecutions": {
+            "nodes": [],
+            "pageInfo": {"hasNextPage": False, "endCursor": None},
+        }
+    }
+
+    async with observability_session as session:
+        result = await session.call_tool(
+            "get_automation_logs",
+            {"automation_id": 42},
+        )
+
+    assert result.isError is False
+    mock_observability_client.get_automation_logs.assert_awaited_once_with(
+        "42", first=30, after=None, status=None, search_term=None
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
 async def test_usage_tools_have_read_only_hint(observability_session):
     async with observability_session as session:
         listed = await session.list_tools()
@@ -872,3 +952,366 @@ async def test_get_ai_credit_usage_coerces_int_organization_uuid(
     mock_observability_client.get_ai_credit_usage.assert_awaited_once_with(
         "302398434", "current_month"
     )
+
+
+# ---------------------------------------------------------------------------
+# get_automation_logs — input validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+async def test_get_automation_logs_rejects_blank_automation_id(
+    observability_session, mock_observability_client, extract_payload
+):
+    async with observability_session as session:
+        result = await session.call_tool("get_automation_logs", {"automation_id": ""})
+
+    mock_observability_client.get_automation_logs.assert_not_called()
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "automation_id" in p["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+@pytest.mark.parametrize("bad_first", [0, _MAX_PAGE_SIZE + 1])
+async def test_get_automation_logs_rejects_out_of_bounds_first(
+    observability_session, mock_observability_client, extract_payload, bad_first
+):
+    async with observability_session as session:
+        result = await session.call_tool(
+            "get_automation_logs", {"automation_id": "auto-1", "first": bad_first}
+        )
+
+    mock_observability_client.get_automation_logs.assert_not_called()
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "first" in p["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# get_automation_logs_by_repo — input validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+async def test_get_automation_logs_by_repo_rejects_blank_repo_id(
+    observability_session, mock_observability_client, extract_payload
+):
+    async with observability_session as session:
+        result = await session.call_tool("get_automation_logs_by_repo", {"repo_id": ""})
+
+    mock_observability_client.get_automation_logs_by_repo.assert_not_called()
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "repo_id" in p["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+@pytest.mark.parametrize("bad_first", [0, _MAX_PAGE_SIZE + 1])
+async def test_get_automation_logs_by_repo_rejects_out_of_bounds_first(
+    observability_session, mock_observability_client, extract_payload, bad_first
+):
+    async with observability_session as session:
+        result = await session.call_tool(
+            "get_automation_logs_by_repo", {"repo_id": "repo-5", "first": bad_first}
+        )
+
+    mock_observability_client.get_automation_logs_by_repo.assert_not_called()
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "first" in p["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# get_agents_usage — invalid organization_uuid
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+async def test_get_agents_usage_graphql_error(
+    observability_session, mock_observability_client, extract_payload
+):
+    mock_observability_client.get_agents_usage.side_effect = TransportQueryError(
+        "failed", errors=[{"message": "unauthorized"}]
+    )
+
+    async with observability_session as session:
+        result = await session.call_tool(
+            "get_agents_usage",
+            {
+                "organization_uuid": "org-1",
+                "filter_date_from": "2026-03-01T00:00:00Z",
+                "filter_date_to": "2026-03-31T23:59:59Z",
+            },
+        )
+
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "unauthorized" in p["error"]
+
+
+# ---------------------------------------------------------------------------
+# get_automations_usage — invalid organization_uuid + GraphQL error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+async def test_get_automations_usage_rejects_empty_org_uuid(
+    observability_session, mock_observability_client, extract_payload
+):
+    async with observability_session as session:
+        result = await session.call_tool(
+            "get_automations_usage",
+            {
+                "organization_uuid": "",
+                "filter_date_from": "2026-03-01T00:00:00Z",
+                "filter_date_to": "2026-03-31T23:59:59Z",
+            },
+        )
+
+    mock_observability_client.get_automations_usage.assert_not_called()
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "organization_uuid" in p["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+async def test_get_automations_usage_graphql_error(
+    observability_session, mock_observability_client, extract_payload
+):
+    mock_observability_client.get_automations_usage.side_effect = TransportQueryError(
+        "failed", errors=[{"message": "service unavailable"}]
+    )
+
+    async with observability_session as session:
+        result = await session.call_tool(
+            "get_automations_usage",
+            {
+                "organization_uuid": "org-1",
+                "filter_date_from": "2026-03-01T00:00:00Z",
+                "filter_date_to": "2026-03-31T23:59:59Z",
+            },
+        )
+
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "service unavailable" in p["error"]
+
+
+# ---------------------------------------------------------------------------
+# get_ai_credit_usage — invalid organization_uuid
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+async def test_get_ai_credit_usage_rejects_empty_org_uuid(
+    observability_session, mock_observability_client, extract_payload
+):
+    async with observability_session as session:
+        result = await session.call_tool(
+            "get_ai_credit_usage",
+            {"organization_uuid": "", "period": "current_month"},
+        )
+
+    mock_observability_client.get_ai_credit_usage.assert_not_called()
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "organization_uuid" in p["error"]
+
+
+# ---------------------------------------------------------------------------
+# export_automation_jobs — invalid organization_id + GraphQL error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+async def test_export_automation_jobs_rejects_empty_org_id(
+    observability_session, mock_observability_client, extract_payload
+):
+    async with observability_session as session:
+        result = await session.call_tool(
+            "export_automation_jobs",
+            {"organization_id": "", "period": "last_month"},
+        )
+
+    mock_observability_client.export_automation_jobs.assert_not_called()
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "organization_id" in p["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+async def test_export_automation_jobs_rejects_invalid_period(
+    observability_session, mock_observability_client, extract_payload
+):
+    async with observability_session as session:
+        result = await session.call_tool(
+            "export_automation_jobs",
+            {"organization_id": "org-1", "period": "all_time"},
+        )
+
+    mock_observability_client.export_automation_jobs.assert_not_called()
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "period" in p["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+async def test_export_automation_jobs_graphql_error(
+    observability_session, mock_observability_client, extract_payload
+):
+    mock_observability_client.export_automation_jobs.side_effect = TransportQueryError(
+        "failed", errors=[{"message": "rate limited"}]
+    )
+
+    async with observability_session as session:
+        result = await session.call_tool(
+            "export_automation_jobs",
+            {"organization_id": "org-1", "period": "last_month"},
+        )
+
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "rate limited" in p["error"]
+
+
+# ---------------------------------------------------------------------------
+# get_ai_agent_log_details — GraphQL error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+async def test_get_ai_agent_log_details_graphql_error(
+    observability_session, mock_observability_client, extract_payload
+):
+    mock_observability_client.get_ai_agent_log_details.side_effect = (
+        TransportQueryError("failed", errors=[{"message": "log not found"}])
+    )
+
+    async with observability_session as session:
+        result = await session.call_tool(
+            "get_ai_agent_log_details", {"log_uuid": "bad-uuid"}
+        )
+
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "log not found" in p["error"]
+
+
+# ---------------------------------------------------------------------------
+# get_automation_logs — GraphQL error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+async def test_get_automation_logs_graphql_error(
+    observability_session, mock_observability_client, extract_payload
+):
+    mock_observability_client.get_automation_logs.side_effect = TransportQueryError(
+        "failed", errors=[{"message": "internal error"}]
+    )
+
+    async with observability_session as session:
+        result = await session.call_tool(
+            "get_automation_logs", {"automation_id": "auto-1"}
+        )
+
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "internal error" in p["error"]
+
+
+# ---------------------------------------------------------------------------
+# get_automation_logs_by_repo — GraphQL error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+async def test_get_automation_logs_by_repo_graphql_error(
+    observability_session, mock_observability_client, extract_payload
+):
+    mock_observability_client.get_automation_logs_by_repo.side_effect = (
+        TransportQueryError("failed", errors=[{"message": "timeout"}])
+    )
+
+    async with observability_session as session:
+        result = await session.call_tool(
+            "get_automation_logs_by_repo", {"repo_id": "repo-5"}
+        )
+
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "timeout" in p["error"]
+
+
+# ---------------------------------------------------------------------------
+# get_automation_jobs_export_csv — invalid limits + GraphQL error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+async def test_get_automation_jobs_export_csv_rejects_bad_max_download_bytes(
+    observability_session, mock_observability_client, extract_payload
+):
+    async with observability_session as session:
+        result = await session.call_tool(
+            "get_automation_jobs_export_csv",
+            {"export_id": "1", "max_download_bytes": 10},
+        )
+
+    mock_observability_client.get_automation_jobs_export_csv.assert_not_called()
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "max_download_bytes" in p["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+async def test_get_automation_jobs_export_csv_graphql_error(
+    observability_session, mock_observability_client, extract_payload
+):
+    mock_observability_client.get_automation_jobs_export_csv.side_effect = Exception(
+        "network failure"
+    )
+
+    async with observability_session as session:
+        result = await session.call_tool(
+            "get_automation_jobs_export_csv",
+            {"export_id": "1"},
+        )
+
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "CSV failed" in p["error"] or "network failure" in p["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+async def test_get_automation_jobs_export_csv_rejects_empty_export_id(
+    observability_session, mock_observability_client, extract_payload
+):
+    async with observability_session as session:
+        result = await session.call_tool(
+            "get_automation_jobs_export_csv",
+            {"export_id": ""},
+        )
+
+    mock_observability_client.get_automation_jobs_export_csv.assert_not_called()
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "export_id" in p["error"]

--- a/tests/tools/test_organization_tools.py
+++ b/tests/tools/test_organization_tools.py
@@ -95,3 +95,30 @@ async def test_get_organization_transport_error(
     payload = extract_payload(result)
     assert payload["success"] is False
     assert isinstance(payload.get("error"), str)
+
+
+## ---------------------------------------------------------------------------
+## PipefyId coercion: int → str through MCP transport (mcporter mitigation)
+## ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("org_session", [None], indirect=True)
+async def test_get_organization_coerces_int_organization_id(
+    org_session, mock_org_client, extract_payload
+):
+    mock_org_client.get_organization = AsyncMock(
+        return_value={
+            "id": "123",
+            "uuid": "abc-def",
+            "name": "My Org",
+            "planName": "Business",
+            "membersCount": 42,
+        }
+    )
+    async with org_session as session:
+        result = await session.call_tool("get_organization", {"organization_id": 123})
+    assert result.isError is False
+    mock_org_client.get_organization.assert_awaited_once_with("123")
+    payload = extract_payload(result)
+    assert payload["success"] is True

--- a/tests/tools/test_report_tools.py
+++ b/tests/tools/test_report_tools.py
@@ -645,6 +645,204 @@ async def test_export_tools_are_not_readonly(report_session):
         )
 
 
+## ---------------------------------------------------------------------------
+## PipefyId coercion: int → str through MCP transport (mcporter mitigation)
+## ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_get_organization_report_coerces_int_report_id(
+    report_session, mock_report_client, extract_payload
+):
+    mock_report_client.get_organization_report.return_value = {
+        "organizationReport": {"id": "500", "name": "Report"}
+    }
+    async with report_session as session:
+        result = await session.call_tool("get_organization_report", {"report_id": 500})
+    assert result.isError is False
+    mock_report_client.get_organization_report.assert_awaited_once_with("500")
+    payload = extract_payload(result)
+    assert payload["success"] is True
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_get_organization_reports_coerces_int_organization_id(
+    report_session, mock_report_client, extract_payload
+):
+    mock_report_client.get_organization_reports.return_value = {
+        "organizationReports": {
+            "edges": [],
+            "pageInfo": {"hasNextPage": False, "endCursor": None},
+        }
+    }
+    async with report_session as session:
+        result = await session.call_tool(
+            "get_organization_reports", {"organization_id": 42}
+        )
+    assert result.isError is False
+    mock_report_client.get_organization_reports.assert_awaited_once_with(
+        "42", first=30, after=None
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_get_pipe_report_export_coerces_int_export_id(
+    report_session, mock_report_client, extract_payload
+):
+    mock_report_client.get_pipe_report_export.return_value = {
+        "pipeReportExport": {"id": "99", "state": "done", "fileURL": "https://x.com/f"}
+    }
+    async with report_session as session:
+        result = await session.call_tool("get_pipe_report_export", {"export_id": 99})
+    assert result.isError is False
+    mock_report_client.get_pipe_report_export.assert_awaited_once_with("99")
+    payload = extract_payload(result)
+    assert payload["success"] is True
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_get_organization_report_export_coerces_int_export_id(
+    report_session, mock_report_client, extract_payload
+):
+    mock_report_client.get_organization_report_export.return_value = {
+        "organizationExport": {"id": "88", "state": "done"}
+    }
+    async with report_session as session:
+        result = await session.call_tool(
+            "get_organization_report_export", {"export_id": 88}
+        )
+    assert result.isError is False
+    mock_report_client.get_organization_report_export.assert_awaited_once_with("88")
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_create_pipe_report_coerces_int_pipe_id(
+    report_session, mock_report_client, extract_payload
+):
+    mock_report_client.create_pipe_report.return_value = {
+        "createPipeReport": {"pipeReport": {"id": "r1"}}
+    }
+    async with report_session as session:
+        result = await session.call_tool(
+            "create_pipe_report", {"pipe_id": 301, "name": "Report"}
+        )
+    assert result.isError is False
+    mock_report_client.create_pipe_report.assert_awaited_once_with(
+        "301", "Report", fields=None, filter=None, formulas=None
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_update_pipe_report_coerces_int_report_id(
+    report_session, mock_report_client, extract_payload
+):
+    mock_report_client.update_pipe_report.return_value = {
+        "updatePipeReport": {"pipeReport": {"id": "200"}}
+    }
+    async with report_session as session:
+        result = await session.call_tool(
+            "update_pipe_report", {"report_id": 200, "name": "Updated"}
+        )
+    assert result.isError is False
+    mock_report_client.update_pipe_report.assert_awaited_once_with(
+        "200",
+        name="Updated",
+        color=None,
+        fields=None,
+        filter=None,
+        formulas=None,
+        featured_field=None,
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_export_pipe_report_coerces_int_ids(
+    report_session, mock_report_client, extract_payload
+):
+    mock_report_client.export_pipe_report.return_value = {
+        "exportPipeReport": {"pipeReportExport": {"id": "e1", "state": "processing"}}
+    }
+    async with report_session as session:
+        result = await session.call_tool(
+            "export_pipe_report", {"pipe_id": 301, "pipe_report_id": 777}
+        )
+    assert result.isError is False
+    mock_report_client.export_pipe_report.assert_awaited_once_with(
+        "301",
+        "777",
+        sort_by=None,
+        filter=None,
+        columns=None,
+    )
+    payload = extract_payload(result)
+    assert payload["success"] is True
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_create_organization_report_coerces_int_organization_id(
+    report_session, mock_report_client, extract_payload
+):
+    mock_report_client.create_organization_report.return_value = {
+        "createOrganizationReport": {"organizationReport": {"id": "or1"}}
+    }
+    async with report_session as session:
+        result = await session.call_tool(
+            "create_organization_report",
+            {"organization_id": 42, "name": "Org Report", "pipe_ids": ["10"]},
+        )
+    assert result.isError is False
+    mock_report_client.create_organization_report.assert_awaited_once_with(
+        "42", "Org Report", ["10"], fields=None, filter=None
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_update_organization_report_coerces_int_report_id(
+    report_session, mock_report_client, extract_payload
+):
+    mock_report_client.update_organization_report.return_value = {
+        "updateOrganizationReport": {"organizationReport": {"id": "300"}}
+    }
+    async with report_session as session:
+        result = await session.call_tool(
+            "update_organization_report", {"report_id": 300, "name": "Renamed"}
+        )
+    assert result.isError is False
+    mock_report_client.update_organization_report.assert_awaited_once_with(
+        "300", name="Renamed", color=None, fields=None, filter=None, pipe_ids=None
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_get_pipe_reports_coerces_int_report_id_filter(
+    report_session, mock_report_client, extract_payload
+):
+    mock_report_client.get_pipe_reports.return_value = {
+        "pipeReports": {
+            "edges": [{"node": {"id": "55", "name": "R"}}],
+            "pageInfo": {"hasNextPage": False, "endCursor": None},
+        }
+    }
+    async with report_session as session:
+        result = await session.call_tool(
+            "get_pipe_reports", {"pipe_uuid": "uuid-x", "report_id": 55}
+        )
+    assert result.isError is False
+    mock_report_client.get_pipe_reports.assert_awaited_once_with(
+        "uuid-x", first=30, after=None, search=None, report_id="55", order=None
+    )
+
+
 @pytest.mark.anyio
 @pytest.mark.parametrize("report_session", [None], indirect=True)
 async def test_delete_tools_have_destructive_hint(report_session):
@@ -658,3 +856,451 @@ async def test_delete_tools_have_destructive_hint(report_session):
         assert tool.annotations.destructiveHint is True, (
             f"{name} should be destructiveHint=True"
         )
+
+
+## ---------------------------------------------------------------------------
+## _blank_field_error validation: non-string and blank string inputs
+## ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_get_pipe_reports_blank_pipe_uuid(report_session, extract_payload):
+    async with report_session as session:
+        result = await session.call_tool("get_pipe_reports", {"pipe_uuid": ""})
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "non-empty" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_get_organization_report_blank_report_id(report_session, extract_payload):
+    async with report_session as session:
+        result = await session.call_tool("get_organization_report", {"report_id": ""})
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "non-empty" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_get_organization_reports_blank_organization_id(
+    report_session, extract_payload
+):
+    async with report_session as session:
+        result = await session.call_tool(
+            "get_organization_reports", {"organization_id": ""}
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "non-empty" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_get_pipe_report_export_blank_export_id(report_session, extract_payload):
+    async with report_session as session:
+        result = await session.call_tool("get_pipe_report_export", {"export_id": ""})
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "non-empty" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_get_organization_report_export_blank_export_id(
+    report_session, extract_payload
+):
+    async with report_session as session:
+        result = await session.call_tool(
+            "get_organization_report_export", {"export_id": ""}
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "non-empty" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_create_pipe_report_blank_pipe_id(report_session, extract_payload):
+    async with report_session as session:
+        result = await session.call_tool(
+            "create_pipe_report", {"pipe_id": "", "name": "x"}
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "pipe_id" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_create_pipe_report_blank_name(report_session, extract_payload):
+    async with report_session as session:
+        result = await session.call_tool(
+            "create_pipe_report", {"pipe_id": "x", "name": ""}
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "name" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_update_pipe_report_blank_report_id(report_session, extract_payload):
+    async with report_session as session:
+        result = await session.call_tool("update_pipe_report", {"report_id": ""})
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "report_id" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_create_organization_report_blank_organization_id(
+    report_session, extract_payload
+):
+    async with report_session as session:
+        result = await session.call_tool(
+            "create_organization_report",
+            {"organization_id": "", "name": "x", "pipe_ids": ["1"]},
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "organization_id" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_create_organization_report_blank_name(report_session, extract_payload):
+    async with report_session as session:
+        result = await session.call_tool(
+            "create_organization_report",
+            {"organization_id": "x", "name": "", "pipe_ids": ["1"]},
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "name" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_update_organization_report_blank_report_id(
+    report_session, extract_payload
+):
+    async with report_session as session:
+        result = await session.call_tool(
+            "update_organization_report", {"report_id": ""}
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "report_id" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_export_pipe_report_blank_pipe_id(report_session, extract_payload):
+    async with report_session as session:
+        result = await session.call_tool(
+            "export_pipe_report", {"pipe_id": "", "pipe_report_id": "x"}
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "pipe_id" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_export_pipe_report_blank_pipe_report_id(report_session, extract_payload):
+    async with report_session as session:
+        result = await session.call_tool(
+            "export_pipe_report", {"pipe_id": "x", "pipe_report_id": ""}
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "pipe_report_id" in payload["error"]
+
+
+## ---------------------------------------------------------------------------
+## first < 1 validation
+## ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_get_pipe_reports_first_less_than_one(report_session, extract_payload):
+    async with report_session as session:
+        result = await session.call_tool(
+            "get_pipe_reports", {"pipe_uuid": "uuid-1", "first": 0}
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "positive integer" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_get_organization_reports_first_less_than_one(
+    report_session, extract_payload
+):
+    async with report_session as session:
+        result = await session.call_tool(
+            "get_organization_reports", {"organization_id": "org-1", "first": 0}
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "positive integer" in payload["error"]
+
+
+## ---------------------------------------------------------------------------
+## pipe_ids validation in create_organization_report
+## ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_create_organization_report_empty_pipe_ids(
+    report_session, extract_payload
+):
+    async with report_session as session:
+        result = await session.call_tool(
+            "create_organization_report",
+            {"organization_id": "org-1", "name": "Report", "pipe_ids": []},
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "pipe_ids" in payload["error"]
+
+
+## ---------------------------------------------------------------------------
+## export_organization_report: organization_id < 1 validation
+## ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_export_organization_report_organization_id_less_than_one(
+    report_session, extract_payload
+):
+    async with report_session as session:
+        result = await session.call_tool(
+            "export_organization_report",
+            {"organization_id": 0, "pipe_ids": [1]},
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "positive integer" in payload["error"]
+
+
+## ---------------------------------------------------------------------------
+## GraphQL error paths (TransportQueryError)
+## ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_get_organization_report_graphql_error(
+    report_session, mock_report_client, extract_payload
+):
+    mock_report_client.get_organization_report.side_effect = TransportQueryError(
+        "failed", errors=[{"message": "org not found"}]
+    )
+
+    async with report_session as session:
+        result = await session.call_tool(
+            "get_organization_report", {"report_id": "or1"}
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "org not found" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_get_organization_reports_graphql_error(
+    report_session, mock_report_client, extract_payload
+):
+    mock_report_client.get_organization_reports.side_effect = TransportQueryError(
+        "failed", errors=[{"message": "access denied"}]
+    )
+
+    async with report_session as session:
+        result = await session.call_tool(
+            "get_organization_reports", {"organization_id": "org-1"}
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "access denied" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_get_pipe_report_export_graphql_error(
+    report_session, mock_report_client, extract_payload
+):
+    mock_report_client.get_pipe_report_export.side_effect = TransportQueryError(
+        "failed", errors=[{"message": "export not found"}]
+    )
+
+    async with report_session as session:
+        result = await session.call_tool(
+            "get_pipe_report_export", {"export_id": "exp1"}
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "export not found" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_get_organization_report_export_graphql_error(
+    report_session, mock_report_client, extract_payload
+):
+    mock_report_client.get_organization_report_export.side_effect = TransportQueryError(
+        "failed", errors=[{"message": "export error"}]
+    )
+
+    async with report_session as session:
+        result = await session.call_tool(
+            "get_organization_report_export", {"export_id": "exp2"}
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "export error" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_update_pipe_report_graphql_error(
+    report_session, mock_report_client, extract_payload
+):
+    mock_report_client.update_pipe_report.side_effect = TransportQueryError(
+        "failed", errors=[{"message": "update denied"}]
+    )
+
+    async with report_session as session:
+        result = await session.call_tool(
+            "update_pipe_report", {"report_id": "r10", "name": "Bad"}
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "update denied" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_delete_pipe_report_graphql_error(
+    report_session, mock_report_client, extract_payload
+):
+    mock_report_client.delete_pipe_report.side_effect = TransportQueryError(
+        "failed", errors=[{"message": "delete denied"}]
+    )
+
+    async with report_session as session:
+        result = await session.call_tool(
+            "delete_pipe_report", {"report_id": "r10", "confirm": True}
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "delete denied" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_create_organization_report_graphql_error(
+    report_session, mock_report_client, extract_payload
+):
+    mock_report_client.create_organization_report.side_effect = TransportQueryError(
+        "failed", errors=[{"message": "org create failed"}]
+    )
+
+    async with report_session as session:
+        result = await session.call_tool(
+            "create_organization_report",
+            {"organization_id": "org-1", "name": "Report", "pipe_ids": ["p1"]},
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "org create failed" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_update_organization_report_graphql_error(
+    report_session, mock_report_client, extract_payload
+):
+    mock_report_client.update_organization_report.side_effect = TransportQueryError(
+        "failed", errors=[{"message": "org update failed"}]
+    )
+
+    async with report_session as session:
+        result = await session.call_tool(
+            "update_organization_report", {"report_id": "or5", "name": "Bad"}
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "org update failed" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_delete_organization_report_graphql_error(
+    report_session, mock_report_client, extract_payload
+):
+    mock_report_client.delete_organization_report.side_effect = TransportQueryError(
+        "failed", errors=[{"message": "org delete failed"}]
+    )
+
+    async with report_session as session:
+        result = await session.call_tool(
+            "delete_organization_report", {"report_id": "or5", "confirm": True}
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "org delete failed" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_export_organization_report_graphql_error(
+    report_session, mock_report_client, extract_payload
+):
+    mock_report_client.export_organization_report.side_effect = TransportQueryError(
+        "failed", errors=[{"message": "export org failed"}]
+    )
+
+    async with report_session as session:
+        result = await session.call_tool(
+            "export_organization_report",
+            {"organization_id": 42, "pipe_ids": [10]},
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "export org failed" in payload["error"]

--- a/tests/tools/test_table_tools.py
+++ b/tests/tools/test_table_tools.py
@@ -868,3 +868,699 @@ async def test_search_tables_returns_client_response(
 
     payload = extract_payload(result)
     assert payload == expected
+
+
+# ---------------------------------------------------------------------------
+# Input validation: get_table
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+@pytest.mark.parametrize("bad_id", [0, ""])
+async def test_get_table_invalid_table_id(
+    table_session, mock_table_client, extract_payload, bad_id
+):
+    async with table_session as session:
+        result = await session.call_tool("get_table", {"table_id": bad_id})
+
+    mock_table_client.get_table.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "table_id" in payload["error"]
+
+
+# ---------------------------------------------------------------------------
+# Input validation: get_tables
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_get_tables_empty_list(table_session, mock_table_client, extract_payload):
+    async with table_session as session:
+        result = await session.call_tool("get_tables", {"table_ids": []})
+
+    mock_table_client.get_tables.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "table_ids" in payload["error"]
+
+
+# ---------------------------------------------------------------------------
+# Input validation: get_table_records
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_get_table_records_invalid_table_id(
+    table_session, mock_table_client, extract_payload
+):
+    async with table_session as session:
+        result = await session.call_tool(
+            "get_table_records", {"table_id": 0, "first": 10}
+        )
+
+    mock_table_client.get_table_records.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "table_id" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_get_table_records_first_too_small(
+    table_session, mock_table_client, extract_payload
+):
+    async with table_session as session:
+        result = await session.call_tool(
+            "get_table_records", {"table_id": "t1", "first": 0}
+        )
+
+    mock_table_client.get_table_records.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "first" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_get_table_records_first_too_large(
+    table_session, mock_table_client, extract_payload
+):
+    async with table_session as session:
+        result = await session.call_tool(
+            "get_table_records", {"table_id": "t1", "first": 201}
+        )
+
+    mock_table_client.get_table_records.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "first" in payload["error"]
+
+
+# ---------------------------------------------------------------------------
+# Input validation: get_table_record
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_get_table_record_invalid_record_id(
+    table_session, mock_table_client, extract_payload
+):
+    async with table_session as session:
+        result = await session.call_tool("get_table_record", {"record_id": 0})
+
+    mock_table_client.get_table_record.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "record_id" in payload["error"]
+
+
+# ---------------------------------------------------------------------------
+# Input validation: find_records
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_find_records_invalid_table_id(
+    table_session, mock_table_client, extract_payload
+):
+    async with table_session as session:
+        result = await session.call_tool(
+            "find_records",
+            {"table_id": 0, "field_id": "f", "field_value": "v"},
+        )
+
+    mock_table_client.find_records.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "table_id" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_find_records_blank_field_id(
+    table_session, mock_table_client, extract_payload
+):
+    async with table_session as session:
+        result = await session.call_tool(
+            "find_records",
+            {"table_id": "t1", "field_id": "", "field_value": "v"},
+        )
+
+    mock_table_client.find_records.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "field_id" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_find_records_blank_field_value(
+    table_session, mock_table_client, extract_payload
+):
+    """field_value is typed as str — empty string is valid per the tool (not blank-checked)."""
+    mock_table_client.find_records.return_value = {
+        "findRecords": {
+            "edges": [],
+            "pageInfo": {"hasNextPage": False, "endCursor": None},
+        }
+    }
+
+    async with table_session as session:
+        result = await session.call_tool(
+            "find_records",
+            {"table_id": "t1", "field_id": "f", "field_value": ""},
+        )
+
+    # Empty string is accepted — the tool only checks isinstance(field_value, str)
+    mock_table_client.find_records.assert_awaited_once()
+    payload = extract_payload(result)
+    assert payload["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# Input validation: update_table_record
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_update_table_record_invalid_record_id(
+    table_session, mock_table_client, extract_payload
+):
+    async with table_session as session:
+        result = await session.call_tool(
+            "update_table_record",
+            {"record_id": 0, "fields": {"title": "x"}},
+        )
+
+    mock_table_client.update_table_record.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "record_id" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_update_table_record_empty_fields(
+    table_session, mock_table_client, extract_payload
+):
+    async with table_session as session:
+        result = await session.call_tool(
+            "update_table_record",
+            {"record_id": 1, "fields": {}},
+        )
+
+    mock_table_client.update_table_record.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+
+
+# ---------------------------------------------------------------------------
+# Input validation: delete_table_record
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_delete_table_record_invalid_record_id(
+    table_session, mock_table_client, extract_payload
+):
+    async with table_session as session:
+        result = await session.call_tool(
+            "delete_table_record",
+            {"record_id": 0, "confirm": True},
+        )
+
+    mock_table_client.delete_table_record.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "record_id" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_delete_table_record_preview_without_confirm(
+    table_session, mock_table_client, extract_payload
+):
+    async with table_session as session:
+        result = await session.call_tool(
+            "delete_table_record",
+            {"record_id": 99, "confirm": False},
+        )
+
+    mock_table_client.delete_table_record.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert payload.get("requires_confirmation") is True
+
+
+# ---------------------------------------------------------------------------
+# Input validation: set_table_record_field_value
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_set_table_record_field_value_invalid_record_id(
+    table_session, mock_table_client, extract_payload
+):
+    async with table_session as session:
+        result = await session.call_tool(
+            "set_table_record_field_value",
+            {"record_id": 0, "field_id": "f", "value": "x"},
+        )
+
+    mock_table_client.set_table_record_field_value.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "record_id" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_set_table_record_field_value_invalid_field_id_zero(
+    table_session, mock_table_client, extract_payload
+):
+    async with table_session as session:
+        result = await session.call_tool(
+            "set_table_record_field_value",
+            {"record_id": "1", "field_id": 0, "value": "x"},
+        )
+
+    mock_table_client.set_table_record_field_value.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "field_id" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_set_table_record_field_value_blank_field_id(
+    table_session, mock_table_client, extract_payload
+):
+    async with table_session as session:
+        result = await session.call_tool(
+            "set_table_record_field_value",
+            {"record_id": "1", "field_id": "", "value": "x"},
+        )
+
+    mock_table_client.set_table_record_field_value.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "field_id" in payload["error"]
+
+
+# ---------------------------------------------------------------------------
+# Input validation: create_table_field
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_create_table_field_invalid_table_id(
+    table_session, mock_table_client, extract_payload
+):
+    async with table_session as session:
+        result = await session.call_tool(
+            "create_table_field",
+            {"table_id": 0, "label": "Name", "field_type": "short_text"},
+        )
+
+    mock_table_client.create_table_field.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "table_id" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_create_table_field_empty_label(
+    table_session, mock_table_client, extract_payload
+):
+    async with table_session as session:
+        result = await session.call_tool(
+            "create_table_field",
+            {"table_id": "1", "label": "", "field_type": "short_text"},
+        )
+
+    mock_table_client.create_table_field.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "label" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_create_table_field_empty_field_type(
+    table_session, mock_table_client, extract_payload
+):
+    async with table_session as session:
+        result = await session.call_tool(
+            "create_table_field",
+            {"table_id": "1", "label": "x", "field_type": ""},
+        )
+
+    mock_table_client.create_table_field.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "field_type" in payload["error"]
+
+
+# ---------------------------------------------------------------------------
+# Input validation: update_table_field
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_update_table_field_invalid_field_id(
+    table_session, mock_table_client, extract_payload
+):
+    async with table_session as session:
+        result = await session.call_tool(
+            "update_table_field",
+            {"field_id": 0, "table_id": 1, "label": "L"},
+        )
+
+    mock_table_client.update_table_field.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "field_id" in payload["error"]
+
+
+# ---------------------------------------------------------------------------
+# Input validation: delete_table_field
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_delete_table_field_invalid_field_id(
+    table_session, mock_table_client, extract_payload
+):
+    async with table_session as session:
+        result = await session.call_tool(
+            "delete_table_field",
+            {"field_id": 0, "confirm": True},
+        )
+
+    mock_table_client.delete_table_field.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "field_id" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_delete_table_field_preview_without_confirm(
+    table_session, mock_table_client, extract_payload
+):
+    async with table_session as session:
+        result = await session.call_tool(
+            "delete_table_field",
+            {"field_id": "slug-1", "confirm": False},
+        )
+
+    mock_table_client.delete_table_field.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert payload.get("requires_confirmation") is True
+
+
+# ---------------------------------------------------------------------------
+# Input validation: create_table_record — empty fields
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_create_table_record_empty_dict_fields(
+    table_session, mock_table_client, extract_payload
+):
+    async with table_session as session:
+        result = await session.call_tool(
+            "create_table_record",
+            {"table_id": 10, "fields": {}},
+        )
+
+    mock_table_client.create_table_record.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "fields" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_create_table_record_empty_list_fields(
+    table_session, mock_table_client, extract_payload
+):
+    async with table_session as session:
+        result = await session.call_tool(
+            "create_table_record",
+            {"table_id": 10, "fields": []},
+        )
+
+    mock_table_client.create_table_record.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "fields" in payload["error"]
+
+
+# ---------------------------------------------------------------------------
+# Input validation: create_table — blank name, invalid org_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_create_table_blank_name(
+    table_session, mock_table_client, extract_payload
+):
+    async with table_session as session:
+        result = await session.call_tool(
+            "create_table",
+            {"name": "", "organization_id": 1},
+        )
+
+    mock_table_client.create_table.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "name" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_create_table_invalid_organization_id(
+    table_session, mock_table_client, extract_payload
+):
+    async with table_session as session:
+        result = await session.call_tool(
+            "create_table",
+            {"name": "T", "organization_id": 0},
+        )
+
+    mock_table_client.create_table.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "organization_id" in payload["error"]
+
+
+# ---------------------------------------------------------------------------
+# Input validation: update_table — invalid table_id, no changes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_update_table_invalid_table_id(
+    table_session, mock_table_client, extract_payload
+):
+    async with table_session as session:
+        result = await session.call_tool(
+            "update_table",
+            {"table_id": 0, "name": "N"},
+        )
+
+    mock_table_client.update_table.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "table_id" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_update_table_no_changes(
+    table_session, mock_table_client, extract_payload
+):
+    async with table_session as session:
+        result = await session.call_tool(
+            "update_table",
+            {"table_id": 1},
+        )
+
+    mock_table_client.update_table.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "at least one" in payload["error"]
+
+
+# ---------------------------------------------------------------------------
+# Input validation: delete_table — invalid table_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_delete_table_invalid_table_id(
+    table_session, mock_table_client, extract_payload
+):
+    async with table_session as session:
+        result = await session.call_tool(
+            "delete_table",
+            {"table_id": 0, "confirm": True},
+        )
+
+    mock_table_client.get_table.assert_not_called()
+    mock_table_client.delete_table.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "table_id" in payload["error"]
+
+
+# ---------------------------------------------------------------------------
+# Input validation: create_table_record — invalid table_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_create_table_record_invalid_table_id(
+    table_session, mock_table_client, extract_payload
+):
+    async with table_session as session:
+        result = await session.call_tool(
+            "create_table_record",
+            {"table_id": 0, "fields": {"f": "v"}},
+        )
+
+    mock_table_client.create_table_record.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "table_id" in payload["error"]
+
+
+# ---------------------------------------------------------------------------
+# Input validation: set_table_record_field_value — null value
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_set_table_record_field_value_null_value(
+    table_session, mock_table_client, extract_payload
+):
+    async with table_session as session:
+        result = await session.call_tool(
+            "set_table_record_field_value",
+            {"record_id": "1", "field_id": "f", "value": None},
+        )
+
+    mock_table_client.set_table_record_field_value.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "value" in payload["error"]
+
+
+# ---------------------------------------------------------------------------
+# delete_table — GraphQL error during get_table lookup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_delete_table_graphql_error_on_lookup(
+    table_session, mock_table_client, extract_payload
+):
+    mock_table_client.get_table.side_effect = TransportQueryError(
+        "failed", errors=[{"message": "table gone"}]
+    )
+
+    async with table_session as session:
+        result = await session.call_tool(
+            "delete_table",
+            {"table_id": 99, "confirm": True},
+        )
+
+    mock_table_client.delete_table.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+
+
+# ---------------------------------------------------------------------------
+# delete_table — confirm True but delete returns success=False
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_delete_table_confirm_returns_false(
+    table_session, mock_table_client, extract_payload
+):
+    mock_table_client.get_table.return_value = {"table": {"id": "5", "name": "T"}}
+    mock_table_client.delete_table.return_value = {"deleteTable": {"success": False}}
+
+    async with table_session as session:
+        result = await session.call_tool(
+            "delete_table",
+            {"table_id": 5, "confirm": True},
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+
+
+# ---------------------------------------------------------------------------
+# get_tables — invalid ID inside list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_get_tables_invalid_id_in_list(
+    table_session, mock_table_client, extract_payload
+):
+    async with table_session as session:
+        result = await session.call_tool("get_tables", {"table_ids": [1, 0]})
+
+    mock_table_client.get_tables.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "each" in payload["error"].lower() or "Each" in payload["error"]
+
+
+# ---------------------------------------------------------------------------
+# update_table_field — no updates and no table_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_update_table_field_no_updates_no_table_id(
+    table_session, mock_table_client, extract_payload
+):
+    async with table_session as session:
+        result = await session.call_tool(
+            "update_table_field",
+            {"field_id": "slug-1"},
+        )
+
+    mock_table_client.update_table_field.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "at least one" in payload["error"].lower() or "table_id" in payload["error"]

--- a/tests/tools/test_webhook_tools.py
+++ b/tests/tools/test_webhook_tools.py
@@ -504,3 +504,448 @@ async def test_get_card_inbox_emails_has_read_only_hint(webhook_session):
     tool = next(t for t in listed.tools if t.name == "get_card_inbox_emails")
     assert tool.annotations is not None
     assert tool.annotations.readOnlyHint is True
+
+
+## ---------------------------------------------------------------------------
+## PipefyId coercion: int → str through MCP transport (mcporter mitigation)
+## ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("webhook_session", [None], indirect=True)
+async def test_get_email_templates_coerces_int_repo_id(
+    webhook_session, mock_webhook_client, extract_payload
+):
+    mock_webhook_client.get_email_templates.return_value = {
+        "emailTemplates": {"edges": [], "pageInfo": {"hasNextPage": False}}
+    }
+    async with webhook_session as session:
+        result = await session.call_tool("get_email_templates", {"repo_id": 301})
+    assert result.isError is False
+    mock_webhook_client.get_email_templates.assert_awaited_once_with(
+        "301", filter_by_name=None, first=50
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("webhook_session", [None], indirect=True)
+async def test_get_card_inbox_emails_coerces_int_card_id(
+    webhook_session, mock_webhook_client, extract_payload
+):
+    mock_webhook_client.get_card_inbox_emails.return_value = {
+        "card": {"inbox_emails": []}
+    }
+    async with webhook_session as session:
+        result = await session.call_tool("get_card_inbox_emails", {"card_id": 555})
+    assert result.isError is False
+    mock_webhook_client.get_card_inbox_emails.assert_awaited_once_with(
+        "555", email_type=None
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("webhook_session", [None], indirect=True)
+async def test_send_inbox_email_coerces_int_card_id(
+    webhook_session, mock_webhook_client, extract_payload
+):
+    mock_webhook_client.send_inbox_email.return_value = {
+        "createAndSendInboxEmail": {
+            "emailSent": True,
+            "errors": [],
+            "inboxEmail": {"id": "e1"},
+        }
+    }
+    async with webhook_session as session:
+        result = await session.call_tool(
+            "send_inbox_email",
+            {
+                "card_id": 100,
+                "to": ["a@x.com"],
+                "subject": "Hi",
+                "body": "Body",
+                "from_": "s@x.com",
+            },
+        )
+    assert result.isError is False
+    mock_webhook_client.send_inbox_email.assert_awaited_once()
+    call_args = mock_webhook_client.send_inbox_email.call_args
+    assert call_args[0][0] == "100"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("webhook_session", [None], indirect=True)
+async def test_send_email_with_template_coerces_int_ids(
+    webhook_session, mock_webhook_client, extract_payload
+):
+    mock_webhook_client.send_email_with_template.return_value = {
+        "createAndSendInboxEmail": {
+            "emailSent": True,
+            "errors": [],
+            "inboxEmail": {"id": "e2"},
+        }
+    }
+    async with webhook_session as session:
+        result = await session.call_tool(
+            "send_email_with_template",
+            {"card_id": 200, "email_template_id": 55},
+        )
+    assert result.isError is False
+    mock_webhook_client.send_email_with_template.assert_awaited_once()
+    call_args = mock_webhook_client.send_email_with_template.call_args
+    assert call_args[0][0] == "200"
+    assert call_args[0][1] == "55"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("webhook_session", [None], indirect=True)
+async def test_create_webhook_coerces_int_pipe_id(
+    webhook_session, mock_webhook_client, extract_payload
+):
+    mock_webhook_client.create_webhook.return_value = {
+        "createWebhook": {"webhook": {"id": "w1"}}
+    }
+    async with webhook_session as session:
+        result = await session.call_tool(
+            "create_webhook",
+            {
+                "pipe_id": 301,
+                "url": "https://hooks.example.com/wh",
+                "actions": ["card.create"],
+            },
+        )
+    assert result.isError is False
+    mock_webhook_client.create_webhook.assert_awaited_once()
+    call_args = mock_webhook_client.create_webhook.call_args
+    assert call_args[0][0] == "301"
+
+
+# ---------------------------------------------------------------------------
+# send_inbox_email — input validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("webhook_session", [None], indirect=True)
+async def test_send_inbox_email_rejects_empty_to_list(
+    webhook_session, mock_webhook_client, extract_payload
+):
+    async with webhook_session as session:
+        result = await session.call_tool(
+            "send_inbox_email",
+            {
+                "card_id": "card-1",
+                "to": [],
+                "subject": "Hi",
+                "body": "Body",
+                "from_": "s@x.com",
+            },
+        )
+
+    mock_webhook_client.send_inbox_email.assert_not_called()
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "'to'" in p["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("webhook_session", [None], indirect=True)
+async def test_send_inbox_email_rejects_to_with_blank_items(
+    webhook_session, mock_webhook_client, extract_payload
+):
+    async with webhook_session as session:
+        result = await session.call_tool(
+            "send_inbox_email",
+            {
+                "card_id": "card-1",
+                "to": ["a@x.com", "   "],
+                "subject": "Hi",
+                "body": "Body",
+                "from_": "s@x.com",
+            },
+        )
+
+    mock_webhook_client.send_inbox_email.assert_not_called()
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "each recipient" in p["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("webhook_session", [None], indirect=True)
+async def test_send_inbox_email_rejects_blank_subject(
+    webhook_session, mock_webhook_client, extract_payload
+):
+    async with webhook_session as session:
+        result = await session.call_tool(
+            "send_inbox_email",
+            {
+                "card_id": "card-1",
+                "to": ["a@x.com"],
+                "subject": "   ",
+                "body": "Body",
+                "from_": "s@x.com",
+            },
+        )
+
+    mock_webhook_client.send_inbox_email.assert_not_called()
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "'subject'" in p["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("webhook_session", [None], indirect=True)
+async def test_send_inbox_email_rejects_blank_from(
+    webhook_session, mock_webhook_client, extract_payload
+):
+    async with webhook_session as session:
+        result = await session.call_tool(
+            "send_inbox_email",
+            {
+                "card_id": "card-1",
+                "to": ["a@x.com"],
+                "subject": "Hi",
+                "body": "Body",
+                "from_": "   ",
+            },
+        )
+
+    mock_webhook_client.send_inbox_email.assert_not_called()
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "'from_'" in p["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("webhook_session", [None], indirect=True)
+async def test_send_inbox_email_rejects_invalid_card_id(
+    webhook_session, mock_webhook_client, extract_payload
+):
+    async with webhook_session as session:
+        result = await session.call_tool(
+            "send_inbox_email",
+            {
+                "card_id": "",
+                "to": ["a@x.com"],
+                "subject": "Hi",
+                "body": "Body",
+                "from_": "s@x.com",
+            },
+        )
+
+    mock_webhook_client.send_inbox_email.assert_not_called()
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "card_id" in p["error"]
+
+
+# ---------------------------------------------------------------------------
+# send_email_with_template — input validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("webhook_session", [None], indirect=True)
+async def test_send_email_with_template_rejects_blank_template_id(
+    webhook_session, mock_webhook_client, extract_payload
+):
+    async with webhook_session as session:
+        result = await session.call_tool(
+            "send_email_with_template",
+            {"card_id": "card-1", "email_template_id": "   "},
+        )
+
+    mock_webhook_client.send_email_with_template.assert_not_called()
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "email_template_id" in p["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("webhook_session", [None], indirect=True)
+async def test_send_email_with_template_value_error_from_client(
+    webhook_session, mock_webhook_client, extract_payload
+):
+    mock_webhook_client.send_email_with_template.side_effect = ValueError(
+        "Template has no subject or body."
+    )
+
+    async with webhook_session as session:
+        result = await session.call_tool(
+            "send_email_with_template",
+            {"card_id": "card-1", "email_template_id": "42"},
+        )
+
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "Template has no subject or body" in p["error"]
+
+
+# ---------------------------------------------------------------------------
+# create_webhook — input validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("webhook_session", [None], indirect=True)
+async def test_create_webhook_rejects_blank_url(
+    webhook_session, mock_webhook_client, extract_payload
+):
+    async with webhook_session as session:
+        result = await session.call_tool(
+            "create_webhook",
+            {"pipe_id": "pipe-1", "url": "   ", "actions": ["card.create"]},
+        )
+
+    mock_webhook_client.create_webhook.assert_not_called()
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "'url'" in p["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("webhook_session", [None], indirect=True)
+async def test_create_webhook_rejects_empty_actions_list(
+    webhook_session, mock_webhook_client, extract_payload
+):
+    async with webhook_session as session:
+        result = await session.call_tool(
+            "create_webhook",
+            {"pipe_id": "pipe-1", "url": "https://example.com/hook", "actions": []},
+        )
+
+    mock_webhook_client.create_webhook.assert_not_called()
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "'actions'" in p["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("webhook_session", [None], indirect=True)
+async def test_create_webhook_rejects_invalid_pipe_id(
+    webhook_session, mock_webhook_client, extract_payload
+):
+    async with webhook_session as session:
+        result = await session.call_tool(
+            "create_webhook",
+            {
+                "pipe_id": "",
+                "url": "https://example.com/hook",
+                "actions": ["card.create"],
+            },
+        )
+
+    mock_webhook_client.create_webhook.assert_not_called()
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "pipe_id" in p["error"]
+
+
+# ---------------------------------------------------------------------------
+# get_email_templates — GraphQL error + input validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("webhook_session", [None], indirect=True)
+async def test_get_email_templates_graphql_error(
+    webhook_session, mock_webhook_client, extract_payload
+):
+    mock_webhook_client.get_email_templates.side_effect = TransportQueryError(
+        "failed", errors=[{"message": "pipe not found"}]
+    )
+
+    async with webhook_session as session:
+        result = await session.call_tool(
+            "get_email_templates",
+            {"repo_id": "999"},
+        )
+
+    assert result.isError is False
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "pipe not found" in p["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("webhook_session", [None], indirect=True)
+async def test_get_email_templates_rejects_invalid_repo_id(
+    webhook_session, mock_webhook_client, extract_payload
+):
+    async with webhook_session as session:
+        result = await session.call_tool(
+            "get_email_templates",
+            {"repo_id": ""},
+        )
+
+    mock_webhook_client.get_email_templates.assert_not_called()
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "repo_id" in p["error"]
+
+
+# ---------------------------------------------------------------------------
+# get_card_inbox_emails — input validation (card_id)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("webhook_session", [None], indirect=True)
+async def test_get_card_inbox_emails_rejects_invalid_card_id(
+    webhook_session, mock_webhook_client, extract_payload
+):
+    async with webhook_session as session:
+        result = await session.call_tool(
+            "get_card_inbox_emails",
+            {"card_id": ""},
+        )
+
+    mock_webhook_client.get_card_inbox_emails.assert_not_called()
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "card_id" in p["error"]
+
+
+# ---------------------------------------------------------------------------
+# send_email_with_template — invalid card_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("webhook_session", [None], indirect=True)
+async def test_send_email_with_template_rejects_invalid_card_id(
+    webhook_session, mock_webhook_client, extract_payload
+):
+    async with webhook_session as session:
+        result = await session.call_tool(
+            "send_email_with_template",
+            {"card_id": "", "email_template_id": "42"},
+        )
+
+    mock_webhook_client.send_email_with_template.assert_not_called()
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "card_id" in p["error"]
+
+
+# ---------------------------------------------------------------------------
+# delete_webhook — GraphQL error with confirm=True (already covered above)
+# and invalid webhook_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("webhook_session", [None], indirect=True)
+async def test_delete_webhook_rejects_blank_webhook_id(
+    webhook_session, mock_webhook_client, extract_payload
+):
+    async with webhook_session as session:
+        result = await session.call_tool(
+            "delete_webhook",
+            {"webhook_id": "   "},
+        )
+
+    mock_webhook_client.delete_webhook.assert_not_called()
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "webhook_id" in p["error"]


### PR DESCRIPTION
## Summary
Introduces `PipefyId` (`Annotated[str, BeforeValidator]`) so clients that send unquoted integers (e.g. mcporter) get values coerced to strings before GraphQL.

- **Models:** `PipefyId` in `models/validators.py`, exported from `pipefy_mcp.models`; attachment upload inputs use it for `organization_id`, `field_id`, `table_record_id`.
- **Tools:** ID parameters updated in organization, AI automation, observability, report, webhook, and attachment tools.
- **Tests:** `test_validators.py`, attachment coercion tests, and broad MCP/service coverage.

Bools are not coerced (`True` would wrongly become `"1"`).

## Testing
`uv run pytest -m "not integration" -v` — all pass; integration suite unchanged for this change set.
