### PR TITLE
fix(ai-agents): align behavior instructions with Pipefy %{field}/%{action} tokens

### DIFF
--- a/src/pipefy_mcp/services/pipefy/ai_agent_service.py
+++ b/src/pipefy_mcp/services/pipefy/ai_agent_service.py
@@ -30,7 +30,7 @@ from pipefy_mcp.settings import PipefySettings
 
 
 def inject_reference_ids(behaviors: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Deep-copy behaviors and assign a UUID ``referenceId`` per action; append ``%{action:<uuid>}`` to instruction.
+    """Deep-copy behaviors and assign a UUID ``referenceId`` per action; append ``%{action:<uuid>}`` lines to instruction.
 
     Args:
         behaviors: Behavior dicts with ``actionParams.aiBehaviorParams.actionsAttributes``.
@@ -107,9 +107,6 @@ class AiAgentService(BasePipefyClient):
 
     async def update_agent(self, agent_input: UpdateAiAgentInput) -> AgentServiceResult:
         """Update an AI Agent with instruction and behaviors.
-
-        Calls inject_reference_ids on behaviors before building the payload
-        so each action gets a fresh UUID v4 referenceId.
 
         Args:
             agent_input: Validated update input with uuid, name, repo_uuid, behaviors.

--- a/src/pipefy_mcp/tools/ai_agent_tools.py
+++ b/src/pipefy_mcp/tools/ai_agent_tools.py
@@ -24,6 +24,9 @@ from pipefy_mcp.tools.ai_tool_helpers import (
     resolve_field_slugs_to_numeric,
     validate_behaviors_against_pipe,
 )
+from pipefy_mcp.tools.behavior_placeholder_interpolation import (
+    expand_behaviors_placeholders,
+)
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.graphql_error_helpers import extract_error_strings
 from pipefy_mcp.tools.phase_transition_helpers import (
@@ -211,8 +214,14 @@ class AiAgentTools:
                 not accept ``update_card_field`` as an actionType for AI behaviors.
               - **``metadata: {}`` is never valid** for known action types — it causes
                 ``RECORD_NOT_SAVED``. Always include the required keys.
-              - The server injects ``referenceId`` UUIDs and ``%{action:<uuid>}`` placeholders
-                into each behavior's instruction automatically — do not set them manually.
+              - Behavior ``instruction``: use ``%{field:<internal_id>}``; slugs are rewritten to ids
+                when an action supplies ``pipeId``. ``%{action:<uuid>}`` lines are appended per action;
+                do not set ``referenceId`` manually. Bare ``{field:…}`` / ``{action:uuid}`` get a ``%``
+                prefix before the API call.
+            - **Template params:** per behavior you may pass ``template_params`` (or ``placeholders``)
+                with string values and use ``{{name}}`` in any string (instruction, metadata IDs, etc.).
+                Optionally set ``instruction_template`` instead of ``actionParams.aiBehaviorParams.instruction``
+                — the tool interpolates and writes the final instruction before calling the API.
 
             Args:
                 name: Agent display name.
@@ -221,6 +230,7 @@ class AiAgentTools:
                 behaviors: 1–5 behavior dicts. Each requires ``name``, ``event_id``, and
                     ``actionParams.aiBehaviorParams`` with a non-empty ``actionsAttributes`` list.
                     Optional: ``eventParams`` to filter event triggers (e.g. ``triggerFieldIds``, ``to_phase_id``).
+                    Optional: ``template_params`` / ``placeholders``, ``instruction_template``.
                     See example above for the full shape.
                 data_source_ids: Optional knowledge-source IDs (same as ``update_ai_agent``).
             """
@@ -236,11 +246,15 @@ class AiAgentTools:
             if not instruction or not instruction.strip():
                 return build_ai_tool_error("instruction must not be blank")
             try:
+                behaviors_expanded = expand_behaviors_placeholders(behaviors)
+            except ValueError as exc:
+                return build_ai_tool_error(str(exc))
+            try:
                 validated = CreateAiAgentInput(
                     name=name,
                     repo_uuid=repo_uuid,
                     instruction=instruction,
-                    behaviors=behaviors,
+                    behaviors=behaviors_expanded,
                     data_source_ids=data_source_ids or [],
                 )
             except ValidationError as exc:
@@ -249,7 +263,9 @@ class AiAgentTools:
             try:
                 create_result = await client.create_ai_agent(validated)
             except Exception as exc:  # noqa: BLE001
-                return build_ai_tool_error(enrich_behavior_error(exc, behaviors))
+                return build_ai_tool_error(
+                    enrich_behavior_error(exc, behaviors_expanded)
+                )
 
             agent_uuid = create_result["agent_uuid"]
 
@@ -270,7 +286,7 @@ class AiAgentTools:
             except Exception as exc:  # noqa: BLE001
                 return build_create_agent_partial_failure(
                     agent_uuid=agent_uuid,
-                    error=await _enrich_with_validation(exc, behaviors),
+                    error=await _enrich_with_validation(exc, behaviors_expanded),
                 )
 
             msg = f"AI Agent created and configured successfully. UUID: {agent_uuid}"
@@ -296,8 +312,8 @@ class AiAgentTools:
             full behavior dict example, discovery workflow, and constraints).
 
             To modify an existing agent: call ``get_ai_agent`` first, edit the returned config,
-            and send the full payload back. The server injects ``referenceId`` and ``%{action:<uuid>}``
-            placeholders automatically — do not set or preserve them from ``get_ai_agent``.
+            and send the full payload back. The server replaces ``referenceId`` and appends
+            ``%{action:<uuid>}`` lines to the instruction on each update (same as create flow).
 
             Known ``actionType`` values and their required ``metadata`` (same as ``create_ai_agent``):
               - ``move_card`` → ``{"destinationPhaseId": "<phase_id>"}``
@@ -321,6 +337,8 @@ class AiAgentTools:
                 behaviors: 1–5 behavior dicts. Same shape as ``create_ai_agent``: each needs ``name``,
                     ``event_id``, and ``actionParams.aiBehaviorParams.actionsAttributes``.
                     Accepts both ``snake_case`` and ``camelCase`` keys.
+                    Optional: ``template_params`` / ``placeholders`` and ``instruction_template``
+                    (same interpolation as ``create_ai_agent``).
                 data_source_ids: Optional list of data source IDs.
             """
             await ctx.debug(
@@ -332,7 +350,13 @@ class AiAgentTools:
                 return build_ai_tool_error("name must not be blank")
             if not repo_uuid or not repo_uuid.strip():
                 return build_ai_tool_error("repo_uuid must not be blank")
-            resolved_behaviors = await resolve_field_slugs_to_numeric(client, behaviors)
+            try:
+                behaviors_expanded = expand_behaviors_placeholders(behaviors)
+            except ValueError as exc:
+                return build_ai_tool_error(str(exc))
+            resolved_behaviors = await resolve_field_slugs_to_numeric(
+                client, behaviors_expanded
+            )
             try:
                 validated = UpdateAiAgentInput(
                     uuid=uuid,
@@ -532,11 +556,22 @@ class AiAgentTools:
             if not pid:
                 return build_ai_tool_error("pipe_id must not be blank")
 
+            try:
+                behaviors_expanded = expand_behaviors_placeholders(behaviors)
+            except ValueError as exc:
+                return {
+                    "success": True,
+                    "valid": False,
+                    "problems": [str(exc)],
+                    "warnings": [],
+                    "message": "Behavior placeholder expansion failed.",
+                }
+
             # Pydantic structural validation
             try:
                 from pipefy_mcp.models.ai_agent import BehaviorInput
 
-                for b in behaviors:
+                for b in behaviors_expanded:
                     BehaviorInput.model_validate(b)
             except ValidationError as exc:
                 return {
@@ -546,6 +581,8 @@ class AiAgentTools:
                     "warnings": [],
                     "message": "Behavior dicts failed structural validation (BehaviorInput).",
                 }
+
+            behaviors = behaviors_expanded
 
             try:
                 (

--- a/src/pipefy_mcp/tools/ai_tool_helpers.py
+++ b/src/pipefy_mcp/tools/ai_tool_helpers.py
@@ -429,6 +429,47 @@ def _extract_slug_field_ids_by_pipe(
     return slugs_by_pipe
 
 
+_INSTRUCTION_FIELD_TOKEN_RE = re.compile(r"%\{field:([^}]+)\}")
+
+
+def _instruction_has_non_numeric_field_tokens(instruction: str) -> bool:
+    for m in _INSTRUCTION_FIELD_TOKEN_RE.finditer(instruction):
+        if m.group(1) and not m.group(1).strip().isdigit():
+            return True
+    return False
+
+
+def _pipe_ids_from_behavior(behavior: dict[str, Any]) -> set[str]:
+    pids: set[str] = set()
+    ap = behavior.get("actionParams") or behavior.get("action_params") or {}
+    if not isinstance(ap, dict):
+        return pids
+    abp = ap.get("aiBehaviorParams") or ap.get("ai_behavior_params") or {}
+    if not isinstance(abp, dict):
+        return pids
+    for a in abp.get("actionsAttributes") or abp.get("actions_attributes") or []:
+        if not isinstance(a, dict):
+            continue
+        pid = str((a.get("metadata") or {}).get("pipeId", ""))
+        if pid:
+            pids.add(pid)
+    return pids
+
+
+def _rewrite_instruction_field_tokens(
+    instruction: str, slug_to_numeric: dict[str, str]
+) -> str:
+    def repl(m: re.Match[str]) -> str:
+        key = m.group(1).strip()
+        if key.isdigit():
+            return m.group(0)
+        if key in slug_to_numeric:
+            return f"%{{field:{slug_to_numeric[key]}}}"
+        return m.group(0)
+
+    return _INSTRUCTION_FIELD_TOKEN_RE.sub(repl, instruction)
+
+
 async def build_field_slug_map(
     client: PipefyClient,
     pipe_id: str | int,
@@ -477,28 +518,36 @@ async def resolve_field_slugs_to_numeric(
     client: PipefyClient,
     behaviors: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    """Replace slug fieldIds with numeric internal_ids in behavior metadata.
-
-    Scans ``fieldsAttributes[].fieldId`` across all behaviors for non-numeric values.
-    When found, fetches each target pipe's fields to build a slug→numeric map and
-    replaces matches. Returns a deep copy; the original ``behaviors`` list is not mutated.
-
-    Unresolvable slugs are left as-is (the API will reject them with the existing
-    enriched error).
+    """Resolve slug ``fieldId`` values and ``%{field:<slug>}`` tokens to numeric internal ids.
 
     Args:
         client: PipefyClient for fetching pipe field data.
         behaviors: Behavior dicts (same shape as ``create_ai_agent`` / ``update_ai_agent``).
 
     Returns:
-        Behaviors with slug fieldIds replaced by numeric IDs where resolvable.
+        New list when any pipe fetch ran; otherwise the original list. Unresolved slugs unchanged.
     """
     slugs_by_pipe = _extract_slug_field_ids_by_pipe(behaviors)
-    if not slugs_by_pipe:
+    pipes_needed: set[str] = set(slugs_by_pipe.keys())
+
+    for b in behaviors:
+        if not isinstance(b, dict):
+            continue
+        ap = b.get("actionParams") or b.get("action_params") or {}
+        if not isinstance(ap, dict):
+            continue
+        abp = ap.get("aiBehaviorParams") or ap.get("ai_behavior_params") or {}
+        if not isinstance(abp, dict):
+            continue
+        instr = abp.get("instruction")
+        if isinstance(instr, str) and _instruction_has_non_numeric_field_tokens(instr):
+            pipes_needed.update(_pipe_ids_from_behavior(b))
+
+    if not pipes_needed:
         return behaviors
 
     slug_to_numeric: dict[str, str] = {}
-    for pipe_id_str in slugs_by_pipe:
+    for pipe_id_str in pipes_needed:
         try:
             field_map = await build_field_slug_map(client, pipe_id_str)
             slug_to_numeric.update(field_map)
@@ -531,6 +580,12 @@ async def resolve_field_slugs_to_numeric(
                 fid = str(fa.get("fieldId", ""))
                 if fid in slug_to_numeric:
                     fa["fieldId"] = slug_to_numeric[fid]
+
+        instr = abp.get("instruction")
+        if isinstance(instr, str):
+            abp["instruction"] = _rewrite_instruction_field_tokens(
+                instr, slug_to_numeric
+            )
 
     return resolved
 

--- a/src/pipefy_mcp/tools/behavior_placeholder_interpolation.py
+++ b/src/pipefy_mcp/tools/behavior_placeholder_interpolation.py
@@ -1,0 +1,160 @@
+"""Optional ``{{name}}`` interpolation for AI behavior dicts; normalizes bare ``{field:…}`` / ``{action:uuid}`` to ``%{…}`` for Pipefy."""
+
+from __future__ import annotations
+
+import copy
+import re
+from typing import Any
+
+_PLACEHOLDER_RE = re.compile(r"\{\{([a-zA-Z_][a-zA-Z0-9_]*)\}\}")
+_PIPEFY_FIELD_REF = re.compile(r"(?<!\%)\{field:([^}]+)\}")
+_PIPEFY_ACTION_UUID = re.compile(
+    r"(?<!\%)\{action:([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12})\}"
+)
+
+_TEMPLATE_PARAM_SOURCE_KEYS = (
+    "template_params",
+    "templateParams",
+    "placeholders",
+)
+_INSTRUCTION_TEMPLATE_KEYS = frozenset(("instruction_template", "instructionTemplate"))
+
+
+def _string_params(params: dict[Any, Any]) -> dict[str, str]:
+    return {str(k): str(v) for k, v in params.items() if v is not None}
+
+
+def _merge_template_param_sources(behavior: dict[str, Any]) -> dict[str, str]:
+    merged: dict[str, str] = {}
+    for key in _TEMPLATE_PARAM_SOURCE_KEYS:
+        raw = behavior.pop(key, None)
+        if isinstance(raw, dict):
+            merged.update(_string_params(raw))
+    return merged
+
+
+def _substitute_in_string(text: str, params: dict[str, str]) -> str:
+    def repl(match: re.Match[str]) -> str:
+        name = match.group(1)
+        if name not in params:
+            msg = (
+                f"Missing template parameter '{name}' for {{{{{name}}}}} "
+                "(set template_params / placeholders on this behavior)."
+            )
+            raise ValueError(msg)
+        return params[name]
+
+    return _PLACEHOLDER_RE.sub(repl, text)
+
+
+def _deep_interpolate(obj: Any, params: dict[str, str]) -> Any:
+    if isinstance(obj, str):
+        if "{{" in obj and not params:
+            raise ValueError(
+                "Behavior strings contain {{placeholders}} but no template_params "
+                "(or placeholders) dict was provided on this behavior."
+            )
+        return _substitute_in_string(obj, params) if params else obj
+    if isinstance(obj, list):
+        return [_deep_interpolate(item, params) for item in obj]
+    if isinstance(obj, dict):
+        return {k: _deep_interpolate(v, params) for k, v in obj.items()}
+    return obj
+
+
+def normalize_pipefy_ai_instruction_tokens(text: str) -> str:
+    """Prefix ``{field:…}`` and ``{action:<uuid>}`` with ``%`` when missing (Pipefy instruction syntax).
+
+    Args:
+        text: ``aiBehaviorParams.instruction`` value (or fragment).
+    """
+    if not text:
+        return text
+    out = _PIPEFY_FIELD_REF.sub(r"%{field:\1}", text)
+    return _PIPEFY_ACTION_UUID.sub(r"%{action:\1}", out)
+
+
+def _normalize_instruction_in_behavior(behavior: dict[str, Any]) -> None:
+    ap = behavior.get("actionParams") or behavior.get("action_params")
+    if not isinstance(ap, dict):
+        return
+    abp = ap.get("aiBehaviorParams") or ap.get("ai_behavior_params")
+    if not isinstance(abp, dict):
+        return
+    instr = abp.get("instruction")
+    if isinstance(instr, str) and instr:
+        abp["instruction"] = normalize_pipefy_ai_instruction_tokens(instr)
+
+
+def _ensure_ai_behavior_instruction(behavior: dict[str, Any], instruction: str) -> None:
+    ap = behavior.get("actionParams") or behavior.get("action_params")
+    if not isinstance(ap, dict):
+        ap = {}
+        behavior["actionParams"] = ap
+    abp = ap.get("aiBehaviorParams") or ap.get("ai_behavior_params")
+    if not isinstance(abp, dict):
+        abp = {}
+        ap["aiBehaviorParams"] = abp
+    abp["instruction"] = instruction
+
+
+def expand_behavior_placeholders(behavior: dict[str, Any]) -> dict[str, Any]:
+    """Copy one behavior, merge ``instruction_template`` into ``actionParams``, strip template keys, interpolate ``{{name}}`` in all string leaves.
+
+    Args:
+        behavior: Raw MCP tool behavior dict. Optional keys (removed before validation):
+            ``template_params`` / ``templateParams`` / ``placeholders`` — flat ``str -> str``
+            map for replacements; ``instruction_template`` / ``instructionTemplate`` —
+            text written to ``actionParams.aiBehaviorParams.instruction`` before interpolation.
+
+    Returns:
+        New dict with the same shape expected by ``BehaviorInput``, without template-only keys.
+    """
+    result: dict[str, Any] = copy.deepcopy(behavior)
+    params = _merge_template_param_sources(result)
+
+    instruction_tmpl = None
+    for k in _INSTRUCTION_TEMPLATE_KEYS:
+        if k in result:
+            instruction_tmpl = result.pop(k)
+            break
+    if instruction_tmpl is not None:
+        _ensure_ai_behavior_instruction(result, str(instruction_tmpl))
+
+    if not params:
+        if isinstance(result, dict):
+            _walk_check_orphan_placeholders(result)
+        _normalize_instruction_in_behavior(result)
+        return result
+
+    out = _deep_interpolate(result, params)
+    _normalize_instruction_in_behavior(out)
+    return out
+
+
+def _walk_check_orphan_placeholders(obj: Any) -> None:
+    if isinstance(obj, str) and "{{" in obj and _PLACEHOLDER_RE.search(obj):
+        raise ValueError(
+            "Behavior contains {{placeholders}} but no template_params "
+            "(or placeholders) dict was provided on this behavior."
+        )
+    if isinstance(obj, list):
+        for item in obj:
+            _walk_check_orphan_placeholders(item)
+    elif isinstance(obj, dict):
+        for v in obj.values():
+            _walk_check_orphan_placeholders(v)
+
+
+def expand_behaviors_placeholders(
+    behaviors: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Apply :func:`expand_behavior_placeholders` to each behavior dict.
+
+    Args:
+        behaviors: List of raw behavior dicts from tool arguments.
+
+    Returns:
+        Expanded list safe for Pydantic ``BehaviorInput`` validation.
+    """
+    return [expand_behavior_placeholders(b) for b in behaviors]

--- a/tests/tools/test_ai_tool_helpers_slug_resolution.py
+++ b/tests/tools/test_ai_tool_helpers_slug_resolution.py
@@ -334,6 +334,33 @@ async def test_resolve_handles_snake_case_keys():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_resolve_rewrites_instruction_field_slug_to_numeric():
+    client = AsyncMock()
+    client.get_pipe = AsyncMock(
+        return_value={
+            "pipe": {
+                "phases": [],
+                "start_form_fields": [
+                    {"id": "resumo_de_briefing_ia", "internal_id": "427911728"},
+                ],
+            }
+        }
+    )
+
+    b = _behavior_with_fields("306996636", ["427911728"])
+    b["actionParams"]["aiBehaviorParams"]["instruction"] = (
+        "Read %{field:resumo_de_briefing_ia} then stop."
+    )
+    resolved = await resolve_field_slugs_to_numeric(client, [b])
+
+    assert (
+        resolved[0]["actionParams"]["aiBehaviorParams"]["instruction"]
+        == "Read %{field:427911728} then stop."
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_resolve_skips_behaviors_without_pipe_id():
     client = AsyncMock()
 

--- a/tests/tools/test_behavior_placeholder_interpolation.py
+++ b/tests/tools/test_behavior_placeholder_interpolation.py
@@ -1,0 +1,165 @@
+"""Tests for AI Agent behavior {{placeholder}} expansion."""
+
+import copy
+
+import pytest
+
+from pipefy_mcp.tools.behavior_placeholder_interpolation import (
+    expand_behavior_placeholders,
+    expand_behaviors_placeholders,
+    normalize_pipefy_ai_instruction_tokens,
+)
+
+
+def _minimal_behavior():
+    return {
+        "name": "B",
+        "event_id": "card_created",
+        "actionParams": {
+            "aiBehaviorParams": {
+                "instruction": "Hello",
+                "actionsAttributes": [
+                    {
+                        "name": "U",
+                        "actionType": "update_card",
+                        "metadata": {
+                            "pipeId": "1",
+                            "fieldsAttributes": [
+                                {
+                                    "fieldId": "f1",
+                                    "inputMode": "fill_with_ai",
+                                    "value": "",
+                                }
+                            ],
+                        },
+                    }
+                ],
+            }
+        },
+    }
+
+
+@pytest.mark.unit
+def test_normalize_pipefy_tokens_adds_percent_prefix():
+    text = (
+        "Read {field:created_by} then %{field:already_ok} "
+        "and {action:78164d3e-8b69-47dd-9dcc-56014f8a55c6} "
+        "or %{action:11111111-1111-4111-8111-111111111111}"
+    )
+    out = normalize_pipefy_ai_instruction_tokens(text)
+    assert "%{field:created_by}" in out
+    assert "%{field:already_ok}" in out
+    assert "%{action:78164d3e-8b69-47dd-9dcc-56014f8a55c6}" in out
+    assert "%{action:11111111-1111-4111-8111-111111111111}" in out
+
+
+@pytest.mark.unit
+def test_expand_normalizes_instruction_tokens_without_template_params():
+    b = _minimal_behavior()
+    b["actionParams"]["aiBehaviorParams"]["instruction"] = (
+        "Use {field:my_slug} with {action:a81bdbec-0b0a-4ba9-b695-f4fe3f4f1f08}."
+    )
+    out = expand_behavior_placeholders(b)
+    instr = out["actionParams"]["aiBehaviorParams"]["instruction"]
+    assert "%{field:my_slug}" in instr
+    assert "%{action:a81bdbec-0b0a-4ba9-b695-f4fe3f4f1f08}" in instr
+
+
+@pytest.mark.unit
+def test_expand_interpolates_metadata_and_instruction():
+    b = _minimal_behavior()
+    b["actionParams"]["aiBehaviorParams"]["instruction"] = "Fill {{field_id}}"
+    b["actionParams"]["aiBehaviorParams"]["actionsAttributes"][0]["metadata"][
+        "pipeId"
+    ] = "{{pipe}}"
+    b["actionParams"]["aiBehaviorParams"]["actionsAttributes"][0]["metadata"][
+        "fieldsAttributes"
+    ][0]["fieldId"] = "{{field_id}}"
+    b["template_params"] = {"pipe": "99", "field_id": "427"}
+
+    out = expand_behavior_placeholders(b)
+
+    assert "template_params" not in out
+    abp = out["actionParams"]["aiBehaviorParams"]
+    assert abp["instruction"] == "Fill 427"
+    meta = abp["actionsAttributes"][0]["metadata"]
+    assert meta["pipeId"] == "99"
+    assert meta["fieldsAttributes"][0]["fieldId"] == "427"
+
+
+@pytest.mark.unit
+def test_instruction_template_sets_instruction_then_interpolates():
+    b = _minimal_behavior()
+    del b["actionParams"]["aiBehaviorParams"]["instruction"]
+    b["instruction_template"] = "Do {{what}}"
+    b["placeholders"] = {"what": "summarize"}
+
+    out = expand_behavior_placeholders(b)
+
+    assert out["actionParams"]["aiBehaviorParams"]["instruction"] == "Do summarize"
+
+
+@pytest.mark.unit
+def test_missing_placeholder_key_raises():
+    b = _minimal_behavior()
+    b["actionParams"]["aiBehaviorParams"]["instruction"] = "{{missing}}"
+    b["template_params"] = {"other": "x"}
+
+    with pytest.raises(ValueError, match="Missing template parameter 'missing'"):
+        expand_behavior_placeholders(b)
+
+
+@pytest.mark.unit
+def test_empty_template_params_with_placeholder_raises():
+    b = _minimal_behavior()
+    b["actionParams"]["aiBehaviorParams"]["instruction"] = "{{missing}}"
+    b["template_params"] = {}
+
+    with pytest.raises(ValueError, match="no template_params"):
+        expand_behavior_placeholders(b)
+
+
+@pytest.mark.unit
+def test_placeholder_without_params_raises():
+    b = _minimal_behavior()
+    b["actionParams"]["aiBehaviorParams"]["instruction"] = "Has {{x}}"
+
+    with pytest.raises(ValueError, match="no template_params"):
+        expand_behavior_placeholders(b)
+
+
+@pytest.mark.unit
+def test_original_dict_not_mutated():
+    b = _minimal_behavior()
+    b["template_params"] = {"a": "1"}
+    b["actionParams"]["aiBehaviorParams"]["instruction"] = "{{a}}"
+    original = copy.deepcopy(b)
+
+    expand_behavior_placeholders(b)
+
+    assert b == original
+
+
+@pytest.mark.unit
+def test_expand_behaviors_placeholders_list():
+    b1 = _minimal_behavior()
+    b1["actionParams"]["aiBehaviorParams"]["instruction"] = "{{g}}"
+    b1["template_params"] = {"g": "one"}
+    b2 = _minimal_behavior()
+    b2["actionParams"]["aiBehaviorParams"]["instruction"] = "{{g}}"
+    b2["template_params"] = {"g": "two"}
+
+    outs = expand_behaviors_placeholders([b1, b2])
+    assert outs[0]["actionParams"]["aiBehaviorParams"]["instruction"] == "one"
+    assert outs[1]["actionParams"]["aiBehaviorParams"]["instruction"] == "two"
+
+
+@pytest.mark.unit
+def test_placeholders_overrides_template_params_same_key():
+    b = _minimal_behavior()
+    b["actionParams"]["aiBehaviorParams"]["instruction"] = "{{k}}"
+    b["template_params"] = {"k": "first"}
+    b["placeholders"] = {"k": "second"}
+
+    out = expand_behavior_placeholders(b)
+    assert out["actionParams"]["aiBehaviorParams"]["instruction"] == "second"


### PR DESCRIPTION
## Summary

Aligns AI Agent behavior payloads with Pipefy's instruction format: **%{field:<internal_id>}** and **%{action:<uuid>}**. Keeps optional **{{name}}** / `template_params` expansion per behavior, and rewrites **%{field:<slug>}** in instructions to numeric internal IDs using existing pipe field maps.

## Background

- `get_ai_agent` shows the API uses `%{action:<uuid>}` and appends lines tied to each action `referenceId`.
- Field tokens should target numeric internal IDs; slugs in instruction are resolved when actions supply `metadata.pipeId`.

## Changes

- **`inject_reference_ids`** (`ai_agent_service.py`): append `%{action:<uuid>}` (not brace-only).
- **`behavior_placeholder_interpolation.py`** (new): normalize `{field:…}` / `{action:<uuid>}` → `%{…}`; optional `template_params` / `instruction_template`; used by create/update/validate AI agent tools.
- **`resolve_field_slugs_to_numeric`** (`ai_tool_helpers.py`): also rewrite `%{field:<slug>}` inside `aiBehaviorParams.instruction`.
- **`ai_agent_tools`**: docstring updates for `create_ai_agent`.
- **Tests**: new `test_behavior_placeholder_interpolation.py`; instruction slug case in `test_ai_tool_helpers_slug_resolution.py`.

## Testing

- `uv run pytest tests/services/test_ai_agent_service.py tests/tools/test_behavior_placeholder_interpolation.py tests/tools/test_ai_tool_helpers_slug_resolution.py`
- `uv run pytest -m "not integration"`