### PR TITLE
refactor: MCP deep-dive — facade, destructive guard, internal API, security

### DIFF
--- a/docs/tools/automations-and-ai.md
+++ b/docs/tools/automations-and-ai.md
@@ -74,6 +74,10 @@ AI automations are separate from traditional rules above. They are prompt-driven
 | `update_card` | `{ "pipeId": "<pipe_id>", "fieldsAttributes": [{ "fieldId": "...", "inputMode": "fill_with_ai", "value": "" }] }` |
 | `create_card` | `{ "pipeId": "<pipe_id>", "fieldsAttributes": [...] }` |
 | `create_connected_card` | `{ "pipeId": "<pipe_id>", "fieldsAttributes": [...] }` |
+| `create_table_record` | `{ "tableId": "<table_id>", "fieldsAttributes": [...] }` (`pipeId` not required; MCP does not check table `fieldId` values against the pipe — use `get_table` / `get_table_record`.) |
+| `send_email_template` | `{ "emailTemplateId": "<template_id>" }` (optional: `allowTemplateModifications` boolean; MCP does not verify that the template ID exists.) |
+
+Optional inside `actionParams.aiBehaviorParams`: **`capabilitiesAttributes`** — list of capability entries (e.g. types `advanced_ocr`, `web_search`). Passed through to the API; the MCP does not deeply validate capability config.
 
 ### Optional `eventParams` (trigger filters)
 
@@ -90,6 +94,7 @@ Use `get_ai_agents` with the pipe's `uuid` (same as `repo_uuid`) before `create_
 |------|-----------|------|
 | `get_ai_agent` | Yes | Loads one agent by UUID: name, instruction, behaviors. |
 | `get_ai_agents` | Yes | Lists agents for a pipe (`repo_uuid` = pipe UUID). |
+| `validate_ai_agent_behaviors` | Yes | Dry-runs behaviors against a pipe (fields, phases, relations); use before create/update. |
 | `delete_ai_agent` | No | Permanently deletes an agent (`destructiveHint=True` — confirm with the user first). |
 
 ---

--- a/src/pipefy_mcp/core/container.py
+++ b/src/pipefy_mcp/core/container.py
@@ -13,8 +13,6 @@ class ServicesContainer:
 
     _instance: Self | None = None
     pipefy_client: PipefyClient | None = None
-    internal_api_client: InternalApiClient | None = None
-    ai_automation_service: AiAutomationService | None = None
 
     @classmethod
     def get_instance(cls) -> Self:
@@ -22,10 +20,6 @@ class ServicesContainer:
         if cls._instance is None:
             cls._instance = cls()
         return cls._instance
-
-    def __init__(self):
-        """Initialize the container."""
-        pass
 
     def initialize_services(self, settings: Settings) -> None:
         """Create and wire all services.
@@ -40,15 +34,12 @@ class ServicesContainer:
         oauth_secret = settings.pipefy.oauth_secret
 
         if oauth_url and oauth_client and oauth_secret:
-            self.internal_api_client = InternalApiClient(
+            internal_client = InternalApiClient(
                 url=settings.pipefy.internal_api_url,
                 oauth_url=oauth_url,
                 oauth_client=oauth_client,
                 oauth_secret=oauth_secret,
             )
-            self.ai_automation_service = AiAutomationService(
-                client=self.internal_api_client
+            self.pipefy_client.set_ai_automation_service(
+                AiAutomationService(client=internal_client)
             )
-
-    def shutdown(self) -> None:
-        pass

--- a/src/pipefy_mcp/models/__init__.py
+++ b/src/pipefy_mcp/models/__init__.py
@@ -7,9 +7,10 @@ from pipefy_mcp.models.attachment import (
     UploadAttachmentToTableRecordInput,
     infer_content_type,
 )
-from pipefy_mcp.models.validators import PipefyId
+from pipefy_mcp.models.validators import NonBlankStr, PipefyId
 
 __all__ = [
+    "NonBlankStr",
     "PipefyId",
     "UploadAttachmentToCardInput",
     "UploadAttachmentToTableRecordInput",

--- a/src/pipefy_mcp/models/ai_agent.py
+++ b/src/pipefy_mcp/models/ai_agent.py
@@ -17,21 +17,8 @@ _CARD_FIELD_ACTION_TYPES = frozenset(
 )
 
 
-def _validate_card_field_metadata(action_type: str, metadata: dict) -> None:
-    """Validate metadata for actions that operate on card fields.
-
-    Args:
-        action_type: The actionType string (used in error messages).
-        metadata: The metadata dict from the action.
-
-    Raises:
-        ValueError: When required keys are missing or malformed.
-    """
-    if not metadata.get("pipeId"):
-        raise ValueError(
-            f"actionType '{action_type}' requires metadata.pipeId "
-            f"(the pipe where the action executes)."
-        )
+def _validate_fields_attributes_entries(action_type: str, metadata: dict) -> None:
+    """Require non-empty ``fieldsAttributes`` with ``fieldId`` and ``inputMode`` per entry."""
     fields = metadata.get("fieldsAttributes")
     if not isinstance(fields, list) or not fields:
         raise ValueError(
@@ -51,6 +38,51 @@ def _validate_card_field_metadata(action_type: str, metadata: dict) -> None:
             raise ValueError(
                 f"actionType '{action_type}': fieldsAttributes[{i}] "
                 f"requires 'inputMode'."
+            )
+
+
+def _validate_card_field_metadata(action_type: str, metadata: dict) -> None:
+    """Validate metadata for actions that operate on card fields.
+
+    Args:
+        action_type: The actionType string (used in error messages).
+        metadata: The metadata dict from the action.
+
+    Raises:
+        ValueError: When required keys are missing or malformed.
+    """
+    if not metadata.get("pipeId"):
+        raise ValueError(
+            f"actionType '{action_type}' requires metadata.pipeId "
+            f"(the pipe where the action executes)."
+        )
+    _validate_fields_attributes_entries(action_type, metadata)
+
+
+def _validate_create_table_record_metadata(metadata: dict) -> None:
+    """Validate metadata for create_table_record (table row, not pipe fields)."""
+    if not metadata.get("tableId"):
+        raise ValueError(
+            "actionType 'create_table_record' requires metadata.tableId "
+            "(target database table ID)."
+        )
+    _validate_fields_attributes_entries("create_table_record", metadata)
+
+
+def _validate_send_email_template_metadata(metadata: dict) -> None:
+    """Validate metadata for send_email_template actions."""
+    template_id = metadata.get("emailTemplateId")
+    if not isinstance(template_id, str) or not template_id.strip():
+        raise ValueError(
+            "actionType 'send_email_template' requires metadata.emailTemplateId "
+            "(non-empty email template ID)."
+        )
+    if "allowTemplateModifications" in metadata:
+        mod = metadata["allowTemplateModifications"]
+        if not isinstance(mod, bool):
+            raise ValueError(
+                "actionType 'send_email_template': metadata.allowTemplateModifications "
+                "must be a boolean when set."
             )
 
 
@@ -82,6 +114,10 @@ def _validate_action_metadata(action: dict) -> None:
         _validate_card_field_metadata(action_type, metadata)
     elif action_type == "move_card":
         _validate_move_card_metadata(metadata)
+    elif action_type == "create_table_record":
+        _validate_create_table_record_metadata(metadata)
+    elif action_type == "send_email_template":
+        _validate_send_email_template_metadata(metadata)
 
 
 class BehaviorInput(BaseModel):
@@ -90,10 +126,19 @@ class BehaviorInput(BaseModel):
     The Pipefy API requires ``actionParams.aiBehaviorParams.actionsAttributes`` with at least
     one action; otherwise ``updateAiAgent`` fails (e.g. "The instructions must contain at least 1 action").
 
-    Optional ``eventParams`` configures the trigger. For each action dict, known ``actionType``
-    values get ``metadata`` checks: ``update_card`` / ``create_card`` / ``create_connected_card``
-    need ``pipeId`` and non-empty ``fieldsAttributes`` (each entry needs ``fieldId`` and
-    ``inputMode``); ``move_card`` needs ``destinationPhaseId``. Other types are not validated here.
+    Optional ``eventParams`` configures the trigger.
+
+    Optional ``actionParams.aiBehaviorParams.capabilitiesAttributes`` is a list of capability
+    entries the API accepts (e.g. ``advanced_ocr``, ``web_search``). No extra structural
+    validation here — the API enforces capability shapes.
+
+    For each action dict, known ``actionType`` values get ``metadata`` checks:
+    ``update_card`` / ``create_card`` / ``create_connected_card`` need ``pipeId`` and non-empty
+    ``fieldsAttributes`` (each entry needs ``fieldId`` and ``inputMode``); ``move_card`` needs
+    ``destinationPhaseId``; ``create_table_record`` needs ``tableId`` and non-empty
+    ``fieldsAttributes`` (same entry shape as card actions; ``pipeId`` not required);
+    ``send_email_template`` needs ``emailTemplateId`` and optional ``allowTemplateModifications``
+    (boolean). Other types are not validated here.
     """
 
     model_config = ConfigDict(populate_by_name=True)

--- a/src/pipefy_mcp/server.py
+++ b/src/pipefy_mcp/server.py
@@ -50,11 +50,11 @@ async def lifespan(app: FastMCP) -> AsyncIterator[FastMCP]:
             mcp=app,
             services_container=services_container,
         ).register_tools()
-
-        yield mcp
     except Exception:
-        logger.exception("Fatal error during server lifespan")
+        logger.exception("Fatal error during server lifespan initialization")
         raise
+
+    yield mcp
 
 
 PIPEFY_INSTRUCTIONS = textwrap.dedent("""

--- a/src/pipefy_mcp/services/pipefy/ai_automation_service.py
+++ b/src/pipefy_mcp/services/pipefy/ai_automation_service.py
@@ -61,7 +61,7 @@ class AiAutomationService:
             AI_CREATE_AUTOMATION_MUTATION, variables
         )
 
-        create_result = response.get("data", {}).get("createAutomation", {})
+        create_result = response.get("createAutomation", {})
         error_details = create_result.get("error_details")
         if error_details:
             messages = error_details.get("messages", [])
@@ -115,7 +115,7 @@ class AiAutomationService:
             AI_UPDATE_AUTOMATION_MUTATION, variables
         )
 
-        update_result = response.get("data", {}).get("updateAutomation", {})
+        update_result = response.get("updateAutomation", {})
         error_details = update_result.get("error_details")
         if error_details:
             messages = error_details.get("messages", [])

--- a/src/pipefy_mcp/services/pipefy/attachment_service.py
+++ b/src/pipefy_mcp/services/pipefy/attachment_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
 from urllib.parse import unquote, urlparse
 
@@ -15,6 +16,9 @@ from pipefy_mcp.services.pipefy.queries.attachment_queries import (
 from pipefy_mcp.settings import PipefySettings
 
 _BODY_SNIPPET_MAX_CHARS = 500
+_ALLOWED_UPLOAD_HOST_RE = re.compile(
+    r"^[\w.-]+\.(amazonaws\.com|pipefy\.com)$", re.IGNORECASE
+)
 
 
 class AttachmentService(BasePipefyClient):
@@ -88,6 +92,12 @@ class AttachmentService(BasePipefyClient):
             file_bytes: Raw file content.
             content_type: Optional ``Content-Type`` header for the request.
         """
+        host = urlparse(presigned_url).hostname or ""
+        if not _ALLOWED_UPLOAD_HOST_RE.match(host):
+            raise ValueError(
+                f"Upload URL host '{host}' is not in the allow-list "
+                "(*.amazonaws.com, *.pipefy.com)."
+            )
         headers: dict[str, str] = {}
         if content_type is not None:
             headers["Content-Type"] = content_type

--- a/src/pipefy_mcp/services/pipefy/client.py
+++ b/src/pipefy_mcp/services/pipefy/client.py
@@ -7,7 +7,12 @@ from typing import Any
 from httpx_auth import OAuth2ClientCredentials
 
 from pipefy_mcp.models.ai_agent import CreateAiAgentInput, UpdateAiAgentInput
+from pipefy_mcp.models.ai_automation import (
+    CreateAiAutomationInput,
+    UpdateAiAutomationInput,
+)
 from pipefy_mcp.services.pipefy.ai_agent_service import AiAgentService
+from pipefy_mcp.services.pipefy.ai_automation_service import AiAutomationService
 from pipefy_mcp.services.pipefy.attachment_service import AttachmentService
 from pipefy_mcp.services.pipefy.automation_graphql_types import (
     AutomationActionRow,
@@ -35,6 +40,7 @@ from pipefy_mcp.services.pipefy.table_service import TableService
 from pipefy_mcp.services.pipefy.types import (
     AgentServiceResult,
     AiAgentGraphPayload,
+    AutomationServiceResult,
     CardSearch,
     ToggleAgentStatusResult,
 )
@@ -75,6 +81,15 @@ class PipefyClient:
         self._introspection_service = SchemaIntrospectionService(
             settings=settings, auth=auth
         )
+        self._ai_automation_service: AiAutomationService | None = None
+
+    def set_ai_automation_service(self, service: AiAutomationService) -> None:
+        """Attach an AI automation service (requires OAuth credentials).
+
+        Args:
+            service: Configured :class:`AiAutomationService` instance.
+        """
+        self._ai_automation_service = service
 
     async def get_pipe(self, pipe_id: int) -> dict:
         """Get a pipe by ID, including phases, labels, and start form fields."""
@@ -551,14 +566,14 @@ class PipefyClient:
                 pass the **destination** pipe ID.
             extra_input: Extra ``CreateAutomationInput`` keys; ``active`` here overrides the ``active`` argument.
         """
-        merged: dict[str, Any] = {"active": active, **(extra_input or {})}
         return await self._automation_service.create_automation(
             pipe_id,
             name,
             trigger_id,
             action_id,
             action_repo_id=action_repo_id,
-            **merged,
+            active=active,
+            **(extra_input or {}),
         )
 
     async def update_automation(
@@ -634,6 +649,28 @@ class PipefyClient:
         return await self._ai_agent_service.toggle_agent_status(
             agent_uuid=agent_uuid, active=active
         )
+
+    async def create_ai_automation(
+        self, automation_input: CreateAiAutomationInput
+    ) -> AutomationServiceResult:
+        """Create an AI Automation (generate_with_ai action via internal API)."""
+        if self._ai_automation_service is None:
+            raise ValueError(
+                "AI Automation requires OAuth credentials "
+                "(PIPEFY_OAUTH_CLIENT, PIPEFY_OAUTH_SECRET, PIPEFY_OAUTH_URL)."
+            )
+        return await self._ai_automation_service.create_automation(automation_input)
+
+    async def update_ai_automation(
+        self, automation_input: UpdateAiAutomationInput
+    ) -> AutomationServiceResult:
+        """Update an existing AI Automation via internal API."""
+        if self._ai_automation_service is None:
+            raise ValueError(
+                "AI Automation requires OAuth credentials "
+                "(PIPEFY_OAUTH_CLIENT, PIPEFY_OAUTH_SECRET, PIPEFY_OAUTH_URL)."
+            )
+        return await self._ai_automation_service.update_automation(automation_input)
 
     async def get_pipe_members(self, pipe_id: int) -> dict:
         """Get the members of a pipe."""

--- a/src/pipefy_mcp/services/pipefy/internal_api_client.py
+++ b/src/pipefy_mcp/services/pipefy/internal_api_client.py
@@ -33,6 +33,10 @@ class InternalApiClient:
             oauth_client: OAuth client ID.
             oauth_secret: OAuth client secret.
         """
+        if not url.strip().lower().startswith("https://"):
+            raise ValueError("internal_api URL must use HTTPS")
+        if not oauth_url.strip().lower().startswith("https://"):
+            raise ValueError("OAuth URL must use HTTPS")
         self._url = url
         self._auth = OAuth2ClientCredentials(
             token_url=oauth_url,
@@ -69,4 +73,5 @@ class InternalApiClient:
             data = response.json()
             if "errors" in data and data["errors"]:
                 raise ValueError(f"GraphQL error response: {data['errors']}")
-            return data
+            # Unwrap the "data" envelope to match BasePipefyClient.execute_query
+            return data.get("data", data)

--- a/src/pipefy_mcp/services/pipefy/member_service.py
+++ b/src/pipefy_mcp/services/pipefy/member_service.py
@@ -72,12 +72,12 @@ class MemberService(BasePipefyClient):
             pipe_data = await self._pipe_service.get_pipe(int(pipe_id_str))
             pipe_obj = pipe_data.get("pipe") or {}
         elif _PIPE_UUID_RE.match(pipe_id_str):
-            pipe_data = await self._pipe_service.get_pipe(pipe_id_str)
-            pipe_obj = pipe_data.get("pipe") or {}
-        else:
             raise ValueError(
-                f"pipe_id must be a numeric pipe ID or a pipe UUID, got {pipe_id!r}."
+                f"pipe_id must be a numeric pipe ID, not a UUID ({pipe_id_str}). "
+                "Use the numeric pipe ID from get_pipe instead."
             )
+        else:
+            raise ValueError(f"pipe_id must be a numeric pipe ID, got {pipe_id!r}.")
 
         pipe_uuid = pipe_obj.get("uuid") or pipe_id_str
         pipe_numeric_id = pipe_obj.get("id")

--- a/src/pipefy_mcp/services/pipefy/observability_service.py
+++ b/src/pipefy_mcp/services/pipefy/observability_service.py
@@ -72,7 +72,7 @@ def _build_log_variables(
 
 def _build_usage_variables(
     organization_uuid: str,
-    filter_date: dict[str, str],
+    filter_date: DateRange,
     *,
     filters: dict[str, Any] | None,
     search: str | None,
@@ -236,7 +236,7 @@ class ObservabilityService(BasePipefyClient):
     async def get_agents_usage(
         self,
         organization_uuid: str,
-        filter_date: dict[str, str],
+        filter_date: DateRange,
         *,
         filters: dict[str, Any] | None = None,
         search: str | None = None,
@@ -265,7 +265,7 @@ class ObservabilityService(BasePipefyClient):
     async def get_automations_usage(
         self,
         organization_uuid: str,
-        filter_date: dict[str, str],
+        filter_date: DateRange,
         *,
         filters: dict[str, Any] | None = None,
         search: str | None = None,

--- a/src/pipefy_mcp/services/pipefy/queries/ai_agent_queries.py
+++ b/src/pipefy_mcp/services/pipefy/queries/ai_agent_queries.py
@@ -52,6 +52,8 @@ GET_AI_AGENT_QUERY = gql(
                                 destinationPhaseId
                                 pipeId
                                 tableId
+                                emailTemplateId
+                                allowTemplateModifications
                                 fieldsAttributes {
                                     fieldId
                                     inputMode
@@ -168,6 +170,8 @@ UPDATE_AI_AGENT_MUTATION = gql(
                                     destinationPhaseId
                                     pipeId
                                     tableId
+                                    emailTemplateId
+                                    allowTemplateModifications
                                     fieldsAttributes {
                                         fieldId
                                         inputMode

--- a/src/pipefy_mcp/services/pipefy/queries/attachment_queries.py
+++ b/src/pipefy_mcp/services/pipefy/queries/attachment_queries.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from gql import gql
 
+__all__ = [
+    "CREATE_PRESIGNED_URL_MUTATION",
+]
+
 CREATE_PRESIGNED_URL_MUTATION = gql(
     """
     mutation createPresignedUrl(

--- a/src/pipefy_mcp/services/pipefy/queries/observability_queries.py
+++ b/src/pipefy_mcp/services/pipefy/queries/observability_queries.py
@@ -145,7 +145,24 @@ GET_AUTOMATION_LOGS_BY_REPO_QUERY = gql(
     """
 )
 
-_STATS_DETAILS_NODE = """
+GET_AGENTS_USAGE_QUERY = gql(
+    """
+    query AgentsUsageDetails(
+        $organizationUuid: ID!
+        $filterDate: DateRange!
+        $filters: FilterParams
+        $search: String
+        $sort: SortCriteria
+    ) {
+        agentsUsageDetails(
+            organizationUuid: $organizationUuid
+            filterDate: $filterDate
+            filters: $filters
+            search: $search
+            sort: $sort
+        ) {
+            usage
+            agents {
                 nodes {
                     id
                     name
@@ -168,28 +185,7 @@ _STATS_DETAILS_NODE = """
                 pageInfo {
                     hasNextPage
                     endCursor
-                }"""
-
-GET_AGENTS_USAGE_QUERY = gql(
-    """
-    query AgentsUsageDetails(
-        $organizationUuid: ID!
-        $filterDate: DateRange!
-        $filters: FilterParams
-        $search: String
-        $sort: SortCriteria
-    ) {
-        agentsUsageDetails(
-            organizationUuid: $organizationUuid
-            filterDate: $filterDate
-            filters: $filters
-            search: $search
-            sort: $sort
-        ) {
-            usage
-            agents {"""
-    + _STATS_DETAILS_NODE
-    + """
+                }
             }
         }
     }
@@ -213,9 +209,30 @@ GET_AUTOMATIONS_USAGE_QUERY = gql(
             sort: $sort
         ) {
             usage
-            automations {"""
-    + _STATS_DETAILS_NODE
-    + """
+            automations {
+                nodes {
+                    id
+                    name
+                    usage
+                    status
+                    action
+                    event
+                    actionRepo {
+                        uuid
+                        name
+                    }
+                    eventRepo {
+                        uuid
+                        name
+                    }
+                    createdAt
+                    updatedAt
+                }
+                totalCount
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
             }
         }
     }

--- a/src/pipefy_mcp/services/pipefy/queries/relation_queries.py
+++ b/src/pipefy_mcp/services/pipefy/queries/relation_queries.py
@@ -6,17 +6,12 @@ from gql import gql
 
 # Schema: Pipe uses parentsRelations/childrenRelations (not pipe_relations); tables use root table_relations(ids: [ID!]!).
 
-_REPO_TYPES_ID_NAME = """... on Pipe {
-    id
-    name
-}
-... on Table {
-    id
-    name
-}"""
-
-_PIPE_RELATION_BODY = (
+GET_PIPE_RELATIONS_QUERY = gql(
     """
+    query GetPipeRelations($pipeId: ID!) {
+        pipe(id: $pipeId) {
+            id
+            parentsRelations {
                 id
                 name
                 allChildrenMustBeDoneToFinishParent
@@ -28,34 +23,67 @@ _PIPE_RELATION_BODY = (
                 childMustExistToFinishParent
                 childMustExistToMoveParent
                 parent {
-"""
-    + _REPO_TYPES_ID_NAME
-    + """
+                    ... on Pipe {
+                        id
+                        name
+                    }
+                    ... on Table {
+                        id
+                        name
+                    }
                 }
                 child {
-"""
-    + _REPO_TYPES_ID_NAME
-    + """
+                    ... on Pipe {
+                        id
+                        name
+                    }
+                    ... on Table {
+                        id
+                        name
+                    }
                 }
                 ownFieldMaps {
                     fieldId
                     inputMode
                     value
-                }"""
-)
-
-GET_PIPE_RELATIONS_QUERY = gql(
-    """
-    query GetPipeRelations($pipeId: ID!) {
-        pipe(id: $pipeId) {
-            id
-            parentsRelations {"""
-    + _PIPE_RELATION_BODY
-    + """
+                }
             }
-            childrenRelations {"""
-    + _PIPE_RELATION_BODY
-    + """
+            childrenRelations {
+                id
+                name
+                allChildrenMustBeDoneToFinishParent
+                allChildrenMustBeDoneToMoveParent
+                autoFillFieldEnabled
+                canConnectExistingItems
+                canConnectMultipleItems
+                canCreateNewItems
+                childMustExistToFinishParent
+                childMustExistToMoveParent
+                parent {
+                    ... on Pipe {
+                        id
+                        name
+                    }
+                    ... on Table {
+                        id
+                        name
+                    }
+                }
+                child {
+                    ... on Pipe {
+                        id
+                        name
+                    }
+                    ... on Table {
+                        id
+                        name
+                    }
+                }
+                ownFieldMaps {
+                    fieldId
+                    inputMode
+                    value
+                }
             }
         }
     }
@@ -76,14 +104,24 @@ GET_TABLE_RELATIONS_QUERY = gql(
             childMustExistToFinishParent
             childMustExistToMoveParent
             parent {
-"""
-    + _REPO_TYPES_ID_NAME
-    + """
+                ... on Pipe {
+                    id
+                    name
+                }
+                ... on Table {
+                    id
+                    name
+                }
             }
             child {
-"""
-    + _REPO_TYPES_ID_NAME
-    + """
+                ... on Pipe {
+                    id
+                    name
+                }
+                ... on Table {
+                    id
+                    name
+                }
             }
         }
     }

--- a/src/pipefy_mcp/services/pipefy/queries/report_queries.py
+++ b/src/pipefy_mcp/services/pipefy/queries/report_queries.py
@@ -6,38 +6,23 @@ from gql import gql
 
 # Column/filter discovery uses field `name` (not `id`). pipeReports omits cardCount (resolver errors).
 
-_PIPE_REPORT_FIELDS = """
-    id
-    name
-    color
-    fields
-    filter
-    sortBy {
-        direction
-        field
-    }
-    createdAt
-    lastUpdatedAt"""
-
-_REPORT_EXPORT_FIELDS = """
-    id
-    state
-    fileURL
-    startedAt
-    finishedAt
-    requestedBy {
-        id
-        name
-    }"""
-
 GET_PIPE_REPORTS_QUERY = gql(
     """
     query pipeReports($pipeUuid: String!, $first: Int, $after: String, $search: String, $reportId: ID, $order: PipeReportsOrder) {
         pipeReports(pipeUuid: $pipeUuid, first: $first, after: $after, search: $search, reportId: $reportId, order: $order) {
             edges {
-                node {"""
-    + _PIPE_REPORT_FIELDS
-    + """
+                node {
+                    id
+                    name
+                    color
+                    fields
+                    filter
+                    sortBy {
+                        direction
+                        field
+                    }
+                    createdAt
+                    lastUpdatedAt
                 }
             }
             pageInfo {
@@ -138,9 +123,16 @@ GET_ORGANIZATION_REPORTS_QUERY = gql(
 GET_PIPE_REPORT_EXPORT_QUERY = gql(
     """
     query pipeReportExport($id: ID!) {
-        pipeReportExport(id: $id) {"""
-    + _REPORT_EXPORT_FIELDS
-    + """
+        pipeReportExport(id: $id) {
+            id
+            state
+            fileURL
+            startedAt
+            finishedAt
+            requestedBy {
+                id
+                name
+            }
         }
     }
     """
@@ -149,9 +141,16 @@ GET_PIPE_REPORT_EXPORT_QUERY = gql(
 GET_ORGANIZATION_REPORT_EXPORT_QUERY = gql(
     """
     query organizationReportExport($id: ID!) {
-        organizationReportExport(id: $id) {"""
-    + _REPORT_EXPORT_FIELDS
-    + """
+        organizationReportExport(id: $id) {
+            id
+            state
+            fileURL
+            startedAt
+            finishedAt
+            requestedBy {
+                id
+                name
+            }
         }
     }
     """

--- a/src/pipefy_mcp/tools/ai_agent_tools.py
+++ b/src/pipefy_mcp/tools/ai_agent_tools.py
@@ -204,6 +204,13 @@ class AiAgentTools:
               - ``create_connected_card`` → ``{"pipeId": "<pipe_id>", "fieldsAttributes": [...]}``
                 Requires a pipe relation between source and destination pipes
                 (verify with ``get_pipe_relations``).
+              - ``create_table_record`` → ``{"tableId": "<table_id>", "fieldsAttributes": [{"fieldId": "...", "inputMode": "...", ...}, ...]}``
+                (``pipeId`` not required; field IDs belong to the table.)
+              - ``send_email_template`` → ``{"emailTemplateId": "<template_id>"}``;
+                optional ``allowTemplateModifications`` (boolean).
+
+            Optional ``actionParams.aiBehaviorParams.capabilitiesAttributes`` (list of strings), e.g.
+            ``advanced_ocr``, ``web_search`` — pass-through; the API validates capability types.
 
             Optional ``eventParams`` per behavior (filters when the trigger fires):
               - ``field_updated`` event → ``{"triggerFieldIds": ["<field_id>"]}`` to fire only on specific fields.
@@ -302,11 +309,25 @@ class AiAgentTools:
             Always send the **complete** behaviors list (1–5). Omitting a behavior deletes it.
             Each behavior must include ``actionParams.aiBehaviorParams.actionsAttributes`` with at least
             one action (same constraint and shape as ``create_ai_agent`` — see its docstring for the
-            full behavior dict example, discovery workflow, known ``actionType`` values, and constraints).
+            full behavior dict example, discovery workflow, and constraints).
 
             To modify an existing agent: call ``get_ai_agent`` first, edit the returned config,
             and send the full payload back. The server injects ``referenceId`` and ``%{action:<uuid>}``
             placeholders automatically — do not set or preserve them from ``get_ai_agent``.
+
+            Known ``actionType`` values and their required ``metadata`` (same as ``create_ai_agent``):
+              - ``move_card`` → ``{"destinationPhaseId": "<phase_id>"}``
+              - ``update_card`` → ``{"pipeId": "<pipe_id>", "fieldsAttributes": [{"fieldId": "...", "inputMode": "fill_with_ai", "value": ""}]}``
+              - ``create_card`` → ``{"pipeId": "<pipe_id>", "fieldsAttributes": [...]}``
+              - ``create_connected_card`` → ``{"pipeId": "<pipe_id>", "fieldsAttributes": [...]}``
+                (requires a pipe relation — verify with ``get_pipe_relations``).
+              - ``create_table_record`` → ``{"tableId": "<table_id>", "fieldsAttributes": [...]}``
+                (``pipeId`` not required; field IDs belong to the table.)
+              - ``send_email_template`` → ``{"emailTemplateId": "<template_id>"}``;
+                optional ``allowTemplateModifications`` (boolean).
+
+            Optional ``actionParams.aiBehaviorParams.capabilitiesAttributes`` (list of strings), e.g.
+            ``advanced_ocr``, ``web_search`` — pass-through; the API validates capability types.
 
             Args:
                 uuid: UUID of the agent to update.
@@ -485,6 +506,14 @@ class AiAgentTools:
 
             Call **before** ``create_ai_agent`` / ``update_ai_agent`` to catch problems early
             (invalid fieldIds, missing phase IDs, absent pipe relations for ``create_connected_card``).
+
+            Known ``actionType`` values for pipe-context checks are:
+            ``move_card``, ``update_card``, ``create_card``, ``create_connected_card``,
+            ``create_table_record``, and ``send_email_template``.
+            For ``create_table_record``, ``fieldsAttributes`` hold **table** field IDs — they are not
+            validated against the source pipe; the tool adds a **warning** to verify IDs with
+            ``get_table`` / ``get_table_record`` instead. ``send_email_template`` does not run
+            pipe field-ID checks on its metadata.
 
             Runs Pydantic model validation (same as the mutation tools) plus cross-references
             against live pipe data. Does not persist anything.

--- a/src/pipefy_mcp/tools/ai_agent_tools.py
+++ b/src/pipefy_mcp/tools/ai_agent_tools.py
@@ -240,7 +240,7 @@ class AiAgentTools:
                     See example above for the full shape.
                 data_source_ids: Optional knowledge-source IDs (same as ``update_ai_agent``).
             """
-            ctx.debug(
+            await ctx.debug(
                 f"create_ai_agent: name={name}, repo_uuid={repo_uuid}, "
                 f"instruction_len={len(instruction)}, behaviors_count={len(behaviors)}, "
                 f"data_source_ids={data_source_ids!r}"
@@ -339,7 +339,9 @@ class AiAgentTools:
                     Accepts both ``snake_case`` and ``camelCase`` keys.
                 data_source_ids: Optional list of data source IDs.
             """
-            ctx.debug(f"update_ai_agent: uuid={uuid}, behaviors_count={len(behaviors)}")
+            await ctx.debug(
+                f"update_ai_agent: uuid={uuid}, behaviors_count={len(behaviors)}"
+            )
             if not uuid or not uuid.strip():
                 return build_ai_tool_error("uuid must not be blank")
             if not name or not name.strip():
@@ -388,7 +390,7 @@ class AiAgentTools:
                 uuid: UUID of the agent to enable/disable.
                 active: True to activate, False to deactivate.
             """
-            ctx.debug(f"toggle_ai_agent_status: uuid={uuid}, active={active}")
+            await ctx.debug(f"toggle_ai_agent_status: uuid={uuid}, active={active}")
             agent_uuid = uuid.strip()
             if not agent_uuid:
                 return build_ai_tool_error("uuid must not be blank")
@@ -422,7 +424,7 @@ class AiAgentTools:
                 uuid: Agent UUID.
             """
             agent_uuid = uuid.strip()
-            ctx.debug(f"get_ai_agent: uuid={agent_uuid}")
+            await ctx.debug(f"get_ai_agent: uuid={agent_uuid}")
             if not agent_uuid:
                 return build_ai_tool_error("uuid must not be blank")
             try:
@@ -443,7 +445,7 @@ class AiAgentTools:
                 repo_uuid: UUID of the pipe.
             """
             pipe_uuid = repo_uuid.strip()
-            ctx.debug(f"get_ai_agents: repo_uuid={pipe_uuid}")
+            await ctx.debug(f"get_ai_agents: repo_uuid={pipe_uuid}")
             if not pipe_uuid:
                 return build_ai_tool_error("repo_uuid must not be blank")
             try:
@@ -469,7 +471,7 @@ class AiAgentTools:
                 confirm: Set to True to execute the deletion (step 2).
             """
             agent_uuid = uuid.strip()
-            ctx.debug(f"delete_ai_agent: uuid={agent_uuid}")
+            await ctx.debug(f"delete_ai_agent: uuid={agent_uuid}")
             if not agent_uuid:
                 return build_ai_tool_error("uuid must not be blank")
 
@@ -606,7 +608,9 @@ class AiAgentTools:
                     if parent_id:
                         related_pipe_ids.add(str(parent_id))
             except Exception:  # noqa: BLE001
-                ctx.debug("Could not fetch pipe relations; skipping relation checks")
+                await ctx.debug(
+                    "Could not fetch pipe relations; skipping relation checks"
+                )
                 related_pipe_ids = None
                 tool_warnings.append(
                     "Could not load pipe relations; create_connected_card pipeId targets "
@@ -654,7 +658,7 @@ class AiAgentTools:
                             target_fields.add(str(fid))
                     cross_pipe_field_ids[target_pid] = target_fields
                 except Exception:  # noqa: BLE001
-                    ctx.debug(
+                    await ctx.debug(
                         f"Could not fetch target pipe {target_pid}; skipping its field checks"
                     )
                     tool_warnings.append(

--- a/src/pipefy_mcp/tools/ai_automation_tools.py
+++ b/src/pipefy_mcp/tools/ai_automation_tools.py
@@ -11,7 +11,7 @@ from pipefy_mcp.models.ai_automation import (
     UpdateAiAutomationInput,
 )
 from pipefy_mcp.models.validators import PipefyId
-from pipefy_mcp.services.pipefy.ai_automation_service import AiAutomationService
+from pipefy_mcp.services.pipefy import PipefyClient
 from pipefy_mcp.tools.ai_tool_helpers import (
     build_ai_tool_error,
     build_create_automation_success,
@@ -23,7 +23,7 @@ class AiAutomationTools:
     """Declares MCP tools for AI Automation create and update."""
 
     @staticmethod
-    def register(mcp: FastMCP, service: AiAutomationService) -> None:
+    def register(mcp: FastMCP, client: PipefyClient) -> None:
         """Register AI Automation tools on the MCP server."""
 
         @mcp.tool(
@@ -53,7 +53,7 @@ class AiAutomationTools:
                 skills_ids: AI skill IDs to attach. Defaults to empty (no skills).
                 condition: Optional condition structure for the automation trigger.
             """
-            ctx.debug(
+            await ctx.debug(
                 f"create_ai_automation: name={name}, event_id={event_id}, pipe_id={pipe_id}"
             )
             optional_fields: dict = {}
@@ -74,7 +74,7 @@ class AiAutomationTools:
                 return build_ai_tool_error(str(exc))
 
             try:
-                result = await service.create_automation(validated)
+                result = await client.create_ai_automation(validated)
             except Exception as exc:  # noqa: BLE001
                 return build_ai_tool_error(str(exc))
 
@@ -107,7 +107,7 @@ class AiAutomationTools:
                 skills_ids: New list of AI skill IDs (optional).
                 condition: New condition structure (optional).
             """
-            ctx.debug(f"update_ai_automation: automation_id={automation_id}")
+            await ctx.debug(f"update_ai_automation: automation_id={automation_id}")
             try:
                 validated = UpdateAiAutomationInput(
                     automation_id=automation_id,
@@ -122,7 +122,7 @@ class AiAutomationTools:
                 return build_ai_tool_error(str(exc))
 
             try:
-                result = await service.update_automation(validated)
+                result = await client.update_ai_automation(validated)
             except Exception as exc:  # noqa: BLE001
                 return build_ai_tool_error(str(exc))
 

--- a/src/pipefy_mcp/tools/ai_tool_helpers.py
+++ b/src/pipefy_mcp/tools/ai_tool_helpers.py
@@ -238,7 +238,14 @@ def _summarize_behaviors(behaviors: list[dict[str, Any]]) -> str:
 
 # actionTypes that the Pipefy AI behavior system recognizes.
 KNOWN_AI_ACTION_TYPES = frozenset(
-    {"move_card", "update_card", "create_card", "create_connected_card"}
+    {
+        "create_card",
+        "create_connected_card",
+        "create_table_record",
+        "move_card",
+        "send_email_template",
+        "update_card",
+    }
 )
 
 
@@ -326,34 +333,46 @@ def validate_behaviors_against_pipe(
             # Check fieldsAttributes fieldId references.
             # Same-pipe actions check against pipe_field_ids; cross-pipe actions
             # check against cross_pipe_field_ids when available.
-            action_pipe = str(metadata.get("pipeId", ""))
-            targets_source = not action_pipe or action_pipe == pipe_id
-            if targets_source:
-                check_fields = pipe_field_ids
-            elif (
-                cross_pipe_field_ids is not None and action_pipe in cross_pipe_field_ids
-            ):
-                check_fields = cross_pipe_field_ids[action_pipe]
-            else:
-                check_fields = None
+            # create_table_record: table field IDs, not pipe fields (FR-6).
+            # send_email_template: no pipe-scoped field metadata (FR-6); missing pipeId
+            # would otherwise make targets_source True and mis-validate stray fieldsAttributes.
+            if action_type not in ("create_table_record", "send_email_template"):
+                action_pipe = str(metadata.get("pipeId", ""))
+                targets_source = not action_pipe or action_pipe == pipe_id
+                if targets_source:
+                    check_fields = pipe_field_ids
+                elif (
+                    cross_pipe_field_ids is not None
+                    and action_pipe in cross_pipe_field_ids
+                ):
+                    check_fields = cross_pipe_field_ids[action_pipe]
+                else:
+                    check_fields = None
 
-            if check_fields is not None:
-                fields_attrs = metadata.get("fieldsAttributes") or []
-                for k, fa in enumerate(fields_attrs):
-                    if not isinstance(fa, dict):
-                        continue
-                    fid = fa.get("fieldId", "")
-                    if fid and check_fields and fid not in check_fields:
-                        pipe_label = (
-                            "pipe fields"
-                            if targets_source
-                            else f"target pipe {action_pipe} fields"
-                        )
-                        problems.append(
-                            f"{prefix}, action [{j}] ({action_type}): "
-                            f'fieldsAttributes[{k}].fieldId "{fid}" '
-                            f"not found in {pipe_label}."
-                        )
+                if check_fields is not None:
+                    fields_attrs = metadata.get("fieldsAttributes") or []
+                    for k, fa in enumerate(fields_attrs):
+                        if not isinstance(fa, dict):
+                            continue
+                        fid = fa.get("fieldId", "")
+                        if fid and check_fields and fid not in check_fields:
+                            pipe_label = (
+                                "pipe fields"
+                                if targets_source
+                                else f"target pipe {action_pipe} fields"
+                            )
+                            problems.append(
+                                f"{prefix}, action [{j}] ({action_type}): "
+                                f'fieldsAttributes[{k}].fieldId "{fid}" '
+                                f"not found in {pipe_label}."
+                            )
+
+            if action_type == "create_table_record":
+                warnings.append(
+                    f"{prefix}, action [{j}] (create_table_record): "
+                    "fieldsAttributes reference table field IDs, which cannot be validated "
+                    "against this pipe. Verify IDs with get_table or get_table_record."
+                )
 
             # Check create_connected_card relation (skipped when related_pipe_ids is None)
             if action_type == "create_connected_card" and related_pipe_ids is not None:

--- a/src/pipefy_mcp/tools/destructive_tool_guard.py
+++ b/src/pipefy_mcp/tools/destructive_tool_guard.py
@@ -70,15 +70,15 @@ async def check_destructive_confirmation(
         A ``dict`` payload when the operation was cancelled or needs
         confirmation — the caller should return this payload as-is.
     """
-    can_elicit = ctx.session.client_params.capabilities.elicitation
+    if confirm:
+        return None
 
-    if not can_elicit and not confirm:
-        return _build_preview_payload(resource_descriptor)
+    can_elicit = ctx.session.client_params.capabilities.elicitation
 
     if can_elicit:
         return await _elicit_confirmation(ctx, resource_descriptor)
 
-    return None
+    return _build_preview_payload(resource_descriptor)
 
 
 def _build_preview_payload(resource_descriptor: str) -> DestructivePreviewPayload:

--- a/src/pipefy_mcp/tools/pipe_config_tools.py
+++ b/src/pipefy_mcp/tools/pipe_config_tools.py
@@ -15,7 +15,6 @@ from pipefy_mcp.tools.graphql_error_helpers import (
 )
 from pipefy_mcp.tools.pipe_config_tool_helpers import (
     build_delete_pipe_error_payload,
-    build_delete_pipe_preview_payload,
     build_delete_pipe_success_payload,
     build_pipe_mutation_success_payload,
     build_pipe_tool_error_payload,
@@ -132,6 +131,7 @@ class PipeConfigTools:
             ),
         )
         async def delete_pipe(
+            ctx: Context[ServerSession, None],
             pipe_id: int,
             confirm: bool = False,
             debug: bool = False,
@@ -173,12 +173,13 @@ class PipeConfigTools:
                     ),
                 )
 
-            if not confirm:
-                return build_delete_pipe_preview_payload(
-                    pipe_id=pipe_id,
-                    pipe_name=pipe_name,
-                    pipe_data=pipe_data,
-                )
+            guard = await check_destructive_confirmation(
+                ctx,
+                confirm=confirm,
+                resource_descriptor=f"pipe '{pipe_name}' (ID: {pipe_id})",
+            )
+            if guard is not None:
+                return guard
 
             try:
                 delete_response = await client.delete_pipe(pipe_id)
@@ -366,7 +367,7 @@ class PipeConfigTools:
             if "name" not in update_attrs:
                 try:
                     phase_info = await client.get_phase_fields(phase_id)
-                except Exception as exc:  # noqa: BLE001  # noqa: BLE001
+                except Exception as exc:  # noqa: BLE001
                     return handle_pipe_config_tool_graphql_error(
                         exc, "Could not load phase.", debug=debug
                     )

--- a/src/pipefy_mcp/tools/pipe_tool_helpers.py
+++ b/src/pipefy_mcp/tools/pipe_tool_helpers.py
@@ -5,6 +5,10 @@ from typing import Literal, cast
 from pydantic import BaseModel, Field
 from typing_extensions import TypedDict
 
+from pipefy_mcp.tools.destructive_tool_guard import (
+    DestructiveCancelledPayload,
+    DestructivePreviewPayload,
+)
 from pipefy_mcp.tools.graphql_error_helpers import extract_error_strings
 
 
@@ -73,7 +77,10 @@ class DeleteCardErrorPayload(TypedDict):
 
 
 DeleteCardPayload = (
-    DeleteCardPreviewPayload | DeleteCardSuccessPayload | DeleteCardErrorPayload
+    DestructivePreviewPayload
+    | DestructiveCancelledPayload
+    | DeleteCardSuccessPayload
+    | DeleteCardErrorPayload
 )
 
 # Message returned by find_cards tool when the API returns no matching cards.

--- a/src/pipefy_mcp/tools/pipe_tools.py
+++ b/src/pipefy_mcp/tools/pipe_tools.py
@@ -17,6 +17,7 @@ from pipefy_mcp.models.comment import (
 from pipefy_mcp.models.form import create_form_model
 from pipefy_mcp.services.pipefy import PipefyClient
 from pipefy_mcp.services.pipefy.types import CardSearch
+from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.graphql_error_helpers import (
     extract_graphql_correlation_id,
     extract_graphql_error_codes,
@@ -25,7 +26,6 @@ from pipefy_mcp.tools.graphql_error_helpers import (
 from pipefy_mcp.tools.pipe_tool_helpers import (
     FIND_CARDS_EMPTY_MESSAGE,
     AddCardCommentPayload,
-    DeleteCardConfirmation,
     DeleteCardPayload,
     DeleteCommentErrorPayload,
     DeleteCommentSuccessPayload,
@@ -37,7 +37,6 @@ from pipefy_mcp.tools.pipe_tool_helpers import (
     build_add_card_comment_error_payload,
     build_add_card_comment_success_payload,
     build_delete_card_error_payload,
-    build_delete_card_preview_payload,
     build_delete_card_success_payload,
     build_delete_comment_error_payload,
     build_delete_comment_success_payload,
@@ -353,7 +352,7 @@ class PipeTools:
             return await client.get_pipe_members(pipe_id)
 
         @mcp.tool(
-            annotations=ToolAnnotations(idempotentHint=True),
+            annotations=ToolAnnotations(readOnlyHint=False, idempotentHint=True),
         )
         async def move_card_to_phase(card_id: int, destination_phase_id: int) -> dict:
             """Move a card to a specific phase."""
@@ -611,6 +610,7 @@ class PipeTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(
+                readOnlyHint=False,
                 destructiveHint=True,
             ),
         )
@@ -671,41 +671,13 @@ class PipeTools:
                     )
                 )
 
-            can_elicit = ctx.session.client_params.capabilities.elicitation
-            if not can_elicit and not confirm:
-                return build_delete_card_preview_payload(
-                    card_id=card_id,
-                    card_title=card_title,
-                    pipe_name=pipe_name,
-                )
-
-            if can_elicit and not confirm:
-                confirmation_message = (
-                    f"⚠️ You are about to permanently delete card '{card_title}' (ID: {card_id}) from pipe '{pipe_name}'. "
-                    "This action is irreversible. Are you sure you want to proceed?"
-                )
-
-                try:
-                    result = await ctx.elicit(
-                        message=confirmation_message,
-                        schema=DeleteCardConfirmation,
-                    )
-
-                    if result.action != "accept":
-                        return build_delete_card_error_payload(
-                            message="Card deletion cancelled by user."
-                        )
-
-                    confirmation_data = result.data.model_dump()
-                    if not confirmation_data.get("confirm"):
-                        return build_delete_card_error_payload(
-                            message="Card deletion cancelled by user."
-                        )
-
-                except Exception as exc:  # noqa: BLE001
-                    return build_delete_card_error_payload(
-                        message=f"Failed to request confirmation: {exc!s}"
-                    )
+            guard = await check_destructive_confirmation(
+                ctx,
+                confirm=confirm,
+                resource_descriptor=f"card '{card_title}' (ID: {card_id}) from pipe '{pipe_name}'",
+            )
+            if guard is not None:
+                return guard
 
             try:
                 delete_response = await client.delete_card(card_id)

--- a/src/pipefy_mcp/tools/registry.py
+++ b/src/pipefy_mcp/tools/registry.py
@@ -46,11 +46,7 @@ class ToolRegistry:
         OrganizationTools.register(self.mcp, self.services_container.pipefy_client)
         ObservabilityTools.register(self.mcp, self.services_container.pipefy_client)
 
-        if self.services_container.ai_automation_service is not None:
-            AiAutomationTools.register(
-                self.mcp, self.services_container.ai_automation_service
-            )
-
+        AiAutomationTools.register(self.mcp, self.services_container.pipefy_client)
         AiAgentTools.register(self.mcp, self.services_container.pipefy_client)
 
         return self.mcp

--- a/src/pipefy_mcp/tools/table_tools.py
+++ b/src/pipefy_mcp/tools/table_tools.py
@@ -21,7 +21,6 @@ from pipefy_mcp.tools.graphql_error_helpers import (
 )
 from pipefy_mcp.tools.table_tool_helpers import (
     build_delete_table_error_payload,
-    build_delete_table_preview_payload,
     build_delete_table_success_payload,
     build_table_mutation_error_payload,
     build_table_mutation_success_payload,
@@ -39,13 +38,7 @@ _TABLE_RECORDS_FIRST_MIN = 1
 _TABLE_RECORDS_FIRST_MAX = 200
 
 
-def _valid_table_field_id(value: str | int) -> bool:
-    """Table field IDs may be numeric or slug strings from Pipefy."""
-    if isinstance(value, int):
-        return value > 0
-    if isinstance(value, str):
-        return bool(value.strip())
-    return False
+_valid_table_field_id = valid_repo_id
 
 
 _CREATE_TABLE_EXTRA_RESERVED = frozenset({"name", "organization_id"})
@@ -384,6 +377,7 @@ class TableTools:
             ),
         )
         async def delete_table(
+            ctx: Context[ServerSession, None],
             table_id: str | int,
             confirm: bool = False,
             debug: bool = False,
@@ -425,12 +419,13 @@ class TableTools:
                     ),
                 )
 
-            if not confirm:
-                return build_delete_table_preview_payload(
-                    table_id=table_id,
-                    table_name=table_name,
-                    table_data=table_data,
-                )
+            guard = await check_destructive_confirmation(
+                ctx,
+                confirm=confirm,
+                resource_descriptor=f"table '{table_name}' (ID: {table_id})",
+            )
+            if guard is not None:
+                return guard
 
             try:
                 delete_response = await client.delete_table(table_id)

--- a/tests/ai_agent_test_payloads.py
+++ b/tests/ai_agent_test_payloads.py
@@ -55,3 +55,92 @@ def behavior_with_action(
             }
         },
     }
+
+
+def mock_api_behavior_response():
+    """Behavior dict as returned by GET_AI_AGENT_QUERY (aliased field names).
+
+    Mirrors the exact GraphQL response shape including aliases
+    (``eventId``, ``eventParams``, ``actionId``, ``actionParams``).
+    """
+    return {
+        "id": "123",
+        "name": "When card created — update fields",
+        "active": True,
+        "eventId": "card_created",
+        "eventParams": {
+            "fromPhaseId": None,
+            "inPhaseId": None,
+            "to_phase_id": None,
+            "triggerFieldIds": None,
+            "triggerAutomationId": None,
+        },
+        "actionId": "ai_behavior",
+        "condition": None,
+        "actionParams": {
+            "aiBehaviorParams": {
+                "instruction": "Analyze the card and fill summary.",
+                "dataSourceIds": [],
+                "referencedFieldIds": [],
+                "actionsAttributes": [
+                    {
+                        "id": "456",
+                        "name": "Update card fields",
+                        "actionType": "update_card",
+                        "referenceId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                        "metadata": {
+                            "destinationPhaseId": None,
+                            "pipeId": "306996636",
+                            "tableId": None,
+                            "emailTemplateId": None,
+                            "allowTemplateModifications": None,
+                            "fieldsAttributes": [
+                                {
+                                    "fieldId": "425829426",
+                                    "inputMode": "fill_with_ai",
+                                    "value": "",
+                                },
+                            ],
+                        },
+                    }
+                ],
+            }
+        },
+    }
+
+
+def mock_api_behavior_response_send_email_template():
+    """One behavior node as returned by GET_AI_AGENT_QUERY for ``send_email_template``.
+
+    Use for round-trip tests (get → update) so ``emailTemplateId`` / ``allowTemplateModifications``
+    are present under ``metadata`` like the expanded query selection.
+    """
+    base = mock_api_behavior_response()
+    base["name"] = "When card created — send email"
+    attrs = base["actionParams"]["aiBehaviorParams"]["actionsAttributes"][0]
+    attrs["name"] = "Send notification email"
+    attrs["actionType"] = "send_email_template"
+    attrs["referenceId"] = "b2c3d4e5-f6a7-8901-bcde-f12345678901"
+    attrs["metadata"] = {
+        "destinationPhaseId": None,
+        "pipeId": None,
+        "tableId": None,
+        "emailTemplateId": "tmpl-12345",
+        "allowTemplateModifications": True,
+        "fieldsAttributes": None,
+    }
+    return base
+
+
+def mock_agent_with_behaviors():
+    """Full ``aiAgent`` API response including behaviors — matches GET_AI_AGENT_QUERY shape."""
+    return {
+        "uuid": "agent-with-behaviors",
+        "name": "Production Assistant",
+        "instruction": "Help users with card triage.",
+        "repoUuid": "repo-uuid-123",
+        "dataSourceIds": ["ds-1"],
+        "disabledAt": None,
+        "needReview": False,
+        "behaviors": [mock_api_behavior_response()],
+    }

--- a/tests/core/test_container.py
+++ b/tests/core/test_container.py
@@ -70,12 +70,6 @@ class TestServicesContainer:
         mock_pipefy_client_class.assert_called_once_with(settings=settings.pipefy)
         assert container.pipefy_client is mock_client
 
-    def test_shutdown_method_exists(self):
-        """Test that shutdown method exists (currently a no-op)"""
-        container = ServicesContainer()
-
-        container.shutdown()
-
     @patch("pipefy_mcp.core.container.InternalApiClient")
     @patch("pipefy_mcp.core.container.AiAutomationService")
     @patch("pipefy_mcp.core.container.PipefyClient")
@@ -85,6 +79,10 @@ class TestServicesContainer:
         mock_ai_automation_service_class,
         mock_internal_api_client_class,
     ):
+        mock_client = Mock(spec=PipefyClient)
+        mock_client.client = Mock()
+        mock_pipefy_client_class.return_value = mock_client
+
         settings = Settings(
             pipefy=PipefySettings(
                 graphql_url="https://api.pipefy.com/graphql",
@@ -97,7 +95,8 @@ class TestServicesContainer:
         container = ServicesContainer()
         container.initialize_services(settings)
 
-        assert container.internal_api_client is not None
-        assert container.ai_automation_service is not None
         mock_internal_api_client_class.assert_called_once()
         mock_ai_automation_service_class.assert_called_once()
+        mock_client.set_ai_automation_service.assert_called_once_with(
+            mock_ai_automation_service_class.return_value
+        )

--- a/tests/models/test_ai_agent.py
+++ b/tests/models/test_ai_agent.py
@@ -469,6 +469,112 @@ def test_metadata_allows_empty_dict_for_unknown_action_type():
     BehaviorInput.model_validate(payload)
 
 
+@pytest.mark.unit
+def test_metadata_valid_for_create_table_record():
+    metadata = {
+        "tableId": "tbl-999",
+        "fieldsAttributes": [VALID_FIELDS_ATTR],
+    }
+    payload = behavior_with_action("create_table_record", metadata)
+    inp = BehaviorInput.model_validate(payload)
+    action = inp.action_params["aiBehaviorParams"]["actionsAttributes"][0]
+    assert action["metadata"]["tableId"] == "tbl-999"
+
+
+@pytest.mark.unit
+def test_metadata_rejects_missing_table_id_for_create_table_record():
+    payload = behavior_with_action(
+        "create_table_record",
+        {"fieldsAttributes": [VALID_FIELDS_ATTR]},
+    )
+    with pytest.raises(ValidationError, match="tableId"):
+        BehaviorInput.model_validate(payload)
+
+
+@pytest.mark.unit
+def test_metadata_rejects_missing_fields_attributes_for_create_table_record():
+    payload = behavior_with_action("create_table_record", {"tableId": "tbl-1"})
+    with pytest.raises(ValidationError, match="fieldsAttributes"):
+        BehaviorInput.model_validate(payload)
+
+
+@pytest.mark.unit
+def test_metadata_create_table_record_does_not_require_pipe_id():
+    metadata = {
+        "tableId": "tbl-1",
+        "fieldsAttributes": [VALID_FIELDS_ATTR],
+    }
+    payload = behavior_with_action("create_table_record", metadata)
+    BehaviorInput.model_validate(payload)
+
+
+@pytest.mark.unit
+def test_metadata_rejects_field_entry_missing_field_id_for_create_table_record():
+    metadata = {
+        "tableId": "tbl-1",
+        "fieldsAttributes": [{"inputMode": "fill_with_ai", "value": ""}],
+    }
+    payload = behavior_with_action("create_table_record", metadata)
+    with pytest.raises(ValidationError, match="fieldId"):
+        BehaviorInput.model_validate(payload)
+
+
+@pytest.mark.unit
+def test_metadata_valid_for_send_email_template():
+    payload = behavior_with_action(
+        "send_email_template",
+        {"emailTemplateId": "tmpl-1"},
+    )
+    inp = BehaviorInput.model_validate(payload)
+    meta = inp.action_params["aiBehaviorParams"]["actionsAttributes"][0]["metadata"]
+    assert meta["emailTemplateId"] == "tmpl-1"
+
+
+@pytest.mark.unit
+def test_metadata_send_email_template_accepts_allow_template_modifications():
+    payload = behavior_with_action(
+        "send_email_template",
+        {"emailTemplateId": "tmpl-1", "allowTemplateModifications": False},
+    )
+    inp = BehaviorInput.model_validate(payload)
+    meta = inp.action_params["aiBehaviorParams"]["actionsAttributes"][0]["metadata"]
+    assert meta["allowTemplateModifications"] is False
+
+
+@pytest.mark.unit
+def test_metadata_rejects_missing_email_template_id():
+    payload = behavior_with_action("send_email_template", {})
+    with pytest.raises(ValidationError, match="emailTemplateId"):
+        BehaviorInput.model_validate(payload)
+
+
+@pytest.mark.unit
+def test_metadata_rejects_blank_email_template_id():
+    payload = behavior_with_action("send_email_template", {"emailTemplateId": "  "})
+    with pytest.raises(ValidationError, match="emailTemplateId"):
+        BehaviorInput.model_validate(payload)
+
+
+@pytest.mark.unit
+def test_metadata_rejects_non_bool_allow_template_modifications():
+    payload = behavior_with_action(
+        "send_email_template",
+        {"emailTemplateId": "tmpl-1", "allowTemplateModifications": "yes"},
+    )
+    with pytest.raises(ValidationError, match="allowTemplateModifications"):
+        BehaviorInput.model_validate(payload)
+
+
+@pytest.mark.unit
+def test_behavior_input_accepts_capabilities_attributes_on_ai_behavior_params():
+    payload = minimal_behavior_dict()
+    abp = payload["actionParams"]["aiBehaviorParams"]
+    abp["capabilitiesAttributes"] = [{"type": "advanced_ocr"}, {"type": "web_search"}]
+    inp = BehaviorInput.model_validate(payload)
+    caps = inp.action_params["aiBehaviorParams"]["capabilitiesAttributes"]
+    assert caps == [{"type": "advanced_ocr"}, {"type": "web_search"}]
+
+
 # --- snake_case / camelCase normalization ---
 
 

--- a/tests/services/pipefy/test_member_service.py
+++ b/tests/services/pipefy/test_member_service.py
@@ -181,3 +181,13 @@ async def test_set_role_transport_error(mock_settings):
     )
     with pytest.raises(TransportQueryError):
         await service.set_role("604", "m1", "member")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_remove_members_rejects_uuid_pipe_id(mock_settings):
+    service = MemberService(settings=mock_settings)
+    with pytest.raises(ValueError, match="numeric pipe ID"):
+        await service.remove_members_from_pipe(
+            "a1b2c3d4-e5f6-7890-abcd-ef1234567890", ["u1"]
+        )

--- a/tests/services/test_ai_agent_service.py
+++ b/tests/services/test_ai_agent_service.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from gql.transport.exceptions import TransportQueryError
+from graphql import print_ast
 
 from pipefy_mcp.models.ai_agent import CreateAiAgentInput, UpdateAiAgentInput
 from pipefy_mcp.services.pipefy.ai_agent_service import (
@@ -18,11 +19,29 @@ from pipefy_mcp.services.pipefy.queries.ai_agent_queries import (
     DELETE_AI_AGENT_MUTATION,
     GET_AI_AGENT_QUERY,
     GET_AI_AGENTS_QUERY,
+    UPDATE_AI_AGENT_MUTATION,
 )
 from pipefy_mcp.settings import PipefySettings
-from tests.ai_agent_test_payloads import minimal_behavior_dict
+from tests.ai_agent_test_payloads import (
+    minimal_behavior_dict,
+    mock_agent_with_behaviors,
+)
 
 UUID_PATTERN = re.compile(r"%\{action:([a-f0-9-]{36})\}")
+
+
+@pytest.mark.unit
+def test_get_ai_agent_query_includes_email_template_metadata_fields():
+    printed = print_ast(GET_AI_AGENT_QUERY)
+    assert "emailTemplateId" in printed
+    assert "allowTemplateModifications" in printed
+
+
+@pytest.mark.unit
+def test_update_ai_agent_mutation_includes_email_template_metadata_fields():
+    printed = print_ast(UPDATE_AI_AGENT_MUTATION)
+    assert "emailTemplateId" in printed
+    assert "allowTemplateModifications" in printed
 
 
 def _make_behavior_dict(instruction="", actions=None):
@@ -467,6 +486,50 @@ async def test_get_agent_success():
     assert query is GET_AI_AGENT_QUERY
     assert variables == {"uuid": "agent-1"}
     assert result == agent_payload
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_agent_includes_behaviors_when_api_returns_them():
+    """get_agent passes through the full behaviors list from the API response."""
+    agent_payload = mock_agent_with_behaviors()
+    service = _create_mock_service({"aiAgent": agent_payload})
+
+    result = await service.get_agent("agent-with-behaviors")
+
+    assert result["behaviors"] is not None
+    assert len(result["behaviors"]) == 1
+    behavior = result["behaviors"][0]
+    assert behavior["id"] == "123"
+    assert behavior["eventId"] == "card_created"
+    ai_params = behavior["actionParams"]["aiBehaviorParams"]
+    assert ai_params["instruction"] == "Analyze the card and fill summary."
+    assert len(ai_params["actionsAttributes"]) == 1
+    assert ai_params["actionsAttributes"][0]["actionType"] == "update_card"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_agent_passes_through_null_behaviors():
+    """When API returns behaviors: null, service passes it through unchanged.
+
+    This documents the current behavior that leads to the bug: callers
+    (e.g. update_ai_agent flow) cannot distinguish "no behaviors" from
+    "behaviors could not be loaded" when the value is null.
+    """
+    agent_payload = {
+        "uuid": "agent-1",
+        "name": "Assistant",
+        "instruction": "Help users",
+        "disabledAt": None,
+        "needReview": False,
+        "behaviors": None,
+    }
+    service = _create_mock_service({"aiAgent": agent_payload})
+
+    result = await service.get_agent("agent-1")
+
+    assert result["behaviors"] is None
 
 
 @pytest.mark.unit

--- a/tests/services/test_ai_automation_service.py
+++ b/tests/services/test_ai_automation_service.py
@@ -17,7 +17,7 @@ def _create_mock_internal_api_client(execute_return: dict | None = None) -> Magi
     mock = MagicMock(spec=InternalApiClient)
     mock.execute_query = AsyncMock(
         return_value=execute_return
-        or {"data": {"createAutomation": {"automation": {"id": "123"}}}}
+        or {"createAutomation": {"automation": {"id": "123"}}}
     )
     return mock
 
@@ -27,7 +27,7 @@ def _create_mock_internal_api_client(execute_return: dict | None = None) -> Magi
 async def test_create_automation_calls_execute_query_with_correct_variables():
     """create_automation calls execute_query with createAutomation mutation and correct variables."""
     mock_client = _create_mock_internal_api_client(
-        {"data": {"createAutomation": {"automation": {"id": "456"}}}}
+        {"createAutomation": {"automation": {"id": "456"}}}
     )
     service = AiAutomationService(client=mock_client)
 
@@ -63,7 +63,7 @@ async def test_create_automation_calls_execute_query_with_correct_variables():
 async def test_create_automation_sends_custom_skills_ids():
     """create_automation forwards custom skills_ids in aiParams.skillsIds."""
     mock_client = _create_mock_internal_api_client(
-        {"data": {"createAutomation": {"automation": {"id": "456"}}}}
+        {"createAutomation": {"automation": {"id": "456"}}}
     )
     service = AiAutomationService(client=mock_client)
 
@@ -89,7 +89,7 @@ async def test_create_automation_sends_custom_skills_ids():
 async def test_create_automation_returns_success_format():
     """create_automation returns automation_id and message in success format."""
     mock_client = _create_mock_internal_api_client(
-        {"data": {"createAutomation": {"automation": {"id": "999"}}}}
+        {"createAutomation": {"automation": {"id": "999"}}}
     )
     service = AiAutomationService(client=mock_client)
 
@@ -113,7 +113,7 @@ async def test_create_automation_returns_success_format():
 async def test_update_automation_calls_execute_query_with_correct_variables():
     """update_automation calls execute_query with updateAutomation mutation and correct variables."""
     mock_client = _create_mock_internal_api_client(
-        {"data": {"updateAutomation": {"automation": {"id": "789"}}}}
+        {"updateAutomation": {"automation": {"id": "789"}}}
     )
     service = AiAutomationService(client=mock_client)
 
@@ -146,7 +146,7 @@ async def test_update_automation_calls_execute_query_with_correct_variables():
 async def test_update_automation_sends_skills_ids_when_provided():
     """update_automation includes skillsIds in aiParams when skills_ids is set."""
     mock_client = _create_mock_internal_api_client(
-        {"data": {"updateAutomation": {"automation": {"id": "789"}}}}
+        {"updateAutomation": {"automation": {"id": "789"}}}
     )
     service = AiAutomationService(client=mock_client)
 
@@ -165,7 +165,7 @@ async def test_update_automation_sends_skills_ids_when_provided():
 async def test_update_automation_returns_success_format():
     """update_automation returns automation_id and message in success format."""
     mock_client = _create_mock_internal_api_client(
-        {"data": {"updateAutomation": {"automation": {"id": "111"}}}}
+        {"updateAutomation": {"automation": {"id": "111"}}}
     )
     service = AiAutomationService(client=mock_client)
 
@@ -216,7 +216,7 @@ async def test_update_automation_propagates_execute_query_error():
 @pytest.mark.asyncio
 async def test_create_automation_missing_automation_id_returns_clear_error():
     """create_automation returns clear error when API response missing automation.id."""
-    mock_client = _create_mock_internal_api_client({"data": {}})
+    mock_client = _create_mock_internal_api_client({"createAutomation": {}})
     service = AiAutomationService(client=mock_client)
 
     inp = CreateAiAutomationInput(
@@ -236,7 +236,7 @@ async def test_create_automation_missing_automation_id_returns_clear_error():
 async def test_update_automation_missing_automation_id_returns_clear_error():
     """update_automation returns clear error when API response missing automation.id."""
     mock_client = _create_mock_internal_api_client(
-        {"data": {"updateAutomation": {"automation": {}}}}
+        {"updateAutomation": {"automation": {}}}
     )
     service = AiAutomationService(client=mock_client)
 
@@ -252,15 +252,13 @@ async def test_create_automation_raises_on_error_details():
     """create_automation raises ValueError when API returns error_details."""
     mock_client = _create_mock_internal_api_client(
         {
-            "data": {
-                "createAutomation": {
-                    "automation": None,
-                    "error_details": {
-                        "object_name": "Automation",
-                        "object_key": "base",
-                        "messages": ["Pipe not found", "AI not enabled"],
-                    },
-                }
+            "createAutomation": {
+                "automation": None,
+                "error_details": {
+                    "object_name": "Automation",
+                    "object_key": "base",
+                    "messages": ["Pipe not found", "AI not enabled"],
+                },
             }
         }
     )
@@ -283,15 +281,13 @@ async def test_update_automation_raises_on_error_details():
     """update_automation raises ValueError when API returns error_details."""
     mock_client = _create_mock_internal_api_client(
         {
-            "data": {
-                "updateAutomation": {
-                    "automation": None,
-                    "error_details": {
-                        "object_name": "Automation",
-                        "object_key": "base",
-                        "messages": ["Invalid field"],
-                    },
-                }
+            "updateAutomation": {
+                "automation": None,
+                "error_details": {
+                    "object_name": "Automation",
+                    "object_key": "base",
+                    "messages": ["Invalid field"],
+                },
             }
         }
     )

--- a/tests/services/test_attachment_service.py
+++ b/tests/services/test_attachment_service.py
@@ -147,7 +147,7 @@ async def test_upload_file_to_s3_success(mock_settings):
     service = AttachmentService(settings=mock_settings)
     with patch("httpx.AsyncClient", return_value=mock_cm):
         result = await service.upload_file_to_s3(
-            "https://s3.example.com/presigned",
+            "https://s3.us-east-1.amazonaws.com/presigned",
             b"hello",
             content_type=None,
         )
@@ -174,7 +174,7 @@ async def test_upload_file_to_s3_forbidden_includes_body_snippet(mock_settings):
     service = AttachmentService(settings=mock_settings)
     with patch("httpx.AsyncClient", return_value=mock_cm):
         result = await service.upload_file_to_s3(
-            "https://s3.example.com/presigned",
+            "https://s3.us-east-1.amazonaws.com/presigned",
             b"x",
             content_type=None,
         )
@@ -201,7 +201,7 @@ async def test_upload_file_to_s3_sets_content_type_header(mock_settings):
     service = AttachmentService(settings=mock_settings)
     with patch("httpx.AsyncClient", return_value=mock_cm):
         await service.upload_file_to_s3(
-            "https://s3.example.com/presigned",
+            "https://s3.us-east-1.amazonaws.com/presigned",
             b"%PDF",
             content_type="application/pdf",
         )
@@ -274,3 +274,35 @@ def test_pipefy_client_extract_storage_path_delegates_to_attachment_service():
     attachment.extract_storage_path.assert_called_once_with(
         "https://bucket/file.pdf?x=1",
     )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_upload_file_to_s3_rejects_non_allowed_host(mock_settings):
+    service = AttachmentService(settings=mock_settings)
+    with pytest.raises(ValueError, match="not in the allow-list"):
+        await service.upload_file_to_s3(
+            "https://evil.example.com/upload",
+            b"data",
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_upload_file_to_s3_accepts_pipefy_host(mock_settings):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = ""
+    mock_inner = MagicMock()
+    mock_inner.put = AsyncMock(return_value=mock_response)
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_inner)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+    service = AttachmentService(settings=mock_settings)
+    with patch("httpx.AsyncClient", return_value=mock_cm):
+        result = await service.upload_file_to_s3(
+            "https://uploads.pipefy.com/presigned",
+            b"ok",
+        )
+    assert result["status_code"] == 200

--- a/tests/services/test_internal_api_client.py
+++ b/tests/services/test_internal_api_client.py
@@ -73,7 +73,7 @@ async def test_execute_query_sends_post_with_correct_headers_and_body(respx_mock
     assert body == {"query": query_string, "variables": variables}
     assert "authorization" in (h.lower() for h in request.headers.keys())
     assert "content-type" in (h.lower() for h in request.headers.keys())
-    assert result == expected_json
+    assert result == expected_json.get("data", expected_json)
 
 
 @pytest.mark.unit
@@ -81,7 +81,7 @@ async def test_execute_query_sends_post_with_correct_headers_and_body(respx_mock
 @respx.mock(assert_all_mocked=False, assert_all_called=False)
 async def test_execute_query_returns_parsed_json_response(respx_mock):
     """Test execute_query returns the parsed JSON response from the API."""
-    expected = {"data": {"automation": {"id": "456"}}}
+    api_response = {"data": {"automation": {"id": "456"}}}
     respx_mock.post(OAUTH_TOKEN_URL).mock(
         return_value=httpx.Response(
             200,
@@ -89,7 +89,7 @@ async def test_execute_query_returns_parsed_json_response(respx_mock):
         )
     )
     respx_mock.post(DEFAULT_INTERNAL_API_URL).mock(
-        return_value=httpx.Response(200, json=expected)
+        return_value=httpx.Response(200, json=api_response)
     )
 
     client = InternalApiClient(
@@ -100,7 +100,7 @@ async def test_execute_query_returns_parsed_json_response(respx_mock):
     )
     result = await client.execute_query("query { x }", {})
 
-    assert result == expected
+    assert result == {"automation": {"id": "456"}}
 
 
 @pytest.mark.unit
@@ -180,3 +180,25 @@ async def test_execute_query_raises_on_timeout():
 
         with pytest.raises(httpx.TimeoutException):
             await client.execute_query("query { x }", {})
+
+
+@pytest.mark.unit
+def test_internal_api_client_rejects_http_url():
+    with pytest.raises(ValueError, match="HTTPS"):
+        InternalApiClient(
+            url="http://app.pipefy.com/internal_api",
+            oauth_url="https://auth.pipefy.com/oauth/token",
+            oauth_client="id",
+            oauth_secret="secret",
+        )
+
+
+@pytest.mark.unit
+def test_internal_api_client_rejects_http_oauth_url():
+    with pytest.raises(ValueError, match="HTTPS"):
+        InternalApiClient(
+            url="https://app.pipefy.com/internal_api",
+            oauth_url="http://auth.pipefy.com/oauth/token",
+            oauth_client="id",
+            oauth_secret="secret",
+        )

--- a/tests/services/test_pipefy_facade.py
+++ b/tests/services/test_pipefy_facade.py
@@ -428,18 +428,6 @@ async def test_pipefy_client_facade_delegates_to_services_without_modifying_args
     )
 
     assert await client.create_automation(
-        "p1",
-        "Rule",
-        "ev",
-        "act",
-        active=True,
-        extra_input={"active": False},
-    ) == {"ok": "create_automation"}
-    automation_service.create_automation.assert_awaited_with(
-        "p1", "Rule", "ev", "act", action_repo_id=None, active=False
-    )
-
-    assert await client.create_automation(
         "p1", "Rule", "ev", "act", action_repo_id="child-pipe"
     ) == {"ok": "create_automation"}
     automation_service.create_automation.assert_awaited_with(

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -9,7 +9,7 @@ import pytest
 def extract_payload():
     """Extract tool payload from CallToolResult across MCP SDK versions."""
 
-    def _extract(result) -> dict:
+    def _extract(result):
         structured = getattr(result, "structuredContent", None)
         if structured is not None:
             if isinstance(structured, dict) and "result" in structured:

--- a/tests/tools/test_ai_agent_tools.py
+++ b/tests/tools/test_ai_agent_tools.py
@@ -13,7 +13,7 @@ from mcp.shared.memory import (
 
 from pipefy_mcp.models.ai_agent import UpdateAiAgentInput
 from pipefy_mcp.tools.ai_agent_tools import AiAgentTools
-from tests.ai_agent_test_payloads import minimal_behavior_dict
+from tests.ai_agent_test_payloads import behavior_with_action, minimal_behavior_dict
 
 
 @pytest.fixture
@@ -700,6 +700,68 @@ class TestValidateAiAgentBehaviors:
         mock_pipefy_client.get_pipe.assert_awaited_once_with(1)
         mock_pipefy_client.get_pipe_relations.assert_awaited_once_with("1")
 
+    async def test_create_table_record_warns_without_treating_table_field_as_pipe_field(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.get_pipe.return_value = _pipe_graph_with_field()
+        mock_pipefy_client.get_pipe_relations.return_value = {
+            "children": [],
+            "parents": [],
+        }
+        behavior = behavior_with_action(
+            "create_table_record",
+            {
+                "tableId": "tbl-1",
+                "fieldsAttributes": [
+                    {
+                        "fieldId": "not-on-pipe-999",
+                        "inputMode": "fill_with_ai",
+                        "value": "",
+                    },
+                ],
+            },
+        )
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_agent_behaviors",
+                {"pipe_id": "1", "behaviors": [behavior]},
+            )
+        payload = extract_payload(result)
+        assert payload["success"] is True
+        assert payload["valid"] is True
+        assert payload["problems"] == []
+        assert len(payload["warnings"]) == 1
+        assert "create_table_record" in payload["warnings"][0]
+
+    async def test_send_email_template_validates_without_pipe_field_problems(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.get_pipe.return_value = _pipe_graph_with_field()
+        mock_pipefy_client.get_pipe_relations.return_value = {
+            "children": [],
+            "parents": [],
+        }
+        behavior = behavior_with_action(
+            "send_email_template",
+            {"emailTemplateId": "tmpl-abc"},
+        )
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_agent_behaviors",
+                {"pipe_id": "1", "behaviors": [behavior]},
+            )
+        payload = extract_payload(result)
+        assert payload["success"] is True
+        assert payload["valid"] is True
+        assert payload["problems"] == []
+        assert payload["warnings"] == []
+
     async def test_relations_fetch_failure_adds_warning_skips_relation_check(
         self,
         client_session,
@@ -824,6 +886,62 @@ class TestGetAiAgent:
         mock_pipefy_client.get_ai_agent.assert_awaited_once_with("agent-1")
         payload = extract_payload(result)
         assert payload == {"success": True, "agent": agent}
+
+    async def test_success_with_behaviors(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        """Behaviors from the API are included verbatim in the MCP tool response."""
+        from tests.ai_agent_test_payloads import mock_agent_with_behaviors
+
+        agent = mock_agent_with_behaviors()
+        mock_pipefy_client.get_ai_agent.return_value = agent
+        async with client_session as session:
+            result = await session.call_tool(
+                "get_ai_agent",
+                {"uuid": "agent-with-behaviors"},
+            )
+        assert result.isError is False
+        payload = extract_payload(result)
+        assert payload["success"] is True
+        behaviors = payload["agent"]["behaviors"]
+        assert behaviors is not None
+        assert len(behaviors) == 1
+        assert behaviors[0]["eventId"] == "card_created"
+        ai_params = behaviors[0]["actionParams"]["aiBehaviorParams"]
+        assert ai_params["instruction"] == "Analyze the card and fill summary."
+
+    async def test_null_behaviors_from_api(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        """When API returns behaviors: null, the tool response exposes it.
+
+        This documents the bug: callers see behaviors=null and cannot safely
+        re-send the config via update_ai_agent without risking data loss.
+        """
+        agent = {
+            "uuid": "agent-1",
+            "name": "Assistant",
+            "instruction": "Help",
+            "disabledAt": None,
+            "needReview": False,
+            "behaviors": None,
+        }
+        mock_pipefy_client.get_ai_agent.return_value = agent
+        async with client_session as session:
+            result = await session.call_tool(
+                "get_ai_agent",
+                {"uuid": "agent-1"},
+            )
+        assert result.isError is False
+        payload = extract_payload(result)
+        assert payload["success"] is True
+        assert payload["agent"]["behaviors"] is None
 
     async def test_not_found_returns_error_payload(
         self,

--- a/tests/tools/test_ai_automation_tools.py
+++ b/tests/tools/test_ai_automation_tools.py
@@ -9,6 +9,7 @@ from mcp.shared.memory import (
     create_connected_server_and_client_session as create_client_session,
 )
 
+from pipefy_mcp.services.pipefy import PipefyClient
 from pipefy_mcp.tools.ai_automation_tools import AiAutomationTools
 
 
@@ -18,17 +19,17 @@ def anyio_backend():
 
 
 @pytest.fixture
-def mock_ai_automation_service():
-    service = MagicMock()
-    service.create_automation = AsyncMock()
-    service.update_automation = AsyncMock()
-    return service
+def mock_pipefy_client():
+    client = MagicMock(spec=PipefyClient)
+    client.create_ai_automation = AsyncMock()
+    client.update_ai_automation = AsyncMock()
+    return client
 
 
 @pytest.fixture
-def mcp_server(mock_ai_automation_service):
+def mcp_server(mock_pipefy_client):
     mcp = FastMCP("AI Automation Tools Test")
-    AiAutomationTools.register(mcp, mock_ai_automation_service)
+    AiAutomationTools.register(mcp, mock_pipefy_client)
     return mcp
 
 
@@ -46,10 +47,10 @@ class TestCreateAiAutomation:
     async def test_success(
         self,
         client_session,
-        mock_ai_automation_service,
+        mock_pipefy_client,
         extract_payload,
     ):
-        mock_ai_automation_service.create_automation.return_value = {
+        mock_pipefy_client.create_ai_automation.return_value = {
             "automation_id": "123",
             "message": "AI Automation created successfully. ID: 123",
         }
@@ -77,10 +78,10 @@ class TestCreateAiAutomation:
     async def test_service_error_returns_error_payload(
         self,
         client_session,
-        mock_ai_automation_service,
+        mock_pipefy_client,
         extract_payload,
     ):
-        mock_ai_automation_service.create_automation.side_effect = RuntimeError(
+        mock_pipefy_client.create_ai_automation.side_effect = RuntimeError(
             "GraphQL error"
         )
         async with client_session as session:
@@ -103,7 +104,7 @@ class TestCreateAiAutomation:
     async def test_validation_error_returns_error_payload(
         self,
         client_session,
-        mock_ai_automation_service,
+        mock_pipefy_client,
         extract_payload,
     ):
         async with client_session as session:
@@ -118,7 +119,7 @@ class TestCreateAiAutomation:
                 },
             )
         assert result.isError is False
-        mock_ai_automation_service.create_automation.assert_not_called()
+        mock_pipefy_client.create_ai_automation.assert_not_called()
         payload = extract_payload(result)
         assert payload["success"] is False
         assert "error" in payload
@@ -129,10 +130,10 @@ class TestUpdateAiAutomation:
     async def test_success(
         self,
         client_session,
-        mock_ai_automation_service,
+        mock_pipefy_client,
         extract_payload,
     ):
-        mock_ai_automation_service.update_automation.return_value = {
+        mock_pipefy_client.update_ai_automation.return_value = {
             "automation_id": "789",
             "message": "AI Automation updated successfully. ID: 789",
         }
@@ -154,10 +155,10 @@ class TestUpdateAiAutomation:
     async def test_service_error_returns_error_payload(
         self,
         client_session,
-        mock_ai_automation_service,
+        mock_pipefy_client,
         extract_payload,
     ):
-        mock_ai_automation_service.update_automation.side_effect = ValueError(
+        mock_pipefy_client.update_ai_automation.side_effect = ValueError(
             "Network error"
         )
         async with client_session as session:
@@ -181,10 +182,10 @@ class TestPipefyIdCoercion:
     async def test_create_ai_automation_coerces_int_pipe_id_and_event_id(
         self,
         client_session,
-        mock_ai_automation_service,
+        mock_pipefy_client,
         extract_payload,
     ):
-        mock_ai_automation_service.create_automation.return_value = {
+        mock_pipefy_client.create_ai_automation.return_value = {
             "automation_id": "456",
             "message": "AI Automation created successfully. ID: 456",
         }
@@ -203,17 +204,17 @@ class TestPipefyIdCoercion:
         payload = extract_payload(result)
         assert payload["success"] is True
 
-        validated_input = mock_ai_automation_service.create_automation.call_args[0][0]
+        validated_input = mock_pipefy_client.create_ai_automation.call_args[0][0]
         assert validated_input.pipe_id == "303"
         assert validated_input.event_id == "101"
 
     async def test_update_ai_automation_coerces_int_automation_id(
         self,
         client_session,
-        mock_ai_automation_service,
+        mock_pipefy_client,
         extract_payload,
     ):
-        mock_ai_automation_service.update_automation.return_value = {
+        mock_pipefy_client.update_ai_automation.return_value = {
             "automation_id": "789",
             "message": "AI Automation updated successfully. ID: 789",
         }
@@ -226,5 +227,5 @@ class TestPipefyIdCoercion:
         payload = extract_payload(result)
         assert payload["success"] is True
 
-        validated_input = mock_ai_automation_service.update_automation.call_args[0][0]
+        validated_input = mock_pipefy_client.update_ai_automation.call_args[0][0]
         assert validated_input.automation_id == "789"

--- a/tests/tools/test_ai_tool_helpers.py
+++ b/tests/tools/test_ai_tool_helpers.py
@@ -194,6 +194,69 @@ def _connected_card_behavior(target_pipe_id="child-pipe"):
     }
 
 
+def _create_table_record_behavior(field_id="tbl-field-999", table_id="tbl-1"):
+    return {
+        "name": "Insert table row",
+        "event_id": "card_created",
+        "actionParams": {
+            "aiBehaviorParams": {
+                "instruction": "go",
+                "actionsAttributes": [
+                    {
+                        "name": "row",
+                        "actionType": "create_table_record",
+                        "metadata": {
+                            "tableId": table_id,
+                            "fieldsAttributes": [
+                                {
+                                    "fieldId": field_id,
+                                    "inputMode": "fill_with_ai",
+                                    "value": "",
+                                },
+                            ],
+                        },
+                    },
+                ],
+            }
+        },
+    }
+
+
+def _send_email_template_behavior(
+    *,
+    email_template_id="tmpl-1",
+    include_stray_fields_attributes=False,
+):
+    metadata = {
+        "emailTemplateId": email_template_id,
+        "allowTemplateModifications": True,
+    }
+    if include_stray_fields_attributes:
+        metadata["fieldsAttributes"] = [
+            {
+                "fieldId": "999",
+                "inputMode": "fill_with_ai",
+                "value": "",
+            },
+        ]
+    return {
+        "name": "Send mail",
+        "event_id": "card_created",
+        "actionParams": {
+            "aiBehaviorParams": {
+                "instruction": "go",
+                "actionsAttributes": [
+                    {
+                        "name": "email",
+                        "actionType": "send_email_template",
+                        "metadata": metadata,
+                    },
+                ],
+            }
+        },
+    }
+
+
 PIPE_FIELDS = {"100", "101", "102"}
 PIPE_PHASES = {"ph-start", "ph-1", "ph-done"}
 RELATED_PIPES = {"child-pipe", "sibling-pipe"}
@@ -301,6 +364,37 @@ def test_validate_create_connected_card_skipped_when_relations_not_loaded():
     )
     assert problems == []
     assert warnings == []
+
+
+@pytest.mark.unit
+def test_validate_create_table_record_skips_pipe_field_id_check():
+    """Table field IDs are not validated against the source pipe (FR-6)."""
+    problems, warnings = validate_behaviors_against_pipe(
+        [_create_table_record_behavior(field_id="999")],
+        pipe_id="1",
+        pipe_field_ids=PIPE_FIELDS,
+        pipe_phase_ids=PIPE_PHASES,
+        related_pipe_ids=RELATED_PIPES,
+    )
+    assert problems == []
+    assert len(warnings) == 1
+    assert "create_table_record" in warnings[0]
+    assert "get_table" in warnings[0] and "get_table_record" in warnings[0]
+
+
+@pytest.mark.unit
+def test_validate_send_email_template_skips_pipe_field_checks():
+    """Email template actions do not cross-validate fieldIds against the pipe (FR-6)."""
+    problems, warnings = validate_behaviors_against_pipe(
+        [_send_email_template_behavior(include_stray_fields_attributes=True)],
+        pipe_id="1",
+        pipe_field_ids=PIPE_FIELDS,
+        pipe_phase_ids=PIPE_PHASES,
+        related_pipe_ids=RELATED_PIPES,
+    )
+    assert problems == []
+    assert warnings == []
+    assert not any("fieldsAttributes" in p for p in problems)
 
 
 @pytest.mark.unit

--- a/tests/tools/test_destructive_tool_guard.py
+++ b/tests/tools/test_destructive_tool_guard.py
@@ -97,8 +97,8 @@ class TestWithElicitation:
         assert payload["requires_confirmation"] is True
         assert payload["resource"] == RESOURCE
 
-    async def test_confirm_true_ignored_when_elicitation_available(self):
-        """Even with confirm=True, elicitation takes precedence when available."""
+    async def test_confirm_true_bypasses_elicitation(self):
+        """When confirm=True, skip elicitation prompt and proceed immediately."""
         ctx = _make_ctx(
             can_elicit=True,
             elicit_result=_elicit_result(action="accept", confirm_value=True),
@@ -107,4 +107,4 @@ class TestWithElicitation:
             ctx, confirm=True, resource_descriptor=RESOURCE
         )
         assert result is None
-        ctx.elicit.assert_called_once()
+        ctx.elicit.assert_not_called()

--- a/tests/tools/test_pipe_tools.py
+++ b/tests/tools/test_pipe_tools.py
@@ -21,7 +21,6 @@ from pipefy_mcp.services.pipefy import PipefyClient
 from pipefy_mcp.tools.pipe_tool_helpers import (
     FIND_CARDS_EMPTY_MESSAGE,
     DeleteCardErrorPayload,
-    DeleteCardPreviewPayload,
     DeleteCardSuccessPayload,
 )
 from pipefy_mcp.tools.pipe_tools import FIND_CARDS_RESPONSE_KEY, PipeTools
@@ -1221,19 +1220,16 @@ class TestDeleteCardTool:
             mock_pipefy_client.delete_card.assert_not_called()
 
             payload = extract_payload(result)
-            expected_payload: DeleteCardPreviewPayload = {
+            assert payload == {
                 "success": False,
                 "requires_confirmation": True,
-                "card_id": 12345,
-                "card_title": "Test Card",
-                "pipe_name": "Test Pipe",
+                "resource": "card 'Test Card' (ID: 12345) from pipe 'Test Pipe'",
                 "message": (
-                    "⚠️ You are about to permanently delete card "
-                    "'Test Card' (ID: 12345) from pipe 'Test Pipe'. "
+                    "⚠️ You are about to permanently delete "
+                    "card 'Test Card' (ID: 12345) from pipe 'Test Pipe'. "
                     "This action is irreversible. Set 'confirm=True' to proceed."
                 ),
             }
-            assert payload == expected_payload
 
     @pytest.mark.parametrize(
         "client_session",
@@ -1262,11 +1258,10 @@ class TestDeleteCardTool:
             mock_pipefy_client.delete_card.assert_not_called()
 
             payload = extract_payload(result)
-            expected_payload: DeleteCardErrorPayload = {
+            assert payload == {
                 "success": False,
-                "error": "Card deletion cancelled by user.",
+                "error": "Action cancelled by user.",
             }
-            assert payload == expected_payload
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
     async def test_invalid_card_id_returns_error(
@@ -1487,7 +1482,7 @@ class TestDeleteCardTool:
         mock_pipefy_client,
         extract_payload,
     ) -> None:
-        """When elicitation for confirmation raises, tool returns error with 'Failed to request confirmation'."""
+        """When elicitation raises, the shared guard falls back to a preview payload."""
         mock_pipefy_client.get_card.return_value = {
             "card": {"id": "12345", "title": "Test Card", "pipe": {"name": "Test Pipe"}}
         }
@@ -1498,7 +1493,7 @@ class TestDeleteCardTool:
         mock_pipefy_client.delete_card.assert_not_called()
         payload = extract_payload(result)
         assert payload["success"] is False
-        assert "Failed to request confirmation" in payload["error"]
+        assert payload["requires_confirmation"] is True
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
     async def test_debug_true_appends_codes_and_correlation_id_to_error(

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -120,10 +120,8 @@ class TestToolRegistry:
     ):
         mock_mcp = Mock(spec=FastMCP)
         mock_client = Mock()
-        mock_ai_automation_service = Mock()
         mock_container = Mock(spec=ServicesContainer)
         mock_container.pipefy_client = mock_client
-        mock_container.ai_automation_service = mock_ai_automation_service
 
         registry = ToolRegistry(mcp=mock_mcp, services_container=mock_container)
         registry.register_tools()
@@ -142,7 +140,5 @@ class TestToolRegistry:
         mock_automation_tools_register.assert_called_once_with(mock_mcp, mock_client)
         mock_introspection_tools_register.assert_called_once_with(mock_mcp, mock_client)
         mock_observability_tools_register.assert_called_once_with(mock_mcp, mock_client)
-        mock_ai_automation_tools_register.assert_called_once_with(
-            mock_mcp, mock_ai_automation_service
-        )
+        mock_ai_automation_tools_register.assert_called_once_with(mock_mcp, mock_client)
         mock_ai_agent_tools_register.assert_called_once_with(mock_mcp, mock_client)

--- a/tests/tools/test_table_tools.py
+++ b/tests/tools/test_table_tools.py
@@ -514,7 +514,7 @@ async def test_delete_table_preview(table_session, mock_table_client, extract_pa
     payload = extract_payload(result)
     assert payload["success"] is False
     assert payload["requires_confirmation"] is True
-    assert payload["table_id"] == 5
+    assert payload["resource"] == "table 'Cat' (ID: 5)"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

This PR bundles deep-dive refactors and fixes for the Pipefy MCP server:

- **Destructive tools**: `confirm=True` bypasses elicitation; `delete_pipe`, `delete_table`, and `delete_card` use the shared confirmation guard with consistent preview payloads.
- **Facade**: AI automation flows through `PipefyClient` (`set_ai_automation_service`, `create_ai_automation` / `update_ai_automation`); `create_automation` no longer merges `active` in a way that overrides `extra_input`.
- **Internal API client**: unwrap GraphQL `data` envelope (aligned with `execute_query`); enforce HTTPS on internal API and OAuth URLs.
- **Security**: allowlist hosts for presigned S3 uploads (`*.amazonaws.com`, `*.pipefy.com`).
- **Members**: reject UUID as `pipe_id` for removal with a clear message.
- **AI agent tools**: `await ctx.debug(...)` so debug lines are not dropped.
- **Queries**: inline GraphQL for reports, relations, and observability (readability / tooling).
- **Server lifespan**: yield MCP instance only after successful initialization.

## Testing

- `uv sync --locked --all-extras --dev`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run pytest -m "not integration"` (all passed)

## Notes

- MCP tools `create_ai_automation` / `update_ai_automation` require OAuth env vars; validation errors surface before that path when inputs are invalid.
