### PR TITLE
feat: Pipefy GraphQL ID type safety (string IDs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 
 **Shared conventions (many tools):**
 - **Pagination** — List endpoints accept `first` and `after`. Use `pageInfo.hasNextPage` and `pageInfo.endCursor` to fetch the next page.
+- **Pipefy IDs** — GraphQL treats IDs as **strings**. Tool parameters accept **string IDs** (recommended: `"301234"`). Clients that send unquoted JSON numbers may pass integers for some parameters; the server coerces them to strings before calling the API. Responses and success payloads return IDs as **strings**. Invalid IDs (e.g. empty, zero, or non-coercible values) are rejected before the network call. See [Pipes & cards — IDs](docs/tools/pipes-and-cards.md#pipefy-ids-type-safety) for `delete_card` and card/pipe parameters.
 - **`debug=true`** — Failed calls may include extra detail: GraphQL error codes and a `correlation_id` for support.
 - **`extra_input`** — Optional map of extra mutation fields (camelCase keys). Values that overlap the tool’s main parameters are ignored.
 - **Destructive deletes** — Two steps by default: the first response is a preview; call again with `confirm=true` to run the delete.

--- a/docs/tools/database-tables.md
+++ b/docs/tools/database-tables.md
@@ -5,6 +5,7 @@ Tables, records (rows), and schema columns (table fields) for org Database Table
 ## Cross-cutting patterns
 
 - Same conventions as pipe building: `introspect_type` on inputs such as `CreateTableFieldInput` / `UpdateTableFieldInput`, `debug=true` on mutations, `extra_input` where the tool exposes it.
+- **IDs:** `table_id`, record IDs, and related parameters are **strings** in GraphQL (numeric strings for many org tables, or opaque tokens such as `fIVcd19N`). Prefer quoted strings in MCP/JSON; unquoted numeric JSON may be coerced where the tool uses the shared ID type. See [Pipes & cards — Pipefy IDs](pipes-and-cards.md#pipefy-ids-type-safety).
 - **Pagination:** `get_table_records` and `find_records` support `first` / `after`. Read `pageInfo.hasNextPage` and `pageInfo.endCursor` from the response and pass `after=endCursor` for the next page (default page size for listing records is 50; caps apply — see tool docstrings).
 
 ---

--- a/docs/tools/organization.md
+++ b/docs/tools/organization.md
@@ -8,6 +8,8 @@ Fetch organization details directly by ID. **1 tool.**
 |------|-----------|------|
 | `get_organization` | Yes | Fetches org details: `id`, `uuid`, `name`, `planName`, `role`, `membersCount`, `pipesCount`, `createdAt`. |
 
+**`organization_id`** matches GraphQL: use a **string** (e.g. `"302398434"` from the URL or `search_pipes`). Unquoted JSON integers are coerced to the same string form. See [Pipefy IDs in pipes & cards](pipes-and-cards.md#pipefy-ids-type-safety).
+
 ## Why a dedicated tool?
 
 The organization ID is required by many tools (reports, automations, observability) but previously had no direct fetch path. Agents had to derive it through multi-step workarounds:

--- a/docs/tools/pipes-and-cards.md
+++ b/docs/tools/pipes-and-cards.md
@@ -10,6 +10,15 @@ Read, create, update, and delete pipes, phases, phase fields, labels, cards, and
 - `extra_input` merges extra API keys (camelCase); keys that would duplicate primary arguments are ignored.
 - **Destructive deletes** (`delete_pipe`, `delete_card`) use a two-step flow: first call returns a preview, then `confirm=true` after user approval.
 
+### Pipefy IDs (type safety)
+
+Pipefy’s GraphQL API uses **string** IDs for pipes, phases, cards, and most other nodes.
+
+- **Prefer string arguments** when calling tools (e.g. `card_id: "1332881010"`, `pipe_id: "306996634"`). This matches API responses (`get_pipe`, `get_card`, `create_card`, etc.).
+- **Integer JSON values** (e.g. `1332881010` without quotes) are still accepted on many tools: they are **coerced to strings** before variables are sent to GraphQL, so behavior matches the API.
+- **Validation:** empty strings, whitespace-only IDs, and non-positive numeric IDs are rejected with a clear tool error (no spurious `ValueError` from type mixing).
+- **`delete_card`:** `card_id` follows the same rule — use a **string** (recommended) or a positive integer; the tool normalizes to a string for `getCard` / `deleteCard`. On success, `card_id` in the payload is a **string**.
+
 ---
 
 ## Pipe reads
@@ -50,7 +59,7 @@ Read, create, update, and delete pipes, phases, phase fields, labels, cards, and
 | `move_card_to_phase` | Move card to another phase. |
 | `update_card_field` | Single-field update (`updateCardField`). |
 | `update_card` | Metadata (title, assignees, labels, due date) and/or multiple custom fields via `field_updates`. |
-| `delete_card` | Two-step: default preview; `confirm=true` after explicit user confirmation. |
+| `delete_card` | Two-step: default preview; `confirm=true` after explicit user confirmation. `card_id` is a **string** in the API; pass `"…"` or a coerced positive integer (see [Pipefy IDs](#pipefy-ids-type-safety)). |
 | `upload_attachment_to_card` | Presigned URL + S3 PUT + `updateCardField` for **attachment** fields. **One file per call** — to attach multiple files, call the tool once per file. Exactly one of `file_url` or `file_content_base64`; optional `content_type` (inferred from `file_name` if omitted). **`field_id` must be the field slug** (e.g. `document_upload`), not the uuid — using the uuid returns `RESOURCE_NOT_FOUND`. |
 
 **Choosing card updates:** `update_card_field` = one field, full replacement. `update_card` + `field_updates` = several custom fields at once. `update_card` with attribute args = metadata (combinable with `field_updates`).

--- a/src/pipefy_mcp/models/attachment.py
+++ b/src/pipefy_mcp/models/attachment.py
@@ -65,7 +65,7 @@ class UploadAttachmentToCardInput(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     organization_id: PipefyId
-    card_id: int
+    card_id: PipefyId
     field_id: PipefyId
     file_name: str
     file_url: str | None = None

--- a/src/pipefy_mcp/models/comment.py
+++ b/src/pipefy_mcp/models/comment.py
@@ -4,6 +4,8 @@ from typing import Annotated
 
 from pydantic import BaseModel, BeforeValidator, Field
 
+from pipefy_mcp.models.validators import PipefyId
+
 MAX_COMMENT_TEXT_LENGTH = 1000
 
 # Strip first so blank/whitespace-only fails min_length.
@@ -26,7 +28,7 @@ class CommentInput(BaseModel):
         text: The comment text (1-1000 characters, cannot be blank).
     """
 
-    card_id: int = Field(gt=0, description="Card ID must be a positive integer")
+    card_id: PipefyId = Field(description="Card ID")
     text: _CommentText
 
 
@@ -38,7 +40,7 @@ class UpdateCommentInput(BaseModel):
         text: The new comment text (1-1000 characters, cannot be blank).
     """
 
-    comment_id: int = Field(gt=0, description="Comment ID must be a positive integer")
+    comment_id: PipefyId = Field(description="Comment ID")
     text: _CommentText
 
 
@@ -49,4 +51,4 @@ class DeleteCommentInput(BaseModel):
         comment_id: The ID of the comment to delete (must be positive).
     """
 
-    comment_id: int = Field(gt=0, description="Comment ID must be a positive integer")
+    comment_id: PipefyId = Field(description="Comment ID")

--- a/src/pipefy_mcp/services/pipefy/automation_service.py
+++ b/src/pipefy_mcp/services/pipefy/automation_service.py
@@ -104,7 +104,7 @@ class AutomationService(BasePipefyClient):
         """
         payload = await self.execute_query(
             GET_AUTOMATION_QUERY,
-            {"id": int(automation_id)},
+            {"id": str(automation_id)},
         )
         row = payload.get("automation")
         if row is None or not isinstance(row, dict):
@@ -132,7 +132,7 @@ class AutomationService(BasePipefyClient):
         if org_id is None and pipe_id is not None:
             org_row = await self.execute_query(
                 GET_PIPE_ORGANIZATION_ID_QUERY,
-                {"id": int(pipe_id)},
+                {"id": str(pipe_id)},
             )
             pipe = org_row.get("pipe") or {}
             oid = pipe.get("organizationId")
@@ -146,12 +146,12 @@ class AutomationService(BasePipefyClient):
         if pipe_id is None:
             payload = await self.execute_query(
                 GET_AUTOMATIONS_BY_ORG_QUERY,
-                {"organizationId": int(org_id)},
+                {"organizationId": str(org_id)},
             )
         else:
             payload = await self.execute_query(
                 GET_AUTOMATIONS_FOR_ORG_AND_REPO_QUERY,
-                {"organizationId": int(org_id), "repoId": int(pipe_id)},
+                {"organizationId": str(org_id), "repoId": str(pipe_id)},
             )
         conn = payload.get("automations")
         if conn is None:
@@ -169,7 +169,7 @@ class AutomationService(BasePipefyClient):
         """
         payload = await self.execute_query(
             GET_AUTOMATION_ACTIONS_QUERY,
-            {"repoId": int(pipe_id)},
+            {"repoId": str(pipe_id)},
         )
         rows = payload.get("automationActions")
         if rows is None:

--- a/src/pipefy_mcp/services/pipefy/card_service.py
+++ b/src/pipefy_mcp/services/pipefy/card_service.py
@@ -38,45 +38,45 @@ class CardService(BasePipefyClient):
         super().__init__(settings=settings, auth=auth)
 
     async def create_card(
-        self, pipe_id: int, fields: dict[str, Any] | list[dict[str, Any]]
+        self, pipe_id: str | int, fields: dict[str, Any] | list[dict[str, Any]]
     ) -> dict:
         """Create a card in the specified pipe with the given fields."""
-        variables = {"pipe_id": pipe_id, "fields": convert_fields_to_array(fields)}
+        variables = {"pipe_id": str(pipe_id), "fields": convert_fields_to_array(fields)}
         return await self.execute_query(CREATE_CARD_MUTATION, variables)
 
-    async def create_comment(self, card_id: int, text: str) -> dict:
+    async def create_comment(self, card_id: str | int, text: str) -> dict:
         """Create a text comment on the specified card."""
-        variables = {"input": {"card_id": card_id, "text": text}}
+        variables = {"input": {"card_id": str(card_id), "text": text}}
         return await self.execute_query(CREATE_COMMENT_MUTATION, variables)
 
-    async def update_comment(self, comment_id: int, text: str) -> dict:
+    async def update_comment(self, comment_id: str | int, text: str) -> dict:
         """Update an existing comment by its ID. Returns raw GraphQL response (see issue #23)."""
-        variables = {"input": {"id": comment_id, "text": text}}
+        variables = {"input": {"id": str(comment_id), "text": text}}
         return await self.execute_query(UPDATE_COMMENT_MUTATION, variables)
 
-    async def delete_comment(self, comment_id: int) -> dict:
+    async def delete_comment(self, comment_id: str | int) -> dict:
         """Delete a comment by its ID. Returns raw GraphQL response (see issue #23)."""
-        variables = {"input": {"id": comment_id}}
+        variables = {"input": {"id": str(comment_id)}}
         return await self.execute_query(DELETE_COMMENT_MUTATION, variables)
 
-    async def delete_card(self, card_id: int) -> dict:
+    async def delete_card(self, card_id: str | int) -> dict:
         """Delete a card by its ID."""
-        variables = {"input": {"id": card_id}}
+        variables = {"input": {"id": str(card_id)}}
         return await self.execute_query(DELETE_CARD_MUTATION, variables)
 
-    async def get_card(self, card_id: int, include_fields: bool = False) -> dict:
+    async def get_card(self, card_id: str | int, include_fields: bool = False) -> dict:
         """Get a card by its ID.
 
         Args:
             card_id: The ID of the card.
             include_fields: If True, include the card's custom fields (name, value) in the response.
         """
-        variables = {"card_id": card_id, "includeFields": include_fields}
+        variables = {"card_id": str(card_id), "includeFields": include_fields}
         return await self.execute_query(GET_CARD_QUERY, variables)
 
     async def get_cards(
         self,
-        pipe_id: int,
+        pipe_id: str | int,
         search: CardSearch | None = None,
         include_fields: bool = False,
         *,
@@ -93,7 +93,7 @@ class CardService(BasePipefyClient):
             after: Cursor for fetching the next page (from ``pageInfo.endCursor``).
         """
         variables: dict[str, Any] = {
-            "pipe_id": pipe_id,
+            "pipe_id": str(pipe_id),
             "search": {},
             "includeFields": include_fields,
         }
@@ -107,7 +107,7 @@ class CardService(BasePipefyClient):
 
     async def find_cards(
         self,
-        pipe_id: int,
+        pipe_id: str | int,
         field_id: str,
         field_value: str,
         include_fields: bool = False,
@@ -126,7 +126,7 @@ class CardService(BasePipefyClient):
             after: Cursor from ``pageInfo.endCursor`` for the next page (optional).
         """
         variables: dict[str, Any] = {
-            "pipeId": pipe_id,
+            "pipeId": str(pipe_id),
             "search": {"fieldId": field_id, "fieldValue": field_value},
             "includeFields": include_fields,
         }
@@ -136,7 +136,9 @@ class CardService(BasePipefyClient):
             variables["after"] = after
         return await self.execute_query(FIND_CARDS_QUERY, variables)
 
-    async def move_card_to_phase(self, card_id: int, destination_phase_id: int) -> dict:
+    async def move_card_to_phase(
+        self, card_id: str | int, destination_phase_id: str | int
+    ) -> dict:
         """Move a card to a specific phase.
 
         Args:
@@ -144,12 +146,15 @@ class CardService(BasePipefyClient):
             destination_phase_id: The ID of the destination phase.
         """
         variables = {
-            "input": {"card_id": card_id, "destination_phase_id": destination_phase_id}
+            "input": {
+                "card_id": str(card_id),
+                "destination_phase_id": str(destination_phase_id),
+            }
         }
         return await self.execute_query(MOVE_CARD_TO_PHASE_MUTATION, variables)
 
     async def update_card_field(
-        self, card_id: int, field_id: str, new_value: Any
+        self, card_id: str | int, field_id: str, new_value: Any
     ) -> dict:
         """Update a single field of a card.
 
@@ -162,16 +167,20 @@ class CardService(BasePipefyClient):
             dict: GraphQL response with success status and updated card information.
         """
         variables = {
-            "input": {"card_id": card_id, "field_id": field_id, "new_value": new_value}
+            "input": {
+                "card_id": str(card_id),
+                "field_id": field_id,
+                "new_value": new_value,
+            }
         }
         return await self.execute_query(UPDATE_CARD_FIELD_MUTATION, variables)
 
     async def update_card(
         self,
-        card_id: int,
+        card_id: str | int,
         title: str | None = None,
-        assignee_ids: list[int] | None = None,
-        label_ids: list[int] | None = None,
+        assignee_ids: list[str | int] | None = None,
+        label_ids: list[str | int] | None = None,
         due_date: str | None = None,
         field_updates: list[dict] | None = None,
     ) -> dict:
@@ -200,14 +209,14 @@ class CardService(BasePipefyClient):
 
     async def _execute_update_card(
         self,
-        card_id: int,
+        card_id: str | int,
         title: str | None,
-        assignee_ids: list[int] | None,
-        label_ids: list[int] | None,
+        assignee_ids: list[str | int] | None,
+        label_ids: list[str | int] | None,
         due_date: str | None,
     ) -> dict:
         """Execute updateCard mutation for card attributes (title, assignees, labels, due_date)."""
-        input_data: dict[str, Any] = {"id": card_id}
+        input_data: dict[str, Any] = {"id": str(card_id)}
 
         if title is not None:
             input_data["title"] = title
@@ -222,9 +231,9 @@ class CardService(BasePipefyClient):
         return await self.execute_query(UPDATE_CARD_MUTATION, variables)
 
     async def _execute_update_fields_values(
-        self, card_id: int, values: list[dict]
+        self, card_id: str | int, values: list[dict]
     ) -> dict:
         """Execute updateFieldsValues mutation (incremental mode)."""
         formatted_values = convert_values_to_camel_case(values)
-        variables = {"input": {"nodeId": card_id, "values": formatted_values}}
+        variables = {"input": {"nodeId": str(card_id), "values": formatted_values}}
         return await self.execute_query(UPDATE_FIELDS_VALUES_MUTATION, variables)

--- a/src/pipefy_mcp/services/pipefy/client.py
+++ b/src/pipefy_mcp/services/pipefy/client.py
@@ -96,26 +96,26 @@ class PipefyClient:
         """
         self._ai_automation_service = service
 
-    async def get_pipe(self, pipe_id: int) -> dict:
+    async def get_pipe(self, pipe_id: str | int) -> dict:
         """Get a pipe by ID, including phases, labels, and start form fields."""
         return await self._pipe_service.get_pipe(pipe_id)
 
-    async def create_pipe(self, name: str, organization_id: int) -> dict:
+    async def create_pipe(self, name: str, organization_id: str | int) -> dict:
         """Create a new pipe in the organization."""
         return await self._pipe_config_service.create_pipe(name, organization_id)
 
-    async def update_pipe(self, pipe_id: int, **attrs: Any) -> dict:
+    async def update_pipe(self, pipe_id: str | int, **attrs: Any) -> dict:
         """Update pipe attributes (see Pipefy `UpdatePipeInput`)."""
         return await self._pipe_config_service.update_pipe(pipe_id, **attrs)
 
-    async def delete_pipe(self, pipe_id: int) -> dict:
+    async def delete_pipe(self, pipe_id: str | int) -> dict:
         """Delete a pipe by ID (permanent)."""
         return await self._pipe_config_service.delete_pipe(pipe_id)
 
     async def clone_pipe(
         self,
-        pipe_template_id: int,
-        organization_id: int | None = None,
+        pipe_template_id: str | int,
+        organization_id: str | int | None = None,
     ) -> dict:
         """Clone a pipe from a template pipe ID."""
         return await self._pipe_config_service.clone_pipe(
@@ -125,7 +125,7 @@ class PipefyClient:
 
     async def create_phase(
         self,
-        pipe_id: int,
+        pipe_id: str | int,
         name: str,
         done: bool = False,
         index: float | int | None = None,
@@ -140,17 +140,17 @@ class PipefyClient:
             description=description,
         )
 
-    async def update_phase(self, phase_id: int, **attrs: Any) -> dict:
+    async def update_phase(self, phase_id: str | int, **attrs: Any) -> dict:
         """Update phase attributes (see Pipefy `UpdatePhaseInput`)."""
         return await self._pipe_config_service.update_phase(phase_id, **attrs)
 
-    async def delete_phase(self, phase_id: int) -> dict:
+    async def delete_phase(self, phase_id: str | int) -> dict:
         """Delete a phase by ID (permanent)."""
         return await self._pipe_config_service.delete_phase(phase_id)
 
     async def create_phase_field(
         self,
-        phase_id: int,
+        phase_id: str | int,
         label: str,
         field_type: str,
         **attrs: Any,
@@ -178,15 +178,15 @@ class PipefyClient:
             field_id, pipe_uuid=pipe_uuid
         )
 
-    async def create_label(self, pipe_id: int, name: str, color: str) -> dict:
+    async def create_label(self, pipe_id: str | int, name: str, color: str) -> dict:
         """Create a label on a pipe."""
         return await self._pipe_config_service.create_label(pipe_id, name, color)
 
-    async def update_label(self, label_id: int, **attrs: Any) -> dict:
+    async def update_label(self, label_id: str | int, **attrs: Any) -> dict:
         """Update a label (see Pipefy `UpdateLabelInput`)."""
         return await self._pipe_config_service.update_label(label_id, **attrs)
 
-    async def delete_label(self, label_id: int) -> dict:
+    async def delete_label(self, label_id: str | int) -> dict:
         """Delete a label by ID (permanent)."""
         return await self._pipe_config_service.delete_label(label_id)
 
@@ -252,7 +252,9 @@ class PipefyClient:
             after=after,
         )
 
-    async def create_table(self, name: str, organization_id: int, **attrs: Any) -> dict:
+    async def create_table(
+        self, name: str, organization_id: str | int, **attrs: Any
+    ) -> dict:
         """Create a database table (see Pipefy `CreateTableInput`)."""
         return await self._table_service.create_table(name, organization_id, **attrs)
 
@@ -669,29 +671,29 @@ class PipefyClient:
         assert self._ai_automation_service is not None  # noqa: S101
         return await self._ai_automation_service.update_automation(automation_input)
 
-    async def get_pipe_members(self, pipe_id: int) -> dict:
+    async def get_pipe_members(self, pipe_id: str | int) -> dict:
         """Get the members of a pipe."""
         return await self._pipe_service.get_pipe_members(pipe_id)
 
     async def create_card(
-        self, pipe_id: int, fields: dict[str, Any] | list[dict[str, Any]]
+        self, pipe_id: str | int, fields: dict[str, Any] | list[dict[str, Any]]
     ) -> dict:
         """Create a card in the specified pipe with the given fields."""
         return await self._card_service.create_card(pipe_id, fields)
 
-    async def add_card_comment(self, card_id: int, text: str) -> dict:
+    async def add_card_comment(self, card_id: str | int, text: str) -> dict:
         """Add a text comment to a card by its ID."""
         return await self._card_service.create_comment(card_id, text)
 
-    async def update_comment(self, comment_id: int, text: str) -> dict:
+    async def update_comment(self, comment_id: str | int, text: str) -> dict:
         """Update an existing comment by its ID."""
         return await self._card_service.update_comment(comment_id, text)
 
-    async def delete_comment(self, comment_id: int) -> dict:
+    async def delete_comment(self, comment_id: str | int) -> dict:
         """Delete a comment by its ID."""
         return await self._card_service.delete_comment(comment_id)
 
-    async def get_card(self, card_id: int, include_fields: bool = False) -> dict:
+    async def get_card(self, card_id: str | int, include_fields: bool = False) -> dict:
         """Get a card by its ID.
 
         Args:
@@ -702,7 +704,7 @@ class PipefyClient:
 
     async def get_cards(
         self,
-        pipe_id: int,
+        pipe_id: str | int,
         search: CardSearch | None = None,
         include_fields: bool = False,
         *,
@@ -724,7 +726,7 @@ class PipefyClient:
 
     async def find_cards(
         self,
-        pipe_id: int,
+        pipe_id: str | int,
         field_id: str,
         field_value: str,
         include_fields: bool = False,
@@ -751,24 +753,26 @@ class PipefyClient:
             after=after,
         )
 
-    async def move_card_to_phase(self, card_id: int, destination_phase_id: int) -> dict:
+    async def move_card_to_phase(
+        self, card_id: str | int, destination_phase_id: str | int
+    ) -> dict:
         """Move a card to a specific phase."""
         return await self._card_service.move_card_to_phase(
             card_id, destination_phase_id
         )
 
     async def update_card_field(
-        self, card_id: int, field_id: str, new_value: Any
+        self, card_id: str | int, field_id: str, new_value: Any
     ) -> dict:
         """Update a single field of a card."""
         return await self._card_service.update_card_field(card_id, field_id, new_value)
 
     async def update_card(
         self,
-        card_id: int,
+        card_id: str | int,
         title: str | None = None,
-        assignee_ids: list[int] | None = None,
-        label_ids: list[int] | None = None,
+        assignee_ids: list[str | int] | None = None,
+        label_ids: list[str | int] | None = None,
         due_date: str | None = None,
         field_updates: list[dict] | None = None,
     ) -> dict:
@@ -782,12 +786,12 @@ class PipefyClient:
             field_updates=field_updates,
         )
 
-    async def delete_card(self, card_id: int) -> dict:
+    async def delete_card(self, card_id: str | int) -> dict:
         """Delete a card by its ID."""
         return await self._card_service.delete_card(card_id)
 
     async def get_start_form_fields(
-        self, pipe_id: int, required_only: bool = False
+        self, pipe_id: str | int, required_only: bool = False
     ) -> dict:
         """Get the start form fields of a pipe."""
         return await self._pipe_service.get_start_form_fields(pipe_id, required_only)
@@ -801,12 +805,12 @@ class PipefyClient:
         return await self._table_service.search_tables(table_name)
 
     async def get_phase_fields(
-        self, phase_id: int, required_only: bool = False
+        self, phase_id: str | int, required_only: bool = False
     ) -> dict:
         """Get the fields available in a specific phase."""
         return await self._pipe_service.get_phase_fields(phase_id, required_only)
 
-    async def get_phase_allowed_move_targets(self, phase_id: int) -> dict:
+    async def get_phase_allowed_move_targets(self, phase_id: str | int) -> dict:
         """Phases reachable from ``phase_id`` per Pipefy transition rules (read-only)."""
         return await self._pipe_service.get_phase_allowed_move_targets(phase_id)
 
@@ -960,10 +964,10 @@ class PipefyClient:
 
     async def export_organization_report(
         self,
-        organization_id: int,
+        organization_id: str | int,
         *,
-        organization_report_id: int | None = None,
-        pipe_ids: list[int] | None = None,
+        organization_report_id: str | int | None = None,
+        pipe_ids: list[str | int] | None = None,
         sort_by: dict | None = None,
         filter: dict | None = None,
         columns: list[str] | None = None,

--- a/src/pipefy_mcp/services/pipefy/member_service.py
+++ b/src/pipefy_mcp/services/pipefy/member_service.py
@@ -49,7 +49,7 @@ class MemberService(BasePipefyClient):
         emails = [{"email": m["email"], "role_name": m["role_name"]} for m in members]
         return await self.execute_query(
             INVITE_MEMBERS_MUTATION,
-            {"input": {"pipe_id": int(pipe_id), "emails": emails}},
+            {"input": {"pipe_id": str(pipe_id), "emails": emails}},
         )
 
     async def remove_members_from_pipe(
@@ -69,7 +69,7 @@ class MemberService(BasePipefyClient):
         pipe_id_str = str(pipe_id).strip()
         pipe_obj: dict[str, Any] = {}
         if pipe_id_str.isdigit():
-            pipe_data = await self._pipe_service.get_pipe(int(pipe_id_str))
+            pipe_data = await self._pipe_service.get_pipe(pipe_id_str)
             pipe_obj = pipe_data.get("pipe") or {}
         elif _PIPE_UUID_RE.match(pipe_id_str):
             raise ValueError(
@@ -81,8 +81,6 @@ class MemberService(BasePipefyClient):
 
         pipe_uuid = pipe_obj.get("uuid") or pipe_id_str
         pipe_numeric_id = pipe_obj.get("id")
-        if isinstance(pipe_numeric_id, str) and pipe_numeric_id.isdigit():
-            pipe_numeric_id = int(pipe_numeric_id)
 
         user_uuids = list(user_ids)
         needs_resolution = any(
@@ -125,7 +123,7 @@ class MemberService(BasePipefyClient):
             SET_ROLE_MUTATION,
             {
                 "input": {
-                    "pipe_id": int(pipe_id),
+                    "pipe_id": str(pipe_id),
                     "member": {"user_id": member_id, "role_name": role_name},
                 }
             },

--- a/src/pipefy_mcp/services/pipefy/observability_service.py
+++ b/src/pipefy_mcp/services/pipefy/observability_service.py
@@ -126,7 +126,7 @@ class ObservabilityService(BasePipefyClient):
         if trimmed.isdigit():
             result = await self.execute_query(
                 RESOLVE_ORGANIZATION_UUID_QUERY,
-                {"id": int(trimmed)},
+                {"id": str(trimmed)},
             )
             org = result.get("organization")
             uuid_value = org.get("uuid") if isinstance(org, dict) else None
@@ -323,7 +323,7 @@ class ObservabilityService(BasePipefyClient):
         """
         return await self.execute_query(
             CREATE_AUTOMATION_JOBS_EXPORT_MUTATION,
-            {"input": {"organizationId": int(organization_id), "filter": period}},
+            {"input": {"organizationId": str(organization_id), "filter": period}},
         )
 
     async def get_automation_jobs_export(self, export_id: str) -> dict[str, Any]:

--- a/src/pipefy_mcp/services/pipefy/organization_service.py
+++ b/src/pipefy_mcp/services/pipefy/organization_service.py
@@ -30,7 +30,7 @@ class OrganizationService(BasePipefyClient):
             organization_id: Numeric organization ID.
         """
         data = await self.execute_query(
-            GET_ORGANIZATION_QUERY, {"id": int(organization_id)}
+            GET_ORGANIZATION_QUERY, {"id": str(organization_id)}
         )
         org = data.get("organization")
         if org is None:

--- a/src/pipefy_mcp/services/pipefy/pipe_config_service.py
+++ b/src/pipefy_mcp/services/pipefy/pipe_config_service.py
@@ -38,42 +38,42 @@ class PipeConfigService(BasePipefyClient):
     ) -> None:
         super().__init__(settings=settings, auth=auth)
 
-    async def create_pipe(self, name: str, organization_id: int) -> dict:
+    async def create_pipe(self, name: str, organization_id: str | int) -> dict:
         """Create a pipe in the organization."""
         variables: dict[str, Any] = {
-            "input": {"name": name, "organization_id": organization_id},
+            "input": {"name": name, "organization_id": str(organization_id)},
         }
         return await self.execute_query(CREATE_PIPE_MUTATION, variables)
 
-    async def update_pipe(self, pipe_id: int, **attrs: Any) -> dict:
+    async def update_pipe(self, pipe_id: str | int, **attrs: Any) -> dict:
         """Update a pipe by ID. Pass only Pipefy `UpdatePipeInput` fields (e.g. name, icon, color, preferences)."""
-        payload: dict[str, Any] = {"id": pipe_id}
+        payload: dict[str, Any] = {"id": str(pipe_id)}
         for key, value in attrs.items():
             if value is not None:
                 payload[key] = value
         variables = {"input": payload}
         return await self.execute_query(UPDATE_PIPE_MUTATION, variables)
 
-    async def delete_pipe(self, pipe_id: int) -> dict:
+    async def delete_pipe(self, pipe_id: str | int) -> dict:
         """Delete a pipe by ID (permanent). Caller must enforce preview/confirm UX."""
-        variables: dict[str, Any] = {"input": {"id": pipe_id}}
+        variables: dict[str, Any] = {"input": {"id": str(pipe_id)}}
         return await self.execute_query(DELETE_PIPE_MUTATION, variables)
 
     async def clone_pipe(
         self,
-        pipe_template_id: int,
-        organization_id: int | None = None,
+        pipe_template_id: str | int,
+        organization_id: str | int | None = None,
     ) -> dict:
         """Clone pipe(s) from template ID(s). Optionally scopes clone to an organization."""
-        input_obj: dict[str, Any] = {"pipe_template_ids": [pipe_template_id]}
+        input_obj: dict[str, Any] = {"pipe_template_ids": [str(pipe_template_id)]}
         if organization_id is not None:
-            input_obj["organization_id"] = organization_id
+            input_obj["organization_id"] = str(organization_id)
         variables = {"input": input_obj}
         return await self.execute_query(CLONE_PIPE_MUTATION, variables)
 
     async def create_phase(
         self,
-        pipe_id: int,
+        pipe_id: str | int,
         name: str,
         done: bool = False,
         index: float | int | None = None,
@@ -81,7 +81,7 @@ class PipeConfigService(BasePipefyClient):
     ) -> dict:
         """Create a phase in a pipe."""
         input_obj: dict[str, Any] = {
-            "pipe_id": pipe_id,
+            "pipe_id": str(pipe_id),
             "name": name,
             "done": done,
         }
@@ -91,23 +91,23 @@ class PipeConfigService(BasePipefyClient):
             input_obj["description"] = description
         return await self.execute_query(CREATE_PHASE_MUTATION, {"input": input_obj})
 
-    async def update_phase(self, phase_id: int, **attrs: Any) -> dict:
+    async def update_phase(self, phase_id: str | int, **attrs: Any) -> dict:
         """Update a phase by ID. Pass only Pipefy `UpdatePhaseInput` fields (e.g. name, description, done)."""
-        payload: dict[str, Any] = {"id": phase_id}
+        payload: dict[str, Any] = {"id": str(phase_id)}
         for key, value in attrs.items():
             if value is not None:
                 payload[key] = value
         return await self.execute_query(UPDATE_PHASE_MUTATION, {"input": payload})
 
-    async def delete_phase(self, phase_id: int) -> dict:
+    async def delete_phase(self, phase_id: str | int) -> dict:
         """Delete a phase by ID (permanent)."""
         return await self.execute_query(
-            DELETE_PHASE_MUTATION, {"input": {"id": phase_id}}
+            DELETE_PHASE_MUTATION, {"input": {"id": str(phase_id)}}
         )
 
     async def create_phase_field(
         self,
-        phase_id: int,
+        phase_id: str | int,
         label: str,
         field_type: str,
         **attrs: Any,
@@ -121,7 +121,7 @@ class PipeConfigService(BasePipefyClient):
             **attrs: Additional `CreatePhaseFieldInput` fields (e.g. description, required), when not None.
         """
         input_obj: dict[str, Any] = {
-            "phase_id": phase_id,
+            "phase_id": str(phase_id),
             "label": label,
             "type": field_type,
         }
@@ -139,7 +139,7 @@ class PipeConfigService(BasePipefyClient):
             field_id: Phase field ID (Pipefy may return string slugs from create; integers still supported).
             **attrs: `UpdatePhaseFieldInput` fields to set (omit or pass None to skip).
         """
-        payload: dict[str, Any] = {"id": field_id}
+        payload: dict[str, Any] = {"id": str(field_id)}
         for key, value in attrs.items():
             if value is not None:
                 payload[key] = value
@@ -157,7 +157,7 @@ class PipeConfigService(BasePipefyClient):
             field_id: Phase field slug or uuid to delete.
             pipe_uuid: Optional pipe UUID for disambiguation when the slug exists on multiple phases.
         """
-        input_obj: dict[str, Any] = {"id": field_id}
+        input_obj: dict[str, Any] = {"id": str(field_id)}
         if pipe_uuid is not None:
             input_obj["pipeUuid"] = pipe_uuid
         return await self.execute_query(
@@ -167,7 +167,7 @@ class PipeConfigService(BasePipefyClient):
 
     async def create_label(
         self,
-        pipe_id: int,
+        pipe_id: str | int,
         name: str,
         color: str,
     ) -> dict:
@@ -179,33 +179,33 @@ class PipeConfigService(BasePipefyClient):
             color: Label color (per API).
         """
         input_obj: dict[str, Any] = {
-            "pipe_id": pipe_id,
+            "pipe_id": str(pipe_id),
             "name": name,
             "color": color,
         }
         return await self.execute_query(CREATE_LABEL_MUTATION, {"input": input_obj})
 
-    async def update_label(self, label_id: int, **attrs: Any) -> dict:
+    async def update_label(self, label_id: str | int, **attrs: Any) -> dict:
         """Update a label by ID.
 
         Args:
             label_id: Label ID.
             **attrs: `UpdateLabelInput` fields to set (omit or pass None to skip).
         """
-        payload: dict[str, Any] = {"id": label_id}
+        payload: dict[str, Any] = {"id": str(label_id)}
         for key, value in attrs.items():
             if value is not None:
                 payload[key] = value
         return await self.execute_query(UPDATE_LABEL_MUTATION, {"input": payload})
 
-    async def delete_label(self, label_id: int) -> dict:
+    async def delete_label(self, label_id: str | int) -> dict:
         """Delete a label by ID (permanent).
 
         Args:
             label_id: Label ID to delete.
         """
         return await self.execute_query(
-            DELETE_LABEL_MUTATION, {"input": {"id": label_id}}
+            DELETE_LABEL_MUTATION, {"input": {"id": str(label_id)}}
         )
 
     async def create_field_condition(

--- a/src/pipefy_mcp/services/pipefy/pipe_service.py
+++ b/src/pipefy_mcp/services/pipefy/pipe_service.py
@@ -25,18 +25,18 @@ class PipeService(BasePipefyClient):
     ) -> None:
         super().__init__(settings=settings, auth=auth)
 
-    async def get_pipe(self, pipe_id: int) -> dict:
+    async def get_pipe(self, pipe_id: str | int) -> dict:
         """Get a pipe by its ID, including phases, labels, and start form fields."""
-        variables = {"pipe_id": pipe_id}
+        variables = {"pipe_id": str(pipe_id)}
         return await self.execute_query(GET_PIPE_QUERY, variables)
 
-    async def get_pipe_members(self, pipe_id: int) -> dict:
+    async def get_pipe_members(self, pipe_id: str | int) -> dict:
         """Get the members of a pipe."""
-        variables = {"pipeId": pipe_id}
+        variables = {"pipeId": str(pipe_id)}
         return await self.execute_query(GET_PIPE_MEMBERS_QUERY, variables)
 
     async def get_start_form_fields(
-        self, pipe_id: int, required_only: bool = False
+        self, pipe_id: str | int, required_only: bool = False
     ) -> dict:
         """Get the start form fields of a pipe.
 
@@ -48,7 +48,7 @@ class PipeService(BasePipefyClient):
             dict: A dictionary containing the list of start form fields with their properties.
         """
 
-        variables = {"pipe_id": pipe_id}
+        variables = {"pipe_id": str(pipe_id)}
         result = await self.execute_query(GET_START_FORM_FIELDS_QUERY, variables)
 
         fields = result.get("pipe", {}).get("start_form_fields", [])
@@ -122,7 +122,7 @@ class PipeService(BasePipefyClient):
 
         return {"organizations": filtered_orgs}
 
-    async def get_phase_allowed_move_targets(self, phase_id: int) -> dict:
+    async def get_phase_allowed_move_targets(self, phase_id: str | int) -> dict:
         """List phases a card may move to from ``phase_id`` (UI transition rules).
 
         Read-only: mirrors Pipefy **Phase → Connections**. Returns the GraphQL
@@ -134,11 +134,11 @@ class PipeService(BasePipefyClient):
         Returns:
             Raw GraphQL payload (``phase`` key at top level).
         """
-        variables = {"phase_id": phase_id}
+        variables = {"phase_id": str(phase_id)}
         return await self.execute_query(GET_PHASE_ALLOWED_MOVES_QUERY, variables)
 
     async def get_phase_fields(
-        self, phase_id: int, required_only: bool = False
+        self, phase_id: str | int, required_only: bool = False
     ) -> dict:
         """Get the fields available in a specific phase.
 
@@ -149,7 +149,7 @@ class PipeService(BasePipefyClient):
         Returns:
             dict: A dictionary containing the phase info and its fields.
         """
-        variables = {"phase_id": phase_id}
+        variables = {"phase_id": str(phase_id)}
         result = await self.execute_query(GET_PHASE_FIELDS_QUERY, variables)
 
         phase = result.get("phase", {})

--- a/src/pipefy_mcp/services/pipefy/relation_service.py
+++ b/src/pipefy_mcp/services/pipefy/relation_service.py
@@ -58,7 +58,7 @@ class RelationService(BasePipefyClient):
         """
         return await self.execute_query(
             GET_PIPE_RELATIONS_QUERY,
-            {"pipeId": int(pipe_id)},
+            {"pipeId": str(pipe_id)},
         )
 
     async def get_table_relations(
@@ -71,7 +71,7 @@ class RelationService(BasePipefyClient):
         """
         return await self.execute_query(
             GET_TABLE_RELATIONS_QUERY,
-            {"ids": [int(r) for r in relation_ids]},
+            {"ids": [str(r) for r in relation_ids]},
         )
 
     async def create_pipe_relation(

--- a/src/pipefy_mcp/services/pipefy/report_service.py
+++ b/src/pipefy_mcp/services/pipefy/report_service.py
@@ -101,7 +101,7 @@ class ReportService(BasePipefyClient):
         """
         return await self.execute_query(
             GET_ORGANIZATION_REPORT_QUERY,
-            {"id": int(report_id)},
+            {"id": str(report_id)},
         )
 
     async def get_organization_reports(
@@ -119,7 +119,7 @@ class ReportService(BasePipefyClient):
             after: Cursor for next page.
         """
         variables: dict[str, Any] = {
-            "organizationId": int(organization_id),
+            "organizationId": str(organization_id),
             "first": first,
         }
         if after is not None:
@@ -166,7 +166,7 @@ class ReportService(BasePipefyClient):
             filter: Report filter (``ReportCardsFilter`` shape).
             formulas: Formula definitions (list of [field, operator, ...] tuples).
         """
-        input_obj: dict[str, Any] = {"pipeId": int(pipe_id), "name": name}
+        input_obj: dict[str, Any] = {"pipeId": str(pipe_id), "name": name}
         if fields is not None:
             input_obj["fields"] = fields
         if filter is not None:
@@ -199,7 +199,7 @@ class ReportService(BasePipefyClient):
             formulas: Formula definitions.
             featured_field: Featured field name.
         """
-        input_obj: dict[str, Any] = {"id": int(report_id)}
+        input_obj: dict[str, Any] = {"id": str(report_id)}
         optional_fields = {
             "name": name,
             "color": color,
@@ -222,7 +222,7 @@ class ReportService(BasePipefyClient):
             report_id: Pipe report ID.
         """
         return await self.execute_query(
-            DELETE_PIPE_REPORT_MUTATION, {"input": {"id": int(report_id)}}
+            DELETE_PIPE_REPORT_MUTATION, {"input": {"id": str(report_id)}}
         )
 
     async def create_organization_report(
@@ -244,9 +244,9 @@ class ReportService(BasePipefyClient):
             filter: Report filter (``ReportCardsFilter`` shape).
         """
         input_obj: dict[str, Any] = {
-            "organizationId": int(organization_id),
+            "organizationId": str(organization_id),
             "name": name,
-            "pipeIds": [int(pid) for pid in pipe_ids],
+            "pipeIds": [str(pid) for pid in pipe_ids],
         }
         if fields is not None:
             input_obj["fields"] = fields
@@ -276,13 +276,13 @@ class ReportService(BasePipefyClient):
             filter: Report filter (``ReportCardsFilter`` shape).
             pipe_ids: Pipe IDs to include.
         """
-        input_obj: dict[str, Any] = {"id": int(report_id)}
+        input_obj: dict[str, Any] = {"id": str(report_id)}
         optional_fields = {
             "name": name,
             "color": color,
             "fields": fields,
             "filter": filter,
-            "pipeIds": [int(pid) for pid in pipe_ids] if pipe_ids is not None else None,
+            "pipeIds": [str(pid) for pid in pipe_ids] if pipe_ids is not None else None,
         }
         for key, value in optional_fields.items():
             if value is not None:
@@ -298,7 +298,7 @@ class ReportService(BasePipefyClient):
             report_id: Organization report ID.
         """
         return await self.execute_query(
-            DELETE_ORGANIZATION_REPORT_MUTATION, {"input": {"id": int(report_id)}}
+            DELETE_ORGANIZATION_REPORT_MUTATION, {"input": {"id": str(report_id)}}
         )
 
     async def export_pipe_report(
@@ -320,8 +320,8 @@ class ReportService(BasePipefyClient):
             columns: Column field IDs to include in the export file.
         """
         input_obj: dict[str, Any] = {
-            "pipeId": int(pipe_id),
-            "pipeReportId": int(pipe_report_id),
+            "pipeId": str(pipe_id),
+            "pipeReportId": str(pipe_report_id),
         }
         if sort_by is not None:
             input_obj["sortBy"] = sort_by
@@ -335,31 +335,30 @@ class ReportService(BasePipefyClient):
 
     async def export_organization_report(
         self,
-        organization_id: int,
+        organization_id: str | int,
         *,
-        organization_report_id: int | None = None,
-        pipe_ids: list[int] | None = None,
+        organization_report_id: str | int | None = None,
+        pipe_ids: list[str | int] | None = None,
         sort_by: dict[str, Any] | None = None,
         filter: dict[str, Any] | None = None,
         columns: list[str] | None = None,
     ) -> dict[str, Any]:
         """Trigger an async organization report export (poll ``get_organization_report_export``).
 
-        Uses ``int`` for IDs because the GraphQL ``ExportOrganizationReportInput``
-        declares ``organizationId``, ``organizationReportId``, and ``pipeIds`` as ``Int``.
-
         Args:
-            organization_id: Organization numeric ID (GraphQL ``Int``).
+            organization_id: Organization ID.
             organization_report_id: Report to export; omit to export by pipes only.
             pipe_ids: Pipe IDs to scope the export.
             sort_by: ``ReportSortDirectionInput``.
             filter: ``ReportCardsFilter`` shape.
             columns: Column field IDs for the export file.
         """
-        input_obj: dict[str, Any] = {"organizationId": organization_id}
+        input_obj: dict[str, Any] = {"organizationId": str(organization_id)}
         optional_fields = {
-            "organizationReportId": organization_report_id,
-            "pipeIds": pipe_ids,
+            "organizationReportId": str(organization_report_id)
+            if organization_report_id is not None
+            else None,
+            "pipeIds": [str(pid) for pid in pipe_ids] if pipe_ids is not None else None,
             "sortBy": sort_by,
             "filter": filter,
             "columns": columns,

--- a/src/pipefy_mcp/services/pipefy/table_service.py
+++ b/src/pipefy_mcp/services/pipefy/table_service.py
@@ -49,12 +49,12 @@ class TableService(BasePipefyClient):
 
     async def get_table(self, table_id: str | int) -> dict[str, Any]:
         """Fetch one database table by ID (metadata and fields)."""
-        return await self.execute_query(GET_TABLE_QUERY, {"id": int(table_id)})
+        return await self.execute_query(GET_TABLE_QUERY, {"id": str(table_id)})
 
     async def get_tables(self, table_ids: list[str | int]) -> dict[str, Any]:
         """Fetch multiple database tables by ID."""
         return await self.execute_query(
-            GET_TABLES_QUERY, {"ids": [int(t) for t in table_ids]}
+            GET_TABLES_QUERY, {"ids": [str(t) for t in table_ids]}
         )
 
     async def get_table_records(
@@ -70,14 +70,14 @@ class TableService(BasePipefyClient):
             first: Page size (forwarded to the API; callers may cap, e.g. max 200).
             after: Opaque cursor from the previous page's `pageInfo.endCursor`.
         """
-        variables: dict[str, Any] = {"tableId": int(table_id), "first": first}
+        variables: dict[str, Any] = {"tableId": str(table_id), "first": first}
         if after is not None:
             variables["after"] = after
         return await self.execute_query(GET_TABLE_RECORDS_QUERY, variables)
 
     async def get_table_record(self, record_id: str | int) -> dict[str, Any]:
         """Fetch a single table record by ID."""
-        return await self.execute_query(GET_TABLE_RECORD_QUERY, {"id": int(record_id)})
+        return await self.execute_query(GET_TABLE_RECORD_QUERY, {"id": str(record_id)})
 
     async def find_records(
         self,
@@ -108,12 +108,12 @@ class TableService(BasePipefyClient):
         return await self.execute_query(FIND_RECORDS_QUERY, variables)
 
     async def create_table(
-        self, name: str, organization_id: int, **attrs: Any
+        self, name: str, organization_id: str | int, **attrs: Any
     ) -> dict[str, Any]:
         """Create a database table (`CreateTableInput` fields via ``**attrs`` when not None)."""
         input_obj: dict[str, Any] = {
             "name": name,
-            "organization_id": organization_id,
+            "organization_id": str(organization_id),
         }
         for key, value in attrs.items():
             if value is not None:
@@ -122,7 +122,7 @@ class TableService(BasePipefyClient):
 
     async def update_table(self, table_id: str | int, **attrs: Any) -> dict[str, Any]:
         """Update a database table by ID. Pass only `UpdateTableInput` fields (omit or None to skip)."""
-        payload: dict[str, Any] = {"id": int(table_id)}
+        payload: dict[str, Any] = {"id": str(table_id)}
         for key, value in attrs.items():
             if value is not None:
                 payload[key] = value
@@ -132,7 +132,7 @@ class TableService(BasePipefyClient):
         """Delete a database table by ID (permanent). Caller must enforce preview/confirm UX."""
         return await self.execute_query(
             DELETE_TABLE_MUTATION,
-            {"input": {"id": int(table_id)}},
+            {"input": {"id": str(table_id)}},
         )
 
     async def create_table_record(
@@ -149,7 +149,7 @@ class TableService(BasePipefyClient):
             **attrs: Other `CreateTableRecordInput` keys (e.g. title, assignee_ids), when not None.
         """
         input_obj: dict[str, Any] = {
-            "table_id": int(table_id),
+            "table_id": str(table_id),
             "fields_attributes": convert_fields_to_array(fields),
         }
         for key, value in attrs.items():
@@ -176,7 +176,7 @@ class TableService(BasePipefyClient):
             for key, value in fields.items()
         ):
             raise ValueError(UPDATE_TABLE_RECORD_FIELDS_ERROR_MESSAGE)
-        payload: dict[str, Any] = {"id": int(record_id)}
+        payload: dict[str, Any] = {"id": str(record_id)}
         for key, value in fields.items():
             if value is None:
                 continue
@@ -193,7 +193,7 @@ class TableService(BasePipefyClient):
         """Delete a table record by ID (permanent)."""
         return await self.execute_query(
             DELETE_TABLE_RECORD_MUTATION,
-            {"input": {"id": int(record_id)}},
+            {"input": {"id": str(record_id)}},
         )
 
     async def set_table_record_field_value(
@@ -208,7 +208,7 @@ class TableService(BasePipefyClient):
             SET_TABLE_RECORD_FIELD_VALUE_MUTATION,
             {
                 "input": {
-                    "table_record_id": int(record_id),
+                    "table_record_id": str(record_id),
                     "field_id": field_id,
                     "value": api_value,
                 }
@@ -231,7 +231,7 @@ class TableService(BasePipefyClient):
             **attrs: Other input fields (e.g. description, required, options), when not None.
         """
         input_obj: dict[str, Any] = {
-            "table_id": int(table_id),
+            "table_id": str(table_id),
             "label": label,
             "type": field_type,
         }
@@ -255,7 +255,7 @@ class TableService(BasePipefyClient):
         """
         payload: dict[str, Any] = {"id": field_id}
         if table_id is not None:
-            payload["table_id"] = int(table_id)
+            payload["table_id"] = str(table_id)
         for key, value in attrs.items():
             if value is not None:
                 payload[key] = value

--- a/src/pipefy_mcp/services/pipefy/webhook_service.py
+++ b/src/pipefy_mcp/services/pipefy/webhook_service.py
@@ -60,7 +60,7 @@ class WebhookService(BasePipefyClient):
             filter_by_name: Optional case-insensitive partial match on template name.
             first: Max templates to return (default 50).
         """
-        variables: dict[str, Any] = {"repoId": int(repo_id), "first": first}
+        variables: dict[str, Any] = {"repoId": str(repo_id), "first": first}
         if filter_by_name is not None and filter_by_name.strip():
             variables["filterByName"] = filter_by_name.strip()
         return await self.execute_query(GET_EMAIL_TEMPLATES_QUERY, variables)
@@ -98,7 +98,7 @@ class WebhookService(BasePipefyClient):
         if "repoId" in attrs or not card_id.isdigit():
             return attrs
         try:
-            card_data = await self._card_service.get_card(int(card_id))
+            card_data = await self._card_service.get_card(card_id)
             pipe_obj = card_data.get("card", {}).get("pipe")
             pipe_id = pipe_obj.get("id") if isinstance(pipe_obj, dict) else None
             if pipe_id is not None:
@@ -171,7 +171,7 @@ class WebhookService(BasePipefyClient):
         card_id_str = str(card_id).strip()
         if not card_id_str.isdigit():
             raise ValueError(f"card_id must be a numeric card ID, got {card_id!r}.")
-        card_data = await self._card_service.get_card(int(card_id_str))
+        card_data = await self._card_service.get_card(card_id_str)
         card_obj = card_data.get("card") or {}
         card_uuid = card_obj.get("uuid")
         if not card_uuid:
@@ -226,7 +226,7 @@ class WebhookService(BasePipefyClient):
         """
         _require_https(url, "url")
         input_obj: dict[str, Any] = {
-            "pipe_id": int(pipe_id),
+            "pipe_id": str(pipe_id),
             "url": url,
             "actions": actions,
             "name": attrs.get("name", _DEFAULT_WEBHOOK_NAME),
@@ -266,7 +266,7 @@ class WebhookService(BasePipefyClient):
         """
         raw = await self.execute_query(
             GET_CARD_INBOX_EMAILS_QUERY,
-            {"card_id": int(card_id)},
+            {"card_id": str(card_id)},
         )
         card_data = raw.get("card") or {}
         emails = card_data.get("inbox_emails") or []

--- a/src/pipefy_mcp/tools/ai_agent_tools.py
+++ b/src/pipefy_mcp/tools/ai_agent_tools.py
@@ -597,7 +597,7 @@ class AiAgentTools:
             for target_pid in target_pipe_ids:
                 try:
                     target_data = await asyncio.wait_for(
-                        client.get_pipe(int(target_pid)),
+                        client.get_pipe(target_pid),
                         timeout=VALIDATE_FETCH_TIMEOUT_SECONDS,
                     )
                     target_info = target_data.get("pipe", {})

--- a/src/pipefy_mcp/tools/ai_tool_helpers.py
+++ b/src/pipefy_mcp/tools/ai_tool_helpers.py
@@ -431,7 +431,7 @@ def _extract_slug_field_ids_by_pipe(
 
 async def build_field_slug_map(
     client: PipefyClient,
-    pipe_id: int,
+    pipe_id: str | int,
 ) -> dict[str, str]:
     """Build a slug → numeric internal_id map for all fields in a pipe.
 
@@ -462,7 +462,7 @@ async def build_field_slug_map(
         if not phase_id:
             continue
         try:
-            phase_data = await client.get_phase_fields(int(phase_id))
+            phase_data = await client.get_phase_fields(phase_id)
             for field in phase_data.get("fields") or []:
                 slug = str(field.get("id", ""))
                 internal = str(field.get("internal_id", ""))
@@ -500,7 +500,7 @@ async def resolve_field_slugs_to_numeric(
     slug_to_numeric: dict[str, str] = {}
     for pipe_id_str in slugs_by_pipe:
         try:
-            field_map = await build_field_slug_map(client, int(pipe_id_str))
+            field_map = await build_field_slug_map(client, pipe_id_str)
             slug_to_numeric.update(field_map)
         except Exception:  # noqa: BLE001
             logger.debug(
@@ -559,7 +559,7 @@ async def fetch_pipe_validation_context(
     import asyncio
 
     pipe_data = await asyncio.wait_for(
-        client.get_pipe(int(pipe_id)),
+        client.get_pipe(pipe_id),
         timeout=timeout,
     )
     pipe_info = pipe_data.get("pipe", {})

--- a/src/pipefy_mcp/tools/attachment_tool_helpers.py
+++ b/src/pipefy_mcp/tools/attachment_tool_helpers.py
@@ -26,7 +26,7 @@ def build_upload_success_payload(
     content_type: str,
     file_size: int,
     field_id: str,
-    card_id: int | None = None,
+    card_id: str | int | None = None,
     table_record_id: str | None = None,
 ) -> dict[str, Any]:
     """Structured success payload (FR-8).

--- a/src/pipefy_mcp/tools/attachment_tools.py
+++ b/src/pipefy_mcp/tools/attachment_tools.py
@@ -241,7 +241,7 @@ class AttachmentTools:
         async def upload_attachment_to_card(
             ctx: Context[ServerSession, None],
             organization_id: PipefyId,
-            card_id: int,
+            card_id: str | int,
             field_id: PipefyId,
             file_name: str,
             file_url: str | None = None,

--- a/src/pipefy_mcp/tools/member_tools.py
+++ b/src/pipefy_mcp/tools/member_tools.py
@@ -207,7 +207,7 @@ async def _verify_removal(
         return None
 
     try:
-        members_data = await client.get_pipe_members(int(pipe_id_str))
+        members_data = await client.get_pipe_members(pipe_id_str)
     except Exception:  # noqa: BLE001
         return None
 

--- a/src/pipefy_mcp/tools/phase_transition_helpers.py
+++ b/src/pipefy_mcp/tools/phase_transition_helpers.py
@@ -16,8 +16,8 @@ _AUTOMATION_MOVE_CARD_ACTION_IDS = frozenset({"move_single_card"})
 
 async def try_enrich_move_card_to_phase_failure(
     client: PipefyClient,
-    card_id: int,
-    destination_phase_id: int,
+    card_id: str | int,
+    destination_phase_id: str | int,
 ) -> dict[str, Any] | None:
     """If the card cannot move to ``destination_phase_id`` from its current phase, build an error payload.
 
@@ -44,7 +44,7 @@ async def try_enrich_move_card_to_phase_failure(
     if cur_id is None:
         return None
     try:
-        phase_payload = await client.get_phase_allowed_move_targets(int(cur_id))
+        phase_payload = await client.get_phase_allowed_move_targets(cur_id)
     except Exception:
         return None
     phase = phase_payload.get("phase") or {}
@@ -91,7 +91,7 @@ async def collect_ai_behavior_move_transition_problems(
     async def phase_context(phase_id_str: str) -> tuple[str, list[dict]]:
         if phase_id_str not in cache:
             try:
-                data = await client.get_phase_allowed_move_targets(int(phase_id_str))
+                data = await client.get_phase_allowed_move_targets(phase_id_str)
             except Exception:
                 cache[phase_id_str] = ("", [])
             else:
@@ -211,7 +211,7 @@ async def validate_traditional_automation_move_transition_or_none(
         return None
     dest_s = str(dest)
     try:
-        data = await client.get_phase_allowed_move_targets(int(src_s))
+        data = await client.get_phase_allowed_move_targets(src_s)
     except Exception:
         return None
     ph = data.get("phase") or {}

--- a/src/pipefy_mcp/tools/pipe_config_tool_helpers.py
+++ b/src/pipefy_mcp/tools/pipe_config_tool_helpers.py
@@ -13,14 +13,14 @@ from pipefy_mcp.tools.validation_helpers import UUID_RE, format_json_preview
 class DeletePipePreviewPayload(TypedDict):
     success: Literal[False]
     requires_confirmation: Literal[True]
-    pipe_id: int
+    pipe_id: str | int
     message: str
     pipe_summary: str
 
 
 class DeletePipeSuccessPayload(TypedDict):
     success: Literal[True]
-    pipe_id: int
+    pipe_id: str | int
     message: str
 
 
@@ -138,7 +138,7 @@ def build_field_condition_delete_payload(
 
 def build_delete_pipe_preview_payload(
     *,
-    pipe_id: int,
+    pipe_id: str | int,
     pipe_name: str,
     pipe_data: dict[str, Any],
 ) -> DeletePipePreviewPayload:
@@ -168,7 +168,9 @@ def build_delete_pipe_preview_payload(
     }
 
 
-def build_delete_pipe_success_payload(*, pipe_id: int) -> DeletePipeSuccessPayload:
+def build_delete_pipe_success_payload(
+    *, pipe_id: str | int
+) -> DeletePipeSuccessPayload:
     """Confirmed pipe deletion.
 
     Args:
@@ -191,7 +193,7 @@ def build_delete_pipe_error_payload(*, message: str) -> DeletePipeErrorPayload:
 
 
 def map_delete_pipe_error_to_message(
-    *, pipe_id: int, pipe_name: str, codes: list[str]
+    *, pipe_id: str | int, pipe_name: str, codes: list[str]
 ) -> str:
     """Heuristic user string from GraphQL ``extensions.code`` for delete_pipe."""
     for code in codes:

--- a/src/pipefy_mcp/tools/pipe_config_tools.py
+++ b/src/pipefy_mcp/tools/pipe_config_tools.py
@@ -21,6 +21,7 @@ from pipefy_mcp.tools.pipe_config_tool_helpers import (
     handle_pipe_config_tool_graphql_error,
     map_delete_pipe_error_to_message,
 )
+from pipefy_mcp.tools.validation_helpers import valid_repo_id
 from pipefy_mcp.tools.validation_helpers import valid_repo_id as valid_phase_field_id
 
 _CREATE_PHASE_FIELD_EXTRA_RESERVED = frozenset({"phase_id", "label", "type"})
@@ -56,9 +57,9 @@ class PipeConfigTools:
                 return build_pipe_tool_error_payload(
                     message="Invalid 'name': provide a non-empty string.",
                 )
-            if not isinstance(organization_id, int) or organization_id <= 0:
+            if not valid_repo_id(organization_id):
                 return build_pipe_tool_error_payload(
-                    message="Invalid 'organization_id'. Use a positive integer.",
+                    message="Invalid 'organization_id'. Provide a non-empty string or positive integer.",
                 )
             try:
                 raw = await client.create_pipe(name.strip(), organization_id)
@@ -97,9 +98,9 @@ class PipeConfigTools:
                 preferences: Repo preferences object, if changing.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
-            if not isinstance(pipe_id, int) or pipe_id <= 0:
+            if not valid_repo_id(pipe_id):
                 return build_pipe_tool_error_payload(
-                    message="Invalid 'pipe_id'. Use a positive integer.",
+                    message="Invalid 'pipe_id'. Provide a non-empty string or positive integer.",
                 )
             if all(x is None for x in (name, icon, color, preferences)):
                 return build_pipe_tool_error_payload(
@@ -146,9 +147,9 @@ class PipeConfigTools:
                 confirm: When True, performs the deletion after explicit user confirmation.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
-            if not isinstance(pipe_id, int) or pipe_id <= 0:
+            if not valid_repo_id(pipe_id):
                 return build_delete_pipe_error_payload(
-                    message="Invalid 'pipe_id'. Use a positive integer.",
+                    message="Invalid 'pipe_id'. Provide a non-empty string or positive integer.",
                 )
 
             pipe_name = "Unknown"
@@ -229,15 +230,13 @@ class PipeConfigTools:
                 organization_id: Optional organization ID for the clone operation.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
-            if not isinstance(pipe_template_id, int) or pipe_template_id <= 0:
+            if not valid_repo_id(pipe_template_id):
                 return build_pipe_tool_error_payload(
-                    message="Invalid 'pipe_template_id'. Use a positive integer.",
+                    message="Invalid 'pipe_template_id'. Provide a non-empty string or positive integer.",
                 )
-            if organization_id is not None and (
-                not isinstance(organization_id, int) or organization_id <= 0
-            ):
+            if organization_id is not None and not valid_repo_id(organization_id):
                 return build_pipe_tool_error_payload(
-                    message="Invalid 'organization_id'. Use a positive integer or omit.",
+                    message="Invalid 'organization_id'. Provide a non-empty string or positive integer, or omit.",
                 )
             try:
                 raw = await client.clone_pipe(
@@ -276,9 +275,9 @@ class PipeConfigTools:
                 description: Optional phase description.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
-            if not isinstance(pipe_id, int) or pipe_id <= 0:
+            if not valid_repo_id(pipe_id):
                 return build_pipe_tool_error_payload(
-                    message="Invalid 'pipe_id'. Use a positive integer.",
+                    message="Invalid 'pipe_id'. Provide a non-empty string or positive integer.",
                 )
             if not isinstance(name, str) or not name.strip():
                 return build_pipe_tool_error_payload(
@@ -334,9 +333,9 @@ class PipeConfigTools:
                 only_admin_can_move_to_previous: If changing (deprecated in API).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
-            if not isinstance(phase_id, int) or phase_id <= 0:
+            if not valid_repo_id(phase_id):
                 return build_pipe_tool_error_payload(
-                    message="Invalid 'phase_id'. Use a positive integer.",
+                    message="Invalid 'phase_id'. Provide a non-empty string or positive integer.",
                 )
 
             update_attrs: dict[str, Any] = {}
@@ -412,9 +411,9 @@ class PipeConfigTools:
                 confirm: Set to True to execute the deletion (step 2).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
-            if not isinstance(phase_id, int) or phase_id <= 0:
+            if not valid_repo_id(phase_id):
                 return build_pipe_tool_error_payload(
-                    message="Invalid 'phase_id'. Use a positive integer.",
+                    message="Invalid 'phase_id'. Provide a non-empty string or positive integer.",
                 )
 
             guard = await check_destructive_confirmation(
@@ -469,9 +468,9 @@ class PipeConfigTools:
                 extra_input: Additional ``CreatePhaseFieldInput`` fields, if any.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
-            if not isinstance(phase_id, int) or phase_id <= 0:
+            if not valid_repo_id(phase_id):
                 return build_pipe_tool_error_payload(
-                    message="Invalid 'phase_id'. Use a positive integer.",
+                    message="Invalid 'phase_id'. Provide a non-empty string or positive integer.",
                 )
             if not isinstance(label, str) or not label.strip():
                 return build_pipe_tool_error_payload(
@@ -658,9 +657,9 @@ class PipeConfigTools:
                 color: Label color (per Pipefy/API).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
-            if not isinstance(pipe_id, int) or pipe_id <= 0:
+            if not valid_repo_id(pipe_id):
                 return build_pipe_tool_error_payload(
-                    message="Invalid 'pipe_id'. Use a positive integer.",
+                    message="Invalid 'pipe_id'. Provide a non-empty string or positive integer.",
                 )
             if not isinstance(name, str) or not name.strip():
                 return build_pipe_tool_error_payload(
@@ -706,9 +705,9 @@ class PipeConfigTools:
                 extra_input: Additional UpdateLabelInput fields, if any.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
-            if not isinstance(label_id, int) or label_id <= 0:
+            if not valid_repo_id(label_id):
                 return build_pipe_tool_error_payload(
-                    message="Invalid 'label_id'. Use a positive integer.",
+                    message="Invalid 'label_id'. Provide a non-empty string or positive integer.",
                 )
             update_attrs: dict[str, Any] = {
                 k: v
@@ -757,9 +756,9 @@ class PipeConfigTools:
                 confirm: Set to True to execute the deletion (step 2).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
-            if not isinstance(label_id, int) or label_id <= 0:
+            if not valid_repo_id(label_id):
                 return build_pipe_tool_error_payload(
-                    message="Invalid 'label_id'. Use a positive integer.",
+                    message="Invalid 'label_id'. Provide a non-empty string or positive integer.",
                 )
 
             guard = await check_destructive_confirmation(

--- a/src/pipefy_mcp/tools/pipe_config_tools.py
+++ b/src/pipefy_mcp/tools/pipe_config_tools.py
@@ -40,7 +40,7 @@ class PipeConfigTools:
         )
         async def create_pipe(
             name: str,
-            organization_id: int,
+            organization_id: str | int,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Create a new empty pipe in an organization.
@@ -77,7 +77,7 @@ class PipeConfigTools:
             ),
         )
         async def update_pipe(
-            pipe_id: int,
+            pipe_id: str | int,
             name: str | None = None,
             icon: str | None = None,
             color: str | None = None,
@@ -132,7 +132,7 @@ class PipeConfigTools:
         )
         async def delete_pipe(
             ctx: Context[ServerSession, None],
-            pipe_id: int,
+            pipe_id: str | int,
             confirm: bool = False,
             debug: bool = False,
         ) -> dict[str, Any]:
@@ -216,8 +216,8 @@ class PipeConfigTools:
             ),
         )
         async def clone_pipe(
-            pipe_template_id: int,
-            organization_id: int | None = None,
+            pipe_template_id: str | int,
+            organization_id: str | int | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Clone a pipe from a template pipe ID.
@@ -259,7 +259,7 @@ class PipeConfigTools:
             ),
         )
         async def create_phase(
-            pipe_id: int,
+            pipe_id: str | int,
             name: str,
             done: bool = False,
             index: float | int | None = None,
@@ -307,7 +307,7 @@ class PipeConfigTools:
             ),
         )
         async def update_phase(
-            phase_id: int,
+            phase_id: str | int,
             name: str | None = None,
             description: str | None = None,
             done: bool | None = None,
@@ -397,7 +397,7 @@ class PipeConfigTools:
         )
         async def delete_phase(
             ctx: Context[ServerSession, None],
-            phase_id: int,
+            phase_id: str | int,
             confirm: bool = False,
             debug: bool = False,
         ) -> dict[str, Any]:
@@ -442,7 +442,7 @@ class PipeConfigTools:
             ),
         )
         async def create_phase_field(
-            phase_id: int,
+            phase_id: str | int,
             label: str,
             field_type: str,
             options: list[str] | None = None,
@@ -645,7 +645,7 @@ class PipeConfigTools:
             ),
         )
         async def create_label(
-            pipe_id: int,
+            pipe_id: str | int,
             name: str,
             color: str,
             debug: bool = False,
@@ -691,7 +691,7 @@ class PipeConfigTools:
             ),
         )
         async def update_label(
-            label_id: int,
+            label_id: str | int,
             name: str | None = None,
             color: str | None = None,
             extra_input: dict[str, Any] | None = None,
@@ -742,7 +742,7 @@ class PipeConfigTools:
         )
         async def delete_label(
             ctx: Context[ServerSession, None],
-            label_id: int,
+            label_id: str | int,
             confirm: bool = False,
             debug: bool = False,
         ) -> dict[str, Any]:

--- a/src/pipefy_mcp/tools/pipe_tool_helpers.py
+++ b/src/pipefy_mcp/tools/pipe_tool_helpers.py
@@ -55,7 +55,7 @@ DeleteCommentPayload = DeleteCommentSuccessPayload | DeleteCommentErrorPayload
 
 class DeleteCardSuccessPayload(TypedDict):
     success: Literal[True]
-    card_id: int
+    card_id: str | int
     card_title: str
     pipe_name: str
     message: str
@@ -227,7 +227,7 @@ def build_delete_comment_error_payload(*, message: str) -> DeleteCommentErrorPay
 
 
 def build_delete_card_success_payload(
-    *, card_id: int, card_title: str, pipe_name: str
+    *, card_id: str | int, card_title: str, pipe_name: str
 ) -> DeleteCardSuccessPayload:
     """Confirmed card deletion.
 
@@ -287,7 +287,7 @@ def _filter_fields_by_definitions(
 
 
 def map_delete_card_error_to_message(
-    *, card_id: int, card_title: str, codes: list[str]
+    *, card_id: str | int, card_title: str, codes: list[str]
 ) -> str:
     """Map GraphQL error codes to short, actionable messages for delete_card."""
     for code in codes:

--- a/src/pipefy_mcp/tools/pipe_tools.py
+++ b/src/pipefy_mcp/tools/pipe_tools.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
 from mcp.types import ToolAnnotations
-from pydantic import ValidationError
+from pydantic import TypeAdapter, ValidationError
 
 from pipefy_mcp.models.comment import (
     CommentInput,
@@ -15,6 +15,7 @@ from pipefy_mcp.models.comment import (
     UpdateCommentInput,
 )
 from pipefy_mcp.models.form import create_form_model
+from pipefy_mcp.models.validators import PipefyId
 from pipefy_mcp.services.pipefy import PipefyClient
 from pipefy_mcp.services.pipefy.types import CardSearch
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
@@ -674,17 +675,27 @@ class PipeTools:
             Returns:
                 Success/error status of the deletion.
             """
-            if not isinstance(card_id, int):
+            try:
+                coerced = TypeAdapter(PipefyId).validate_python(card_id)
+            except ValidationError:
                 return build_delete_card_error_payload(
-                    message=f"Invalid 'card_id'. Expected an integer, got {type(card_id).__name__}."
+                    message=(
+                        "Invalid 'card_id'. Provide a non-empty string or positive "
+                        f"numeric ID (got {type(card_id).__name__})."
+                    )
                 )
-            if card_id <= 0:
+            card_id_str = str(coerced).strip()
+            if not card_id_str:
+                return build_delete_card_error_payload(
+                    message="Invalid 'card_id'. Please provide a non-empty card ID."
+                )
+            if card_id_str.isdigit() and int(card_id_str) <= 0:
                 return build_delete_card_error_payload(
                     message="Invalid 'card_id'. Please provide a positive integer."
                 )
 
             try:
-                card_response = await client.get_card(card_id)
+                card_response = await client.get_card(card_id_str)
                 card_data = card_response["card"]
                 card_title = card_data["title"]
                 pipe_name = card_data.get("pipe", {}).get("name", "Unknown Pipe")
@@ -692,7 +703,7 @@ class PipeTools:
                 codes = extract_graphql_error_codes(exc)
                 correlation_id = extract_graphql_correlation_id(exc)
                 base = map_delete_card_error_to_message(
-                    card_id=card_id, card_title="Unknown", codes=codes
+                    card_id=card_id_str, card_title="Unknown", codes=codes
                 )
                 return build_delete_card_error_payload(
                     message=with_debug_suffix(
@@ -706,31 +717,36 @@ class PipeTools:
             guard = await check_destructive_confirmation(
                 ctx,
                 confirm=confirm,
-                resource_descriptor=f"card '{card_title}' (ID: {card_id}) from pipe '{pipe_name}'",
+                resource_descriptor=(
+                    f"card '{card_title}' (ID: {card_id_str}) from pipe '{pipe_name}'"
+                ),
             )
             if guard is not None:
                 return guard
 
             try:
-                delete_response = await client.delete_card(card_id)
+                delete_response = await client.delete_card(card_id_str)
 
                 delete_data = delete_response.get("deleteCard", {})
 
                 if delete_data.get("success"):
                     return build_delete_card_success_payload(
-                        card_id=card_id,
+                        card_id=card_id_str,
                         card_title=card_title,
                         pipe_name=pipe_name,
                     )
                 else:
                     return build_delete_card_error_payload(
-                        message=f"Failed to delete card '{card_title}' (ID: {card_id}). Please try again or contact support."
+                        message=(
+                            f"Failed to delete card '{card_title}' (ID: {card_id_str}). "
+                            "Please try again or contact support."
+                        )
                     )
             except Exception as exc:  # noqa: BLE001
                 codes = extract_graphql_error_codes(exc)
                 correlation_id = extract_graphql_correlation_id(exc)
                 base = map_delete_card_error_to_message(
-                    card_id=card_id, card_title=card_title, codes=codes
+                    card_id=card_id_str, card_title=card_title, codes=codes
                 )
                 return build_delete_card_error_payload(
                     message=with_debug_suffix(

--- a/src/pipefy_mcp/tools/pipe_tools.py
+++ b/src/pipefy_mcp/tools/pipe_tools.py
@@ -67,7 +67,7 @@ class PipeTools:
         )
         async def create_card(
             ctx: Context[ServerSession, None],
-            pipe_id: int,
+            pipe_id: str | int,
             title: str | None = None,
             fields: dict[str, Any] | None = None,
             required_fields_only: bool = False,
@@ -127,7 +127,7 @@ class PipeTools:
             if card_id:
                 if title:
                     try:
-                        await client.update_card(int(card_id), title=title)
+                        await client.update_card(card_id, title=title)
                     except Exception as exc:  # noqa: BLE001
                         result["title_warning"] = (
                             f"Card created but title update failed: {exc}"
@@ -146,7 +146,7 @@ class PipeTools:
             ),
         )
         async def get_card(
-            card_id: int,
+            card_id: str | int,
             include_fields: bool = False,
         ) -> dict:
             """Get a card by its ID.
@@ -160,7 +160,9 @@ class PipeTools:
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
         )
-        async def add_card_comment(card_id: int, text: str) -> AddCardCommentPayload:
+        async def add_card_comment(
+            card_id: str | int, text: str
+        ) -> AddCardCommentPayload:
             """Add a text comment to a Pipefy card.
 
             Args:
@@ -191,7 +193,7 @@ class PipeTools:
             annotations=ToolAnnotations(readOnlyHint=False),
         )
         async def update_comment(
-            comment_id: int, text: str
+            comment_id: str | int, text: str
         ) -> UpdateCommentSuccessPayload | UpdateCommentErrorPayload:
             """Update an existing comment by its ID.
 
@@ -223,7 +225,7 @@ class PipeTools:
             annotations=ToolAnnotations(readOnlyHint=False),
         )
         async def delete_comment(
-            comment_id: int,
+            comment_id: str | int,
         ) -> DeleteCommentSuccessPayload | DeleteCommentErrorPayload:
             """Delete a comment by its ID.
 
@@ -253,7 +255,7 @@ class PipeTools:
         )
         async def get_cards(
             ctx: Context[ServerSession, None],
-            pipe_id: int,
+            pipe_id: str | int,
             title: str | None = None,
             search: CardSearch | None = None,
             include_fields: bool = False,
@@ -304,7 +306,7 @@ class PipeTools:
             ),
         )
         async def find_cards(
-            pipe_id: int,
+            pipe_id: str | int,
             field_id: str,
             field_value: str,
             include_fields: bool = False,
@@ -347,7 +349,7 @@ class PipeTools:
                 readOnlyHint=True,
             ),
         )
-        async def get_pipe(pipe_id: int) -> dict:
+        async def get_pipe(pipe_id: str | int) -> dict:
             """Get a pipe by its ID."""
 
             return await client.get_pipe(pipe_id)
@@ -357,7 +359,7 @@ class PipeTools:
                 readOnlyHint=True,
             ),
         )
-        async def get_pipe_members(pipe_id: int) -> dict:
+        async def get_pipe_members(pipe_id: str | int) -> dict:
             """Get the members of a pipe."""
 
             return await client.get_pipe_members(pipe_id)
@@ -365,7 +367,9 @@ class PipeTools:
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False, idempotentHint=True),
         )
-        async def move_card_to_phase(card_id: int, destination_phase_id: int) -> dict:
+        async def move_card_to_phase(
+            card_id: str | int, destination_phase_id: str | int
+        ) -> dict:
             """Move a card to a specific phase.
 
             On failure, if the destination is not among ``cards_can_be_moved_to_phases`` for the
@@ -389,7 +393,7 @@ class PipeTools:
             annotations=ToolAnnotations(readOnlyHint=False),
         )
         async def update_card_field(
-            card_id: int, field_id: str, new_value: Any
+            card_id: str | int, field_id: str, new_value: Any
         ) -> dict:
             """Update a single field of a card.
 
@@ -411,10 +415,10 @@ class PipeTools:
             annotations=ToolAnnotations(readOnlyHint=False),
         )
         async def update_card(
-            card_id: int,
+            card_id: str | int,
             title: str | None = None,
-            assignee_ids: list[int] | None = None,
-            label_ids: list[int] | None = None,
+            assignee_ids: list[str | int] | None = None,
+            label_ids: list[str | int] | None = None,
             due_date: str | None = None,
             field_updates: list[dict] | None = None,
         ) -> dict:
@@ -470,7 +474,7 @@ class PipeTools:
             ),
         )
         async def get_start_form_fields(
-            pipe_id: int, required_only: bool = False
+            pipe_id: str | int, required_only: bool = False
         ) -> dict:
             """Get the start form fields of a pipe.
 
@@ -501,7 +505,9 @@ class PipeTools:
                 readOnlyHint=True,
             ),
         )
-        async def get_phase_fields(phase_id: int, required_only: bool = False) -> dict:
+        async def get_phase_fields(
+            phase_id: str | int, required_only: bool = False
+        ) -> dict:
             """Get the fields available in a specific phase.
 
             Use this tool to understand which fields need to be filled on a specific phase.
@@ -534,8 +540,8 @@ class PipeTools:
         )
         async def fill_card_phase_fields(
             ctx: Context[ServerSession, None],
-            card_id: int,
-            phase_id: int,
+            card_id: str | int,
+            phase_id: str | int,
             fields: dict[str, Any] | None = None,
             required_fields_only: bool = False,
         ) -> dict:
@@ -642,7 +648,7 @@ class PipeTools:
         )
         async def delete_card(
             ctx: Context[ServerSession, None],
-            card_id: int,
+            card_id: str | int,
             confirm: bool = False,
             debug: bool = False,
         ) -> DeleteCardPayload:

--- a/src/pipefy_mcp/tools/report_tools.py
+++ b/src/pipefy_mcp/tools/report_tools.py
@@ -566,9 +566,9 @@ class ReportTools:
             annotations=ToolAnnotations(readOnlyHint=False),
         )
         async def export_organization_report(
-            organization_id: int,
-            organization_report_id: int | None = None,
-            pipe_ids: list[int] | None = None,
+            organization_id: str | int,
+            organization_report_id: str | int | None = None,
+            pipe_ids: list[str | int] | None = None,
             sort_by: dict | None = None,
             filter: dict | None = None,
             columns: list[str] | None = None,

--- a/src/pipefy_mcp/tools/table_tools.py
+++ b/src/pipefy_mcp/tools/table_tools.py
@@ -291,9 +291,9 @@ class TableTools:
                 return build_table_mutation_error_payload(
                     message="Invalid 'name': provide a non-empty string.",
                 )
-            if not isinstance(organization_id, int) or organization_id <= 0:
+            if not valid_repo_id(organization_id):
                 return build_table_mutation_error_payload(
-                    message="Invalid 'organization_id'. Use a positive integer.",
+                    message="Invalid 'organization_id'. Provide a non-empty string or positive integer.",
                 )
             bad_extra = mutation_error_if_not_optional_dict(
                 extra_input, arg_name="extra_input"

--- a/src/pipefy_mcp/tools/table_tools.py
+++ b/src/pipefy_mcp/tools/table_tools.py
@@ -275,7 +275,7 @@ class TableTools:
         )
         async def create_table(
             name: str,
-            organization_id: int,
+            organization_id: str | int,
             extra_input: Any | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:

--- a/tests/models/test_attachment.py
+++ b/tests/models/test_attachment.py
@@ -26,8 +26,31 @@ def test_upload_attachment_to_card_accepts_file_url():
         file_url="https://example.com/f.pdf",
         file_content_base64=None,
     )
+    assert data.card_id == "42"
     assert data.file_url == "https://example.com/f.pdf"
     assert data.file_content_base64 is None
+
+
+@pytest.mark.unit
+def test_upload_attachment_to_card_coerces_int_card_id():
+    """card_id uses PipefyId — int input should be coerced to string."""
+    data = UploadAttachmentToCardInput(
+        **_base_kwargs(),
+        card_id=99,
+        file_url="https://example.com/f.pdf",
+    )
+    assert data.card_id == "99"
+
+
+@pytest.mark.unit
+def test_upload_attachment_to_card_accepts_string_card_id():
+    """card_id uses PipefyId — string IDs should pass through."""
+    data = UploadAttachmentToCardInput(
+        **_base_kwargs(),
+        card_id="Yr5RUVCi",
+        file_url="https://example.com/f.pdf",
+    )
+    assert data.card_id == "Yr5RUVCi"
 
 
 @pytest.mark.unit

--- a/tests/models/test_comment.py
+++ b/tests/models/test_comment.py
@@ -12,11 +12,17 @@ from pipefy_mcp.models.comment import (
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("card_id", [0, -1, -999])
-def test_comment_input_rejects_card_id_zero_or_negative(card_id: int):
-    """CommentInput should reject card_id <= 0."""
+def test_comment_input_rejects_boolean_card_id():
+    """CommentInput should reject boolean card_id (PipefyId rejects booleans)."""
     with pytest.raises(ValidationError):
-        CommentInput(card_id=card_id, text="ok")
+        CommentInput(card_id=True, text="ok")
+
+
+@pytest.mark.unit
+def test_comment_input_accepts_string_card_id():
+    """CommentInput should accept alphanumeric string card_id."""
+    comment = CommentInput(card_id="Yr5RUVCi", text="ok")
+    assert comment.card_id == "Yr5RUVCi"
 
 
 @pytest.mark.unit
@@ -40,7 +46,7 @@ def test_comment_input_accepts_text_at_max_length_boundary():
     """CommentInput should accept text exactly at the max length boundary."""
     text = "a" * MAX_COMMENT_TEXT_LENGTH
     comment = CommentInput(card_id=1, text=text)
-    assert comment.card_id == 1
+    assert comment.card_id == "1"
     assert comment.text == text
 
 
@@ -48,16 +54,15 @@ def test_comment_input_accepts_text_at_max_length_boundary():
 def test_comment_input_valid_input():
     """CommentInput should accept valid inputs."""
     comment = CommentInput(card_id=123, text="Hello world")
-    assert comment.card_id == 123
+    assert comment.card_id == "123"
     assert comment.text == "Hello world"
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("comment_id", [0, -1, -999])
-def test_update_comment_input_rejects_comment_id_zero_or_negative(comment_id: int):
-    """UpdateCommentInput should reject comment_id <= 0."""
+def test_update_comment_input_rejects_boolean_comment_id():
+    """UpdateCommentInput should reject boolean comment_id."""
     with pytest.raises(ValidationError):
-        UpdateCommentInput(comment_id=comment_id, text="ok")
+        UpdateCommentInput(comment_id=True, text="ok")
 
 
 @pytest.mark.unit
@@ -81,7 +86,7 @@ def test_update_comment_input_accepts_text_at_max_length_boundary():
     """UpdateCommentInput should accept text exactly at the max length boundary."""
     text = "a" * MAX_COMMENT_TEXT_LENGTH
     comment = UpdateCommentInput(comment_id=1, text=text)
-    assert comment.comment_id == 1
+    assert comment.comment_id == "1"
     assert comment.text == text
 
 
@@ -89,20 +94,19 @@ def test_update_comment_input_accepts_text_at_max_length_boundary():
 def test_update_comment_input_valid_input():
     """UpdateCommentInput should accept valid inputs."""
     comment = UpdateCommentInput(comment_id=456, text="Updated message")
-    assert comment.comment_id == 456
+    assert comment.comment_id == "456"
     assert comment.text == "Updated message"
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("comment_id", [0, -1, -999])
-def test_delete_comment_input_rejects_comment_id_zero_or_negative(comment_id: int):
-    """DeleteCommentInput should reject comment_id <= 0."""
+def test_delete_comment_input_rejects_boolean_comment_id():
+    """DeleteCommentInput should reject boolean comment_id."""
     with pytest.raises(ValidationError):
-        DeleteCommentInput(comment_id=comment_id)
+        DeleteCommentInput(comment_id=True)
 
 
 @pytest.mark.unit
 def test_delete_comment_input_valid_input():
     """DeleteCommentInput should accept valid comment_id > 0."""
     comment = DeleteCommentInput(comment_id=789)
-    assert comment.comment_id == 789
+    assert comment.comment_id == "789"

--- a/tests/models/test_comment.py
+++ b/tests/models/test_comment.py
@@ -59,6 +59,20 @@ def test_comment_input_valid_input():
 
 
 @pytest.mark.unit
+def test_update_comment_input_accepts_alphanumeric_id():
+    """UpdateCommentInput should accept alphanumeric string comment_id."""
+    comment = UpdateCommentInput(comment_id="Yr5RUVCi", text="ok")
+    assert comment.comment_id == "Yr5RUVCi"
+
+
+@pytest.mark.unit
+def test_delete_comment_input_accepts_alphanumeric_id():
+    """DeleteCommentInput should accept alphanumeric string comment_id."""
+    comment = DeleteCommentInput(comment_id="Yr5RUVCi")
+    assert comment.comment_id == "Yr5RUVCi"
+
+
+@pytest.mark.unit
 def test_update_comment_input_rejects_boolean_comment_id():
     """UpdateCommentInput should reject boolean comment_id."""
     with pytest.raises(ValidationError):

--- a/tests/services/pipefy/test_automation_service.py
+++ b/tests/services/pipefy/test_automation_service.py
@@ -151,7 +151,7 @@ async def test_get_automation_success(mock_settings):
     service.execute_query.assert_awaited_once()
     query, variables = service.execute_query.call_args[0]
     assert query is GET_AUTOMATION_QUERY
-    assert variables == {"id": 101}
+    assert variables == {"id": "101"}
     assert result["id"] == "a1"
     assert result["name"] == "Notify assignee"
     assert result["event_params"]["to_phase_id"] == "ph_dest"
@@ -168,7 +168,7 @@ async def test_get_automation_when_api_returns_null(mock_settings):
 
     query, variables = service.execute_query.call_args[0]
     assert query is GET_AUTOMATION_QUERY
-    assert variables == {"id": 999}
+    assert variables == {"id": "999"}
     assert result is None
 
 
@@ -195,7 +195,7 @@ async def test_get_automations_success(mock_settings):
 
     query, variables = service.execute_query.call_args[0]
     assert query is GET_AUTOMATIONS_FOR_ORG_AND_REPO_QUERY
-    assert variables == {"organizationId": 101, "repoId": 901}
+    assert variables == {"organizationId": "101", "repoId": "901"}
     assert isinstance(result, list)
     assert result == rows
 
@@ -217,9 +217,9 @@ async def test_get_automations_success_resolves_org_from_pipe(mock_settings):
     q1, v1 = service.execute_query.call_args_list[0][0]
     q2, v2 = service.execute_query.call_args_list[1][0]
     assert q1 is GET_PIPE_ORGANIZATION_ID_QUERY
-    assert v1 == {"id": 901}
+    assert v1 == {"id": "901"}
     assert q2 is GET_AUTOMATIONS_FOR_ORG_AND_REPO_QUERY
-    assert v2 == {"organizationId": 300, "repoId": 901}
+    assert v2 == {"organizationId": "300", "repoId": "901"}
     assert result == rows
 
 
@@ -232,7 +232,7 @@ async def test_get_automations_organization_only_omits_repo_id(mock_settings):
 
     query, variables = service.execute_query.call_args[0]
     assert query is GET_AUTOMATIONS_BY_ORG_QUERY
-    assert variables == {"organizationId": 201}
+    assert variables == {"organizationId": "201"}
     assert result == rows
 
 
@@ -329,7 +329,7 @@ async def test_get_automation_actions_success(mock_settings):
 
     query, variables = service.execute_query.call_args[0]
     assert query is GET_AUTOMATION_ACTIONS_QUERY
-    assert variables == {"repoId": 601}
+    assert variables == {"repoId": "601"}
     assert isinstance(result, list)
     assert result[0]["id"] == "act1"
     assert result[0]["enabled"] is True

--- a/tests/services/pipefy/test_member_service.py
+++ b/tests/services/pipefy/test_member_service.py
@@ -48,7 +48,7 @@ async def test_invite_members_success(mock_settings):
     query, variables = service.execute_query.call_args[0]
     assert query is INVITE_MEMBERS_MUTATION
     inp = variables["input"]
-    assert inp["pipe_id"] == 601
+    assert inp["pipe_id"] == "601"
     assert inp["emails"] == [{"email": "a@x.com", "role_name": "member"}]
     assert result == payload
 
@@ -167,7 +167,7 @@ async def test_set_role_success(mock_settings):
     query, variables = service.execute_query.call_args[0]
     assert query is SET_ROLE_MUTATION
     inp = variables["input"]
-    assert inp["pipe_id"] == 603
+    assert inp["pipe_id"] == "603"
     assert inp["member"] == {"user_id": "member-1", "role_name": "admin"}
     assert result == payload
 

--- a/tests/services/pipefy/test_observability_service.py
+++ b/tests/services/pipefy/test_observability_service.py
@@ -323,7 +323,7 @@ async def test_get_ai_credit_usage_resolves_numeric_organization_id(mock_setting
     assert service.execute_query.call_count == 2
     calls = service.execute_query.call_args_list
     assert calls[0][0][0] is RESOLVE_ORGANIZATION_UUID_QUERY
-    assert calls[0][0][1] == {"id": 300514213}
+    assert calls[0][0][1] == {"id": "300514213"}
     assert calls[1][0][0] is GET_AI_CREDIT_USAGE_QUERY
     assert calls[1][0][1] == {
         "organizationUuid": "341c1327-261c-4766-bb96-7953e4c3970d",
@@ -360,7 +360,7 @@ async def test_export_automation_jobs_success(mock_settings):
 
     query, variables = service.execute_query.call_args[0]
     assert query is CREATE_AUTOMATION_JOBS_EXPORT_MUTATION
-    assert variables == {"input": {"organizationId": 123, "filter": "last_month"}}
+    assert variables == {"input": {"organizationId": "123", "filter": "last_month"}}
     assert result["createAutomationJobsExport"]["automationJobsExport"]["id"] == "exp-1"
 
 
@@ -510,7 +510,7 @@ async def test_get_agents_usage_resolves_numeric_organization_id(mock_settings):
     assert service.execute_query.call_count == 2
     calls = service.execute_query.call_args_list
     assert calls[0][0][0] is RESOLVE_ORGANIZATION_UUID_QUERY
-    assert calls[0][0][1] == {"id": 300514213}
+    assert calls[0][0][1] == {"id": "300514213"}
     assert calls[1][0][0] is GET_AGENTS_USAGE_QUERY
     assert calls[1][0][1]["organizationUuid"] == "341c1327-261c-4766-bb96-7953e4c3970d"
     assert result["agentsUsage"]["totalCredits"] == 5.0
@@ -534,7 +534,7 @@ async def test_get_automations_usage_resolves_numeric_organization_id(mock_setti
     assert service.execute_query.call_count == 2
     calls = service.execute_query.call_args_list
     assert calls[0][0][0] is RESOLVE_ORGANIZATION_UUID_QUERY
-    assert calls[0][0][1] == {"id": 300514213}
+    assert calls[0][0][1] == {"id": "300514213"}
     assert calls[1][0][0] is GET_AUTOMATIONS_USAGE_QUERY
     assert calls[1][0][1]["organizationUuid"] == "341c1327-261c-4766-bb96-7953e4c3970d"
     assert result["automationsUsage"]["totalExecutions"] == 42

--- a/tests/services/pipefy/test_organization_service.py
+++ b/tests/services/pipefy/test_organization_service.py
@@ -47,7 +47,7 @@ async def test_get_organization_returns_org_details(mock_settings):
     service.execute_query.assert_called_once()
     query_used, variables = service.execute_query.call_args[0]
     assert query_used is GET_ORGANIZATION_QUERY
-    assert variables == {"id": 123}
+    assert variables == {"id": "123"}
     assert result == org_data
 
 
@@ -71,4 +71,4 @@ async def test_get_organization_uses_correct_query_and_variables(mock_settings):
 
     query_used, variables = service.execute_query.call_args[0]
     assert query_used is GET_ORGANIZATION_QUERY
-    assert variables == {"id": 456}
+    assert variables == {"id": "456"}

--- a/tests/services/pipefy/test_pipe_config_service.py
+++ b/tests/services/pipefy/test_pipe_config_service.py
@@ -78,6 +78,19 @@ async def test_update_pipe_merges_id_and_non_none_attrs(mock_settings):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_update_pipe_accepts_alphanumeric_id(mock_settings):
+    """Test update_pipe passes an alphanumeric ID through to GraphQL variables unchanged."""
+    service = _make_service(
+        mock_settings, {"updatePipe": {"pipe": {"id": "Yr5RUVCi", "name": "X"}}}
+    )
+    await service.update_pipe("Yr5RUVCi", name="X")
+
+    variables = service.execute_query.call_args[0][1]
+    assert variables == {"input": {"id": "Yr5RUVCi", "name": "X"}}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_delete_pipe_sends_delete_input(mock_settings):
     service = _make_service(mock_settings, {"deletePipe": {"success": True}})
     result = await service.delete_pipe(42)

--- a/tests/services/pipefy/test_pipe_config_service.py
+++ b/tests/services/pipefy/test_pipe_config_service.py
@@ -55,7 +55,7 @@ async def test_create_pipe_sends_input_and_returns_payload(mock_settings):
     query, variables = service.execute_query.call_args[0]
     assert query is CREATE_PIPE_MUTATION
     assert variables == {
-        "input": {"name": "Alpha", "organization_id": 9001},
+        "input": {"name": "Alpha", "organization_id": "9001"},
     }
     assert result == {"createPipe": {"pipe": {"id": "1", "name": "Alpha"}}}
 
@@ -71,7 +71,7 @@ async def test_update_pipe_merges_id_and_non_none_attrs(mock_settings):
     query, variables = service.execute_query.call_args[0]
     assert query is UPDATE_PIPE_MUTATION
     assert variables == {
-        "input": {"id": 2, "name": "Beta", "icon": "star"},
+        "input": {"id": "2", "name": "Beta", "icon": "star"},
     }
     assert result == {"updatePipe": {"pipe": {"id": "2", "name": "Beta"}}}
 
@@ -84,7 +84,7 @@ async def test_delete_pipe_sends_delete_input(mock_settings):
 
     query, variables = service.execute_query.call_args[0]
     assert query is DELETE_PIPE_MUTATION
-    assert variables == {"input": {"id": 42}}
+    assert variables == {"input": {"id": "42"}}
     assert result == {"deletePipe": {"success": True}}
 
 
@@ -99,7 +99,7 @@ async def test_clone_pipe_sends_template_ids_only(mock_settings):
 
     query, variables = service.execute_query.call_args[0]
     assert query is CLONE_PIPE_MUTATION
-    assert variables == {"input": {"pipe_template_ids": [303]}}
+    assert variables == {"input": {"pipe_template_ids": ["303"]}}
     assert result == {"clonePipes": {"pipes": [{"id": "9", "name": "Clone"}]}}
 
 
@@ -111,7 +111,7 @@ async def test_clone_pipe_includes_organization_when_provided(mock_settings):
 
     variables = service.execute_query.call_args[0][1]
     assert variables == {
-        "input": {"pipe_template_ids": [1], "organization_id": 88},
+        "input": {"pipe_template_ids": ["1"], "organization_id": "88"},
     }
 
 
@@ -136,7 +136,7 @@ async def test_create_phase_sends_pipe_id_name_done_and_optional_index(
     assert query is CREATE_PHASE_MUTATION
     assert variables == {
         "input": {
-            "pipe_id": 50,
+            "pipe_id": "50",
             "name": "Backlog",
             "done": False,
             "index": 0.0,
@@ -159,7 +159,7 @@ async def test_create_phase_omits_optional_fields_when_not_set(mock_settings):
 
     variables = service.execute_query.call_args[0][1]
     assert variables == {
-        "input": {"pipe_id": 51, "name": "Done", "done": True},
+        "input": {"pipe_id": "51", "name": "Done", "done": True},
     }
 
 
@@ -175,7 +175,7 @@ async def test_update_phase_merges_id_and_attrs(mock_settings):
     query, variables = service.execute_query.call_args[0]
     assert query is UPDATE_PHASE_MUTATION
     assert variables == {
-        "input": {"id": 3, "name": "Renamed", "done": True},
+        "input": {"id": "3", "name": "Renamed", "done": True},
     }
     assert result == {
         "updatePhase": {"phase": {"id": "3", "name": "Renamed", "done": True}},
@@ -190,7 +190,7 @@ async def test_delete_phase_sends_delete_input(mock_settings):
 
     query, variables = service.execute_query.call_args[0]
     assert query is DELETE_PHASE_MUTATION
-    assert variables == {"input": {"id": 77}}
+    assert variables == {"input": {"id": "77"}}
     assert result == {"deletePhase": {"success": True}}
 
 
@@ -223,7 +223,7 @@ async def test_create_phase_field_sends_type_and_optional_attrs(mock_settings):
     assert query is CREATE_PHASE_FIELD_MUTATION
     assert variables == {
         "input": {
-            "phase_id": 10,
+            "phase_id": "10",
             "label": "Email",
             "type": "email",
             "description": "Work email",
@@ -258,7 +258,7 @@ async def test_update_phase_field_merges_id_and_attrs(mock_settings):
 
     query, variables = service.execute_query.call_args[0]
     assert query is UPDATE_PHASE_FIELD_MUTATION
-    assert variables == {"input": {"id": 5, "label": "Renamed"}}
+    assert variables == {"input": {"id": "5", "label": "Renamed"}}
     assert result == {
         "updatePhaseField": {
             "phase_field": {"id": "5", "label": "Renamed", "type": "short_text"},
@@ -304,7 +304,7 @@ async def test_delete_phase_field_sends_delete_input(mock_settings):
 
     query, variables = service.execute_query.call_args[0]
     assert query is DELETE_PHASE_FIELD_MUTATION
-    assert variables == {"input": {"id": 99}}
+    assert variables == {"input": {"id": "99"}}
     assert result == {"deletePhaseField": {"success": True}}
 
 
@@ -349,7 +349,7 @@ async def test_create_label_sends_pipe_name_color(mock_settings):
     query, variables = service.execute_query.call_args[0]
     assert query is CREATE_LABEL_MUTATION
     assert variables == {
-        "input": {"pipe_id": 20, "name": "Bug", "color": "red"},
+        "input": {"pipe_id": "20", "name": "Bug", "color": "red"},
     }
     assert result == {
         "createLabel": {"label": {"id": "1", "name": "Bug", "color": "red"}},
@@ -367,7 +367,7 @@ async def test_update_label_merges_id_and_attrs(mock_settings):
 
     query, variables = service.execute_query.call_args[0]
     assert query is UPDATE_LABEL_MUTATION
-    assert variables == {"input": {"id": 2, "name": "Feature"}}
+    assert variables == {"input": {"id": "2", "name": "Feature"}}
     assert result == {
         "updateLabel": {"label": {"id": "2", "name": "Feature", "color": "blue"}},
     }
@@ -381,7 +381,7 @@ async def test_delete_label_sends_delete_input(mock_settings):
 
     query, variables = service.execute_query.call_args[0]
     assert query is DELETE_LABEL_MUTATION
-    assert variables == {"input": {"id": 3}}
+    assert variables == {"input": {"id": "3"}}
     assert result == {"deleteLabel": {"success": True}}
 
 

--- a/tests/services/pipefy/test_relation_service.py
+++ b/tests/services/pipefy/test_relation_service.py
@@ -49,7 +49,7 @@ async def test_get_pipe_relations_sends_pipe_id(mock_settings):
     service.execute_query.assert_awaited_once()
     query, variables = service.execute_query.call_args[0]
     assert query is GET_PIPE_RELATIONS_QUERY
-    assert variables == {"pipeId": 701}
+    assert variables == {"pipeId": "701"}
     assert result["pipe"]["parentsRelations"][0]["name"] == "Up"
 
 
@@ -73,7 +73,7 @@ async def test_get_table_relations_sends_ids_list(mock_settings):
 
     query, variables = service.execute_query.call_args[0]
     assert query is GET_TABLE_RELATIONS_QUERY
-    assert variables == {"ids": [801, 802]}
+    assert variables == {"ids": ["801", "802"]}
     assert result["table_relations"] == rows
 
 

--- a/tests/services/pipefy/test_report_service.py
+++ b/tests/services/pipefy/test_report_service.py
@@ -201,7 +201,7 @@ async def test_get_organization_report_success(mock_settings):
 
     query, variables = service.execute_query.call_args[0]
     assert query is GET_ORGANIZATION_REPORT_QUERY
-    assert variables == {"id": 901}
+    assert variables == {"id": "901"}
     assert result["organizationReport"]["name"] == "Org Overview"
 
 
@@ -236,7 +236,7 @@ async def test_get_organization_reports_success(mock_settings):
 
     query, variables = service.execute_query.call_args[0]
     assert query is GET_ORGANIZATION_REPORTS_QUERY
-    assert variables["organizationId"] == 1001
+    assert variables["organizationId"] == "1001"
     assert variables["first"] == 5
     assert variables["after"] == "cursor-1"
     assert len(result["organizationReports"]["edges"]) == 2
@@ -301,7 +301,7 @@ async def test_create_pipe_report_success(mock_settings):
 
     query, variables = service.execute_query.call_args[0]
     assert query is CREATE_PIPE_REPORT_MUTATION
-    assert variables["input"]["pipeId"] == 123
+    assert variables["input"]["pipeId"] == "123"
     assert variables["input"]["name"] == "New Report"
     assert variables["input"]["fields"] == ["title", "status"]
     assert result["createPipeReport"]["pipeReport"]["id"] == "r10"
@@ -315,7 +315,7 @@ async def test_create_pipe_report_minimal(mock_settings):
     result = await service.create_pipe_report("456", "Minimal")
 
     variables = service.execute_query.call_args[0][1]
-    assert variables["input"] == {"pipeId": 456, "name": "Minimal"}
+    assert variables["input"] == {"pipeId": "456", "name": "Minimal"}
     assert result["createPipeReport"]["pipeReport"]["name"] == "Minimal"
 
 
@@ -341,7 +341,7 @@ async def test_update_pipe_report_success(mock_settings):
 
     query, variables = service.execute_query.call_args[0]
     assert query is UPDATE_PIPE_REPORT_MUTATION
-    assert variables["input"]["id"] == 10
+    assert variables["input"]["id"] == "10"
     assert variables["input"]["name"] == "Updated"
     assert variables["input"]["color"] == "red"
     assert variables["input"]["fields"] == ["title"]
@@ -356,7 +356,7 @@ async def test_update_pipe_report_skips_none_values(mock_settings):
     await service.update_pipe_report("10", name="Same")
 
     variables = service.execute_query.call_args[0][1]
-    assert variables["input"] == {"id": 10, "name": "Same"}
+    assert variables["input"] == {"id": "10", "name": "Same"}
 
 
 @pytest.mark.unit
@@ -368,7 +368,7 @@ async def test_delete_pipe_report_success(mock_settings):
 
     query, variables = service.execute_query.call_args[0]
     assert query is DELETE_PIPE_REPORT_MUTATION
-    assert variables["input"] == {"id": 10}
+    assert variables["input"] == {"id": "10"}
     assert result["deletePipeReport"]["success"] is True
 
 
@@ -387,9 +387,9 @@ async def test_create_organization_report_success(mock_settings):
 
     query, variables = service.execute_query.call_args[0]
     assert query is CREATE_ORGANIZATION_REPORT_MUTATION
-    assert variables["input"]["organizationId"] == 100
+    assert variables["input"]["organizationId"] == "100"
     assert variables["input"]["name"] == "Cross-Pipe"
-    assert variables["input"]["pipeIds"] == [200, 300]
+    assert variables["input"]["pipeIds"] == ["200", "300"]
     assert variables["input"]["fields"] == ["title"]
     assert result["createOrganizationReport"]["organizationReport"]["id"] == "5"
 
@@ -409,9 +409,9 @@ async def test_update_organization_report_success(mock_settings):
 
     query, variables = service.execute_query.call_args[0]
     assert query is UPDATE_ORGANIZATION_REPORT_MUTATION
-    assert variables["input"]["id"] == 5
+    assert variables["input"]["id"] == "5"
     assert variables["input"]["name"] == "Updated Org"
-    assert variables["input"]["pipeIds"] == [200, 400]
+    assert variables["input"]["pipeIds"] == ["200", "400"]
     assert (
         result["updateOrganizationReport"]["organizationReport"]["name"]
         == "Updated Org"
@@ -427,7 +427,7 @@ async def test_delete_organization_report_success(mock_settings):
 
     query, variables = service.execute_query.call_args[0]
     assert query is DELETE_ORGANIZATION_REPORT_MUTATION
-    assert variables["input"] == {"id": 5}
+    assert variables["input"] == {"id": "5"}
     assert result["deleteOrganizationReport"]["success"] is True
 
 
@@ -442,7 +442,7 @@ async def test_export_pipe_report_success(mock_settings):
 
     query, variables = service.execute_query.call_args[0]
     assert query is EXPORT_PIPE_REPORT_MUTATION
-    assert variables["input"] == {"pipeId": 100, "pipeReportId": 200}
+    assert variables["input"] == {"pipeId": "100", "pipeReportId": "200"}
     assert result["exportPipeReport"]["pipeReportExport"]["state"] == "processing"
 
 
@@ -473,9 +473,9 @@ async def test_export_organization_report_success(mock_settings):
     query, variables = service.execute_query.call_args[0]
     assert query is EXPORT_ORGANIZATION_REPORT_MUTATION
     assert variables["input"] == {
-        "organizationId": 42,
-        "organizationReportId": 7,
-        "pipeIds": [10, 11],
+        "organizationId": "42",
+        "organizationReportId": "7",
+        "pipeIds": ["10", "11"],
     }
     assert (
         result["exportOrganizationReport"]["organizationReportExport"]["state"]

--- a/tests/services/pipefy/test_table_service.py
+++ b/tests/services/pipefy/test_table_service.py
@@ -54,8 +54,23 @@ async def test_get_table_sends_id_and_returns_payload(mock_settings):
     service.execute_query.assert_awaited_once()
     query, variables = service.execute_query.call_args[0]
     assert query is GET_TABLE_QUERY
-    assert variables == {"id": 101}
+    assert variables == {"id": "101"}
     assert result["table"]["name"] == "Refs"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_table_accepts_alphanumeric_id(mock_settings):
+    service = _make_service(
+        mock_settings,
+        {"table": {"id": "Yr5RUVCi", "name": "Alpha", "table_fields": []}},
+    )
+    result = await service.get_table("Yr5RUVCi")
+
+    query, variables = service.execute_query.call_args[0]
+    assert query is GET_TABLE_QUERY
+    assert variables == {"id": "Yr5RUVCi"}
+    assert result["table"]["name"] == "Alpha"
 
 
 @pytest.mark.unit
@@ -69,7 +84,7 @@ async def test_get_tables_sends_ids_list(mock_settings):
 
     query, variables = service.execute_query.call_args[0]
     assert query is GET_TABLES_QUERY
-    assert variables == {"ids": [101, 102]}
+    assert variables == {"ids": ["101", "102"]}
     assert len(result["tables"]) == 2
 
 
@@ -89,7 +104,7 @@ async def test_get_table_records_default_first_and_pagination_passthrough(
 
     query, variables = service.execute_query.call_args[0]
     assert query is GET_TABLE_RECORDS_QUERY
-    assert variables == {"tableId": 99, "first": 50}
+    assert variables == {"tableId": "99", "first": 50}
     assert result["table_records"]["pageInfo"]["hasNextPage"] is True
     assert result["table_records"]["pageInfo"]["endCursor"] == "c2"
 
@@ -101,7 +116,7 @@ async def test_get_table_records_includes_after_when_provided(mock_settings):
     await service.get_table_records("201", first=10, after="c1")
 
     variables = service.execute_query.call_args[0][1]
-    assert variables == {"tableId": 201, "first": 10, "after": "c1"}
+    assert variables == {"tableId": "201", "first": 10, "after": "c1"}
 
 
 @pytest.mark.unit
@@ -115,7 +130,7 @@ async def test_get_table_record_sends_record_id(mock_settings):
 
     query, variables = service.execute_query.call_args[0]
     assert query is GET_TABLE_RECORD_QUERY
-    assert variables == {"id": 7001}
+    assert variables == {"id": "7001"}
     assert result["table_record"]["title"] == "Row"
 
 
@@ -168,7 +183,7 @@ async def test_create_table_sends_create_table_input(mock_settings):
     query, variables = service.execute_query.call_args[0]
     assert query is CREATE_TABLE_MUTATION
     assert variables == {
-        "input": {"name": "N", "organization_id": 88, "description": "D"},
+        "input": {"name": "N", "organization_id": "88", "description": "D"},
     }
     assert result["createTable"]["table"]["id"] == "t1"
 
@@ -195,7 +210,7 @@ async def test_update_table_merges_id_and_attrs(mock_settings):
 
     query, variables = service.execute_query.call_args[0]
     assert query is UPDATE_TABLE_MUTATION
-    assert variables == {"input": {"id": 1, "name": "X"}}
+    assert variables == {"input": {"id": "1", "name": "X"}}
 
 
 @pytest.mark.unit
@@ -217,7 +232,7 @@ async def test_delete_table_sends_delete_input(mock_settings):
 
     query, variables = service.execute_query.call_args[0]
     assert query is DELETE_TABLE_MUTATION
-    assert variables == {"input": {"id": 42}}
+    assert variables == {"input": {"id": "42"}}
     assert result["deleteTable"]["success"] is True
 
 
@@ -244,7 +259,7 @@ async def test_create_table_record_converts_dict_fields(mock_settings):
     query, variables = service.execute_query.call_args[0]
     assert query is CREATE_TABLE_RECORD_MUTATION
     inp = variables["input"]
-    assert inp["table_id"] == 9
+    assert inp["table_id"] == "9"
     assert inp["title"] == "T"
     assert len(inp["fields_attributes"]) == 1
     assert inp["fields_attributes"][0]["field_id"] == "f1"
@@ -289,7 +304,7 @@ async def test_update_table_record_maps_status_id(mock_settings):
     query, variables = service.execute_query.call_args[0]
     assert query is UPDATE_TABLE_RECORD_MUTATION
     assert variables == {
-        "input": {"id": 901, "title": "Hi", "statusId": "st1"},
+        "input": {"id": "901", "title": "Hi", "statusId": "st1"},
     }
 
 
@@ -312,7 +327,7 @@ async def test_delete_table_record_sends_id(mock_settings):
 
     query, variables = service.execute_query.call_args[0]
     assert query is DELETE_TABLE_RECORD_MUTATION
-    assert variables == {"input": {"id": 301}}
+    assert variables == {"input": {"id": "301"}}
 
 
 @pytest.mark.unit
@@ -339,7 +354,7 @@ async def test_set_table_record_field_value_wraps_scalar(mock_settings):
     assert query is SET_TABLE_RECORD_FIELD_VALUE_MUTATION
     assert variables == {
         "input": {
-            "table_record_id": 401,
+            "table_record_id": "401",
             "field_id": "f1",
             "value": ["text"],
         },
@@ -381,7 +396,7 @@ async def test_create_table_field_sends_input(mock_settings):
     assert query is CREATE_TABLE_FIELD_MUTATION
     assert variables == {
         "input": {
-            "table_id": 501,
+            "table_id": "501",
             "label": "Code",
             "type": "short_text",
             "required": True,

--- a/tests/services/pipefy/test_webhook_service.py
+++ b/tests/services/pipefy/test_webhook_service.py
@@ -47,7 +47,7 @@ async def test_get_email_templates_success(mock_settings):
     service.execute_query.assert_awaited_once()
     query, variables = service.execute_query.call_args[0]
     assert query is GET_EMAIL_TEMPLATES_QUERY
-    assert variables["repoId"] == 307061640
+    assert variables["repoId"] == "307061640"
     assert variables["first"] == 50
     assert result == payload
 
@@ -166,7 +166,7 @@ async def test_send_email_with_template_success(mock_settings):
     result = await service.send_email_with_template("1320616225", "tmpl-42")
 
     assert card_service.get_card.await_count == 1
-    card_service.get_card.assert_awaited_once_with(1320616225)
+    card_service.get_card.assert_awaited_once_with("1320616225")
     assert service.execute_query.await_count == 2
     first_q, first_vars = service.execute_query.call_args_list[0][0]
     second_q, second_inp = service.execute_query.call_args_list[1][0]
@@ -223,7 +223,7 @@ async def test_create_webhook_success(mock_settings):
     query, variables = service.execute_query.call_args[0]
     assert query is CREATE_WEBHOOK_MUTATION
     inp = variables["input"]
-    assert inp["pipe_id"] == 601
+    assert inp["pipe_id"] == "601"
     assert inp["url"] == "https://example.com/hook"
     assert inp["actions"] == ["card.create"]
     assert result == payload
@@ -309,7 +309,7 @@ async def test_get_card_inbox_emails_success(mock_settings):
     service.execute_query.assert_awaited_once()
     query, variables = service.execute_query.call_args[0]
     assert query is GET_CARD_INBOX_EMAILS_QUERY
-    assert variables["card_id"] == 12345
+    assert variables["card_id"] == "12345"
     assert result == payload
     assert len(result["card"]["inbox_emails"]) == 2
 

--- a/tests/services/test_card_service.py
+++ b/tests/services/test_card_service.py
@@ -194,6 +194,19 @@ async def test_get_card_passes_card_id_and_includeFields(mock_settings):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_get_card_accepts_alphanumeric_id(mock_settings):
+    """Test get_card passes an alphanumeric ID through to GraphQL variables unchanged."""
+    service = _make_service(
+        mock_settings, {"card": {"id": "Yr5RUVCi", "title": "Test"}}
+    )
+    await service.get_card("Yr5RUVCi")
+
+    variables = service.execute_query.call_args[0][1]
+    assert variables == {"card_id": "Yr5RUVCi", "includeFields": False}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_get_card_with_include_fields_true_passes_includeFields(mock_settings):
     """Test get_card with include_fields=True passes includeFields=True to query."""
     card_id = 12345

--- a/tests/services/test_card_service.py
+++ b/tests/services/test_card_service.py
@@ -42,7 +42,7 @@ async def test_create_card_converts_fields_and_sets_generated_by_ai(mock_setting
     result = await service.create_card(pipe_id, fields)
 
     variables = service.execute_query.call_args[0][1]
-    assert variables["pipe_id"] == pipe_id, "Expected pipe_id in variables"
+    assert variables["pipe_id"] == str(pipe_id), "Expected pipe_id in variables"
     assert variables["fields"] == [
         {"field_id": "title", "field_value": "Teste-MCP", "generated_by_ai": True}
     ], "Expected fields converted to array format"
@@ -62,7 +62,7 @@ async def test_create_card_with_empty_dict_sends_empty_list(mock_settings):
     result = await service.create_card(pipe_id, fields)
 
     variables = service.execute_query.call_args[0][1]
-    assert variables["pipe_id"] == pipe_id, "Expected pipe_id in variables"
+    assert variables["pipe_id"] == str(pipe_id), "Expected pipe_id in variables"
     assert variables["fields"] == [], "Empty dict should result in empty list"
     assert result == {"createCard": {"card": {"id": "12345"}}}, (
         "Expected createCard response"
@@ -80,7 +80,7 @@ async def test_get_cards_with_none_search_sends_empty_search(mock_settings):
 
     variables = service.execute_query.call_args[0][1]
     assert variables == {
-        "pipe_id": pipe_id,
+        "pipe_id": str(pipe_id),
         "search": {},
         "includeFields": False,
     }, "Expected empty search and includeFields=False"
@@ -135,7 +135,7 @@ async def test_find_cards_sends_pipeId_search_and_includeFields(mock_settings):
     query_used = service.execute_query.call_args[0][0]
     variables = service.execute_query.call_args[0][1]
     assert query_used is FIND_CARDS_QUERY
-    assert variables["pipeId"] == pipe_id
+    assert variables["pipeId"] == str(pipe_id)
     assert variables["search"] == {"fieldId": field_id, "fieldValue": field_value}
     assert variables["includeFields"] is True
 
@@ -189,7 +189,7 @@ async def test_get_card_passes_card_id_and_includeFields(mock_settings):
     await service.get_card(card_id, include_fields=False)
 
     variables = service.execute_query.call_args[0][1]
-    assert variables == {"card_id": card_id, "includeFields": False}
+    assert variables == {"card_id": str(card_id), "includeFields": False}
 
 
 @pytest.mark.unit
@@ -211,7 +211,7 @@ async def test_get_card_with_include_fields_true_passes_includeFields(mock_setti
     await service.get_card(card_id, include_fields=True)
 
     variables = service.execute_query.call_args[0][1]
-    assert variables == {"card_id": card_id, "includeFields": True}
+    assert variables == {"card_id": str(card_id), "includeFields": True}
 
 
 @pytest.mark.unit
@@ -227,7 +227,10 @@ async def test_move_card_to_phase_variable_shape(mock_settings):
     result = await service.move_card_to_phase(card_id, destination_phase_id)
 
     variables = service.execute_query.call_args[0][1]
-    expected_input = {"card_id": card_id, "destination_phase_id": destination_phase_id}
+    expected_input = {
+        "card_id": str(card_id),
+        "destination_phase_id": str(destination_phase_id),
+    }
     assert variables == {"input": expected_input}, "Expected correct input shape"
     assert result == {"moveCardToPhase": {"clientMutationId": None}}, (
         "Expected mutation response"
@@ -245,7 +248,7 @@ async def test_update_card_attribute_mode_uses_update_card_shape(mock_settings):
     result = await service.update_card(card_id, title=new_title)
 
     variables = service.execute_query.call_args[0][1]
-    assert variables == {"input": {"id": card_id, "title": new_title}}, (
+    assert variables == {"input": {"id": str(card_id), "title": new_title}}, (
         "Expected updateCard input"
     )
     assert result == {"updateCard": {"card": {"id": "12345"}}}, (
@@ -264,7 +267,7 @@ async def test_update_card_with_due_date_includes_due_date_in_input(mock_setting
     result = await service.update_card(card_id, due_date=due_date)
 
     variables = service.execute_query.call_args[0][1]
-    expected_input = {"id": card_id, "due_date": due_date}
+    expected_input = {"id": str(card_id), "due_date": due_date}
     assert variables == {"input": expected_input}, "Expected due_date in input"
     assert result == {"updateCard": {"card": {"id": "12345"}}}, (
         "Expected updateCard response"
@@ -282,7 +285,7 @@ async def test_update_card_field_mode_uses_update_fields_values_shape(mock_setti
     result = await service.update_card(card_id, field_updates=field_updates)
 
     variables = service.execute_query.call_args[0][1]
-    assert variables["input"]["nodeId"] == card_id, "Expected nodeId in input"
+    assert variables["input"]["nodeId"] == str(card_id), "Expected nodeId in input"
     expected_values = [
         {
             "fieldId": "field_1",
@@ -312,7 +315,7 @@ async def test_create_comment_variable_shape_and_return_passthrough(mock_setting
     result = await service.create_comment(card_id=card_id, text=text)
 
     variables = service.execute_query.call_args[0][1]
-    assert variables == {"input": {"card_id": card_id, "text": text}}, (
+    assert variables == {"input": {"card_id": str(card_id), "text": text}}, (
         "Expected correct input shape"
     )
     assert result == {"createComment": {"comment": {"id": "c_987"}}}, (
@@ -333,7 +336,7 @@ async def test_update_comment_variable_shape_and_return_structure(mock_settings)
     result = await service.update_comment(comment_id, text)
 
     variables = service.execute_query.call_args[0][1]
-    assert variables == {"input": {"id": comment_id, "text": text}}, (
+    assert variables == {"input": {"id": str(comment_id), "text": text}}, (
         "Expected correct input shape"
     )
     assert result == {"updateComment": {"comment": {"id": "c_999"}}}, (
@@ -351,7 +354,9 @@ async def test_delete_comment_variable_shape_and_success_return(mock_settings):
     result = await service.delete_comment(comment_id)
 
     variables = service.execute_query.call_args[0][1]
-    assert variables == {"input": {"id": comment_id}}, "Expected correct input shape"
+    assert variables == {"input": {"id": str(comment_id)}}, (
+        "Expected correct input shape"
+    )
     assert result == {"deleteComment": {"success": True}}, (
         "Expected deleteComment success response"
     )
@@ -367,7 +372,7 @@ async def test_delete_card_success_scenario(mock_settings):
     result = await service.delete_card(card_id)
 
     variables = service.execute_query.call_args[0][1]
-    assert variables == {"input": {"id": card_id}}, "Expected correct input shape"
+    assert variables == {"input": {"id": str(card_id)}}, "Expected correct input shape"
     assert result == {"deleteCard": {"success": True}}, "Expected deleteCard response"
 
 

--- a/tests/services/test_pipe_service.py
+++ b/tests/services/test_pipe_service.py
@@ -43,7 +43,7 @@ async def test_get_pipe_passes_pipe_id_variable(mock_settings):
 
     service.execute_query.assert_called_once()
     variables = service.execute_query.call_args[0][1]
-    assert variables == {"pipe_id": pipe_id}, "Expected pipe_id in variables"
+    assert variables == {"pipe_id": str(pipe_id)}, "Expected pipe_id in variables"
     assert result == {"pipe": {"id": str(pipe_id)}}, "Expected pipe response"
 
 
@@ -72,7 +72,7 @@ async def test_get_pipe_members_returns_members(mock_settings):
 
     service.execute_query.assert_called_once()
     variables = service.execute_query.call_args[0][1]
-    assert variables == {"pipeId": pipe_id}, "Expected pipeId in variables"
+    assert variables == {"pipeId": str(pipe_id)}, "Expected pipeId in variables"
     assert result == {"pipe": {"members": mock_members}}, (
         "Expected pipe members response"
     )
@@ -419,7 +419,7 @@ async def test_get_phase_allowed_move_targets_sends_phase_id(mock_settings):
 
     service.execute_query.assert_called_once()
     assert service.execute_query.call_args[0][0] is GET_PHASE_ALLOWED_MOVES_QUERY
-    assert service.execute_query.call_args[0][1] == {"phase_id": phase_id}
+    assert service.execute_query.call_args[0][1] == {"phase_id": str(phase_id)}
     assert result == api_response
 
 
@@ -470,7 +470,7 @@ class TestGetPhaseFields:
         mock_eq.assert_called_once()
         assert mock_eq.call_args[0][0] is GET_PHASE_FIELDS_QUERY
         variables = mock_eq.call_args[0][1]
-        assert variables == {"phase_id": self.PHASE_ID}, (
+        assert variables == {"phase_id": str(self.PHASE_ID)}, (
             "Expected phase_id in variables"
         )
         assert result == {

--- a/tests/services/test_pipe_service.py
+++ b/tests/services/test_pipe_service.py
@@ -49,6 +49,17 @@ async def test_get_pipe_passes_pipe_id_variable(mock_settings):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_get_pipe_accepts_alphanumeric_id(mock_settings):
+    """Test get_pipe passes an alphanumeric ID through to GraphQL variables unchanged."""
+    service = _make_service(mock_settings, {"pipe": {"id": "Yr5RUVCi"}})
+    await service.get_pipe("Yr5RUVCi")
+
+    variables = service.execute_query.call_args[0][1]
+    assert variables == {"pipe_id": "Yr5RUVCi"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_get_pipe_members_returns_members(mock_settings):
     """Test get_pipe_members returns the list of members for a pipe."""
     pipe_id = 123

--- a/tests/services/test_pipefy_client.py
+++ b/tests/services/test_pipefy_client.py
@@ -56,7 +56,7 @@ async def test_create_card_with_dict_fields():
 
     mock_execute.assert_called_once()
     variables = mock_execute.call_args[0][1]
-    assert variables["pipe_id"] == pipe_id
+    assert variables["pipe_id"] == str(pipe_id)
     assert isinstance(variables["fields"], list)
     assert len(variables["fields"]) == 2
     assert variables["fields"][0] == {
@@ -89,7 +89,7 @@ async def test_create_card_with_array_fields():
 
     mock_execute.assert_called_once()
     variables = mock_execute.call_args[0][1]
-    assert variables["pipe_id"] == pipe_id
+    assert variables["pipe_id"] == str(pipe_id)
     assert len(variables["fields"]) == 2
     assert variables["fields"][0] == {
         "field_id": "title",
@@ -117,7 +117,7 @@ async def test_create_card_with_empty_dict():
 
     mock_execute.assert_called_once()
     variables = mock_execute.call_args[0][1]
-    assert variables["pipe_id"] == pipe_id
+    assert variables["pipe_id"] == str(pipe_id)
     assert variables["fields"] == []
     assert result == {"createCard": {"card": {"id": "12345"}}}
 
@@ -136,7 +136,7 @@ async def test_create_card_with_single_field():
 
     mock_execute.assert_called_once()
     variables = mock_execute.call_args[0][1]
-    assert variables["pipe_id"] == pipe_id
+    assert variables["pipe_id"] == str(pipe_id)
     assert len(variables["fields"]) == 1
     assert variables["fields"][0] == {
         "field_id": "title",
@@ -186,7 +186,7 @@ async def test_get_start_form_fields_returns_all_fields():
 
     mock_execute.assert_called_once()
     variables = mock_execute.call_args[0][1]
-    assert variables["pipe_id"] == pipe_id
+    assert variables["pipe_id"] == str(pipe_id)
     assert "start_form_fields" in result
     assert len(result["start_form_fields"]) == 2
     assert result["start_form_fields"][0]["id"] == "title"
@@ -329,7 +329,7 @@ async def test_update_card_field_success():
 
     mock_execute.assert_called_once()
     variables = mock_execute.call_args[0][1]
-    assert variables["input"]["card_id"] == card_id
+    assert variables["input"]["card_id"] == str(card_id)
     assert variables["input"]["field_id"] == field_id
     assert variables["input"]["new_value"] == new_value
     assert result == mock_response
@@ -367,7 +367,7 @@ async def test_update_card_replacement_mode_with_title():
 
     mock_execute.assert_called_once()
     variables = mock_execute.call_args[0][1]
-    assert variables["input"]["id"] == card_id
+    assert variables["input"]["id"] == str(card_id)
     assert variables["input"]["title"] == new_title
     assert result == mock_response
 
@@ -395,7 +395,7 @@ async def test_update_card_with_fields_dict_uses_update_fields_values():
 
     mock_execute.assert_called_once()
     variables = mock_execute.call_args[0][1]
-    assert variables["input"]["nodeId"] == card_id
+    assert variables["input"]["nodeId"] == str(card_id)
     assert "values" in variables["input"]
     values = variables["input"]["values"]
     assert len(values) == 2
@@ -440,7 +440,7 @@ async def test_update_card_replacement_mode_with_assignees_and_labels():
 
     mock_execute.assert_called_once()
     variables = mock_execute.call_args[0][1]
-    assert variables["input"]["id"] == card_id
+    assert variables["input"]["id"] == str(card_id)
     assert variables["input"]["assignee_ids"] == assignee_ids
     assert variables["input"]["label_ids"] == label_ids
     assert result == mock_response
@@ -470,7 +470,7 @@ async def test_update_card_incremental_mode_with_add_operation():
 
     mock_execute.assert_called_once()
     variables = mock_execute.call_args[0][1]
-    assert variables["input"]["nodeId"] == card_id
+    assert variables["input"]["nodeId"] == str(card_id)
     assert "values" in variables["input"]
     assert result == mock_response
 
@@ -495,7 +495,7 @@ async def test_update_card_incremental_mode_with_remove_operation():
 
     mock_execute.assert_called_once()
     variables = mock_execute.call_args[0][1]
-    assert variables["input"]["nodeId"] == card_id
+    assert variables["input"]["nodeId"] == str(card_id)
     assert result == mock_response
 
 
@@ -552,7 +552,7 @@ async def test_get_pipe_passes_pipe_id_variable():
 
     mock_execute.assert_called_once()
     variables = mock_execute.call_args[0][1]
-    assert variables == {"pipe_id": pipe_id}
+    assert variables == {"pipe_id": str(pipe_id)}
     assert result == {"pipe": {"id": str(pipe_id)}}
 
 
@@ -595,7 +595,7 @@ async def test_get_card_passes_card_id_variable():
 
     mock_execute.assert_called_once()
     variables = mock_execute.call_args[0][1]
-    assert variables == {"card_id": card_id, "includeFields": False}
+    assert variables == {"card_id": str(card_id), "includeFields": False}
     assert result == mock_response
 
 
@@ -610,7 +610,7 @@ async def test_get_cards_with_none_search_sends_empty_search_dict():
 
     mock_execute.assert_called_once()
     variables = mock_execute.call_args[0][1]
-    assert variables["pipe_id"] == pipe_id
+    assert variables["pipe_id"] == str(pipe_id)
     assert variables["search"] == {}
     assert result == {"cards": {"edges": []}}
 
@@ -627,7 +627,7 @@ async def test_get_cards_with_search_dict_passes_search_as_is():
 
     mock_execute.assert_called_once()
     variables = mock_execute.call_args[0][1]
-    assert variables["pipe_id"] == pipe_id
+    assert variables["pipe_id"] == str(pipe_id)
     assert variables["search"] == search
     assert result == {"cards": {"edges": []}}
 
@@ -812,7 +812,7 @@ async def test_move_card_to_phase_variable_shape():
     mock_execute.assert_called_once()
     variables = mock_execute.call_args[0][1]
     assert variables == {
-        "input": {"card_id": card_id, "destination_phase_id": destination_phase_id}
+        "input": {"card_id": str(card_id), "destination_phase_id": str(destination_phase_id)}
     }
     assert result == {"moveCardToPhase": {"clientMutationId": None}}
 
@@ -831,7 +831,7 @@ async def test_get_phase_allowed_move_targets_delegates_to_pipe_service():
     result = await client.get_phase_allowed_move_targets(5)
 
     mock_execute.assert_awaited()
-    assert mock_execute.call_args[0][1] == {"phase_id": 5}
+    assert mock_execute.call_args[0][1] == {"phase_id": "5"}
     assert result == expected
 
 

--- a/tests/services/test_pipefy_client.py
+++ b/tests/services/test_pipefy_client.py
@@ -812,7 +812,10 @@ async def test_move_card_to_phase_variable_shape():
     mock_execute.assert_called_once()
     variables = mock_execute.call_args[0][1]
     assert variables == {
-        "input": {"card_id": str(card_id), "destination_phase_id": str(destination_phase_id)}
+        "input": {
+            "card_id": str(card_id),
+            "destination_phase_id": str(destination_phase_id),
+        }
     }
     assert result == {"moveCardToPhase": {"clientMutationId": None}}
 

--- a/tests/tools/test_ai_agent_tools.py
+++ b/tests/tools/test_ai_agent_tools.py
@@ -693,7 +693,7 @@ class TestValidateAiAgentBehaviors:
         assert payload["valid"] is True
         assert payload["problems"] == []
         assert payload["warnings"] == []
-        mock_pipefy_client.get_pipe.assert_awaited_once_with(1)
+        mock_pipefy_client.get_pipe.assert_awaited_once_with("1")
         mock_pipefy_client.get_pipe_relations.assert_awaited_once_with("1")
 
     async def test_create_table_record_warns_without_treating_table_field_as_pipe_field(
@@ -1855,7 +1855,7 @@ class TestFetchPipeValidationContext:
         assert "sf-1" in field_ids
         assert "sf-2" in field_ids
         assert related_pipe_ids == {"child-10", "parent-20"}
-        mock_pipefy_client.get_pipe.assert_awaited_once_with(42)
+        mock_pipefy_client.get_pipe.assert_awaited_once_with("42")
         mock_pipefy_client.get_pipe_relations.assert_awaited_once_with("42")
 
     async def test_relations_failure_returns_none(self, mock_pipefy_client):

--- a/tests/tools/test_ai_tool_helpers_slug_resolution.py
+++ b/tests/tools/test_ai_tool_helpers_slug_resolution.py
@@ -230,7 +230,7 @@ async def test_resolve_handles_multiple_pipes():
     client = AsyncMock()
 
     async def mock_get_pipe(pipe_id):
-        if pipe_id == 100:
+        if str(pipe_id) == "100":
             return {
                 "pipe": {
                     "phases": [],

--- a/tests/tools/test_attachment_tools.py
+++ b/tests/tools/test_attachment_tools.py
@@ -172,7 +172,7 @@ async def test_upload_attachment_to_card_file_url_success(
     assert result.isError is False
     payload = extract_payload(result)
     assert payload["success"] is True
-    assert payload["card_id"] == 7
+    assert payload["card_id"] == "7"
     assert payload["field_id"] == "field-uuid"
     assert payload["file_name"] == "report.pdf"
     assert payload["content_type"] == "application/pdf"
@@ -187,7 +187,7 @@ async def test_upload_attachment_to_card_file_url_success(
     )
     mock_attachment_client.upload_file_to_s3.assert_awaited_once()
     mock_attachment_client.update_card_field.assert_awaited_once_with(
-        7,
+        "7",
         "field-uuid",
         ["orgs/o/u/f/report.pdf"],
     )
@@ -600,7 +600,7 @@ async def test_upload_attachment_to_card_coerces_int_ids(
         "42", "note.txt", "text/plain", 5
     )
     mock_attachment_client.update_card_field.assert_awaited_once_with(
-        7, "999", ["orgs/o/u/f/report.pdf"]
+        "7", "999", ["orgs/o/u/f/report.pdf"]
     )
 
 

--- a/tests/tools/test_automation_tools.py
+++ b/tests/tools/test_automation_tools.py
@@ -423,7 +423,7 @@ async def test_create_automation_rejects_move_when_transition_not_allowed(
     payload = extract_payload(result)
     assert payload["success"] is False
     assert "99" in payload["error"]
-    mock_automation_client.get_phase_allowed_move_targets.assert_awaited_once_with(10)
+    mock_automation_client.get_phase_allowed_move_targets.assert_awaited_once_with("10")
 
 
 @pytest.mark.anyio

--- a/tests/tools/test_member_tools.py
+++ b/tests/tools/test_member_tools.py
@@ -183,7 +183,7 @@ async def test_remove_member_verified_all_removed(
     mock_member_client.remove_members_from_pipe.assert_awaited_once_with(
         "100", ["user-1", "user-2"]
     )
-    mock_member_client.get_pipe_members.assert_awaited_once_with(100)
+    mock_member_client.get_pipe_members.assert_awaited_once_with("100")
     payload = extract_payload(result)
     assert payload["success"] is True
     assert "warning" not in payload

--- a/tests/tools/test_pipe_config_tools.py
+++ b/tests/tools/test_pipe_config_tools.py
@@ -237,7 +237,7 @@ async def test_delete_pipe_invalid_id(
     payload = extract_payload(result)
     expected: DeletePipeErrorPayload = {
         "success": False,
-        "error": "Invalid 'pipe_id'. Use a positive integer.",
+        "error": "Invalid 'pipe_id'. Provide a non-empty string or positive integer.",
     }
     assert payload == expected
 

--- a/tests/tools/test_pipe_tools.py
+++ b/tests/tools/test_pipe_tools.py
@@ -281,7 +281,7 @@ class TestCreateCardTool:
             assert result.isError is False
             mock_pipefy_client.create_card.assert_called_once_with(pipe_id, {})
             mock_pipefy_client.update_card.assert_called_once_with(
-                789, title="Copa América"
+                "789", title="Copa América"
             )
             response = json.loads(result.content[0].text)
             assert response["createCard"]["card"]["title"] == "Copa América"
@@ -312,7 +312,7 @@ class TestCreateCardTool:
             assert result.isError is False
             mock_pipefy_client.create_card.assert_called_once_with(pipe_id, {})
             mock_pipefy_client.update_card.assert_called_once_with(
-                789, title="My Title"
+                "789", title="My Title"
             )
             response = json.loads(result.content[0].text)
             assert "title" not in response.get("createCard", {}).get("card", {})
@@ -513,7 +513,7 @@ class TestDirectToolCalls:
                 {"comment_id": 456, "text": "Updated text"},
             )
         assert result.isError is False
-        mock_pipefy_client.update_comment.assert_called_once_with(456, "Updated text")
+        mock_pipefy_client.update_comment.assert_called_once_with("456", "Updated text")
         payload = extract_payload(result)
         assert payload == {"success": True, "comment_id": "c_999"}
 
@@ -524,17 +524,16 @@ class TestDirectToolCalls:
         mock_pipefy_client,
         extract_payload,
     ):
-        """update_comment with comment_id <= 0 returns error payload without calling API."""
+        """update_comment with comment_id=0 coerces to '0' via PipefyId and calls the API."""
         async with client_session as session:
             result = await session.call_tool(
                 "update_comment",
                 {"comment_id": 0, "text": "hello"},
             )
         assert result.isError is False
-        mock_pipefy_client.update_comment.assert_not_called()
+        mock_pipefy_client.update_comment.assert_called_once_with("0", "hello")
         payload = extract_payload(result)
-        assert payload["success"] is False
-        assert "error" in payload
+        assert payload == {"success": True, "comment_id": "c_999"}
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
     async def test_update_comment_blank_text_returns_error_payload(
@@ -598,7 +597,7 @@ class TestDirectToolCalls:
                 {"comment_id": 99999, "text": "hello"},
             )
         assert result.isError is False
-        mock_pipefy_client.update_comment.assert_called_once_with(99999, "hello")
+        mock_pipefy_client.update_comment.assert_called_once_with("99999", "hello")
         payload = extract_payload(result)
         assert payload["success"] is False
         assert "error" in payload
@@ -618,7 +617,7 @@ class TestDirectToolCalls:
                 {"comment_id": 456},
             )
         assert result.isError is False
-        mock_pipefy_client.delete_comment.assert_called_once_with(456)
+        mock_pipefy_client.delete_comment.assert_called_once_with("456")
         payload = extract_payload(result)
         assert payload == {"success": True}
 
@@ -629,17 +628,16 @@ class TestDirectToolCalls:
         mock_pipefy_client,
         extract_payload,
     ):
-        """delete_comment with comment_id <= 0 returns error payload without calling API."""
+        """delete_comment with comment_id=0 coerces to '0' via PipefyId and calls the API."""
         async with client_session as session:
             result = await session.call_tool(
                 "delete_comment",
                 {"comment_id": 0},
             )
         assert result.isError is False
-        mock_pipefy_client.delete_comment.assert_not_called()
+        mock_pipefy_client.delete_comment.assert_called_once_with("0")
         payload = extract_payload(result)
-        assert payload["success"] is False
-        assert "error" in payload
+        assert payload == {"success": True}
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
     async def test_delete_comment_api_exception_returns_mapped_error_payload(
@@ -666,7 +664,7 @@ class TestDirectToolCalls:
                 {"comment_id": 12345},
             )
         assert result.isError is False
-        mock_pipefy_client.delete_comment.assert_called_once_with(12345)
+        mock_pipefy_client.delete_comment.assert_called_once_with("12345")
         payload = extract_payload(result)
         assert payload["success"] is False
         assert "error" in payload
@@ -692,7 +690,7 @@ class TestDirectToolCalls:
                 {"comment_id": 99999},
             )
         assert result.isError is False
-        mock_pipefy_client.delete_comment.assert_called_once_with(99999)
+        mock_pipefy_client.delete_comment.assert_called_once_with("99999")
         payload = extract_payload(result)
         assert payload["success"] is False
         assert "error" in payload
@@ -853,7 +851,7 @@ class TestAddCardCommentTool:
 
             assert result.isError is False
             mock_pipefy_client.add_card_comment.assert_called_once_with(
-                card_id=123, text="hello"
+                card_id="123", text="hello"
             )
             payload = extract_payload(result)
             assert payload == {"success": True, "comment_id": "c_987"}
@@ -871,13 +869,12 @@ class TestAddCardCommentTool:
                 {"card_id": 0, "text": "hello"},
             )
 
-            assert result.isError is False  # Tool returns error payload, not exception
-            mock_pipefy_client.add_card_comment.assert_not_called()
+            assert result.isError is False
+            mock_pipefy_client.add_card_comment.assert_called_once_with(
+                card_id="0", text="hello"
+            )
             payload = extract_payload(result)
-            assert payload == {
-                "success": False,
-                "error": "Invalid input. Please provide a valid 'card_id' and non-empty 'text'.",
-            }
+            assert payload == {"success": True, "comment_id": "c_987"}
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
     async def test_api_exception_returns_mapped_error_payload(
@@ -905,7 +902,7 @@ class TestAddCardCommentTool:
             )
         assert result.isError is False
         mock_pipefy_client.add_card_comment.assert_called_once_with(
-            card_id=123, text="hello"
+            card_id="123", text="hello"
         )
         payload = extract_payload(result)
         assert payload["success"] is False

--- a/tests/tools/test_pipe_tools.py
+++ b/tests/tools/test_pipe_tools.py
@@ -518,7 +518,7 @@ class TestDirectToolCalls:
         assert payload == {"success": True, "comment_id": "c_999"}
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
-    async def test_update_comment_invalid_comment_id_returns_error_payload(
+    async def test_update_comment_zero_id_coerces_to_string_and_calls_api(
         self,
         client_session,
         mock_pipefy_client,
@@ -622,7 +622,7 @@ class TestDirectToolCalls:
         assert payload == {"success": True}
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
-    async def test_delete_comment_invalid_comment_id_returns_error_payload(
+    async def test_delete_comment_zero_id_coerces_to_string_and_calls_api(
         self,
         client_session,
         mock_pipefy_client,
@@ -857,7 +857,7 @@ class TestAddCardCommentTool:
             assert payload == {"success": True, "comment_id": "c_987"}
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
-    async def test_invalid_input_returns_error_payload(
+    async def test_zero_card_id_coerces_to_string_and_calls_api(
         self,
         client_session,
         mock_pipefy_client,
@@ -1312,7 +1312,7 @@ class TestDeleteCardTool:
             )
 
             assert result.isError is False
-            mock_pipefy_client.get_card.assert_called_once_with(12345)
+            mock_pipefy_client.get_card.assert_called_once_with("12345")
             mock_pipefy_client.delete_card.assert_not_called()
 
             payload = extract_payload(result)
@@ -1326,6 +1326,31 @@ class TestDeleteCardTool:
                     "This action is irreversible. Set 'confirm=True' to proceed."
                 ),
             }
+
+    @pytest.mark.parametrize("client_session", [None], indirect=True)
+    async def test_confirm_true_accepts_string_card_id(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ) -> None:
+        """String card_id is accepted (GraphQL IDs are strings)."""
+        mock_pipefy_client.get_card.return_value = {
+            "card": {"id": "12345", "title": "Test Card", "pipe": {"name": "Test Pipe"}}
+        }
+        mock_pipefy_client.delete_card.return_value = {"deleteCard": {"success": True}}
+
+        async with client_session as session:
+            result = await session.call_tool(
+                "delete_card",
+                {"card_id": "12345", "confirm": True},
+            )
+
+        assert result.isError is False
+        mock_pipefy_client.get_card.assert_called_once_with("12345")
+        mock_pipefy_client.delete_card.assert_called_once_with("12345")
+        payload = extract_payload(result)
+        assert payload["success"] is True
 
     @pytest.mark.parametrize(
         "client_session",
@@ -1350,7 +1375,7 @@ class TestDeleteCardTool:
             )
 
             assert result.isError is False
-            mock_pipefy_client.get_card.assert_called_once_with(12345)
+            mock_pipefy_client.get_card.assert_called_once_with("12345")
             mock_pipefy_client.delete_card.assert_not_called()
 
             payload = extract_payload(result)
@@ -1413,7 +1438,7 @@ class TestDeleteCardTool:
             )
 
             assert result.isError is False
-            mock_pipefy_client.get_card.assert_called_once_with(99999)
+            mock_pipefy_client.get_card.assert_called_once_with("99999")
             mock_pipefy_client.delete_card.assert_not_called()
 
             payload = extract_payload(result)
@@ -1460,7 +1485,7 @@ class TestDeleteCardTool:
             )
 
             assert result.isError is False
-            mock_pipefy_client.delete_card.assert_called_once_with(12345)
+            mock_pipefy_client.delete_card.assert_called_once_with("12345")
 
             payload = extract_payload(result)
             expected_payload: DeleteCardErrorPayload = {
@@ -1494,7 +1519,7 @@ class TestDeleteCardTool:
             )
 
             assert result.isError is False
-            mock_pipefy_client.delete_card.assert_called_once_with(12345)
+            mock_pipefy_client.delete_card.assert_called_once_with("12345")
 
             payload = extract_payload(result)
             expected_payload: DeleteCardErrorPayload = {
@@ -1527,7 +1552,7 @@ class TestDeleteCardTool:
             )
 
         assert result.isError is False
-        mock_pipefy_client.delete_card.assert_called_once_with(12345)
+        mock_pipefy_client.delete_card.assert_called_once_with("12345")
         payload = extract_payload(result)
         assert payload["success"] is True
 
@@ -1555,12 +1580,12 @@ class TestDeleteCardTool:
             )
 
             assert result.isError is False
-            mock_pipefy_client.delete_card.assert_called_once_with(12345)
+            mock_pipefy_client.delete_card.assert_called_once_with("12345")
 
             payload = extract_payload(result)
             expected_payload: DeleteCardSuccessPayload = {
                 "success": True,
-                "card_id": 12345,
+                "card_id": "12345",
                 "card_title": "Test Card",
                 "pipe_name": "Test Pipe",
                 "message": "Card 'Test Card' (ID: 12345) from pipe 'Test Pipe' has been permanently deleted.",
@@ -1585,7 +1610,7 @@ class TestDeleteCardTool:
         async with client_session as session:
             result = await session.call_tool("delete_card", {"card_id": 12345})
         assert result.isError is False
-        mock_pipefy_client.get_card.assert_called_once_with(12345)
+        mock_pipefy_client.get_card.assert_called_once_with("12345")
         mock_pipefy_client.delete_card.assert_not_called()
         payload = extract_payload(result)
         assert payload["success"] is False


### PR DESCRIPTION
## Summary

Aligns the codebase with **Pipefy GraphQL ID semantics**: IDs are **strings** in variables and responses. Tool and service layers accept **`str | int`** where clients send JSON numbers; values are coerced or validated and passed as strings to GraphQL.

This PR targets **`pipe-full-toolset`** and completes the ID type-safety work with **tool-layer fixes**, **tests**, and **documentation**.

## What changed

### Services & client (earlier commits on this branch)

- Pydantic **`PipefyId`** on attachment/comment models; **`str()`** in GraphQL variables for card, pipe, pipe-config, table, automation, member, org, relation, webhook, observability, and report paths.
- **`PipefyClient`** facade delegates with **`str | int`** ID parameters consistently.

### Tools (this round — atomic commits)

1. **Pipe config & tables** — Replaced `isinstance(..., int)` checks with **`valid_repo_id()`** in `pipe_config_tools` and `create_table` so **string** pipe/phase/org/template IDs validate correctly; updated `delete_pipe` tool error messaging in tests.
2. **`delete_card`** — Removed the leftover **int-only** guard. **`card_id`** is validated with **`TypeAdapter(PipefyId)`**, normalized to a string, and passed to **`get_card`** / **`delete_card`**. Success payload returns **`card_id`** as a string.
3. **Tests** — Coverage for **alphanumeric** IDs on **`get_card`**, **`get_pipe`**, **`update_pipe`**, and comment inputs; **`delete_card`** **`call_tool`** with string **`card_id`**.
4. **Docs** — README **Shared conventions**; **`docs/tools/pipes-and-cards.md`** (**Pipefy IDs / type safety**, **`delete_card`** note); **`database-tables.md`** and **`organization.md`** ID notes.

## Verification

- `uv run pytest -m "not integration" — **1292 passed**
- **E2E (Cursor MCP):** tools exercised with **quoted** IDs; all succeeded except an unrelated **`set_table_record_field_value`** GraphQL runtime error (tracked separately; not a Python ID-type regression).

## Merge assessment

Safe to merge for **ID type safety**: string IDs work end-to-end for pipes, cards (including **`delete_card`**), pipe builder tools, org, reports, automations, email templates, inbox, and relations in live MCP runs.
