### PR TITLE
feat: phase transition validation (moves, AI behaviors, automations)

### DIFF
--- a/src/pipefy_mcp/services/pipefy/client.py
+++ b/src/pipefy_mcp/services/pipefy/client.py
@@ -806,6 +806,10 @@ class PipefyClient:
         """Get the fields available in a specific phase."""
         return await self._pipe_service.get_phase_fields(phase_id, required_only)
 
+    async def get_phase_allowed_move_targets(self, phase_id: int) -> dict:
+        """Phases reachable from ``phase_id`` per Pipefy transition rules (read-only)."""
+        return await self._pipe_service.get_phase_allowed_move_targets(phase_id)
+
     async def get_pipe_reports(
         self,
         pipe_uuid: str,

--- a/src/pipefy_mcp/services/pipefy/pipe_service.py
+++ b/src/pipefy_mcp/services/pipefy/pipe_service.py
@@ -5,6 +5,7 @@ from rapidfuzz import fuzz
 
 from pipefy_mcp.services.pipefy.base_client import BasePipefyClient
 from pipefy_mcp.services.pipefy.queries.pipe_queries import (
+    GET_PHASE_ALLOWED_MOVES_QUERY,
     GET_PHASE_FIELDS_QUERY,
     GET_PIPE_MEMBERS_QUERY,
     GET_PIPE_QUERY,
@@ -120,6 +121,21 @@ class PipeService(BasePipefyClient):
                 )
 
         return {"organizations": filtered_orgs}
+
+    async def get_phase_allowed_move_targets(self, phase_id: int) -> dict:
+        """List phases a card may move to from ``phase_id`` (UI transition rules).
+
+        Read-only: mirrors Pipefy **Phase → Connections**. Returns the GraphQL
+        ``phase`` object including ``cards_can_be_moved_to_phases``.
+
+        Args:
+            phase_id: Source phase ID.
+
+        Returns:
+            Raw GraphQL payload (``phase`` key at top level).
+        """
+        variables = {"phase_id": phase_id}
+        return await self.execute_query(GET_PHASE_ALLOWED_MOVES_QUERY, variables)
 
     async def get_phase_fields(
         self, phase_id: int, required_only: bool = False

--- a/src/pipefy_mcp/services/pipefy/queries/pipe_queries.py
+++ b/src/pipefy_mcp/services/pipefy/queries/pipe_queries.py
@@ -85,6 +85,21 @@ GET_PIPE_MEMBERS_QUERY = gql(
     """
 )
 
+GET_PHASE_ALLOWED_MOVES_QUERY = gql(
+    """
+    query GetPhaseAllowedMoves($phase_id: ID!) {
+        phase(id: $phase_id) {
+            id
+            name
+            cards_can_be_moved_to_phases {
+                id
+                name
+            }
+        }
+    }
+    """
+)
+
 GET_PHASE_FIELDS_QUERY = gql(
     """
     query GetPhaseFields($phase_id: ID!) {
@@ -109,6 +124,7 @@ GET_PHASE_FIELDS_QUERY = gql(
 )
 
 __all__ = [
+    "GET_PHASE_ALLOWED_MOVES_QUERY",
     "GET_PHASE_FIELDS_QUERY",
     "GET_PIPE_MEMBERS_QUERY",
     "GET_PIPE_QUERY",

--- a/src/pipefy_mcp/tools/ai_agent_tools.py
+++ b/src/pipefy_mcp/tools/ai_agent_tools.py
@@ -26,6 +26,9 @@ from pipefy_mcp.tools.ai_tool_helpers import (
 )
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.graphql_error_helpers import extract_error_strings
+from pipefy_mcp.tools.phase_transition_helpers import (
+    collect_ai_behavior_move_transition_problems,
+)
 
 VALIDATE_FETCH_TIMEOUT_SECONDS = 30
 
@@ -116,13 +119,19 @@ class AiAgentTools:
                     related_pipe_ids=related_pipe_ids,
                     unknown_action_types="error",
                 )
+                transition_problems = (
+                    await collect_ai_behavior_move_transition_problems(
+                        client, behaviors
+                    )
+                )
+                all_problems = [*problems, *transition_problems]
 
-                if not problems:
+                if not all_problems:
                     return enriched + _PAYLOAD_OK_SUFFIX
                 return (
                     enriched
                     + "\n\nValidation found problems:\n"
-                    + "\n".join(f"  - {p}" for p in problems)
+                    + "\n".join(f"  - {p}" for p in all_problems)
                 )
             except Exception:  # noqa: BLE001
                 return enriched
@@ -487,6 +496,9 @@ class AiAgentTools:
             Known ``actionType`` values for pipe-context checks are:
             ``move_card``, ``update_card``, ``create_card``, ``create_connected_card``,
             ``create_table_record``, and ``send_email_template``.
+            For ``move_card`` with trigger ``card_moved`` and ``eventParams.to_phase_id``/``toPhaseId``,
+            the tool also checks that ``destinationPhaseId`` is allowed from that phase
+            (``cards_can_be_moved_to_phases``).
             For ``create_table_record``, ``fieldsAttributes`` hold **table** field IDs — they are not
             validated against the source pipe; the tool adds a **warning** to verify IDs with
             ``get_table`` / ``get_table_record`` instead. ``send_email_template`` does not run
@@ -619,6 +631,10 @@ class AiAgentTools:
                 cross_pipe_field_ids=cross_pipe_field_ids or None,
                 unknown_action_types=unknown_action_types,
             )
+            transition_problems = await collect_ai_behavior_move_transition_problems(
+                client, behaviors
+            )
+            problems = [*problems, *transition_problems]
             warnings = [*tool_warnings, *helper_warnings]
 
             if problems:

--- a/src/pipefy_mcp/tools/automation_tools.py
+++ b/src/pipefy_mcp/tools/automation_tools.py
@@ -19,6 +19,9 @@ from pipefy_mcp.tools.automation_tool_helpers import (
     handle_automation_tool_graphql_error,
 )
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
+from pipefy_mcp.tools.phase_transition_helpers import (
+    validate_traditional_automation_move_transition_or_none,
+)
 from pipefy_mcp.tools.validation_helpers import (
     mutation_error_if_not_optional_dict,
     valid_repo_id,
@@ -331,6 +334,11 @@ class AutomationTools:
             ``CreateAutomationInput`` (camelCase keys). Use ``update_automation`` with ``active: false``
             to disable a rule after creation.
 
+            For ``card_moved`` rules with action ``move_single_card``, when ``extra_input`` includes
+            ``event_params.to_phase_id`` (or ``toPhaseId``) and ``action_params.to_phase_id`` (or
+            ``phase.id``), the tool rejects impossible transitions before calling the API, using the
+            same read-only transition data as ``move_card_to_phase``.
+
             **Cross-pipe actions** (e.g. ``create_connected_card``, ``move_card_to_pipe``):
             set ``action_repo_id`` to the **destination** pipe ID. When omitted it defaults to
             ``pipe_id`` (same-pipe automation). Cross-pipe actions typically require
@@ -376,6 +384,13 @@ class AutomationTools:
             )
             if bad is not None:
                 return bad
+            transition_msg = (
+                await validate_traditional_automation_move_transition_or_none(
+                    client, tid, aid, extra_input
+                )
+            )
+            if transition_msg is not None:
+                return build_automation_error_payload(transition_msg)
             try:
                 raw = await client.create_automation(
                     pid,

--- a/src/pipefy_mcp/tools/phase_transition_helpers.py
+++ b/src/pipefy_mcp/tools/phase_transition_helpers.py
@@ -1,0 +1,236 @@
+"""Helpers for validating Pipefy phase transitions (read-only API rules)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pipefy_mcp.services.pipefy import PipefyClient
+from pipefy_mcp.tools.transition_hints import (
+    TRANSITION_RULES_HINT,
+    format_allowed_destinations_phrase,
+)
+
+# Traditional automation action IDs that move the current card to another phase (same repo).
+_AUTOMATION_MOVE_CARD_ACTION_IDS = frozenset({"move_single_card"})
+
+
+async def try_enrich_move_card_to_phase_failure(
+    client: PipefyClient,
+    card_id: int,
+    destination_phase_id: int,
+) -> dict[str, Any] | None:
+    """If the card cannot move to ``destination_phase_id`` from its current phase, build an error payload.
+
+    Used after ``moveCardToPhase`` fails: extra GraphQL calls only on the error path.
+    Returns ``None`` when enrichment is not possible or the destination is already allowed
+    (caller should surface the original API error).
+
+    Args:
+        client: Pipefy facade.
+        card_id: Card that was being moved.
+        destination_phase_id: Requested destination phase ID.
+
+    Returns:
+        Dict with ``success: False``, ``error``, ``valid_destinations``, ``current_phase``; or ``None``.
+    """
+    try:
+        card_payload = await client.get_card(card_id, include_fields=False)
+    except Exception:
+        return None
+    card = card_payload.get("card") or {}
+    current = card.get("current_phase") or {}
+    cur_id = current.get("id")
+    cur_name = str(current.get("name") or "")
+    if cur_id is None:
+        return None
+    try:
+        phase_payload = await client.get_phase_allowed_move_targets(int(cur_id))
+    except Exception:
+        return None
+    phase = phase_payload.get("phase") or {}
+    allowed = phase.get("cards_can_be_moved_to_phases") or []
+    dest_str = str(destination_phase_id)
+    allowed_ids = {str(p.get("id")) for p in allowed if p.get("id") is not None}
+    if dest_str in allowed_ids:
+        return None
+
+    valid_label = format_allowed_destinations_phrase(allowed)
+    from_label = f"'{cur_name}'" if cur_name else f"id {cur_id}"
+    msg = (
+        f"Cannot move card from phase {from_label} (id {cur_id}) to destination phase "
+        f"id {destination_phase_id}. Valid destinations from that phase: {valid_label}. "
+        f"{TRANSITION_RULES_HINT}"
+    )
+    return {
+        "success": False,
+        "error": msg,
+        "valid_destinations": allowed,
+        "current_phase": {"id": str(cur_id), "name": cur_name or None},
+    }
+
+
+async def collect_ai_behavior_move_transition_problems(
+    client: PipefyClient,
+    behaviors: list[dict[str, Any]],
+) -> list[str]:
+    """Append-style validation: ``move_card`` when trigger is ``card_moved`` with ``to_phase_id``.
+
+    The card is in ``eventParams.to_phase_id`` when the behavior runs; the move action's
+    ``destinationPhaseId`` must appear in that phase's ``cards_can_be_moved_to_phases``.
+
+    Args:
+        client: Pipefy facade.
+        behaviors: Raw behavior dicts (camelCase or snake_case keys).
+
+    Returns:
+        Human-readable problem strings (empty if none).
+    """
+    problems: list[str] = []
+    cache: dict[str, tuple[str, list[dict]]] = {}
+
+    async def phase_context(phase_id_str: str) -> tuple[str, list[dict]]:
+        if phase_id_str not in cache:
+            try:
+                data = await client.get_phase_allowed_move_targets(int(phase_id_str))
+            except Exception:
+                cache[phase_id_str] = ("", [])
+            else:
+                ph = data.get("phase") or {}
+                cache[phase_id_str] = (
+                    str(ph.get("name") or ""),
+                    ph.get("cards_can_be_moved_to_phases") or [],
+                )
+        return cache[phase_id_str]
+
+    for i, b in enumerate(behaviors):
+        event_id = str(b.get("event_id") or b.get("eventId") or "")
+        if event_id != "card_moved":
+            continue
+        ep = b.get("eventParams") or b.get("event_params") or {}
+        src = ep.get("to_phase_id") or ep.get("toPhaseId")
+        if not src:
+            continue
+        src_s = str(src)
+        bname = b.get("name", f"<behavior {i}>")
+        prefix = f'Behavior [{i}] "{bname}"'
+
+        ap = b.get("actionParams") or b.get("action_params") or {}
+        abp = ap.get("aiBehaviorParams") or ap.get("ai_behavior_params") or {}
+        attrs = abp.get("actionsAttributes") or abp.get("actions_attributes") or []
+        for j, action in enumerate(attrs):
+            if not isinstance(action, dict):
+                continue
+            if action.get("actionType") != "move_card":
+                continue
+            meta = action.get("metadata") or {}
+            dest = meta.get("destinationPhaseId")
+            if not dest:
+                continue
+            dest_s = str(dest)
+            src_name, allowed = await phase_context(src_s)
+            allowed_ids = {str(p.get("id")) for p in allowed if p.get("id") is not None}
+            if dest_s in allowed_ids:
+                continue
+            dest_name = ""
+            for p in allowed:
+                if str(p.get("id")) == dest_s:
+                    dest_name = str(p.get("name") or "")
+                    break
+            src_label = f"'{src_name}'" if src_name else f"id {src_s}"
+            dest_label = f"'{dest_name}'" if dest_name else f"id {dest_s}"
+            valid_label = format_allowed_destinations_phrase(allowed)
+            problems.append(
+                f"{prefix}, action [{j}] (move_card): phase {src_label} cannot move cards "
+                f"to {dest_label}. Valid destinations: {valid_label}. {TRANSITION_RULES_HINT}"
+            )
+
+    return problems
+
+
+def collect_automation_move_transition_error_message(
+    *,
+    allowed_phases: list[dict],
+    source_phase_name: str,
+    source_phase_id: str,
+    dest_phase_id: str,
+) -> str:
+    """Build blocking error text for traditional automation move rules.
+
+    Args:
+        allowed_phases: ``cards_can_be_moved_to_phases`` from the source phase.
+        source_phase_name: Name of source phase (may be empty).
+        source_phase_id: Source phase id string.
+        dest_phase_id: Requested destination phase id string.
+
+    Returns:
+        Single message suitable for ``build_automation_error_payload``.
+    """
+    src_l = f"'{source_phase_name}'" if source_phase_name else f"id {source_phase_id}"
+    valid_label = format_allowed_destinations_phrase(allowed_phases)
+    return (
+        f"This automation would move a card from phase {src_l} (id {source_phase_id}) "
+        f"to phase id {dest_phase_id}, which is not an allowed transition. "
+        f"Valid destinations from that phase: {valid_label}. {TRANSITION_RULES_HINT}"
+    )
+
+
+async def validate_traditional_automation_move_transition_or_none(
+    client: PipefyClient,
+    trigger_id: str,
+    action_id: str,
+    extra_input: Any,
+) -> str | None:
+    """Return an error message when a move-card automation has an impossible transition; else ``None``.
+
+    Only runs when the trigger is ``card_moved`` with ``to_phase_id``, the action is a same-pipe
+    move action, and ``extra_input`` exposes source/destination phase ids.
+
+    Args:
+        client: Pipefy facade.
+        trigger_id: Rule trigger (e.g. ``card_moved``).
+        action_id: Rule action id from the catalog (e.g. ``move_single_card``).
+        extra_input: Optional ``CreateAutomationInput``-style dict (event_params, action_params).
+    """
+    if str(trigger_id) != "card_moved":
+        return None
+    aid = str(action_id)
+    if aid not in _AUTOMATION_MOVE_CARD_ACTION_IDS:
+        return None
+    extra = extra_input if isinstance(extra_input, dict) else {}
+    ev = extra.get("event_params") or extra.get("eventParams") or {}
+    src = ev.get("to_phase_id") or ev.get("toPhaseId")
+    if not src:
+        return None
+    src_s = str(src)
+    act = extra.get("action_params") or extra.get("actionParams") or {}
+    dest = act.get("to_phase_id") or act.get("toPhaseId")
+    phase_nested = act.get("phase")
+    if dest is None and isinstance(phase_nested, dict):
+        dest = phase_nested.get("id")
+    if not dest:
+        return None
+    dest_s = str(dest)
+    try:
+        data = await client.get_phase_allowed_move_targets(int(src_s))
+    except Exception:
+        return None
+    ph = data.get("phase") or {}
+    allowed = ph.get("cards_can_be_moved_to_phases") or []
+    allowed_ids = {str(p.get("id")) for p in allowed if p.get("id") is not None}
+    if dest_s in allowed_ids:
+        return None
+    src_name = str(ph.get("name") or "")
+    return collect_automation_move_transition_error_message(
+        allowed_phases=allowed,
+        source_phase_name=src_name,
+        source_phase_id=src_s,
+        dest_phase_id=dest_s,
+    )
+
+
+__all__ = [
+    "collect_ai_behavior_move_transition_problems",
+    "collect_automation_move_transition_error_message",
+    "try_enrich_move_card_to_phase_failure",
+    "validate_traditional_automation_move_transition_or_none",
+]

--- a/src/pipefy_mcp/tools/pipe_tools.py
+++ b/src/pipefy_mcp/tools/pipe_tools.py
@@ -23,6 +23,9 @@ from pipefy_mcp.tools.graphql_error_helpers import (
     extract_graphql_error_codes,
     with_debug_suffix,
 )
+from pipefy_mcp.tools.phase_transition_helpers import (
+    try_enrich_move_card_to_phase_failure,
+)
 from pipefy_mcp.tools.pipe_tool_helpers import (
     FIND_CARDS_EMPTY_MESSAGE,
     AddCardCommentPayload,
@@ -363,9 +366,24 @@ class PipeTools:
             annotations=ToolAnnotations(readOnlyHint=False, idempotentHint=True),
         )
         async def move_card_to_phase(card_id: int, destination_phase_id: int) -> dict:
-            """Move a card to a specific phase."""
+            """Move a card to a specific phase.
 
-            return await client.move_card_to_phase(card_id, destination_phase_id)
+            On failure, if the destination is not among ``cards_can_be_moved_to_phases`` for the
+            card's current phase, returns ``success: false`` with ``valid_destinations`` instead of
+            only the raw API error.
+            """
+
+            try:
+                return await client.move_card_to_phase(card_id, destination_phase_id)
+            except Exception as exc:  # noqa: BLE001
+                enriched = await try_enrich_move_card_to_phase_failure(
+                    client,
+                    card_id,
+                    destination_phase_id,
+                )
+                if enriched is not None:
+                    return enriched
+                raise exc
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),

--- a/src/pipefy_mcp/tools/transition_hints.py
+++ b/src/pipefy_mcp/tools/transition_hints.py
@@ -1,0 +1,29 @@
+"""Shared copy for phase transition validation (UI rules vs GraphQL read-only)."""
+
+from __future__ import annotations
+
+TRANSITION_RULES_HINT = (
+    "Phase transition rules are configured in the Pipefy UI "
+    "(Pipe settings → Phase → Connections) and are not editable via API. "
+    "Use get_phase_allowed_move_targets on the source phase to list valid destinations "
+    "(GraphQL field phase.cards_can_be_moved_to_phases)."
+)
+
+
+def format_allowed_destinations_phrase(allowed_phases: list[dict]) -> str:
+    """Human-readable list of phase names and IDs for error messages.
+
+    Args:
+        allowed_phases: Items with ``id`` and optional ``name`` (GraphQL Phase rows).
+    """
+    if not allowed_phases:
+        return "(none configured)"
+    parts: list[str] = []
+    for p in allowed_phases:
+        pid = p.get("id")
+        name = p.get("name") or ""
+        if name and pid is not None:
+            parts.append(f"{name} ({pid})")
+        elif pid is not None:
+            parts.append(str(pid))
+    return ", ".join(parts) if parts else "(none configured)"

--- a/tests/services/test_pipe_service.py
+++ b/tests/services/test_pipe_service.py
@@ -9,7 +9,10 @@ import pytest
 from graphql import print_ast
 
 from pipefy_mcp.services.pipefy.pipe_service import PipeService
-from pipefy_mcp.services.pipefy.queries.pipe_queries import GET_PHASE_FIELDS_QUERY
+from pipefy_mcp.services.pipefy.queries.pipe_queries import (
+    GET_PHASE_ALLOWED_MOVES_QUERY,
+    GET_PHASE_FIELDS_QUERY,
+)
 from pipefy_mcp.settings import PipefySettings
 
 
@@ -392,6 +395,32 @@ def test_get_phase_fields_query_selects_internal_id_and_uuid():
     printed = print_ast(GET_PHASE_FIELDS_QUERY)
     assert "internal_id" in printed
     assert "uuid" in printed
+
+
+@pytest.mark.unit
+def test_get_phase_allowed_moves_query_requests_transition_field():
+    printed = print_ast(GET_PHASE_ALLOWED_MOVES_QUERY)
+    assert "cards_can_be_moved_to_phases" in printed
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_phase_allowed_move_targets_sends_phase_id(mock_settings):
+    phase_id = 342182335
+    api_response = {
+        "phase": {
+            "id": str(phase_id),
+            "name": "Doing",
+            "cards_can_be_moved_to_phases": [{"id": "200", "name": "Done"}],
+        }
+    }
+    service = _make_service(mock_settings, api_response)
+    result = await service.get_phase_allowed_move_targets(phase_id)
+
+    service.execute_query.assert_called_once()
+    assert service.execute_query.call_args[0][0] is GET_PHASE_ALLOWED_MOVES_QUERY
+    assert service.execute_query.call_args[0][1] == {"phase_id": phase_id}
+    assert result == api_response
 
 
 @pytest.mark.unit

--- a/tests/services/test_pipefy_client.py
+++ b/tests/services/test_pipefy_client.py
@@ -817,6 +817,24 @@ async def test_move_card_to_phase_variable_shape():
     assert result == {"moveCardToPhase": {"clientMutationId": None}}
 
 
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_phase_allowed_move_targets_delegates_to_pipe_service():
+    expected = {
+        "phase": {
+            "id": "5",
+            "name": "Backlog",
+            "cards_can_be_moved_to_phases": [{"id": "6", "name": "Doing"}],
+        }
+    }
+    client, mock_execute = _make_facade_client(expected)
+    result = await client.get_phase_allowed_move_targets(5)
+
+    mock_execute.assert_awaited()
+    assert mock_execute.call_args[0][1] == {"phase_id": 5}
+    assert result == expected
+
+
 @pytest.mark.asyncio
 async def test_search_pipes_delegates_to_pipe_service():
     """Test search_pipes delegates unchanged to PipeService.search_pipes."""

--- a/tests/tools/test_ai_agent_tools.py
+++ b/tests/tools/test_ai_agent_tools.py
@@ -27,6 +27,7 @@ def mock_pipefy_client():
     client.delete_ai_agent = AsyncMock()
     client.get_pipe = AsyncMock()
     client.get_pipe_relations = AsyncMock()
+    client.get_phase_allowed_move_targets = AsyncMock()
     return client
 
 
@@ -1376,6 +1377,109 @@ class TestValidateAiAgentBehaviorsErrorPaths:
             "parents": [],
         }
         behavior = _behavior_update_card_on_pipe(pipe_id="1", field_id="sf-1")
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_agent_behaviors",
+                {"pipe_id": "1", "behaviors": [behavior]},
+            )
+        payload = extract_payload(result)
+        assert payload["success"] is True
+        assert payload["valid"] is True
+        assert payload["problems"] == []
+
+    async def test_move_card_reports_invalid_transition_when_trigger_phase_known(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.get_pipe.return_value = {
+            "pipe": {
+                "phases": [
+                    {"id": "100", "fields": []},
+                    {"id": "200", "fields": []},
+                ],
+                "start_form_fields": [],
+            }
+        }
+        mock_pipefy_client.get_pipe_relations.return_value = {
+            "children": [],
+            "parents": [],
+        }
+        mock_pipefy_client.get_phase_allowed_move_targets.return_value = {
+            "phase": {
+                "id": "100",
+                "name": "Doing",
+                "cards_can_be_moved_to_phases": [{"id": "200", "name": "Done"}],
+            }
+        }
+        behavior = {
+            "name": "After valid lands",
+            "event_id": "card_moved",
+            "eventParams": {"to_phase_id": "100"},
+            "actionParams": {
+                "aiBehaviorParams": {
+                    "instruction": "move",
+                    "actionsAttributes": [
+                        {
+                            "name": "m",
+                            "actionType": "move_card",
+                            "metadata": {"destinationPhaseId": "999"},
+                        }
+                    ],
+                }
+            },
+        }
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_agent_behaviors",
+                {"pipe_id": "1", "behaviors": [behavior]},
+            )
+        payload = extract_payload(result)
+        assert payload["success"] is True
+        assert payload["valid"] is False
+        assert any("999" in p for p in payload["problems"])
+
+    async def test_move_card_transition_ok_when_destination_allowed(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.get_pipe.return_value = {
+            "pipe": {
+                "phases": [{"id": "100", "fields": []}, {"id": "200", "fields": []}],
+                "start_form_fields": [],
+            }
+        }
+        mock_pipefy_client.get_pipe_relations.return_value = {
+            "children": [],
+            "parents": [],
+        }
+        mock_pipefy_client.get_phase_allowed_move_targets.return_value = {
+            "phase": {
+                "id": "100",
+                "name": "Doing",
+                "cards_can_be_moved_to_phases": [{"id": "200", "name": "Done"}],
+            }
+        }
+        behavior = {
+            "name": "Move when landed",
+            "event_id": "card_moved",
+            "eventParams": {"to_phase_id": "100"},
+            "actionParams": {
+                "aiBehaviorParams": {
+                    "instruction": "move",
+                    "actions_attributes": [
+                        {
+                            "name": "m",
+                            "actionType": "move_card",
+                            "metadata": {"destinationPhaseId": "200"},
+                        }
+                    ],
+                }
+            },
+        }
         async with client_session as session:
             result = await session.call_tool(
                 "validate_ai_agent_behaviors",

--- a/tests/tools/test_automation_tools.py
+++ b/tests/tools/test_automation_tools.py
@@ -25,6 +25,7 @@ def mock_automation_client():
     client.update_automation = AsyncMock()
     client.simulate_automation = AsyncMock()
     client.delete_automation = AsyncMock()
+    client.get_phase_allowed_move_targets = AsyncMock()
     return client
 
 
@@ -384,6 +385,45 @@ async def test_create_automation_success(
         "name": "Notify",
         "active": True,
     }
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("automation_session", [None], indirect=True)
+async def test_create_automation_rejects_move_when_transition_not_allowed(
+    automation_session, mock_automation_client, extract_payload
+):
+    mock_automation_client.get_phase_allowed_move_targets.return_value = {
+        "phase": {
+            "id": "10",
+            "name": "Doing",
+            "cards_can_be_moved_to_phases": [{"id": "11", "name": "Done"}],
+        }
+    }
+
+    async with automation_session as session:
+        result = await session.call_tool(
+            "create_automation",
+            {
+                "pipe_id": "p1",
+                "name": "Bad move",
+                "trigger_id": "card_moved",
+                "action_id": "move_single_card",
+                "active": True,
+                "action_repo_id": None,
+                "extra_input": {
+                    "event_params": {"to_phase_id": "10"},
+                    "action_params": {"to_phase_id": "99"},
+                },
+                "debug": False,
+            },
+        )
+
+    assert result.isError is False
+    mock_automation_client.create_automation.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "99" in payload["error"]
+    mock_automation_client.get_phase_allowed_move_targets.assert_awaited_once_with(10)
 
 
 @pytest.mark.anyio

--- a/tests/tools/test_pipe_tools.py
+++ b/tests/tools/test_pipe_tools.py
@@ -411,6 +411,77 @@ class TestDirectToolCalls:
         mock_pipefy_client.move_card_to_phase.assert_called_once_with(100, 200)
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
+    async def test_move_card_to_phase_returns_enriched_payload_when_transition_invalid(
+        self, client_session, mock_pipefy_client, extract_payload
+    ):
+        """On API failure, enrich if destination is not in cards_can_be_moved_to_phases."""
+
+        async def _fail_move(*_args):
+            raise RuntimeError("not a valid target phase")
+
+        mock_pipefy_client.move_card_to_phase = AsyncMock(side_effect=_fail_move)
+        mock_pipefy_client.get_card = AsyncMock(
+            return_value={
+                "card": {"id": "1", "current_phase": {"id": "10", "name": "Doing"}},
+            }
+        )
+        mock_pipefy_client.get_phase_allowed_move_targets = AsyncMock(
+            return_value={
+                "phase": {
+                    "id": "10",
+                    "name": "Doing",
+                    "cards_can_be_moved_to_phases": [
+                        {"id": "11", "name": "Done"},
+                    ],
+                }
+            }
+        )
+        async with client_session as session:
+            result = await session.call_tool(
+                "move_card_to_phase",
+                {"card_id": 1, "destination_phase_id": 99},
+            )
+        assert result.isError is False
+        payload = extract_payload(result)
+        assert payload.get("success") is False
+        assert "99" in payload["error"]
+        assert payload["valid_destinations"] == [{"id": "11", "name": "Done"}]
+
+    @pytest.mark.parametrize("client_session", [None], indirect=True)
+    async def test_move_card_to_phase_surfaces_original_error_when_destination_allowed(
+        self, client_session, mock_pipefy_client
+    ):
+        """If transition is allowed, surface the original API error (e.g. permissions)."""
+
+        async def _fail_move(*_args):
+            raise RuntimeError("forbidden")
+
+        mock_pipefy_client.move_card_to_phase = AsyncMock(side_effect=_fail_move)
+        mock_pipefy_client.get_card = AsyncMock(
+            return_value={
+                "card": {"current_phase": {"id": "10", "name": "Doing"}},
+            }
+        )
+        mock_pipefy_client.get_phase_allowed_move_targets = AsyncMock(
+            return_value={
+                "phase": {
+                    "id": "10",
+                    "name": "Doing",
+                    "cards_can_be_moved_to_phases": [
+                        {"id": "99", "name": "Target"},
+                    ],
+                }
+            }
+        )
+        async with client_session as session:
+            result = await session.call_tool(
+                "move_card_to_phase",
+                {"card_id": 1, "destination_phase_id": 99},
+            )
+        assert result.isError is True
+        assert "forbidden" in (result.content[0].text if result.content else "")
+
+    @pytest.mark.parametrize("client_session", [None], indirect=True)
     async def test_get_start_form_fields_forwards_params_to_client(
         self, client_session, mock_pipefy_client, pipe_id, extract_payload
     ):


### PR DESCRIPTION
## Summary
Adds **read-only** validation of phase transition rules (`cards_can_be_moved_to_phases`) for:
- `move_card_to_phase` — enriched error payload on mutation failure when the destination is not allowed
- `validate_ai_agent_behaviors` — `move_card` with `card_moved` and `to_phase_id` / `toPhaseId`
- `create_automation` — pre-flight check for `card_moved` + `move_single_card` when event/action phase IDs are present in `extra_input`

## Implementation
- New GraphQL query and `PipefyClient.get_phase_allowed_move_targets`
- `transition_hints` and `phase_transition_helpers` modules

## Testing
- `uv run pytest -m "not integration"` — passing
- `uv run pytest -m integration` — passing locally (15 passed, 13 skipped optional cases)

## Commits
Five atomic commits: services → shared helpers → `move_card_to_phase` → `validate_ai_agent_behaviors` → `create_automation`.