### PR TITLE
feat(mcp): elicitation, tool lifecycle, AI automation hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 
 ### Manual tool testing (E2E)
 - **Preferred:** Use **Cursor’s MCP integration** (add this server in Cursor MCP settings, run `pipefy-mcp-server`, then invoke tools from the chat / MCP panel). This matches how maintainers and agents exercise the server in daily use.
+- **After `server.py`, lifespan, or registration changes:** Run a short **Cursor MCP smoke test** (list tools and/or call a read-only tool). See README **Development & Testing → Manual smoke test (Cursor MCP)**.
 - **Optional:** `npx @modelcontextprotocol/inspector uv --directory . run pipefy-mcp-server` — MCP Inspector is fine for protocol debugging or when Cursor is not in the loop; it is not the primary sign-off for “tools work for us.”
 
 ## Coding Style & Naming Conventions
@@ -43,9 +44,10 @@ When implementing a new tool, follow this checklist (TDD-first):
 1. **Write tests first** in `tests/tools/` mirroring the source structure (e.g., `test_pipe_tools.py`).
 2. **Run the tests and confirm they fail** for the new behavior.
 3. **Implement the tool logic** in `src/pipefy_mcp/tools/` (e.g., `pipe_tools.py` or create a new file if appropriate).
-4. **Register the tool** in `src/pipefy_mcp/server.py` by adding its function or reference to the MCP server setup.
-5. **Re-run tests and ensure they pass**.
-6. **Update the README** if the tool introduces new user-facing functionality or configuration options.
+4. **Register the tool** by calling the appropriate `*Tools.register(mcp, client)` from `ToolRegistry.register_tools()` in `src/pipefy_mcp/tools/registry.py` (only if not already wired for that domain).
+5. **Add the MCP tool name** to **`PIPEFY_TOOL_NAMES`** in `src/pipefy_mcp/tools/registry.py` (same string the client sees). Omitting this breaks startup preflight and `tests/test_server.py`.
+6. **Re-run tests and ensure they pass** (including `tests/test_server.py` if the tool list changed).
+7. **Update the README** if the tool introduces new user-facing functionality or configuration options.
 
 ## Commit & Pull Request Guidelines
 - Commit messages follow a conventional style such as `feat:`, `fix:`, `refactor:`, `style:`, `test:`, `docs:` with optional scopes (e.g., `feat(tools): ...`).

--- a/README.md
+++ b/README.md
@@ -136,6 +136,20 @@ uv run ruff check src/
 uv run ruff format src/
 ```
 
+### Adding or renaming an MCP tool
+
+1. Implement the tool in the appropriate module under `src/pipefy_mcp/tools/` and call its `*Tools.register(...)` from `ToolRegistry.register_tools()` in [`src/pipefy_mcp/tools/registry.py`](src/pipefy_mcp/tools/registry.py) if it is not already wired.
+2. Add the **exact tool name** (as exposed to MCP clients) to **`PIPEFY_TOOL_NAMES`** in the same file. The server uses that set for collision checks at startup and for cleanup after a failed registration; `tests/test_server.py` also asserts the live tool list matches this set.
+
+### Manual smoke test (Cursor MCP)
+
+After meaningful changes to **`server.py`**, the **lifespan**, or **tool registration** (including `PIPEFY_TOOL_NAMES`), validate the real stack—not only unit tests:
+
+1. Add or enable this server in **Cursor MCP settings** and run the server, for example: `uv run pipefy-mcp-server` — this starts the MCP server defined in this repo so Cursor can connect to it.
+2. From the chat or MCP tools panel, confirm tools load (e.g. list tools / invoke a simple read-only tool you care about).
+
+Inspector (`npx @modelcontextprotocol/inspector …`) remains useful for protocol debugging; Cursor MCP is the preferred sign-off for “tools work as we use them.”
+
 ## Contributing
 We are building this in public and we need your feedback!
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 <p align="center">
   <a href="#mcp-tools">MCP tools</a> •
   <a href="#getting-started">Getting started</a> •
+  <a href="#why-these-dependencies">Why these dependencies?</a> •
   <a href="#mcp-clients">MCP clients</a> •
   <a href="#development--testing">Development & Testing</a> •
   <a href="#contributing">Contributing</a>
@@ -80,6 +81,16 @@ cp .env.example .env
 ```
 
 **Environment variables:** names, placeholders, and how `.env` interacts with Pydantic Settings are documented in **[Configuration](docs/configuration.md)** (keys themselves live only in [`.env.example`](.env.example)).
+
+### Why these dependencies?
+
+The runtime stack in [`pyproject.toml`](pyproject.toml) is small on purpose. For a longer rationale (code references and security notes), see **[Dependencies](docs/dependencies.md)**. Summary:
+
+| Package | Role in this server |
+|--------|---------------------|
+| **httpx** | Async HTTP client used by `gql` for GraphQL (`HTTPXAsyncTransport`), Pipefy’s internal GraphQL API, presigned S3 uploads/downloads for attachments, and downloading signed export URLs (automation job / observability flows). |
+| **httpx-auth** | `OAuth2ClientCredentials` for service-account token acquisition and refresh; shared across GraphQL clients and direct `httpx` calls that need the same Pipefy OAuth settings. |
+| **openpyxl** | Reads `.xlsx` export files (e.g. automation job exports) and converts the first worksheet to CSV text for MCP responses — see `observability_export_csv`. |
 
 ## MCP clients
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MCP server for Pipefy
 
 <p align="center">
-  <strong>Open-source MCP for Pipefy: 115 tools across pipes, cards, tables, relations, reports, automations, AI agents and observability — built for your IDE, with pagination, introspection and safe deletes.</strong>
+  <strong>Open-source MCP for Pipefy: 116 tools across pipes, cards, tables, relations, reports, automations, AI agents and observability — built for your IDE, with pagination, introspection and safe deletes.</strong>
 </p>
 
 <p align="center">
@@ -33,21 +33,24 @@
 
 ## MCP tools
 
-**115 tools** across 9 categories. Each tool has a docstring consumed by LLM clients for routing — treat those as the source of truth for arguments.
+The server exposes **116 tools**, grouped below into **nine** surface areas. Canonical names live in `PIPEFY_TOOL_NAMES` (`src/pipefy_mcp/tools/registry.py`).
 
-**Shared conventions (many tools):**
-- **Pagination** — List endpoints accept `first` and `after`. Use `pageInfo.hasNextPage` and `pageInfo.endCursor` to fetch the next page.
-- **Pipefy IDs** — GraphQL treats IDs as **strings**. Tool parameters accept **string IDs** (recommended: `"301234"`). Clients that send unquoted JSON numbers may pass integers for some parameters; the server coerces them to strings before calling the API. Responses and success payloads return IDs as **strings**. Invalid IDs (e.g. empty, zero, or non-coercible values) are rejected before the network call. See [Pipes & cards — IDs](docs/tools/pipes-and-cards.md#pipefy-ids-type-safety) for `delete_card` and card/pipe parameters.
-- **`debug=true`** — Failed calls may include extra detail: GraphQL error codes and a `correlation_id` for support.
-- **`extra_input`** — Optional map of extra mutation fields (camelCase keys). Values that overlap the tool’s main parameters are ignored.
-- **Destructive deletes** — Two steps by default: the first response is a preview; call again with `confirm=true` to run the delete.
-- **Schema introspection** — `introspect_type`, `introspect_query`, `introspect_mutation` reveal live schema shapes; `search_schema` finds types by keyword with optional `kind` filter; `max_depth` on any introspection tool resolves sub-types in a single call.
+**Documentation for agents:** each tool’s description and `Args:` come from its Python docstring—MCP clients show that text to LLMs for routing. Use the docstrings (and the per-area docs linked in the table) as the authority on parameters and edge cases.
+
+**Cross-cutting behavior**
+
+- **Pagination** — List-style tools accept `first` and `after`. Continue with `pageInfo.endCursor` while `pageInfo.hasNextPage` is true.
+- **IDs** — Pipefy GraphQL uses string IDs. Pass IDs as strings (e.g. `"301234"`). Some parameters also accept JSON integers; the server normalizes to string before calling the API. Success payloads return string IDs. Empty, zero, or otherwise invalid IDs fail validation before any network call. More detail: [Pipefy IDs and type safety](docs/tools/pipes-and-cards.md#pipefy-ids-type-safety).
+- **`debug=true`** — On failures, error text may include GraphQL codes and a `correlation_id` for support.
+- **`extra_input`** — Optional map of extra mutation fields (camelCase keys). Keys that duplicate the tool’s primary parameters are ignored.
+- **Destructive operations** — Deletes use a two-step contract: call with `confirm=false` (default) for a preview, then `confirm=true` only after explicit approval to execute.
+- **Introspection** — `introspect_type`, `introspect_query`, and `introspect_mutation` expose live schema; `search_schema` lists types by keyword (optional `kind` filter). Use `max_depth` where supported to expand nested types in one round trip.
 
 | Category | Tools | Description | Docs |
 |----------|:-----:|-------------|------|
-| **Pipes & cards** | 34 | Read, create, update, and delete pipes, phases, fields, labels, cards, field conditions, and card attachment uploads. | [Details](docs/tools/pipes-and-cards.md) |
+| **Pipes & cards** | 34 | Pipes, phases, fields, labels, cards, field conditions, and card-level attachments—read/write/delete as documented per tool. | [Details](docs/tools/pipes-and-cards.md) |
 | **Database tables** | 18 | Tables, records (rows), schema columns (table fields), org-wide table discovery, and table-record attachment uploads. | [Details](docs/tools/database-tables.md) |
-| **Relations** | 5 | Link pipes, tables, and cards across workflows. | [Details](docs/tools/relations.md) |
+| **Relations** | 6 | Pipe relations, table relations by ID, and card links across workflows. | [Details](docs/tools/relations.md) |
 | **Reports** | 16 | Pipe and organization reports: discovery, CRUD, and async exports. | [Details](docs/tools/reports.md) |
 | **Automations & AI** | 17 | Traditional automations (rules engine) and AI-powered automations and agents. | [Details](docs/tools/automations-and-ai.md) |
 | **Observability** | 10 | AI agent and automation logs, usage stats, credits, job exports, status polling, and CSV fetch for finished exports. | [Details](docs/tools/observability.md) |

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,0 +1,41 @@
+# Python runtime dependencies
+
+This document explains **why** the main third-party packages in [`pyproject.toml`](../pyproject.toml) are required. It complements the short summary in the README (*Getting started → Why these dependencies?*).
+
+## httpx
+
+**Role:** Async HTTP client for every non-trivial network path in the server.
+
+**Where it is used:**
+
+- **GraphQL (public Pipefy API)** — `gql` uses `HTTPXAsyncTransport` (see `pipefy_mcp.services.pipefy.base_client`).
+- **Internal Pipefy GraphQL** — `InternalApiClient` uses `httpx.AsyncClient` with timeouts (`pipefy_mcp.services.pipefy.internal_api_client`).
+- **Attachments** — Presigned URL upload/download flows (`pipefy_mcp.services.pipefy.attachment_service`, `pipefy_mcp.tools.attachment_tools`).
+- **Exports** — Downloading signed HTTPS URLs before parsing or streaming (`pipefy_mcp.services.pipefy.observability_export_csv`).
+
+**Why httpx (and not e.g. sync `requests` alone):** the codebase is async end-to-end for MCP handlers and GraphQL; one client family keeps timeouts, connection limits, and error types consistent.
+
+## httpx-auth
+
+**Role:** OAuth2 **client credentials** for Pipefy service accounts (token fetch and refresh).
+
+**Where it is used:**
+
+- Passed into GraphQL transport setup and into direct `httpx` clients that must use the same Pipefy OAuth settings — see imports of `OAuth2ClientCredentials` under `pipefy_mcp.services.pipefy/`.
+
+**Why a dedicated auth helper:** avoids hand-rolling refresh and header injection; aligns all authenticated HTTP with the same credential source as Pydantic Settings.
+
+## openpyxl
+
+**Role:** Read `.xlsx` workbooks and turn sheet data into text the MCP can return (CSV-like).
+
+**Where it is used:**
+
+- `pipefy_mcp.services.pipefy.observability_export_csv` — `load_workbook` on downloaded export bytes, first worksheet to CSV with optional size limits.
+
+**Why openpyxl:** some Pipefy exports are delivered as Excel files, not plain CSV; a dedicated reader is the reliable way to extract rows without fragile format guesses.
+
+## Supply-chain and security notes
+
+- Prefer **pinned versions** in `pyproject.toml` as the project already does; review upgrades in PRs with a quick grep for breaking API usage.
+- Export downloads use **HTTPS** and host allowlisting in code (see `is_allowed_pipefy_export_download_url` in `observability_export_csv`); do not bypass those checks when extending download paths.

--- a/docs/tools/automations-and-ai.md
+++ b/docs/tools/automations-and-ai.md
@@ -31,6 +31,10 @@ AI automations are separate from traditional rules above. They are prompt-driven
 |------|------|
 | `create_ai_automation` | Prompt-driven automation writing to one or more card fields (AI must be enabled on the pipe). |
 | `update_ai_automation` | Change name, `active`, prompt, `field_ids`, or `condition`. |
+
+### `create_ai_automation`: `condition` (contract)
+
+**Source of truth:** **Required-on-wire via default (branch B).** If the tool caller omits `condition`, the MCP layer applies `DEFAULT_CONDITION` in code (`CreateAiAutomationInput`): an empty-expression structure meaning “no extra trigger conditions” in Pipefy. The internal API **always** receives a `condition` key on create, avoiding ambiguous “key absent” behavior. Pass an explicit `condition` dict to override. **`update_ai_automation`:** omit `condition` to leave the existing rule unchanged; pass a dict to replace it.
 | `create_ai_agent` | Creates and configures an AI agent with `instruction` (= Pipefy UI "Description") and 1–5 `behaviors` in one call. `repo_uuid` is the pipe UUID from `get_pipe`. Optional: `data_source_ids`. |
 | `update_ai_agent` | Replaces full agent config; send the complete `behaviors` list (1-5). |
 | `toggle_ai_agent_status` | Enable/disable without resending configuration. |

--- a/docs/tools/introspection.md
+++ b/docs/tools/introspection.md
@@ -1,6 +1,6 @@
 # Introspection & Raw GraphQL
 
-Schema discovery tools plus a last-resort executor. Same OAuth client as everything else. **6 tools.**
+Schema discovery tools plus a last-resort executor. Same OAuth client as everything else. **5 tools.**
 
 Prefer dedicated tools for standard operations. Use these when the schema shifts or no dedicated tool exists.
 

--- a/docs/tools/relations.md
+++ b/docs/tools/relations.md
@@ -8,6 +8,12 @@ Link processes and cards across workflows. **6 tools.**
 - **Card relations** connect individual cards through an existing pipe relation: pass `source_id` = that pipe relation's ID (from `get_pipe_relations`). Default `sourceType` is `PipeRelation`; use `extra_input` (e.g. `sourceType: Field`) when the API requires a field-based link — see `introspect_type` on `CreateCardRelationInput`.
 - **Table relations** in GraphQL are loaded by table-relation ID, not by database table ID: `get_table_relations` takes a non-empty list of those IDs (root `table_relations` query).
 
+## Common mistakes (agents)
+
+- **`get_table_relations` + `table_id`:** The tool argument is `relation_ids` (table **relation** IDs). The database table id from `search_tables` / `get_table` is the wrong kind of id — the MCP client may reject the call or GraphQL will not find what you expect.
+- **`create_card_relation` + wrong `source_id`:** `source_id` must be a **pipe relation** id from `get_pipe_relations`. It is not a table-relation id, not a `table_id`, and not a pipe/card id.
+- **Symmetry trap:** `get_pipe_relations(pipe_id)` takes a pipe id, but `get_table_relations(relation_ids)` does **not** take a table id — the APIs differ by design.
+
 ---
 
 | Tool | Read-only | Role |

--- a/src/pipefy_mcp/core/fastmcp_tool_lifecycle.py
+++ b/src/pipefy_mcp/core/fastmcp_tool_lifecycle.py
@@ -1,0 +1,42 @@
+"""FastMCP internals used for in-process server lifespan and tool rebinding."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from mcp.server.fastmcp.exceptions import ToolError
+
+if TYPE_CHECKING:
+    from mcp.server.fastmcp import FastMCP
+
+logger = logging.getLogger(__name__)
+
+
+def remove_fastmcp_tools_by_name(app: FastMCP, names: set[str]) -> None:
+    """Remove tools registered on ``app`` by exact name.
+
+    Used when re-entering ``lifespan`` so Pipefy tools pick up a new client
+    without deleting third-party or test-registered tools.
+
+    Args:
+        app: FastMCP server instance.
+        names: Names as returned by the tool manager (must match ``remove_tool``).
+
+    """
+    if not names:
+        return
+    try:
+        tool_manager = app._tool_manager
+    except AttributeError:
+        logger.warning(
+            "FastMCP internal API changed; missing _tool_manager. "
+            "Cannot remove tools by name; re-registration may leave stale handlers."
+        )
+        return
+
+    for name in names:
+        try:
+            tool_manager.remove_tool(name)
+        except ToolError:
+            logger.debug("Tool %r not registered; skipping remove.", name)

--- a/src/pipefy_mcp/core/fastmcp_tool_lifecycle.py
+++ b/src/pipefy_mcp/core/fastmcp_tool_lifecycle.py
@@ -1,4 +1,7 @@
-"""FastMCP internals used for in-process server lifespan and tool rebinding."""
+"""FastMCP ``_tool_manager`` boundary for removing tools by name.
+
+Pipefy selective cleanup policy lives in :mod:`pipefy_mcp.core.pipefy_tool_lifecycle`.
+"""
 
 from __future__ import annotations
 

--- a/src/pipefy_mcp/core/pipefy_tool_lifecycle.py
+++ b/src/pipefy_mcp/core/pipefy_tool_lifecycle.py
@@ -14,6 +14,33 @@ logger = logging.getLogger(__name__)
 
 PIPEFY_REPEAT_VISIT_FLAG_ATTR = "_pipefy_cleared_tools_once"
 PIPEFY_OWNED_TOOL_NAMES_ATTR = "_pipefy_tool_names"
+PIPEFY_PENDING_TOOL_NAMES_ATTR = "_pipefy_pending_tool_names"
+
+
+def mark_pipefy_tool_registration_started(app: FastMCP, names: set[str]) -> None:
+    """Record which Pipefy tool names the current registration attempt may leave behind.
+
+    If :func:`cleanup_failed_pipefy_tool_registration` runs, only these names are
+    removed so foreign tools registered under the same app are untouched.
+
+    Args:
+        app: FastMCP server instance.
+        names: Pipefy-owned tool names for this attempt (see ``PIPEFY_TOOL_NAMES``).
+    """
+    setattr(app, PIPEFY_PENDING_TOOL_NAMES_ATTR, set(names))
+
+
+def cleanup_failed_pipefy_tool_registration(app: FastMCP) -> None:
+    """Remove tools registered so far in a failed attempt; clear pending state.
+
+    Args:
+        app: FastMCP server instance.
+    """
+    pending = getattr(app, PIPEFY_PENDING_TOOL_NAMES_ATTR, None)
+    if pending:
+        remove_fastmcp_tools_by_name(app, set(pending))
+    if hasattr(app, PIPEFY_PENDING_TOOL_NAMES_ATTR):
+        delattr(app, PIPEFY_PENDING_TOOL_NAMES_ATTR)
 
 
 def prepare_app_for_repeat_pipefy_tool_registration(app: FastMCP) -> None:
@@ -54,8 +81,9 @@ def mark_pipefy_tool_registration_complete(app: FastMCP, names: set[str]) -> Non
 
     Args:
         app: FastMCP server instance.
-        names: Exact tool names from :class:`pipefy_mcp.tools.registry.ToolRegistry`
-            (must match ``ToolManager.remove_tool``).
+        names: Exact Pipefy tool names (must match ``ToolManager.remove_tool``).
     """
     setattr(app, PIPEFY_OWNED_TOOL_NAMES_ATTR, set(names))
     setattr(app, PIPEFY_REPEAT_VISIT_FLAG_ATTR, True)
+    if hasattr(app, PIPEFY_PENDING_TOOL_NAMES_ATTR):
+        delattr(app, PIPEFY_PENDING_TOOL_NAMES_ATTR)

--- a/src/pipefy_mcp/core/pipefy_tool_lifecycle.py
+++ b/src/pipefy_mcp/core/pipefy_tool_lifecycle.py
@@ -1,0 +1,53 @@
+"""Pipefy tool rebinding when FastMCP ``lifespan`` runs more than once in-process."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from pipefy_mcp.core.fastmcp_tool_lifecycle import remove_fastmcp_tools_by_name
+
+if TYPE_CHECKING:
+    from mcp.server.fastmcp import FastMCP
+
+logger = logging.getLogger(__name__)
+
+PIPEFY_REPEAT_VISIT_FLAG_ATTR = "_pipefy_cleared_tools_once"
+PIPEFY_OWNED_TOOL_NAMES_ATTR = "_pipefy_tool_names"
+
+
+def prepare_app_for_repeat_pipefy_tool_registration(app: FastMCP) -> None:
+    """Remove only Pipefy-owned tools before re-registering on a repeat lifespan visit.
+
+    FastMCP's ToolManager keeps the first registered callable when names collide.
+    In-process MCP sessions (tests, Cursor) can enter lifespan multiple times;
+    ``initialize_services`` then updates the container but tools would still call
+    the old client unless we remove stale Pipefy tools before ``register_tools``.
+
+    Tools registered outside :class:`pipefy_mcp.tools.registry.ToolRegistry` are left intact.
+
+    Args:
+        app: FastMCP server instance bound to this process.
+    """
+    if getattr(app, PIPEFY_REPEAT_VISIT_FLAG_ATTR, False):
+        owned = getattr(app, PIPEFY_OWNED_TOOL_NAMES_ATTR, None)
+        if not owned:
+            logger.warning(
+                "Repeat MCP lifespan visit but %s is missing or empty; "
+                "skipping selective Pipefy tool cleanup.",
+                PIPEFY_OWNED_TOOL_NAMES_ATTR,
+            )
+        else:
+            remove_fastmcp_tools_by_name(app, set(owned))
+    setattr(app, PIPEFY_REPEAT_VISIT_FLAG_ATTR, True)
+
+
+def store_pipefy_owned_tool_names(app: FastMCP, names: set[str]) -> None:
+    """Record Pipefy-registered tool names on ``app`` for the next selective cleanup.
+
+    Args:
+        app: FastMCP server instance.
+        names: Exact tool names from :class:`pipefy_mcp.tools.registry.ToolRegistry`
+            (must match ``ToolManager.remove_tool``).
+    """
+    setattr(app, PIPEFY_OWNED_TOOL_NAMES_ATTR, set(names))

--- a/src/pipefy_mcp/core/pipefy_tool_lifecycle.py
+++ b/src/pipefy_mcp/core/pipefy_tool_lifecycle.py
@@ -19,6 +19,11 @@ PIPEFY_OWNED_TOOL_NAMES_ATTR = "_pipefy_tool_names"
 def prepare_app_for_repeat_pipefy_tool_registration(app: FastMCP) -> None:
     """Remove only Pipefy-owned tools before re-registering on a repeat lifespan visit.
 
+    Runs **only** after a prior lifespan completed tool registration successfully
+    (see :func:`mark_pipefy_tool_registration_complete`). Does not mutate the
+    repeat-visit flag: that is set only after ``register_tools()`` succeeds so a
+    failed initialization cannot leave the app marked as a consolidated repeat visit.
+
     FastMCP's ToolManager keeps the first registered callable when names collide.
     In-process MCP sessions (tests, Cursor) can enter lifespan multiple times;
     ``initialize_services`` then updates the container but tools would still call
@@ -29,21 +34,23 @@ def prepare_app_for_repeat_pipefy_tool_registration(app: FastMCP) -> None:
     Args:
         app: FastMCP server instance bound to this process.
     """
-    if getattr(app, PIPEFY_REPEAT_VISIT_FLAG_ATTR, False):
-        owned = getattr(app, PIPEFY_OWNED_TOOL_NAMES_ATTR, None)
-        if not owned:
-            logger.warning(
-                "Repeat MCP lifespan visit but %s is missing or empty; "
-                "skipping selective Pipefy tool cleanup.",
-                PIPEFY_OWNED_TOOL_NAMES_ATTR,
-            )
-        else:
-            remove_fastmcp_tools_by_name(app, set(owned))
-    setattr(app, PIPEFY_REPEAT_VISIT_FLAG_ATTR, True)
+    if not getattr(app, PIPEFY_REPEAT_VISIT_FLAG_ATTR, False):
+        return
+    owned = getattr(app, PIPEFY_OWNED_TOOL_NAMES_ATTR, None)
+    if not owned:
+        logger.warning(
+            "Repeat MCP lifespan visit but %s is missing or empty; "
+            "skipping selective Pipefy tool cleanup.",
+            PIPEFY_OWNED_TOOL_NAMES_ATTR,
+        )
+        return
+    remove_fastmcp_tools_by_name(app, set(owned))
 
 
-def store_pipefy_owned_tool_names(app: FastMCP, names: set[str]) -> None:
-    """Record Pipefy-registered tool names on ``app`` for the next selective cleanup.
+def mark_pipefy_tool_registration_complete(app: FastMCP, names: set[str]) -> None:
+    """Persist owned tool names and mark that a lifespan registration completed.
+
+    Call only after ``ToolRegistry.register_tools()`` succeeds.
 
     Args:
         app: FastMCP server instance.
@@ -51,3 +58,4 @@ def store_pipefy_owned_tool_names(app: FastMCP, names: set[str]) -> None:
             (must match ``ToolManager.remove_tool``).
     """
     setattr(app, PIPEFY_OWNED_TOOL_NAMES_ATTR, set(names))
+    setattr(app, PIPEFY_REPEAT_VISIT_FLAG_ATTR, True)

--- a/src/pipefy_mcp/models/__init__.py
+++ b/src/pipefy_mcp/models/__init__.py
@@ -8,6 +8,8 @@ from pipefy_mcp.models.ai_agent import (
     UpdateAiAgentInput,
 )
 from pipefy_mcp.models.ai_automation import (
+    AutomationConditionInput,
+    AutomationEventParamsInput,
     CreateAiAutomationInput,
     UpdateAiAutomationInput,
 )
@@ -20,6 +22,8 @@ from pipefy_mcp.models.send_task_automation import CreateSendTaskAutomationInput
 from pipefy_mcp.models.validators import NonBlankStr, PipefyId
 
 __all__ = [
+    "AutomationConditionInput",
+    "AutomationEventParamsInput",
     "BehaviorInput",
     "CreateAiAgentInput",
     "CreateAiAutomationInput",

--- a/src/pipefy_mcp/models/ai_automation.py
+++ b/src/pipefy_mcp/models/ai_automation.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import copy
 import re
-from typing import Annotated
+from typing import Annotated, Any
 
-from pydantic import BaseModel, BeforeValidator, Field
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
 
 from pipefy_mcp.models.validators import NonBlankStr
 
@@ -14,12 +14,42 @@ EVENT_ID_BLACKLIST = frozenset({"scheduler"})
 
 FIELD_REF_PATTERN = re.compile(r"%\{[^}]+\}")
 
-DEFAULT_CONDITION = {
+# Sent on every create when the caller omits ``condition``. Pipefy's internal
+# ``createAutomation`` expects a condition object; omitting the variable can
+# differ semantically from an explicit "no user condition" shape. This placeholder
+# matches an empty expression list so the API receives a stable payload.
+DEFAULT_CONDITION: dict[str, Any] = {
     "expressions": [
         {"structure_id": 0, "field_address": "", "operation": "", "value": ""}
     ],
     "expressions_structure": [[0]],
 }
+
+
+class AutomationConditionInput(BaseModel):
+    """Pipefy ``ConditionInput``-shaped payload. Unknown top-level keys are preserved."""
+
+    model_config = ConfigDict(extra="allow")
+
+    expressions: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="Condition expressions (Pipefy ConditionInput).",
+    )
+    expressions_structure: list[Any] | None = Field(
+        default=None,
+        description="Expression grouping indices for Pipefy condition trees.",
+    )
+
+
+class AutomationEventParamsInput(BaseModel):
+    """Pipefy automation trigger params (e.g. ``to_phase_id``, ``triggerFieldIds``)."""
+
+    model_config = ConfigDict(extra="allow")
+
+
+def _default_automation_condition() -> AutomationConditionInput:
+    """Fresh placeholder condition (deep copy) for each new create input."""
+    return AutomationConditionInput.model_validate(copy.deepcopy(DEFAULT_CONDITION))
 
 
 def _reject_blacklisted_event_id(v: str) -> str:
@@ -69,7 +99,12 @@ _AiPrompt = Annotated[
 
 
 class CreateAiAutomationInput(BaseModel):
-    """Validated input for creating an AI Automation (generate_with_ai)."""
+    """Validated input for creating an AI Automation (generate_with_ai).
+
+    When ``condition`` is omitted, it defaults to a deep copy of
+    :data:`DEFAULT_CONDITION` so the internal API always receives an explicit
+    condition object (see ``docs/tools/automations-and-ai.md``).
+    """
 
     name: NonBlankStr
     event_id: _EventId
@@ -87,14 +122,20 @@ class CreateAiAutomationInput(BaseModel):
         default_factory=list,
         description="AI skill IDs to attach. Defaults to empty (no skills).",
     )
-    event_params: dict | None = Field(
+    event_params: AutomationEventParamsInput | None = Field(
         default=None,
         description=(
             "Trigger-specific filters (e.g. to_phase_id for card_moved, "
             "triggerFieldIds for field_updated). Omit when not needed."
         ),
     )
-    condition: dict = Field(default_factory=lambda: copy.deepcopy(DEFAULT_CONDITION))
+    condition: AutomationConditionInput = Field(
+        default_factory=_default_automation_condition,
+        description=(
+            "Trigger condition for the automation. Omit to use DEFAULT_CONDITION "
+            "(empty-expression placeholder sent to Pipefy). Pass a dict to override."
+        ),
+    )
 
 
 class UpdateAiAutomationInput(BaseModel):
@@ -106,8 +147,8 @@ class UpdateAiAutomationInput(BaseModel):
     prompt: _AiPrompt | None = None
     field_ids: list[str] | None = Field(default=None, min_length=1)
     skills_ids: list[str] | None = None
-    event_params: dict | None = Field(
+    event_params: AutomationEventParamsInput | None = Field(
         default=None,
         description="Trigger-specific filters. Pass to change; omit to keep current.",
     )
-    condition: dict | None = None
+    condition: AutomationConditionInput | None = None

--- a/src/pipefy_mcp/server.py
+++ b/src/pipefy_mcp/server.py
@@ -9,7 +9,9 @@ from mcp.server.fastmcp import FastMCP
 
 from pipefy_mcp.core.container import ServicesContainer
 from pipefy_mcp.core.pipefy_tool_lifecycle import (
+    cleanup_failed_pipefy_tool_registration,
     mark_pipefy_tool_registration_complete,
+    mark_pipefy_tool_registration_started,
     prepare_app_for_repeat_pipefy_tool_registration,
 )
 from pipefy_mcp.settings import settings
@@ -30,9 +32,12 @@ async def lifespan(app: FastMCP) -> AsyncIterator[FastMCP]:
             mcp=app,
             services_container=services_container,
         )
+        registry.check_for_name_collisions()
+        mark_pipefy_tool_registration_started(app, set(registry.pipefy_tool_names))
         mcp = registry.register_tools()
         mark_pipefy_tool_registration_complete(app, set(registry.pipefy_tool_names))
     except Exception:
+        cleanup_failed_pipefy_tool_registration(app)
         logger.exception("Fatal error during server lifespan initialization")
         raise
 

--- a/src/pipefy_mcp/server.py
+++ b/src/pipefy_mcp/server.py
@@ -8,33 +8,36 @@ from contextlib import asynccontextmanager
 from mcp.server.fastmcp import FastMCP
 
 from pipefy_mcp.core.container import ServicesContainer
+from pipefy_mcp.core.fastmcp_tool_lifecycle import remove_fastmcp_tools_by_name
 from pipefy_mcp.settings import settings
 from pipefy_mcp.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
 
 _PIPEFY_APP_TOOLS_ATTR = "_pipefy_cleared_tools_once"
+_PIPEFY_OWNED_TOOL_NAMES_ATTR = "_pipefy_tool_names"
 
 
-def _clear_fastmcp_tools_if_repeat_visit(app: FastMCP) -> None:
-    """Ensure tool handlers are re-bound when lifespan runs again on the same app.
+def _prepare_app_for_repeat_pipefy_tool_registration(app: FastMCP) -> None:
+    """Remove only Pipefy-owned tools before re-registering on a repeat lifespan visit.
 
     FastMCP's ToolManager keeps the first registered callable when names collide.
     In-process MCP sessions (tests, Cursor) can enter lifespan multiple times;
     ``initialize_services`` then updates the container but tools would still call
-    the old client unless we remove stale tools before ``register_tools``.
+    the old client unless we remove stale Pipefy tools before ``register_tools``.
 
-    NOTE: Uses private ``app._tool_manager`` (tested with mcp[cli]>=1.25.0).
+    Tools registered outside :class:`ToolRegistry` are left intact.
     """
     if getattr(app, _PIPEFY_APP_TOOLS_ATTR, False):
-        try:
-            for tool in list(app._tool_manager.list_tools()):
-                app._tool_manager.remove_tool(tool.name)
-        except AttributeError:
+        owned = getattr(app, _PIPEFY_OWNED_TOOL_NAMES_ATTR, None)
+        if not owned:
             logger.warning(
-                "FastMCP internal API changed; could not clear stale tools. "
-                "Tool re-registration may produce duplicates."
+                "Repeat MCP lifespan visit but %s is missing or empty; "
+                "skipping selective Pipefy tool cleanup.",
+                _PIPEFY_OWNED_TOOL_NAMES_ATTR,
             )
+        else:
+            remove_fastmcp_tools_by_name(app, set(owned))
     setattr(app, _PIPEFY_APP_TOOLS_ATTR, True)
 
 
@@ -45,11 +48,13 @@ async def lifespan(app: FastMCP) -> AsyncIterator[FastMCP]:
         logger.info("Initializing services")
         services_container = ServicesContainer.get_instance()
         services_container.initialize_services(settings)
-        _clear_fastmcp_tools_if_repeat_visit(app)
-        mcp = ToolRegistry(
+        _prepare_app_for_repeat_pipefy_tool_registration(app)
+        registry = ToolRegistry(
             mcp=app,
             services_container=services_container,
-        ).register_tools()
+        )
+        mcp = registry.register_tools()
+        setattr(app, _PIPEFY_OWNED_TOOL_NAMES_ATTR, set(registry.pipefy_tool_names))
     except Exception:
         logger.exception("Fatal error during server lifespan initialization")
         raise

--- a/src/pipefy_mcp/server.py
+++ b/src/pipefy_mcp/server.py
@@ -8,37 +8,14 @@ from contextlib import asynccontextmanager
 from mcp.server.fastmcp import FastMCP
 
 from pipefy_mcp.core.container import ServicesContainer
-from pipefy_mcp.core.fastmcp_tool_lifecycle import remove_fastmcp_tools_by_name
+from pipefy_mcp.core.pipefy_tool_lifecycle import (
+    prepare_app_for_repeat_pipefy_tool_registration,
+    store_pipefy_owned_tool_names,
+)
 from pipefy_mcp.settings import settings
 from pipefy_mcp.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
-
-_PIPEFY_APP_TOOLS_ATTR = "_pipefy_cleared_tools_once"
-_PIPEFY_OWNED_TOOL_NAMES_ATTR = "_pipefy_tool_names"
-
-
-def _prepare_app_for_repeat_pipefy_tool_registration(app: FastMCP) -> None:
-    """Remove only Pipefy-owned tools before re-registering on a repeat lifespan visit.
-
-    FastMCP's ToolManager keeps the first registered callable when names collide.
-    In-process MCP sessions (tests, Cursor) can enter lifespan multiple times;
-    ``initialize_services`` then updates the container but tools would still call
-    the old client unless we remove stale Pipefy tools before ``register_tools``.
-
-    Tools registered outside :class:`ToolRegistry` are left intact.
-    """
-    if getattr(app, _PIPEFY_APP_TOOLS_ATTR, False):
-        owned = getattr(app, _PIPEFY_OWNED_TOOL_NAMES_ATTR, None)
-        if not owned:
-            logger.warning(
-                "Repeat MCP lifespan visit but %s is missing or empty; "
-                "skipping selective Pipefy tool cleanup.",
-                _PIPEFY_OWNED_TOOL_NAMES_ATTR,
-            )
-        else:
-            remove_fastmcp_tools_by_name(app, set(owned))
-    setattr(app, _PIPEFY_APP_TOOLS_ATTR, True)
 
 
 @asynccontextmanager
@@ -48,13 +25,13 @@ async def lifespan(app: FastMCP) -> AsyncIterator[FastMCP]:
         logger.info("Initializing services")
         services_container = ServicesContainer.get_instance()
         services_container.initialize_services(settings)
-        _prepare_app_for_repeat_pipefy_tool_registration(app)
+        prepare_app_for_repeat_pipefy_tool_registration(app)
         registry = ToolRegistry(
             mcp=app,
             services_container=services_container,
         )
         mcp = registry.register_tools()
-        setattr(app, _PIPEFY_OWNED_TOOL_NAMES_ATTR, set(registry.pipefy_tool_names))
+        store_pipefy_owned_tool_names(app, set(registry.pipefy_tool_names))
     except Exception:
         logger.exception("Fatal error during server lifespan initialization")
         raise

--- a/src/pipefy_mcp/server.py
+++ b/src/pipefy_mcp/server.py
@@ -9,8 +9,8 @@ from mcp.server.fastmcp import FastMCP
 
 from pipefy_mcp.core.container import ServicesContainer
 from pipefy_mcp.core.pipefy_tool_lifecycle import (
+    mark_pipefy_tool_registration_complete,
     prepare_app_for_repeat_pipefy_tool_registration,
-    store_pipefy_owned_tool_names,
 )
 from pipefy_mcp.settings import settings
 from pipefy_mcp.tools.registry import ToolRegistry
@@ -31,7 +31,7 @@ async def lifespan(app: FastMCP) -> AsyncIterator[FastMCP]:
             services_container=services_container,
         )
         mcp = registry.register_tools()
-        store_pipefy_owned_tool_names(app, set(registry.pipefy_tool_names))
+        mark_pipefy_tool_registration_complete(app, set(registry.pipefy_tool_names))
     except Exception:
         logger.exception("Fatal error during server lifespan initialization")
         raise

--- a/src/pipefy_mcp/services/pipefy/ai_automation_service.py
+++ b/src/pipefy_mcp/services/pipefy/ai_automation_service.py
@@ -38,7 +38,9 @@ class AiAutomationService:
         """Create an AI Automation (generate_with_ai action).
 
         Args:
-            automation_input: Validated create input.
+            automation_input: Validated create input. ``condition`` is always
+                present on the mutation variables: the model supplies
+                ``DEFAULT_CONDITION`` when the caller did not set one.
 
         Raises:
             ValueError: When API response is missing automation.id.
@@ -57,10 +59,12 @@ class AiAutomationService:
                     "skillsIds": automation_input.skills_ids,
                 }
             },
-            "condition": automation_input.condition,
+            "condition": automation_input.condition.model_dump(mode="python"),
         }
         if automation_input.event_params is not None:
-            variables["event_params"] = automation_input.event_params
+            variables["event_params"] = automation_input.event_params.model_dump(
+                mode="python"
+            )
 
         response = await self._client.execute_query(
             AI_CREATE_AUTOMATION_MUTATION, variables
@@ -112,9 +116,13 @@ class AiAutomationService:
             input_dict["action_params"] = {"aiParams": ai_params}
 
         if automation_input.event_params is not None:
-            input_dict["event_params"] = automation_input.event_params
+            input_dict["event_params"] = automation_input.event_params.model_dump(
+                mode="python"
+            )
         if automation_input.condition is not None:
-            input_dict["condition"] = automation_input.condition
+            input_dict["condition"] = automation_input.condition.model_dump(
+                mode="python"
+            )
 
         variables = {"input": input_dict}
 

--- a/src/pipefy_mcp/services/pipefy/ai_automation_service.py
+++ b/src/pipefy_mcp/services/pipefy/ai_automation_service.py
@@ -23,7 +23,9 @@ from pipefy_mcp.services.pipefy.types import AutomationServiceResult
 ACTION_ID_GENERATE_WITH_AI = "generate_with_ai"
 
 
-def _automation_condition_for_api(condition: AutomationConditionInput) -> dict[str, Any]:
+def _automation_condition_for_api(
+    condition: AutomationConditionInput,
+) -> dict[str, Any]:
     """Serialize condition for GraphQL without injecting unset model defaults."""
     return condition.model_dump(
         mode="python",
@@ -32,7 +34,9 @@ def _automation_condition_for_api(condition: AutomationConditionInput) -> dict[s
     )
 
 
-def _automation_event_params_for_api(params: AutomationEventParamsInput) -> dict[str, Any]:
+def _automation_event_params_for_api(
+    params: AutomationEventParamsInput,
+) -> dict[str, Any]:
     """Serialize event_params without unset fields or explicit ``None`` values."""
     return params.model_dump(
         mode="python",

--- a/src/pipefy_mcp/services/pipefy/ai_automation_service.py
+++ b/src/pipefy_mcp/services/pipefy/ai_automation_service.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from typing import Any
 
 from pipefy_mcp.models.ai_automation import (
+    AutomationConditionInput,
+    AutomationEventParamsInput,
     CreateAiAutomationInput,
     UpdateAiAutomationInput,
 )
@@ -19,6 +21,24 @@ from pipefy_mcp.services.pipefy.queries.ai_automation_queries import (
 from pipefy_mcp.services.pipefy.types import AutomationServiceResult
 
 ACTION_ID_GENERATE_WITH_AI = "generate_with_ai"
+
+
+def _automation_condition_for_api(condition: AutomationConditionInput) -> dict[str, Any]:
+    """Serialize condition for GraphQL without injecting unset model defaults."""
+    return condition.model_dump(
+        mode="python",
+        exclude_unset=True,
+        exclude_none=True,
+    )
+
+
+def _automation_event_params_for_api(params: AutomationEventParamsInput) -> dict[str, Any]:
+    """Serialize event_params without unset fields or explicit ``None`` values."""
+    return params.model_dump(
+        mode="python",
+        exclude_unset=True,
+        exclude_none=True,
+    )
 
 
 class AiAutomationService:
@@ -59,11 +79,11 @@ class AiAutomationService:
                     "skillsIds": automation_input.skills_ids,
                 }
             },
-            "condition": automation_input.condition.model_dump(mode="python"),
+            "condition": _automation_condition_for_api(automation_input.condition),
         }
         if automation_input.event_params is not None:
-            variables["event_params"] = automation_input.event_params.model_dump(
-                mode="python"
+            variables["event_params"] = _automation_event_params_for_api(
+                automation_input.event_params
             )
 
         response = await self._client.execute_query(
@@ -116,12 +136,12 @@ class AiAutomationService:
             input_dict["action_params"] = {"aiParams": ai_params}
 
         if automation_input.event_params is not None:
-            input_dict["event_params"] = automation_input.event_params.model_dump(
-                mode="python"
+            input_dict["event_params"] = _automation_event_params_for_api(
+                automation_input.event_params
             )
         if automation_input.condition is not None:
-            input_dict["condition"] = automation_input.condition.model_dump(
-                mode="python"
+            input_dict["condition"] = _automation_condition_for_api(
+                automation_input.condition
             )
 
         variables = {"input": input_dict}

--- a/src/pipefy_mcp/services/pipefy/internal_api_client.py
+++ b/src/pipefy_mcp/services/pipefy/internal_api_client.py
@@ -78,6 +78,8 @@ class InternalApiClient:
                     ext = err.get("extensions", {})
                     code = ext.get("code", "")
                     corr = ext.get("correlation_id", "")
+                    # Include extensions for logs and service-layer tests; MCP-facing tools
+                    # should omit these suffixes from default user-visible errors.
                     suffix = f" [code={code}]" if code else ""
                     suffix += f" [correlation_id={corr}]" if corr else ""
                     error_msgs.append(f"{msg}{suffix}")

--- a/src/pipefy_mcp/tools/__init__.py
+++ b/src/pipefy_mcp/tools/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from pipefy_mcp.tools.registry import PIPEFY_TOOL_NAMES, ToolRegistry
+
+__all__ = ["PIPEFY_TOOL_NAMES", "ToolRegistry"]

--- a/src/pipefy_mcp/tools/ai_agent_tools.py
+++ b/src/pipefy_mcp/tools/ai_agent_tools.py
@@ -72,6 +72,33 @@ def _extract_pipe_id_from_behaviors(behaviors: list[dict]) -> str | None:
     return None
 
 
+def _behavior_input_validation_problems(exc: ValidationError) -> list[str]:
+    """Turn ``BehaviorInput`` validation errors into short, actionable strings."""
+
+    def _targets_name_field(err: dict) -> bool:
+        loc = err.get("loc") or ()
+        return bool(loc) and loc[-1] == "name"
+
+    raw_errors = exc.errors()
+    problems: list[str] = []
+
+    if any(_targets_name_field(e) for e in raw_errors):
+        problems.append(
+            "Each behavior must include `name` (non-blank display name). "
+            "Match create_ai_agent: `event_id` or `eventId`, plus `actionParams` with "
+            "`aiBehaviorParams.instruction` and at least one entry in `actionsAttributes`."
+        )
+
+    for e in raw_errors:
+        if _targets_name_field(e):
+            continue
+        loc = e.get("loc") or ()
+        path = " -> ".join(str(p) for p in loc) if loc else "behavior"
+        problems.append(f"{path}: {e.get('msg', 'validation error')}")
+
+    return problems if problems else [str(exc)]
+
+
 class AiAgentTools:
     """Declares MCP tools for AI Agent CRUD and status."""
 
@@ -470,13 +497,13 @@ class AiAgentTools:
         ) -> dict:
             """Delete an AI Agent permanently. This action is irreversible.
 
-            Two-step operation: call without ``confirm`` to preview, then with
-            ``confirm=True`` after user approval. When the MCP client supports
-            elicitation, the user is prompted interactively instead.
+            Two-step operation: preview with ``confirm=False`` (default), then execute with
+            ``confirm=True`` after explicit human approval. Elicitation does not authorize
+            deletion (only ``confirm=True`` does).
 
             Args:
                 uuid: Agent UUID.
-                confirm: Set to True to execute the deletion (step 2).
+                confirm: Must be ``True`` to run the delete mutation.
             """
             agent_uuid = uuid.strip()
             await ctx.debug(f"delete_ai_agent: uuid={agent_uuid}")
@@ -548,7 +575,9 @@ class AiAgentTools:
 
             Args:
                 pipe_id: Numeric pipe ID (used to fetch fields, phases, and relations).
-                behaviors: 1–5 behavior dicts (same shape as ``create_ai_agent``).
+                behaviors: 1–5 behavior dicts (same shape as ``create_ai_agent``). Each must
+                    include ``name``, ``event_id`` (or ``eventId``), and ``actionParams`` with
+                    ``aiBehaviorParams`` (``instruction`` + ``actionsAttributes``).
                 strict_unknown_action_types: When ``True`` (default), unknown ``actionType`` values
                     are reported in ``problems``. When ``False``, they appear in ``warnings`` only.
             """
@@ -577,7 +606,7 @@ class AiAgentTools:
                 return {
                     "success": True,
                     "valid": False,
-                    "problems": [str(exc)],
+                    "problems": _behavior_input_validation_problems(exc),
                     "warnings": [],
                     "message": "Behavior dicts failed structural validation (BehaviorInput).",
                 }

--- a/src/pipefy_mcp/tools/ai_automation_tools.py
+++ b/src/pipefy_mcp/tools/ai_automation_tools.py
@@ -17,12 +17,48 @@ from pipefy_mcp.tools.ai_tool_helpers import (
     build_create_automation_success,
     build_update_automation_success,
 )
+from pipefy_mcp.tools.graphql_error_helpers import (
+    extract_internal_api_bracket_codes,
+    extract_internal_api_bracket_correlation_id,
+    strip_internal_api_diagnostic_markers,
+    with_debug_suffix,
+)
+
+AI_AUTOMATION_CREATE_FAILED = (
+    "Could not create the AI automation. Verify pipe, fields, prompt, and that AI is "
+    "enabled for the pipe."
+)
+AI_AUTOMATION_UPDATE_FAILED = (
+    "Could not update the AI automation. Verify the automation ID and your changes."
+)
 
 AI_AUTOMATION_NOT_CONFIGURED = (
     "AI Automation requires OAuth credentials "
     "(PIPEFY_OAUTH_CLIENT, PIPEFY_OAUTH_SECRET, PIPEFY_OAUTH_URL). "
     "Check .env.example for the required variables."
 )
+
+
+def _ai_automation_api_failure_payload(
+    exc: BaseException, *, fallback: str, debug: bool = False
+) -> dict:
+    """Build a sanitized tool error for internal_api / service failures (default MCP).
+
+    Args:
+        exc: Exception from ``PipefyClient`` create/update AI automation.
+        fallback: Stable message when the exception text is empty after stripping.
+        debug: When True, append stripped bracket codes and correlation id to the message.
+    """
+    raw = str(exc).strip()
+    cleaned = strip_internal_api_diagnostic_markers(raw) if raw else ""
+    message = cleaned if cleaned else fallback
+    if debug:
+        codes = extract_internal_api_bracket_codes(raw)
+        cid = extract_internal_api_bracket_correlation_id(raw)
+        message = with_debug_suffix(
+            message, debug=True, codes=codes, correlation_id=cid
+        )
+    return build_ai_tool_error(message)
 
 
 class AiAutomationTools:
@@ -45,6 +81,7 @@ class AiAutomationTools:
             skills_ids: list[str] | None = None,
             event_params: dict | None = None,
             condition: dict | None = None,
+            debug: bool = False,
         ) -> dict:
             """Create a simple AI automation that generates content with a prompt and writes the result to one or more card fields.
 
@@ -59,7 +96,8 @@ class AiAutomationTools:
                 field_ids: List of field internal IDs where the AI writes its output.
                 skills_ids: AI skill IDs to attach. Defaults to empty (no skills).
                 event_params: Trigger-specific filters (e.g. {"to_phase_id": "..."} for card_moved, {"triggerFieldIds": [...]} for field_updated).
-                condition: Optional condition structure for the automation trigger.
+                condition: Optional trigger condition dict. Omit to use the built-in placeholder (empty expression list) so Pipefy always receives a condition on create. Pass a dict to set a custom condition.
+                debug: When True, append internal_api code and correlation_id to create failures (after sanitizing the main message).
             """
             await ctx.debug(
                 f"create_ai_automation: name={name}, event_id={event_id}, pipe_id={pipe_id}"
@@ -89,7 +127,9 @@ class AiAutomationTools:
             try:
                 result = await client.create_ai_automation(validated)
             except Exception as exc:  # noqa: BLE001
-                return build_ai_tool_error(str(exc))
+                return _ai_automation_api_failure_payload(
+                    exc, fallback=AI_AUTOMATION_CREATE_FAILED, debug=debug
+                )
 
             return build_create_automation_success(
                 automation_id=result["automation_id"],
@@ -109,6 +149,7 @@ class AiAutomationTools:
             skills_ids: list[str] | None = None,
             event_params: dict | None = None,
             condition: dict | None = None,
+            debug: bool = False,
         ) -> dict:
             """Update an existing AI automation's name, prompt, destination fields, or active state.
 
@@ -120,7 +161,8 @@ class AiAutomationTools:
                 field_ids: New list of field internal IDs (optional).
                 skills_ids: New list of AI skill IDs (optional).
                 event_params: Trigger-specific filters (e.g. {"to_phase_id": "..."} for card_moved). Pass to change; omit to keep current.
-                condition: New condition structure (optional).
+                condition: New trigger condition dict. Omit to leave the automation's condition unchanged; pass a dict to replace it.
+                debug: When True, append internal_api code and correlation_id to update failures (after sanitizing the main message).
             """
             await ctx.debug(f"update_ai_automation: automation_id={automation_id}")
             if not client.ai_automation_available:
@@ -143,7 +185,9 @@ class AiAutomationTools:
             try:
                 result = await client.update_ai_automation(validated)
             except Exception as exc:  # noqa: BLE001
-                return build_ai_tool_error(str(exc))
+                return _ai_automation_api_failure_payload(
+                    exc, fallback=AI_AUTOMATION_UPDATE_FAILED, debug=debug
+                )
 
             return build_update_automation_success(
                 automation_id=result["automation_id"],

--- a/src/pipefy_mcp/tools/ai_tool_helpers.py
+++ b/src/pipefy_mcp/tools/ai_tool_helpers.py
@@ -10,7 +10,10 @@ from typing import TYPE_CHECKING, Any, Literal
 from typing_extensions import TypedDict
 
 from pipefy_mcp.services.pipefy.types import AiAgentGraphPayload
-from pipefy_mcp.tools.graphql_error_helpers import extract_error_strings
+from pipefy_mcp.tools.graphql_error_helpers import (
+    extract_error_strings,
+    strip_internal_api_diagnostic_markers,
+)
 
 if TYPE_CHECKING:
     from pipefy_mcp.services.pipefy import PipefyClient
@@ -164,6 +167,9 @@ def build_delete_agent_success(*, message: str) -> DeleteAiAgentSuccessPayload:
 def build_ai_tool_error(message: str) -> AiToolErrorPayload:
     """Generic AI-tool failure envelope.
 
+    Does not alter ``message``; callers must pass user-safe text (sanitized when
+    the source is ``InternalApiClient`` / GraphQL errors with diagnostic suffixes).
+
     Args:
         message: User-visible failure reason.
     """
@@ -185,6 +191,10 @@ def build_create_agent_partial_failure(
 # --- Error enrichment for behavior-level failures ---
 
 # Patterns the Pipefy API returns that map to actionable advice.
+_BEHAVIOR_ERROR_EMPTY_AFTER_SANITIZE = (
+    "The AI behavior request failed. Check behaviors and pipe context, then retry."
+)
+
 _ERROR_HINTS: list[tuple[re.Pattern[str], str]] = [
     (
         re.compile(r"RECORD_NOT_SAVED", re.IGNORECASE),
@@ -659,8 +669,9 @@ def enrich_behavior_error(
 ) -> str:
     """Build an enriched error message with behavior context and actionable hints.
 
-    Extracts raw GraphQL messages, appends a behavior summary, and matches
-    known error patterns to actionable advice.
+    Extracts GraphQL messages, strips InternalApiClient-style ``[code=…]`` /
+    ``[correlation_id=…]`` markers from the primary line, appends a behavior
+    summary, and matches known error patterns to actionable advice.
 
     Args:
         exc: The exception from the service call.
@@ -668,6 +679,9 @@ def enrich_behavior_error(
     """
     msgs = extract_error_strings(exc)
     base = "; ".join(msgs) if msgs else str(exc)
+    base = strip_internal_api_diagnostic_markers(base).strip()
+    if not base:
+        base = _BEHAVIOR_ERROR_EMPTY_AFTER_SANITIZE
 
     hints: list[str] = []
     for pattern, hint in _ERROR_HINTS:

--- a/src/pipefy_mcp/tools/automation_tools.py
+++ b/src/pipefy_mcp/tools/automation_tools.py
@@ -548,9 +548,9 @@ class AutomationTools:
         ) -> dict[str, Any]:
             """Delete an automation rule permanently.
 
-            Two-step operation: call without ``confirm`` to preview, then with
-            ``confirm=True`` after user approval. When the MCP client supports
-            elicitation, the user is prompted interactively instead.
+            Two-step operation: preview with ``confirm=False`` (default), then execute with
+            ``confirm=True`` after explicit human approval. Elicitation does not authorize
+            deletion (only ``confirm=True`` does).
 
             Args:
                 automation_id: Automation rule ID to delete.

--- a/src/pipefy_mcp/tools/destructive_tool_guard.py
+++ b/src/pipefy_mcp/tools/destructive_tool_guard.py
@@ -2,11 +2,12 @@
 
 Every tool with ``destructiveHint=True`` should call
 :func:`check_destructive_confirmation` **before** executing the deletion.
-The guard handles three scenarios:
 
-* **Elicitation available** → prompts the user interactively.
-* **No elicitation, ``confirm=False``** → returns a preview payload (no deletion).
-* **``confirm=True``** → returns ``None`` so the caller proceeds.
+* ``confirm=False`` → returns a preview payload; **never** deletes. Some MCP clients
+  auto-accept elicitation prompts when tools are invoked programmatically; this
+  guard therefore does **not** use elicitation to authorize deletion—only an
+  explicit follow-up call with ``confirm=True`` does.
+* ``confirm=True`` → returns ``None`` so the caller proceeds with the deletion.
 """
 
 from __future__ import annotations
@@ -15,23 +16,11 @@ from typing import Any, Literal
 
 from mcp.server.fastmcp import Context
 from mcp.server.session import ServerSession
-from pydantic import BaseModel, Field
 from typing_extensions import TypedDict
-
-from pipefy_mcp.tools.mcp_capabilities import supports_elicitation
-
-
-class DestructiveActionConfirmation(BaseModel):
-    """Schema shown to the user when the MCP client supports elicitation."""
-
-    confirm: bool = Field(
-        ...,
-        description="Set to true to confirm the action, or false to cancel.",
-    )
 
 
 class DestructivePreviewPayload(TypedDict):
-    """Returned when the tool needs confirmation and elicitation is not available."""
+    """Returned when the tool needs confirmation before deletion."""
 
     success: Literal[False]
     requires_confirmation: Literal[True]
@@ -44,41 +33,31 @@ class DestructiveCancelledPayload(TypedDict):
     error: str
 
 
-_CANCEL_MESSAGE = "Action cancelled by user."
-
-
 async def check_destructive_confirmation(
-    ctx: Context[ServerSession, None],
+    _ctx: Context[ServerSession, None],
     *,
     confirm: bool,
     resource_descriptor: str,
 ) -> dict[str, Any] | None:
-    """Gate a destructive operation behind user confirmation.
+    """Gate a destructive operation behind explicit ``confirm=True``.
 
     Call this **after** fetching resource info but **before** executing the
-    deletion.  The function handles elicitation (when supported) and the
-    two-step ``confirm`` fallback.
+    deletion.
 
     Args:
-        ctx: MCP request context (used to check elicitation support and prompt
-            the user).
-        confirm: Explicit confirmation flag from the tool caller.
+        _ctx: MCP request context (reserved for future use / logging).
+        confirm: Must be ``True`` to allow the deletion to run.
         resource_descriptor: Human-readable description of the resource about
-            to be deleted (e.g. ``"phase 'Initial' (ID: 42)"``).  Used in
-            preview payloads and elicitation prompts.
+            to be deleted (e.g. ``"phase 'Initial' (ID: 42)"``). Used in
+            preview payloads.
 
     Returns:
         ``None`` when the caller should proceed with the deletion.
-        A ``dict`` payload when the operation was cancelled or needs
-        confirmation — the caller should return this payload as-is.
+        A preview ``dict`` when ``confirm`` is false — the caller must return
+        it as-is.
     """
     if confirm:
         return None
-
-    can_elicit = supports_elicitation(ctx)
-
-    if can_elicit:
-        return await _elicit_confirmation(ctx, resource_descriptor)
 
     return _build_preview_payload(resource_descriptor)
 
@@ -95,40 +74,7 @@ def _build_preview_payload(resource_descriptor: str) -> DestructivePreviewPayloa
     }
 
 
-async def _elicit_confirmation(
-    ctx: Context[ServerSession, None],
-    resource_descriptor: str,
-) -> dict[str, Any] | None:
-    """Prompt the user via MCP elicitation. Returns ``None`` to proceed."""
-    confirmation_message = (
-        f"⚠️ You are about to permanently delete {resource_descriptor}. "
-        "This action is irreversible. Are you sure you want to proceed?"
-    )
-
-    try:
-        result = await ctx.elicit(
-            message=confirmation_message,
-            schema=DestructiveActionConfirmation,
-        )
-
-        if result.action != "accept":
-            return _build_cancel_payload()
-
-        if not result.data.model_dump().get("confirm"):
-            return _build_cancel_payload()
-
-    except Exception:  # noqa: BLE001
-        return _build_preview_payload(resource_descriptor)
-
-    return None
-
-
-def _build_cancel_payload() -> DestructiveCancelledPayload:
-    return {"success": False, "error": _CANCEL_MESSAGE}
-
-
 __all__ = [
-    "DestructiveActionConfirmation",
     "DestructiveCancelledPayload",
     "DestructivePreviewPayload",
     "check_destructive_confirmation",

--- a/src/pipefy_mcp/tools/destructive_tool_guard.py
+++ b/src/pipefy_mcp/tools/destructive_tool_guard.py
@@ -18,6 +18,8 @@ from mcp.server.session import ServerSession
 from pydantic import BaseModel, Field
 from typing_extensions import TypedDict
 
+from pipefy_mcp.tools.mcp_capabilities import supports_elicitation
+
 
 class DestructiveActionConfirmation(BaseModel):
     """Schema shown to the user when the MCP client supports elicitation."""
@@ -73,7 +75,7 @@ async def check_destructive_confirmation(
     if confirm:
         return None
 
-    can_elicit = ctx.session.client_params.capabilities.elicitation
+    can_elicit = supports_elicitation(ctx)
 
     if can_elicit:
         return await _elicit_confirmation(ctx, resource_descriptor)

--- a/src/pipefy_mcp/tools/field_condition_tools.py
+++ b/src/pipefy_mcp/tools/field_condition_tools.py
@@ -234,9 +234,9 @@ class FieldConditionTools:
         ) -> dict[str, Any]:
             """Delete a field condition permanently.
 
-            Two-step operation: call without ``confirm`` to preview, then with
-            ``confirm=True`` after user approval. When the MCP client supports
-            elicitation, the user is prompted interactively instead.
+            Two-step operation: preview with ``confirm=False`` (default), then execute with
+            ``confirm=True`` after explicit human approval. Elicitation does not authorize
+            deletion (only ``confirm=True`` does).
 
             Args:
                 ctx: MCP context for debug logging.

--- a/src/pipefy_mcp/tools/graphql_error_helpers.py
+++ b/src/pipefy_mcp/tools/graphql_error_helpers.py
@@ -5,6 +5,58 @@ from __future__ import annotations
 import re
 from typing import Any
 
+# Suffixes appended by InternalApiClient for service-layer diagnostics; MCP tools
+# should strip these from default user-visible errors (see task 4.2).
+_INTERNAL_API_CODE_SUFFIX_RE = re.compile(r"\s*\[code=[^\]]*\]")
+_INTERNAL_API_CORRELATION_SUFFIX_RE = re.compile(r"\s*\[correlation_id=[^\]]*\]")
+_INTERNAL_API_CODE_BRACKET_CAPTURE_RE = re.compile(r"\[code=([^\]]*)\]")
+_INTERNAL_API_CORRELATION_BRACKET_CAPTURE_RE = re.compile(
+    r"\[correlation_id=([^\]]*)\]"
+)
+
+
+def strip_internal_api_diagnostic_markers(message: str) -> str:
+    """Remove ``[code=…]`` / ``[correlation_id=…]`` markers from a message string.
+
+    ``InternalApiClient`` appends these to GraphQL error text for logs and tests.
+    Multiple occurrences (e.g. ``; ``-joined errors) are all removed.
+
+    Args:
+        message: Raw error text, often ``str(ValueError(...))`` from the client.
+    """
+    stripped = _INTERNAL_API_CORRELATION_SUFFIX_RE.sub("", message)
+    stripped = _INTERNAL_API_CODE_SUFFIX_RE.sub("", stripped)
+    return stripped.strip()
+
+
+def extract_internal_api_bracket_codes(message: str) -> list[str]:
+    """Collect distinct ``code`` values from ``[code=…]`` markers (InternalApiClient).
+
+    Args:
+        message: Raw exception text before stripping markers.
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    for raw_code in _INTERNAL_API_CODE_BRACKET_CAPTURE_RE.findall(message):
+        code = raw_code.strip()
+        if code and code not in seen:
+            seen.add(code)
+            out.append(code)
+    return out
+
+
+def extract_internal_api_bracket_correlation_id(message: str) -> str | None:
+    """Return the first non-empty correlation id from ``[correlation_id=…]`` markers.
+
+    Args:
+        message: Raw exception text before stripping markers.
+    """
+    for raw_cid in _INTERNAL_API_CORRELATION_BRACKET_CAPTURE_RE.findall(message):
+        cid = raw_cid.strip()
+        if cid:
+            return cid
+    return None
+
 
 def extract_error_strings(exc: BaseException) -> list[str]:
     """Best-effort extraction of error messages from gql/GraphQL exceptions."""

--- a/src/pipefy_mcp/tools/mcp_capabilities.py
+++ b/src/pipefy_mcp/tools/mcp_capabilities.py
@@ -1,0 +1,36 @@
+"""Safe access to MCP client capability flags.
+
+MCP transports and SDK versions differ in whether ``client_params`` and nested
+``capabilities`` are present. Tools must not assume the full chain exists.
+"""
+
+from __future__ import annotations
+
+from mcp.server.fastmcp import Context
+from mcp.server.session import ServerSession
+
+
+def supports_elicitation(ctx: Context[ServerSession, None]) -> bool:
+    """Return whether the connected client advertises elicitation support.
+
+    Args:
+        ctx: MCP request context for the active call.
+
+    Returns:
+        ``True`` when ``capabilities.elicitation`` is truthy; ``False`` if any
+        link in the chain is missing or ``elicitation`` is false/absent.
+    """
+    session = getattr(ctx, "session", None)
+    if session is None:
+        return False
+    client_params = getattr(session, "client_params", None)
+    if client_params is None:
+        return False
+    capabilities = getattr(client_params, "capabilities", None)
+    if capabilities is None:
+        return False
+    elicitation = getattr(capabilities, "elicitation", None)
+    return bool(elicitation)
+
+
+__all__ = ["supports_elicitation"]

--- a/src/pipefy_mcp/tools/member_tools.py
+++ b/src/pipefy_mcp/tools/member_tools.py
@@ -84,9 +84,9 @@ class MemberTools:
         ) -> dict[str, Any]:
             """Permanently remove one or more users from a pipe.
 
-            Two-step operation: call without ``confirm`` to preview, then with
-            ``confirm=True`` after user approval. When the MCP client supports
-            elicitation, the user is prompted interactively instead.
+            Two-step operation: preview with ``confirm=False`` (default), then execute with
+            ``confirm=True`` after explicit human approval. Elicitation does not authorize
+            deletion (only ``confirm=True`` does).
 
             Args:
                 pipe_id: ID of the pipe.

--- a/src/pipefy_mcp/tools/pipe_config_tools.py
+++ b/src/pipefy_mcp/tools/pipe_config_tools.py
@@ -402,9 +402,9 @@ class PipeConfigTools:
         ) -> dict[str, Any]:
             """Delete a phase permanently.
 
-            Two-step operation: call without ``confirm`` to preview, then with
-            ``confirm=True`` after user approval. When the MCP client supports
-            elicitation, the user is prompted interactively instead.
+            Two-step operation: preview with ``confirm=False`` (default), then execute with
+            ``confirm=True`` after explicit human approval. Elicitation does not authorize
+            deletion (only ``confirm=True`` does).
 
             Args:
                 phase_id: Phase ID to delete.
@@ -596,9 +596,9 @@ class PipeConfigTools:
         ) -> dict[str, Any]:
             """Delete a phase field permanently.
 
-            Two-step operation: call without ``confirm`` to preview, then with
-            ``confirm=True`` after user approval. When the MCP client supports
-            elicitation, the user is prompted interactively instead.
+            Two-step operation: preview with ``confirm=False`` (default), then execute with
+            ``confirm=True`` after explicit human approval. Elicitation does not authorize
+            deletion (only ``confirm=True`` does).
 
             ``field_id`` is the field slug (e.g. ``"prioridade"``) or uuid.
             When the slug is shared across phases, pass ``pipe_uuid`` to
@@ -747,9 +747,9 @@ class PipeConfigTools:
         ) -> dict[str, Any]:
             """Delete a label permanently.
 
-            Two-step operation: call without ``confirm`` to preview, then with
-            ``confirm=True`` after user approval. When the MCP client supports
-            elicitation, the user is prompted interactively instead.
+            Two-step operation: preview with ``confirm=False`` (default), then execute with
+            ``confirm=True`` after explicit human approval. Elicitation does not authorize
+            deletion (only ``confirm=True`` does).
 
             Args:
                 label_id: Label ID to delete.

--- a/src/pipefy_mcp/tools/pipe_tools.py
+++ b/src/pipefy_mcp/tools/pipe_tools.py
@@ -321,12 +321,18 @@ class PipeTools:
             (e.g. Status = "In Progress"). This tool does **not** support
             searching by card title — use ``get_cards(title=...)`` for that.
 
+            Do **not** use column ``name`` values from ``get_pipe_report_columns`` or
+            ``get_pipe_report_filterable_fields`` (e.g. ``field_2_string``) as ``field_id``:
+            those keys are for pipe **reports**, not for the ``findCards`` GraphQL field.
+            Always take ``field_id`` from ``get_phase_fields`` or ``get_start_form_fields``
+            (the field's ``id`` / slug).
+
             Args:
                 pipe_id: The ID of the pipe to search in.
-                field_id: Pipefy field slug (e.g. "status", "id_da_solicita_o") — the ``id``
+                field_id: Pipefy field slug (e.g. "status", "campaign_name") — the ``id``
                     value returned by get_start_form_fields or get_phase_fields, NOT the
-                    human-readable label. Call get_start_form_fields first to discover valid
-                    field slugs for your pipe.
+                    human-readable label and NOT pipe-report column names. Call
+                    get_phase_fields (per phase) or get_start_form_fields to discover valid slugs.
                 field_value: Value to match for that field (string; use the format expected by the field type).
                 include_fields: If True, include each card's custom fields (name, value) in the response.
                 first: Max cards per page (optional).
@@ -656,21 +662,16 @@ class PipeTools:
         ) -> DeleteCardPayload:
             """Delete a card from Pipefy.
 
-            This is a destructive, two-step operation:
+            Two-step operation:
 
-            1. **Preview** — call without ``confirm`` (or ``confirm=False``) to see
-               which card will be deleted.  When the MCP client supports elicitation
-               the user is prompted interactively; otherwise a preview payload is
-               returned and no deletion happens.
-            2. **Execute** — call again with ``confirm=True`` after the user has
-               reviewed the preview.
+            1. **Preview** — call with ``confirm=False`` (default). Returns a preview payload;
+               nothing is deleted. Elicitation is **not** used to authorize deletion (automated
+               clients may auto-accept prompts).
+            2. **Execute** — call again with ``confirm=True`` after explicit human approval.
 
             Args:
                 card_id: The ID of the card to delete.
-                confirm: Set to True to execute the deletion (step 2).
-                    When the client supports elicitation, ``confirm=True`` still
-                    applies: use it to skip the dialog after explicit user approval
-                    (e.g. agent workflows); omit it to show the interactive prompt.
+                confirm: Must be ``True`` to run the delete mutation.
                 debug: When true, appends GraphQL error codes and correlation_id to the error message.
 
             Returns:

--- a/src/pipefy_mcp/tools/pipe_tools.py
+++ b/src/pipefy_mcp/tools/pipe_tools.py
@@ -24,6 +24,7 @@ from pipefy_mcp.tools.graphql_error_helpers import (
     extract_graphql_error_codes,
     with_debug_suffix,
 )
+from pipefy_mcp.tools.mcp_capabilities import supports_elicitation
 from pipefy_mcp.tools.phase_transition_helpers import (
     try_enrich_move_card_to_phase_failure,
 )
@@ -108,7 +109,7 @@ class PipeTools:
             await ctx.debug(f"Provided fields: {fields}")
 
             card_data = fields or {}
-            can_elicit = ctx.session.client_params.capabilities.elicitation
+            can_elicit = supports_elicitation(ctx)
 
             if can_elicit:
                 try:
@@ -574,7 +575,7 @@ class PipeTools:
             await ctx.debug(f"Provided fields: {fields}")
 
             field_data = fields or {}
-            can_elicit = ctx.session.client_params.capabilities.elicitation
+            can_elicit = supports_elicitation(ctx)
 
             if can_elicit and expected_fields:
                 try:

--- a/src/pipefy_mcp/tools/registry.py
+++ b/src/pipefy_mcp/tools/registry.py
@@ -19,6 +19,127 @@ from pipefy_mcp.tools.report_tools import ReportTools
 from pipefy_mcp.tools.table_tools import TableTools
 from pipefy_mcp.tools.webhook_tools import WebhookTools
 
+PIPEFY_TOOL_NAMES = frozenset(
+    {
+        "add_card_comment",
+        "clone_pipe",
+        "create_ai_agent",
+        "create_ai_automation",
+        "create_automation",
+        "create_card",
+        "create_card_relation",
+        "create_field_condition",
+        "create_label",
+        "create_organization_report",
+        "create_phase",
+        "create_phase_field",
+        "create_pipe",
+        "create_pipe_relation",
+        "create_pipe_report",
+        "create_send_task_automation",
+        "create_table",
+        "create_table_field",
+        "create_table_record",
+        "create_webhook",
+        "delete_ai_agent",
+        "delete_automation",
+        "delete_card",
+        "delete_comment",
+        "delete_field_condition",
+        "delete_label",
+        "delete_organization_report",
+        "delete_phase",
+        "delete_phase_field",
+        "delete_pipe",
+        "delete_pipe_relation",
+        "delete_pipe_report",
+        "delete_table",
+        "delete_table_field",
+        "delete_table_record",
+        "delete_webhook",
+        "execute_graphql",
+        "export_automation_jobs",
+        "export_organization_report",
+        "export_pipe_audit_logs",
+        "export_pipe_report",
+        "fill_card_phase_fields",
+        "find_cards",
+        "find_records",
+        "get_agents_usage",
+        "get_ai_agent",
+        "get_ai_agent_log_details",
+        "get_ai_agent_logs",
+        "get_ai_agents",
+        "get_ai_credit_usage",
+        "get_automation",
+        "get_automation_actions",
+        "get_automation_events",
+        "get_automation_jobs_export",
+        "get_automation_jobs_export_csv",
+        "get_automation_logs",
+        "get_automation_logs_by_repo",
+        "get_automations",
+        "get_automations_usage",
+        "get_card",
+        "get_card_inbox_emails",
+        "get_cards",
+        "get_email_templates",
+        "get_organization",
+        "get_organization_report",
+        "get_organization_report_export",
+        "get_organization_reports",
+        "get_phase_fields",
+        "get_pipe",
+        "get_pipe_members",
+        "get_pipe_relations",
+        "get_pipe_report_columns",
+        "get_pipe_report_export",
+        "get_pipe_report_filterable_fields",
+        "get_pipe_reports",
+        "get_start_form_fields",
+        "get_table",
+        "get_table_record",
+        "get_table_records",
+        "get_tables",
+        "get_table_relations",
+        "introspect_mutation",
+        "introspect_query",
+        "introspect_type",
+        "invite_members",
+        "move_card_to_phase",
+        "remove_member_from_pipe",
+        "search_pipes",
+        "search_schema",
+        "search_tables",
+        "send_email_with_template",
+        "send_inbox_email",
+        "simulate_automation",
+        "set_role",
+        "set_table_record_field_value",
+        "toggle_ai_agent_status",
+        "update_ai_agent",
+        "update_ai_automation",
+        "update_automation",
+        "update_card",
+        "update_card_field",
+        "update_comment",
+        "update_field_condition",
+        "update_label",
+        "update_organization_report",
+        "update_phase",
+        "update_phase_field",
+        "update_pipe",
+        "update_pipe_relation",
+        "update_pipe_report",
+        "update_table",
+        "update_table_field",
+        "update_table_record",
+        "upload_attachment_to_card",
+        "upload_attachment_to_table_record",
+        "validate_ai_agent_behaviors",
+    }
+)
+
 
 class ToolRegistry:
     """Responsible for registering tools with the MCP server."""
@@ -26,7 +147,7 @@ class ToolRegistry:
     def __init__(self, mcp: FastMCP, services_container: ServicesContainer):
         self.mcp = mcp
         self.services_container = services_container
-        self.pipefy_tool_names: frozenset[str] = frozenset()
+        self.pipefy_tool_names: frozenset[str] = PIPEFY_TOOL_NAMES
 
     @staticmethod
     def _snapshot_tool_names(mcp: FastMCP) -> set[str]:
@@ -46,12 +167,25 @@ class ToolRegistry:
                 continue
         return names
 
+    def check_for_name_collisions(self) -> None:
+        """Fail fast if any Pipefy tool name is already registered on the app.
+
+        FastMCP keeps the first handler when names collide; preflight avoids
+        silently running a foreign ``create_card`` (or other) handler.
+        """
+        existing = self._snapshot_tool_names(self.mcp)
+        collisions = existing & set(self.pipefy_tool_names)
+        if collisions:
+            names = ", ".join(sorted(collisions))
+            raise RuntimeError(
+                "Cannot register Pipefy tools because these names already exist: "
+                f"{names}"
+            )
+
     def register_tools(self) -> FastMCP:
         """Register tools with the MCP server."""
         if self.services_container.pipefy_client is None:
             raise ValueError("Pipefy client is not initialized in services container")
-
-        before = self._snapshot_tool_names(self.mcp)
 
         PipeTools.register(self.mcp, self.services_container.pipefy_client)
         PipeConfigTools.register(self.mcp, self.services_container.pipefy_client)
@@ -69,8 +203,5 @@ class ToolRegistry:
 
         AiAutomationTools.register(self.mcp, self.services_container.pipefy_client)
         AiAgentTools.register(self.mcp, self.services_container.pipefy_client)
-
-        after = self._snapshot_tool_names(self.mcp)
-        self.pipefy_tool_names = frozenset(after - before)
 
         return self.mcp

--- a/src/pipefy_mcp/tools/registry.py
+++ b/src/pipefy_mcp/tools/registry.py
@@ -26,11 +26,32 @@ class ToolRegistry:
     def __init__(self, mcp: FastMCP, services_container: ServicesContainer):
         self.mcp = mcp
         self.services_container = services_container
+        self.pipefy_tool_names: frozenset[str] = frozenset()
+
+    @staticmethod
+    def _snapshot_tool_names(mcp: FastMCP) -> set[str]:
+        try:
+            tools = mcp._tool_manager.list_tools()
+        except AttributeError:
+            return set()
+        try:
+            tool_list = list(tools)
+        except TypeError:
+            return set()
+        names: set[str] = set()
+        for tool in tool_list:
+            try:
+                names.add(tool.name)
+            except AttributeError:
+                continue
+        return names
 
     def register_tools(self) -> FastMCP:
         """Register tools with the MCP server."""
         if self.services_container.pipefy_client is None:
             raise ValueError("Pipefy client is not initialized in services container")
+
+        before = self._snapshot_tool_names(self.mcp)
 
         PipeTools.register(self.mcp, self.services_container.pipefy_client)
         PipeConfigTools.register(self.mcp, self.services_container.pipefy_client)
@@ -48,5 +69,8 @@ class ToolRegistry:
 
         AiAutomationTools.register(self.mcp, self.services_container.pipefy_client)
         AiAgentTools.register(self.mcp, self.services_container.pipefy_client)
+
+        after = self._snapshot_tool_names(self.mcp)
+        self.pipefy_tool_names = frozenset(after - before)
 
         return self.mcp

--- a/src/pipefy_mcp/tools/relation_tools.py
+++ b/src/pipefy_mcp/tools/relation_tools.py
@@ -190,9 +190,9 @@ class RelationTools:
         ) -> dict[str, Any]:
             """Permanently delete a pipe relation by ID.
 
-            Two-step operation: call without ``confirm`` to preview, then with
-            ``confirm=True`` after user approval. When the MCP client supports
-            elicitation, the user is prompted interactively instead.
+            Two-step operation: preview with ``confirm=False`` (default), then execute with
+            ``confirm=True`` after explicit human approval. Elicitation does not authorize
+            deletion (only ``confirm=True`` does).
 
             Args:
                 relation_id: Pipe relation ID to delete.

--- a/src/pipefy_mcp/tools/relation_tools.py
+++ b/src/pipefy_mcp/tools/relation_tools.py
@@ -33,6 +33,10 @@ class RelationTools:
         async def get_pipe_relations(pipe_id: str | int) -> dict[str, Any]:
             """List pipe relations for a pipe (parent and child links, config, and repo refs).
 
+            Takes a **pipe** ID. Each relation's ``id`` in the response is a **pipe relation**
+            ID (use as ``source_id`` in ``create_card_relation``). Do not confuse with
+            ``get_table_relations``, which takes **table relation** IDs, not ``pipe_id``.
+
             Args:
                 pipe_id: Pipe ID.
             """
@@ -55,10 +59,16 @@ class RelationTools:
             annotations=ToolAnnotations(readOnlyHint=True),
         )
         async def get_table_relations(relation_ids: list[str | int]) -> dict[str, Any]:
-            """Load table relations by their IDs (Pipefy root `table_relations`).
+            """Load table relations by ID (Pipefy root ``table_relations``).
+
+            **Do not pass** ``table_id`` or a database table ID — this tool only accepts
+            **table relation** identifiers (the link object between tables). To resolve
+            table IDs for schema/records, use ``get_table`` / ``search_tables`` instead.
+            Obtain table-relation IDs from the Pipefy UI, your saved metadata, or GraphQL
+            (e.g. introspection / ``execute_graphql``), not from ``get_pipe_relations``.
 
             Args:
-                relation_ids: Non-empty list of **table relation** IDs (not the database table ID).
+                relation_ids: Non-empty list of **table relation** IDs (never the database table ID).
             """
             if not isinstance(relation_ids, list) or not relation_ids:
                 return build_relation_error_payload(
@@ -91,6 +101,7 @@ class RelationTools:
         ) -> dict[str, Any]:
             """Create a parent-child relation between two pipes.
 
+            ``parent_id`` and ``child_id`` are **pipe** IDs (not table or card IDs).
             Optional ``extra_input`` merges into Pipefy ``CreatePipeRelationInput`` (camelCase keys), e.g. ``canCreateNewItems``, ``ownFieldMaps``.
 
             Args:
@@ -140,6 +151,7 @@ class RelationTools:
         ) -> dict[str, Any]:
             """Update an existing pipe relation (name, auto-fill, connection flags).
 
+            ``relation_id`` is the **pipe relation** id from ``get_pipe_relations`` (not a table relation id).
             Optional ``extra_input`` merges into Pipefy ``UpdatePipeRelationInput`` (camelCase keys), overriding defaults for flags or ``ownFieldMaps``.
 
             Args:
@@ -190,6 +202,7 @@ class RelationTools:
         ) -> dict[str, Any]:
             """Permanently delete a pipe relation by ID.
 
+            ``relation_id`` is the **pipe relation** id from ``get_pipe_relations`` (not a table relation id).
             Two-step operation: preview with ``confirm=False`` (default), then execute with
             ``confirm=True`` after explicit human approval. Elicitation does not authorize
             deletion (only ``confirm=True`` does).
@@ -235,7 +248,8 @@ class RelationTools:
         ) -> dict[str, Any]:
             """Connect a child card to a parent card using an existing pipe relation.
 
-            Use ``get_pipe_relations`` on the parent or child pipe to obtain the pipe relation ``id`` (pass it as ``source_id``).
+            ``source_id`` must be a **pipe relation** id from ``get_pipe_relations`` (the link between pipes).
+            It is **not** a table-relation id (``get_table_relations``), not a database ``table_id``, and not a pipe or card id.
 
             Args:
                 parent_id: Parent card ID.

--- a/src/pipefy_mcp/tools/report_tools.py
+++ b/src/pipefy_mcp/tools/report_tools.py
@@ -88,6 +88,9 @@ class ReportTools:
         ) -> dict[str, Any]:
             """Get available columns for a pipe report. Each item includes `name` (internal field id for `fields`) and `label`.
 
+            The ``name`` values here are for **report** configuration and exports only; they are
+            not the same slugs used by ``find_cards`` (use ``get_phase_fields`` / ``get_start_form_fields`` for that).
+
             Args:
                 pipe_uuid: Pipe UUID.
                 debug: When True, append GraphQL codes and correlation_id to errors.
@@ -114,6 +117,8 @@ class ReportTools:
             debug: bool = False,
         ) -> dict[str, Any]:
             """Get filterable fields for a pipe report (nested groups; use `name` for filter fields).
+
+            Like ``get_pipe_report_columns``, the ``name`` keys are for **reports**, not for ``find_cards``.
 
             Args:
                 pipe_uuid: Pipe UUID.
@@ -352,9 +357,9 @@ class ReportTools:
         ) -> dict[str, Any]:
             """Delete a pipe report. This action is irreversible.
 
-            Two-step operation: call without ``confirm`` to preview, then with
-            ``confirm=True`` after user approval. When the MCP client supports
-            elicitation, the user is prompted interactively instead.
+            Two-step operation: preview with ``confirm=False`` (default), then execute with
+            ``confirm=True`` after explicit human approval. Elicitation does not authorize
+            deletion (only ``confirm=True`` does).
 
             Args:
                 report_id: Pipe report ID to delete.
@@ -486,9 +491,9 @@ class ReportTools:
         ) -> dict[str, Any]:
             """Delete an organization report. This action is irreversible.
 
-            Two-step operation: call without ``confirm`` to preview, then with
-            ``confirm=True`` after user approval. When the MCP client supports
-            elicitation, the user is prompted interactively instead.
+            Two-step operation: preview with ``confirm=False`` (default), then execute with
+            ``confirm=True`` after explicit human approval. Elicitation does not authorize
+            deletion (only ``confirm=True`` does).
 
             Args:
                 report_id: Organization report ID to delete.

--- a/src/pipefy_mcp/tools/table_tools.py
+++ b/src/pipefy_mcp/tools/table_tools.py
@@ -586,9 +586,9 @@ class TableTools:
         ) -> dict[str, Any]:
             """Delete a table record permanently.
 
-            Two-step operation: call without ``confirm`` to preview, then with
-            ``confirm=True`` after user approval. When the MCP client supports
-            elicitation, the user is prompted interactively instead.
+            Two-step operation: preview with ``confirm=False`` (default), then execute with
+            ``confirm=True`` after explicit human approval. Elicitation does not authorize
+            deletion (only ``confirm=True`` does).
 
             Args:
                 record_id: Record ID to delete.
@@ -824,9 +824,9 @@ class TableTools:
         ) -> dict[str, Any]:
             """Delete a database table field (column) permanently.
 
-            Two-step operation: call without ``confirm`` to preview, then with
-            ``confirm=True`` after user approval. When the MCP client supports
-            elicitation, the user is prompted interactively instead.
+            Two-step operation: preview with ``confirm=False`` (default), then execute with
+            ``confirm=True`` after explicit human approval. Elicitation does not authorize
+            deletion (only ``confirm=True`` does).
 
             Args:
                 field_id: Table field ID to delete.

--- a/src/pipefy_mcp/tools/table_tools.py
+++ b/src/pipefy_mcp/tools/table_tools.py
@@ -89,6 +89,10 @@ class TableTools:
         async def get_table(table_id: str | int) -> dict[str, Any]:
             """Load one database table: name, description, fields, and authorization.
 
+            ``table_id`` is the **database table** id (from ``search_tables`` / ``get_tables``).
+            For **table-to-table relation link** metadata, use ``get_table_relations`` with
+            table-**relation** ids — not this argument.
+
             Args:
                 table_id: Pipefy database table ID.
             """
@@ -110,6 +114,8 @@ class TableTools:
         )
         async def get_tables(table_ids: list[str | int]) -> dict[str, Any]:
             """Load several database tables by ID (same shape as get_table per table).
+
+            IDs are **database table** ids, not table-**relation** ids (see ``get_table_relations``).
 
             Args:
                 table_ids: Non-empty list of table IDs.

--- a/src/pipefy_mcp/tools/webhook_tools.py
+++ b/src/pipefy_mcp/tools/webhook_tools.py
@@ -321,9 +321,9 @@ class WebhookTools:
         ) -> dict[str, Any]:
             """Delete a webhook permanently.
 
-            Two-step operation: call without ``confirm`` to preview, then with
-            ``confirm=True`` after user approval. When the MCP client supports
-            elicitation, the user is prompted interactively instead.
+            Two-step operation: preview with ``confirm=False`` (default), then execute with
+            ``confirm=True`` after explicit human approval. Elicitation does not authorize
+            deletion (only ``confirm=True`` does).
 
             Args:
                 ctx: MCP context for debug logging.

--- a/tests/models/test_ai_automation.py
+++ b/tests/models/test_ai_automation.py
@@ -83,6 +83,43 @@ def test_create_ai_automation_input_condition_explicit_override():
 
 
 @pytest.mark.unit
+def test_create_ai_automation_input_condition_partial_arbitrary_keys_round_trip():
+    """Partial condition dict does not populate unset ``expressions`` / ``expressions_structure``."""
+    inp = CreateAiAutomationInput(
+        name="My Automation",
+        event_id="card_created",
+        pipe_id="123",
+        prompt="Summarize %{133}",
+        field_ids=["133"],
+        condition={"foo": "bar"},
+    )
+    dumped = inp.condition.model_dump(
+        mode="python", exclude_unset=True, exclude_none=True
+    )
+    assert dumped == {"foo": "bar"}
+    assert "expressions" not in dumped
+    assert "expressions_structure" not in dumped
+
+
+@pytest.mark.unit
+def test_create_ai_automation_input_condition_partial_expressions_structure_only():
+    """Caller may send only ``expressions_structure`` without default empty ``expressions``."""
+    inp = CreateAiAutomationInput(
+        name="My Automation",
+        event_id="card_created",
+        pipe_id="123",
+        prompt="Summarize %{133}",
+        field_ids=["133"],
+        condition={"expressions_structure": [[1]]},
+    )
+    dumped = inp.condition.model_dump(
+        mode="python", exclude_unset=True, exclude_none=True
+    )
+    assert dumped == {"expressions_structure": [[1]]}
+    assert "expressions" not in dumped
+
+
+@pytest.mark.unit
 def test_create_ai_automation_input_field_ids_rejects_empty_list():
     """CreateAiAutomationInput rejects empty field_ids."""
     with pytest.raises(ValidationError):

--- a/tests/models/test_ai_automation.py
+++ b/tests/models/test_ai_automation.py
@@ -4,16 +4,11 @@ import pytest
 from pydantic import ValidationError
 
 from pipefy_mcp.models.ai_automation import (
+    DEFAULT_CONDITION,
+    AutomationConditionInput,
     CreateAiAutomationInput,
     UpdateAiAutomationInput,
 )
-
-DEFAULT_CONDITION = {
-    "expressions": [
-        {"structure_id": 0, "field_address": "", "operation": "", "value": ""}
-    ],
-    "expressions_structure": [[0]],
-}
 
 
 @pytest.mark.unit
@@ -56,7 +51,35 @@ def test_create_ai_automation_input_condition_defaults_to_placeholder():
         prompt="Summarize %{133}",
         field_ids=["133"],
     )
-    assert inp.condition == DEFAULT_CONDITION
+    assert inp.condition.model_dump(mode="python") == DEFAULT_CONDITION
+    inp2 = CreateAiAutomationInput(
+        name="My Automation",
+        event_id="card_created",
+        pipe_id="123",
+        prompt="Summarize %{133}",
+        field_ids=["133"],
+    )
+    assert inp.condition is not inp2.condition
+
+
+@pytest.mark.unit
+def test_create_ai_automation_input_condition_explicit_override():
+    """CreateAiAutomationInput uses caller-provided condition when passed."""
+    custom = {
+        "expressions": [
+            {"structure_id": 1, "field_address": "f", "op": "x", "value": "y"}
+        ],
+        "expressions_structure": [[1]],
+    }
+    inp = CreateAiAutomationInput(
+        name="My Automation",
+        event_id="card_created",
+        pipe_id="123",
+        prompt="Summarize %{133}",
+        field_ids=["133"],
+        condition=custom,
+    )
+    assert inp.condition.model_dump(mode="python") == custom
 
 
 @pytest.mark.unit
@@ -164,7 +187,8 @@ def test_create_ai_automation_input_event_params_pass_through():
         field_ids=["133"],
         event_params=params,
     )
-    assert inp.event_params == params
+    assert inp.event_params is not None
+    assert inp.event_params.model_dump(mode="python") == params
 
 
 @pytest.mark.unit
@@ -190,7 +214,11 @@ def test_update_ai_automation_input_accepts_optional_fields():
     assert inp.active is False
     assert inp.prompt == "New prompt %{133}"
     assert inp.field_ids == ["133", "789"]
-    assert inp.condition == {"expressions": [], "expressions_structure": []}
+    assert isinstance(inp.condition, AutomationConditionInput)
+    assert inp.condition.model_dump(mode="python") == {
+        "expressions": [],
+        "expressions_structure": [],
+    }
 
 
 @pytest.mark.unit
@@ -211,7 +239,8 @@ def test_update_ai_automation_input_event_params_pass_through():
     """UpdateAiAutomationInput stores event_params when provided."""
     params = {"to_phase_id": "phase-99"}
     inp = UpdateAiAutomationInput(automation_id="456", event_params=params)
-    assert inp.event_params == params
+    assert inp.event_params is not None
+    assert inp.event_params.model_dump(mode="python") == params
 
 
 @pytest.mark.unit

--- a/tests/services/test_ai_automation_service.py
+++ b/tests/services/test_ai_automation_service.py
@@ -164,6 +164,55 @@ async def test_create_automation_forwards_custom_condition():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_create_automation_sends_partial_condition_without_injected_defaults():
+    """Partial ``condition`` omits unset keys (no ``expressions``, no ``expressions_structure``)."""
+    mock_client = _create_mock_internal_api_client(
+        {"createAutomation": {"automation": {"id": "456"}}}
+    )
+    service = AiAutomationService(client=mock_client)
+
+    inp = CreateAiAutomationInput(
+        name="Partial cond",
+        event_id="card_created",
+        pipe_id="303",
+        prompt="Summarize %{1}",
+        field_ids=["1"],
+        condition={"foo": "bar"},
+    )
+    await service.create_automation(inp)
+
+    variables = mock_client.execute_query.call_args[0][1]
+    assert variables["condition"] == {"foo": "bar"}
+    assert "expressions" not in variables["condition"]
+    assert "expressions_structure" not in variables["condition"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_automation_sends_partial_condition_expressions_structure_only():
+    """Only user-provided condition keys appear in mutation variables."""
+    mock_client = _create_mock_internal_api_client(
+        {"createAutomation": {"automation": {"id": "456"}}}
+    )
+    service = AiAutomationService(client=mock_client)
+
+    inp = CreateAiAutomationInput(
+        name="Partial structure",
+        event_id="card_created",
+        pipe_id="303",
+        prompt="Summarize %{1}",
+        field_ids=["1"],
+        condition={"expressions_structure": [[1]]},
+    )
+    await service.create_automation(inp)
+
+    variables = mock_client.execute_query.call_args[0][1]
+    assert variables["condition"] == {"expressions_structure": [[1]]}
+    assert "expressions" not in variables["condition"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_create_automation_omits_event_params_when_none():
     """create_automation does not include event_params key when None."""
     mock_client = _create_mock_internal_api_client(
@@ -220,6 +269,26 @@ async def test_update_automation_passes_condition_when_provided():
 
     variables = mock_client.execute_query.call_args[0][1]
     assert variables["input"]["condition"] == cond
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_update_automation_partial_condition_omits_unset_fields():
+    """Update sends only keys the caller set on ``condition``."""
+    mock_client = _create_mock_internal_api_client(
+        {"updateAutomation": {"automation": {"id": "789"}}}
+    )
+    service = AiAutomationService(client=mock_client)
+
+    inp = UpdateAiAutomationInput(
+        automation_id="789",
+        condition={"custom_key": "only_this"},
+    )
+    await service.update_automation(inp)
+
+    variables = mock_client.execute_query.call_args[0][1]
+    assert variables["input"]["condition"] == {"custom_key": "only_this"}
+    assert "expressions" not in variables["input"]["condition"]
 
 
 @pytest.mark.unit

--- a/tests/services/test_ai_automation_service.py
+++ b/tests/services/test_ai_automation_service.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from pipefy_mcp.models.ai_automation import (
+    DEFAULT_CONDITION,
     CreateAiAutomationInput,
     UpdateAiAutomationInput,
 )
@@ -111,6 +112,58 @@ async def test_create_automation_passes_event_params_when_provided():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_create_automation_includes_default_condition_placeholder():
+    """create_automation always sends condition (model default when caller omits it)."""
+    mock_client = _create_mock_internal_api_client(
+        {"createAutomation": {"automation": {"id": "456"}}}
+    )
+    service = AiAutomationService(client=mock_client)
+
+    inp = CreateAiAutomationInput(
+        name="No explicit condition",
+        event_id="card_created",
+        pipe_id="303",
+        prompt="Summarize %{1}",
+        field_ids=["1"],
+    )
+    await service.create_automation(inp)
+
+    variables = mock_client.execute_query.call_args[0][1]
+    assert "condition" in variables
+    assert variables["condition"] == DEFAULT_CONDITION
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_automation_forwards_custom_condition():
+    """create_automation sends caller-provided condition in variables."""
+    mock_client = _create_mock_internal_api_client(
+        {"createAutomation": {"automation": {"id": "456"}}}
+    )
+    service = AiAutomationService(client=mock_client)
+
+    custom = {
+        "expressions": [
+            {"structure_id": 1, "field_address": "f", "operation": "eq", "value": "v"}
+        ],
+        "expressions_structure": [[1]],
+    }
+    inp = CreateAiAutomationInput(
+        name="Custom condition",
+        event_id="card_created",
+        pipe_id="303",
+        prompt="Summarize %{1}",
+        field_ids=["1"],
+        condition=custom,
+    )
+    await service.create_automation(inp)
+
+    variables = mock_client.execute_query.call_args[0][1]
+    assert variables["condition"] == custom
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_create_automation_omits_event_params_when_none():
     """create_automation does not include event_params key when None."""
     mock_client = _create_mock_internal_api_client(
@@ -129,6 +182,44 @@ async def test_create_automation_omits_event_params_when_none():
 
     variables = mock_client.execute_query.call_args[0][1]
     assert "event_params" not in variables
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_update_automation_omits_condition_when_not_provided():
+    """update_automation does not include condition in input when omitted."""
+    mock_client = _create_mock_internal_api_client(
+        {"updateAutomation": {"automation": {"id": "789"}}}
+    )
+    service = AiAutomationService(client=mock_client)
+
+    inp = UpdateAiAutomationInput(automation_id="789", name="Only name")
+    await service.update_automation(inp)
+
+    variables = mock_client.execute_query.call_args[0][1]
+    assert "condition" not in variables["input"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_update_automation_passes_condition_when_provided():
+    """update_automation includes condition in input dict when set."""
+    mock_client = _create_mock_internal_api_client(
+        {"updateAutomation": {"automation": {"id": "789"}}}
+    )
+    service = AiAutomationService(client=mock_client)
+
+    cond = {
+        "expressions": [
+            {"structure_id": 0, "field_address": "", "operation": "", "value": ""}
+        ],
+        "expressions_structure": [[0]],
+    }
+    inp = UpdateAiAutomationInput(automation_id="789", condition=cond)
+    await service.update_automation(inp)
+
+    variables = mock_client.execute_query.call_args[0][1]
+    assert variables["input"]["condition"] == cond
 
 
 @pytest.mark.unit

--- a/tests/services/test_internal_api_client.py
+++ b/tests/services/test_internal_api_client.py
@@ -1,6 +1,9 @@
 """Unit tests for InternalApiClient and PipefySettings.internal_api_url.
 
-Tests validate the internal API client behavior without real network calls.
+Service-layer tests intentionally assert the full GraphQL error text produced by
+``InternalApiClient`` (including ``[code=…]`` / ``[correlation_id=…]`` suffixes).
+MCP tools must not surface that raw text to users by default; see AI automation
+tool handlers and ``strip_internal_api_diagnostic_markers``.
 """
 
 import json
@@ -194,6 +197,45 @@ async def test_execute_query_error_includes_extensions_code_and_correlation_id(
     with pytest.raises(
         ValueError,
         match=r"Permission Denied \[code=PERMISSION_DENIED\] \[correlation_id=abc-123\]",
+    ):
+        await client.execute_query("query { x }", {})
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@respx.mock(assert_all_mocked=False, assert_all_called=False)
+async def test_execute_query_error_includes_correlation_id_when_code_absent(
+    respx_mock,
+):
+    """``correlation_id`` is appended even when ``extensions.code`` is missing."""
+    graphql_error_response = {
+        "errors": [
+            {
+                "message": "Rate limited",
+                "extensions": {"correlation_id": "corr-only-99"},
+            }
+        ]
+    }
+    respx_mock.post(OAUTH_TOKEN_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={"access_token": "tok", "token_type": "bearer", "expires_in": 3600},
+        )
+    )
+    respx_mock.post(DEFAULT_INTERNAL_API_URL).mock(
+        return_value=httpx.Response(200, json=graphql_error_response)
+    )
+
+    client = InternalApiClient(
+        url=DEFAULT_INTERNAL_API_URL,
+        oauth_url=OAUTH_TOKEN_URL,
+        oauth_client="client_id",
+        oauth_secret="client_secret",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"^Rate limited \[correlation_id=corr-only-99\]$",
     ):
         await client.execute_query("query { x }", {})
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -229,3 +229,74 @@ async def test_lifespan_logs_error_when_initialization_raises():
         mock_logger.exception.assert_called_once()
         call_msg = mock_logger.exception.call_args[0][0]
         assert "Fatal error during server lifespan" in call_msg
+
+
+@pytest.mark.unit
+@pytest.mark.anyio
+async def test_lifespan_failed_register_tools_does_not_mark_repeat_visit_state():
+    """``register_tools`` failure must not set repeat-visit flag or owned tool names."""
+    import pipefy_mcp.core.pipefy_tool_lifecycle as ptl
+    from pipefy_mcp.server import lifespan
+
+    app = FastMCP("fail-register-tools")
+    mock_container = MagicMock()
+    mock_container.pipefy_client = MagicMock()
+
+    with (
+        patch("pipefy_mcp.server.settings", _MINIMAL_PIPEFY_SETTINGS),
+        patch(
+            "pipefy_mcp.server.ServicesContainer.get_instance",
+            return_value=mock_container,
+        ),
+        patch("pipefy_mcp.server.ToolRegistry") as mock_registry_cls,
+    ):
+        mock_registry = MagicMock()
+        mock_registry_cls.return_value = mock_registry
+        mock_registry.register_tools.side_effect = RuntimeError("register failed")
+
+        with pytest.raises(RuntimeError, match="register failed"):
+            async with lifespan(app):
+                pass
+
+    assert getattr(app, ptl.PIPEFY_REPEAT_VISIT_FLAG_ATTR, False) is False
+    assert getattr(app, ptl.PIPEFY_OWNED_TOOL_NAMES_ATTR, None) is None
+
+
+@pytest.mark.unit
+@pytest.mark.anyio
+async def test_lifespan_retry_after_failed_register_tools_succeeds():
+    """After a failed ``register_tools``, a later successful run completes mark state."""
+    import pipefy_mcp.core.pipefy_tool_lifecycle as ptl
+    from pipefy_mcp.server import lifespan
+
+    app = FastMCP("retry-after-fail")
+    mock_container = MagicMock()
+    mock_container.pipefy_client = MagicMock()
+
+    with (
+        patch("pipefy_mcp.server.settings", _MINIMAL_PIPEFY_SETTINGS),
+        patch(
+            "pipefy_mcp.server.ServicesContainer.get_instance",
+            return_value=mock_container,
+        ),
+        patch("pipefy_mcp.server.ToolRegistry") as mock_registry_cls,
+    ):
+        mock_fail = MagicMock()
+        mock_fail.register_tools.side_effect = RuntimeError("register failed")
+        mock_ok = MagicMock()
+        mock_ok.register_tools.return_value = app
+        mock_ok.pipefy_tool_names = {"create_card"}
+        mock_registry_cls.side_effect = [mock_fail, mock_ok]
+
+        with pytest.raises(RuntimeError, match="register failed"):
+            async with lifespan(app):
+                pass
+
+        assert getattr(app, ptl.PIPEFY_REPEAT_VISIT_FLAG_ATTR, False) is False
+
+        async with lifespan(app):
+            pass
+
+        mock_ok.register_tools.assert_called_once()
+        assert getattr(app, ptl.PIPEFY_REPEAT_VISIT_FLAG_ATTR, False) is True
+        assert getattr(app, ptl.PIPEFY_OWNED_TOOL_NAMES_ATTR) == {"create_card"}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,6 +10,7 @@ from mcp.shared.memory import (
 from pipefy_mcp.server import mcp as mcp_server
 from pipefy_mcp.server import run_server
 from pipefy_mcp.settings import PipefySettings, Settings
+from pipefy_mcp.tools.registry import PIPEFY_TOOL_NAMES
 
 
 @pytest.fixture(scope="module")
@@ -33,132 +34,15 @@ _MINIMAL_PIPEFY_SETTINGS = Settings(
 
 @pytest.mark.anyio
 async def test_register_tools(client_session):
-    expected_tool_names = [
-        "add_card_comment",
-        "clone_pipe",
-        "create_ai_agent",
-        "create_ai_automation",
-        "create_automation",
-        "create_card",
-        "create_card_relation",
-        "create_field_condition",
-        "create_label",
-        "create_organization_report",
-        "create_phase",
-        "create_phase_field",
-        "create_pipe",
-        "create_pipe_relation",
-        "create_pipe_report",
-        "create_send_task_automation",
-        "create_table",
-        "create_table_field",
-        "create_table_record",
-        "create_webhook",
-        "delete_ai_agent",
-        "toggle_ai_agent_status",
-        "delete_automation",
-        "delete_card",
-        "delete_comment",
-        "delete_field_condition",
-        "delete_label",
-        "delete_organization_report",
-        "delete_phase",
-        "delete_phase_field",
-        "delete_pipe",
-        "delete_pipe_relation",
-        "delete_pipe_report",
-        "delete_table",
-        "delete_table_field",
-        "delete_table_record",
-        "delete_webhook",
-        "execute_graphql",
-        "export_automation_jobs",
-        "export_organization_report",
-        "export_pipe_audit_logs",
-        "export_pipe_report",
-        "fill_card_phase_fields",
-        "find_cards",
-        "find_records",
-        "get_agents_usage",
-        "get_ai_agent",
-        "get_ai_agent_log_details",
-        "get_ai_agent_logs",
-        "get_ai_agents",
-        "get_ai_credit_usage",
-        "get_automation",
-        "get_automation_actions",
-        "get_automation_events",
-        "get_automation_jobs_export",
-        "get_automation_jobs_export_csv",
-        "get_automation_logs",
-        "get_automation_logs_by_repo",
-        "get_automations",
-        "get_automations_usage",
-        "get_card",
-        "get_card_inbox_emails",
-        "get_cards",
-        "get_email_templates",
-        "get_organization",
-        "get_organization_report",
-        "get_organization_report_export",
-        "get_organization_reports",
-        "get_phase_fields",
-        "get_pipe",
-        "get_pipe_members",
-        "get_pipe_relations",
-        "get_pipe_report_columns",
-        "get_pipe_report_export",
-        "get_pipe_report_filterable_fields",
-        "get_pipe_reports",
-        "get_start_form_fields",
-        "get_table",
-        "get_table_record",
-        "get_table_records",
-        "get_tables",
-        "get_table_relations",
-        "introspect_mutation",
-        "introspect_query",
-        "introspect_type",
-        "invite_members",
-        "move_card_to_phase",
-        "remove_member_from_pipe",
-        "search_pipes",
-        "search_schema",
-        "search_tables",
-        "send_email_with_template",
-        "send_inbox_email",
-        "simulate_automation",
-        "set_role",
-        "set_table_record_field_value",
-        "update_ai_agent",
-        "update_ai_automation",
-        "update_automation",
-        "update_card",
-        "update_card_field",
-        "update_comment",
-        "update_field_condition",
-        "update_label",
-        "update_organization_report",
-        "update_phase",
-        "update_phase_field",
-        "update_pipe",
-        "update_pipe_relation",
-        "update_pipe_report",
-        "update_table",
-        "update_table_field",
-        "update_table_record",
-        "upload_attachment_to_card",
-        "upload_attachment_to_table_record",
-        "validate_ai_agent_behaviors",
-    ]
+    expected_tool_names = sorted(PIPEFY_TOOL_NAMES)
 
     with patch("pipefy_mcp.server.settings", _MINIMAL_PIPEFY_SETTINGS):
         async with client_session as session:
             result = await session.list_tools()
-            actual_tool_names = [tool.name for tool in result.tools]
+            actual_tool_names = sorted(tool.name for tool in result.tools)
 
-            assert sorted(expected_tool_names) == sorted(actual_tool_names), (
-                "Expected create_card to be available"
+            assert actual_tool_names == expected_tool_names, (
+                "Registered tool names must match PIPEFY_TOOL_NAMES"
             )
 
 
@@ -252,6 +136,7 @@ async def test_lifespan_failed_register_tools_does_not_mark_repeat_visit_state()
     ):
         mock_registry = MagicMock()
         mock_registry_cls.return_value = mock_registry
+        mock_registry.pipefy_tool_names = frozenset({"create_card"})
         mock_registry.register_tools.side_effect = RuntimeError("register failed")
 
         with pytest.raises(RuntimeError, match="register failed"):
@@ -285,7 +170,7 @@ async def test_lifespan_retry_after_failed_register_tools_succeeds():
         mock_fail.register_tools.side_effect = RuntimeError("register failed")
         mock_ok = MagicMock()
         mock_ok.register_tools.return_value = app
-        mock_ok.pipefy_tool_names = {"create_card"}
+        mock_ok.pipefy_tool_names = frozenset({"create_card"})
         mock_registry_cls.side_effect = [mock_fail, mock_ok]
 
         with pytest.raises(RuntimeError, match="register failed"):
@@ -300,3 +185,101 @@ async def test_lifespan_retry_after_failed_register_tools_succeeds():
         mock_ok.register_tools.assert_called_once()
         assert getattr(app, ptl.PIPEFY_REPEAT_VISIT_FLAG_ATTR, False) is True
         assert getattr(app, ptl.PIPEFY_OWNED_TOOL_NAMES_ATTR) == {"create_card"}
+
+
+@pytest.mark.unit
+@pytest.mark.anyio
+async def test_lifespan_tool_name_collision_fails_before_registration():
+    """Foreign tool already named create_card: preflight raises; pending never set."""
+    import pipefy_mcp.core.pipefy_tool_lifecycle as ptl
+    from pipefy_mcp.server import lifespan
+
+    app = FastMCP("collision-test")
+
+    @app.tool()
+    async def create_card() -> str:
+        """Shadows Pipefy tool name; must trigger collision check."""
+        return "foreign"
+
+    mock_container = MagicMock()
+    mock_container.pipefy_client = MagicMock()
+
+    with (
+        patch("pipefy_mcp.server.settings", _MINIMAL_PIPEFY_SETTINGS),
+        patch(
+            "pipefy_mcp.server.ServicesContainer.get_instance",
+            return_value=mock_container,
+        ),
+    ):
+        with pytest.raises(
+            RuntimeError, match="these names already exist: create_card"
+        ):
+            async with lifespan(app):
+                pass
+
+    assert not hasattr(app, ptl.PIPEFY_PENDING_TOOL_NAMES_ATTR)
+
+
+@pytest.mark.unit
+@pytest.mark.anyio
+async def test_lifespan_partial_register_failure_cleans_pipefy_tools_retry_uses_new_client():
+    """PipeTools registers then PipeConfigTools raises; cleanup; second run binds new client."""
+    import pipefy_mcp.core.pipefy_tool_lifecycle as ptl
+    from pipefy_mcp.server import lifespan
+    from pipefy_mcp.tools.pipe_config_tools import PipeConfigTools
+    from pipefy_mcp.tools.pipe_tools import PipeTools
+
+    app = FastMCP("partial-reg")
+    mock_container = MagicMock()
+    client1 = MagicMock()
+    client2 = MagicMock()
+    mock_container.pipefy_client = client1
+
+    pipe_tools_register_clients = []
+    real_pipe_tools_register = PipeTools.register
+
+    def wrapping_pipe_tools_register(mcp, client):
+        pipe_tools_register_clients.append(client)
+        return real_pipe_tools_register(mcp, client)
+
+    with (
+        patch("pipefy_mcp.server.settings", _MINIMAL_PIPEFY_SETTINGS),
+        patch(
+            "pipefy_mcp.server.ServicesContainer.get_instance",
+            return_value=mock_container,
+        ),
+        patch.object(PipeTools, "register", side_effect=wrapping_pipe_tools_register),
+        patch.object(
+            PipeConfigTools,
+            "register",
+            side_effect=RuntimeError("pipe config boom"),
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="pipe config boom"):
+            async with lifespan(app):
+                pass
+
+    assert not hasattr(app, ptl.PIPEFY_PENDING_TOOL_NAMES_ATTR)
+    assert getattr(app, ptl.PIPEFY_REPEAT_VISIT_FLAG_ATTR, False) is False
+    after_fail_names = {t.name for t in app._tool_manager.list_tools()}
+    assert "create_card" not in after_fail_names
+
+    mock_container.pipefy_client = client2
+    with (
+        patch("pipefy_mcp.server.settings", _MINIMAL_PIPEFY_SETTINGS),
+        patch(
+            "pipefy_mcp.server.ServicesContainer.get_instance",
+            return_value=mock_container,
+        ),
+        patch.object(
+            PipeTools,
+            "register",
+            side_effect=wrapping_pipe_tools_register,
+        ),
+    ):
+        async with lifespan(app):
+            pass
+
+    assert pipe_tools_register_clients[0] is client1
+    assert pipe_tools_register_clients[-1] is client2
+    assert "create_card" in {t.name for t in app._tool_manager.list_tools()}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -174,6 +174,38 @@ def test_run_server_calls_logger_and_mcp_run():
         mock_mcp.run.assert_called_once()
 
 
+@pytest.mark.anyio
+async def test_repeat_lifespan_preserves_foreign_tools_and_stable_pipefy_names():
+    """Second lifespan visit removes only Pipefy-owned tools, then re-registers; foreign tools stay."""
+    from pipefy_mcp.server import lifespan
+
+    app = FastMCP("repeat-lifespan-test")
+
+    @app.tool()
+    async def foreign_mcp_tool() -> str:
+        """Registered outside ToolRegistry; must survive a second lifespan run."""
+        return "ok"
+
+    mock_container = MagicMock()
+    mock_container.pipefy_client = MagicMock()
+
+    with (
+        patch("pipefy_mcp.server.settings", _MINIMAL_PIPEFY_SETTINGS),
+        patch(
+            "pipefy_mcp.server.ServicesContainer.get_instance",
+            return_value=mock_container,
+        ),
+    ):
+        async with lifespan(app):
+            first_names = {t.name for t in app._tool_manager.list_tools()}
+        async with lifespan(app):
+            second_names = {t.name for t in app._tool_manager.list_tools()}
+
+    assert first_names == second_names
+    assert "foreign_mcp_tool" in second_names
+    assert "create_card" in second_names
+
+
 @pytest.mark.unit
 @pytest.mark.anyio
 async def test_lifespan_logs_error_when_initialization_raises():

--- a/tests/tools/test_ai_agent_tools.py
+++ b/tests/tools/test_ai_agent_tools.py
@@ -1324,6 +1324,25 @@ class TestValidateAiAgentBehaviorsErrorPaths:
         assert payload["success"] is True
         assert payload["valid"] is False
         assert len(payload["problems"]) > 0
+        assert any("event_id" in p.lower() or "eventid" in p.lower() for p in payload["problems"])
+
+    async def test_pydantic_validation_missing_name_hint(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        """Missing behavior name returns an actionable lead problem."""
+        no_name = {"event_id": "card_created"}
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_agent_behaviors",
+                {"pipe_id": "1", "behaviors": [no_name]},
+            )
+        payload = extract_payload(result)
+        assert payload["success"] is True
+        assert payload["valid"] is False
+        assert any("name" in p.lower() and "behavior" in p.lower() for p in payload["problems"])
 
     async def test_pipe_fetch_timeout(
         self,

--- a/tests/tools/test_ai_agent_tools.py
+++ b/tests/tools/test_ai_agent_tools.py
@@ -1324,7 +1324,10 @@ class TestValidateAiAgentBehaviorsErrorPaths:
         assert payload["success"] is True
         assert payload["valid"] is False
         assert len(payload["problems"]) > 0
-        assert any("event_id" in p.lower() or "eventid" in p.lower() for p in payload["problems"])
+        assert any(
+            "event_id" in p.lower() or "eventid" in p.lower()
+            for p in payload["problems"]
+        )
 
     async def test_pydantic_validation_missing_name_hint(
         self,
@@ -1342,7 +1345,9 @@ class TestValidateAiAgentBehaviorsErrorPaths:
         payload = extract_payload(result)
         assert payload["success"] is True
         assert payload["valid"] is False
-        assert any("name" in p.lower() and "behavior" in p.lower() for p in payload["problems"])
+        assert any(
+            "name" in p.lower() and "behavior" in p.lower() for p in payload["problems"]
+        )
 
     async def test_pipe_fetch_timeout(
         self,

--- a/tests/tools/test_ai_automation_tools.py
+++ b/tests/tools/test_ai_automation_tools.py
@@ -210,6 +210,72 @@ class TestCreateAiAutomation:
         assert "[correlation_id=" not in err
         assert "Could not create the AI automation" in err
 
+    async def test_omitted_condition_sends_default_condition_to_client(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        from pipefy_mcp.models.ai_automation import DEFAULT_CONDITION
+
+        mock_pipefy_client.create_ai_automation.return_value = {
+            "automation_id": "999",
+            "message": "AI Automation created successfully. ID: 999",
+        }
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_ai_automation",
+                {
+                    "name": "No Condition",
+                    "event_id": "card_created",
+                    "pipe_id": "303",
+                    "prompt": "Summarize %{133}",
+                    "field_ids": ["133"],
+                },
+            )
+        assert result.isError is False
+        validated_input = mock_pipefy_client.create_ai_automation.call_args[0][0]
+        assert validated_input.condition.model_dump(mode="python") == DEFAULT_CONDITION
+
+    async def test_explicit_condition_overrides_default(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        custom_condition = {
+            "expressions": [
+                {
+                    "structure_id": 1,
+                    "field_address": "status",
+                    "operation": "eq",
+                    "value": "open",
+                }
+            ],
+            "expressions_structure": [[1]],
+        }
+        mock_pipefy_client.create_ai_automation.return_value = {
+            "automation_id": "888",
+            "message": "AI Automation created successfully. ID: 888",
+        }
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_ai_automation",
+                {
+                    "name": "Custom Condition",
+                    "event_id": "card_created",
+                    "pipe_id": "303",
+                    "prompt": "Summarize %{133}",
+                    "field_ids": ["133"],
+                    "condition": custom_condition,
+                },
+            )
+        assert result.isError is False
+        validated_input = mock_pipefy_client.create_ai_automation.call_args[0][0]
+        dumped = validated_input.condition.model_dump(mode="python")
+        assert dumped["expressions"][0]["field_address"] == "status"
+        assert dumped["expressions"][0]["operation"] == "eq"
+
     async def test_validation_error_returns_error_payload(
         self,
         client_session,

--- a/tests/tools/test_ai_automation_tools.py
+++ b/tests/tools/test_ai_automation_tools.py
@@ -121,6 +121,95 @@ class TestCreateAiAutomation:
         assert "error" in payload
         assert isinstance(payload["error"], str)
 
+    async def test_internal_api_style_error_strips_code_and_correlation_from_payload(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.create_ai_automation.side_effect = ValueError(
+            "Invalid prompt [code=INVALID_PROMPT] [correlation_id=abc-123-def]"
+        )
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_ai_automation",
+                {
+                    "name": "My Auto",
+                    "event_id": "card_created",
+                    "pipe_id": "303",
+                    "prompt": "Summarize %{133}",
+                    "field_ids": ["133"],
+                },
+            )
+        assert result.isError is False
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        err = payload["error"]
+        assert "[code=" not in err
+        assert "[correlation_id=" not in err
+        assert "Invalid prompt" in err
+        assert "abc-123-def" not in err
+
+    async def test_create_debug_true_includes_correlation_and_codes_in_error(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.create_ai_automation.side_effect = ValueError(
+            "Invalid prompt [code=INVALID_PROMPT] [correlation_id=abc-123-def]"
+        )
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_ai_automation",
+                {
+                    "name": "My Auto",
+                    "event_id": "card_created",
+                    "pipe_id": "303",
+                    "prompt": "Summarize %{133}",
+                    "field_ids": ["133"],
+                    "debug": True,
+                },
+            )
+        assert result.isError is False
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        err = payload["error"]
+        assert "[code=" not in err
+        assert "[correlation_id=" not in err
+        assert "Invalid prompt" in err
+        assert "(debug:" in err
+        assert "INVALID_PROMPT" in err
+        assert "abc-123-def" in err
+
+    async def test_only_diagnostic_suffixes_use_stable_fallback(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.create_ai_automation.side_effect = ValueError(
+            " [code=X] [correlation_id=Y]"
+        )
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_ai_automation",
+                {
+                    "name": "My Auto",
+                    "event_id": "card_created",
+                    "pipe_id": "303",
+                    "prompt": "Summarize %{133}",
+                    "field_ids": ["133"],
+                },
+            )
+        assert result.isError is False
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        err = payload["error"]
+        assert "[code=" not in err
+        assert "[correlation_id=" not in err
+        assert "Could not create the AI automation" in err
+
     async def test_validation_error_returns_error_payload(
         self,
         client_session,
@@ -190,6 +279,58 @@ class TestUpdateAiAutomation:
         payload = extract_payload(result)
         assert payload["success"] is False
         assert "error" in payload
+
+    async def test_internal_api_style_error_strips_code_and_correlation_on_update(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.update_ai_automation.side_effect = ValueError(
+            "Not found [code=NOT_FOUND] [correlation_id=corr-9]"
+        )
+        async with client_session as session:
+            result = await session.call_tool(
+                "update_ai_automation",
+                {"automation_id": "789", "name": "Updated", "active": False},
+            )
+        assert result.isError is False
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        err = payload["error"]
+        assert "[code=" not in err
+        assert "[correlation_id=" not in err
+        assert "Not found" in err
+        assert "corr-9" not in err
+
+    async def test_update_debug_true_includes_correlation_and_codes(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.update_ai_automation.side_effect = ValueError(
+            "Not found [code=NOT_FOUND] [correlation_id=corr-9]"
+        )
+        async with client_session as session:
+            result = await session.call_tool(
+                "update_ai_automation",
+                {
+                    "automation_id": "789",
+                    "name": "Updated",
+                    "active": False,
+                    "debug": True,
+                },
+            )
+        assert result.isError is False
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        err = payload["error"]
+        assert "[code=" not in err
+        assert "Not found" in err
+        assert "(debug:" in err
+        assert "NOT_FOUND" in err
+        assert "corr-9" in err
 
 
 ## ---------------------------------------------------------------------------

--- a/tests/tools/test_ai_automation_tools_live.py
+++ b/tests/tools/test_ai_automation_tools_live.py
@@ -1,0 +1,100 @@
+"""Live MCP path for AI automation create (optional integration).
+
+Exercises **create_ai_automation** without ``condition`` (default placeholder) through
+the full **pipefy_mcp.server.mcp** app (ToolRegistry + real **PipefyClient**), then
+tears down with **delete_automation** (``confirm=True``).
+
+Skips without **PIPEFY_*** OAuth or when **PIPE_AI_AUTOMATION_LIVE_PIPE_ID** /
+**PIPE_AI_AUTOMATION_LIVE_FIELD_ID** are unset.
+
+**Setup:** Disposable pipe with **AI enabled** and at least one card field. Set
+``PIPE_AI_AUTOMATION_LIVE_FIELD_ID`` to that field's **internal_id** (string). Grant the
+service account permission to create/delete automations on that pipe.
+
+Run:
+
+    uv run pytest tests/tools/test_ai_automation_tools_live.py -m integration -v
+
+Env:
+
+    PIPE_AI_AUTOMATION_LIVE_PIPE_ID   — pipe numeric ID (required for this module)
+    PIPE_AI_AUTOMATION_LIVE_FIELD_ID  — field internal_id for prompt + field_ids (required)
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+from mcp.shared.memory import (
+    create_connected_server_and_client_session as create_client_session,
+)
+
+from pipefy_mcp.server import mcp as mcp_server
+from pipefy_mcp.settings import settings
+from tests.integration_helpers import require_live_creds
+
+
+@pytest.mark.integration
+@pytest.mark.anyio
+async def test_live_create_ai_automation_omits_condition_uses_default_placeholder(
+    extract_payload,
+):
+    """Full stack: create_ai_automation without condition; delete when possible."""
+    require_live_creds()
+    pipe_raw = os.environ.get("PIPE_AI_AUTOMATION_LIVE_PIPE_ID")
+    field_raw = os.environ.get("PIPE_AI_AUTOMATION_LIVE_FIELD_ID")
+    if not pipe_raw or not str(pipe_raw).strip():
+        pytest.skip("Set PIPE_AI_AUTOMATION_LIVE_PIPE_ID (see module docstring).")
+    if not field_raw or not str(field_raw).strip():
+        pytest.skip(
+            "Set PIPE_AI_AUTOMATION_LIVE_FIELD_ID to a field internal_id "
+            "(see module docstring)."
+        )
+
+    pipe_id = str(pipe_raw).strip()
+    field_id = str(field_raw).strip()
+    token = uuid.uuid4().hex[:10]
+    name = f"MCP AI auto live {token}"
+
+    with patch("pipefy_mcp.server.settings", settings):
+        async with create_client_session(
+            mcp_server,
+            read_timeout_seconds=timedelta(seconds=120),
+            raise_exceptions=True,
+        ) as session:
+            create_result = await session.call_tool(
+                "create_ai_automation",
+                {
+                    "name": name,
+                    "event_id": "card_created",
+                    "pipe_id": pipe_id,
+                    "prompt": f"Summarize card %{field_id}",
+                    "field_ids": [field_id],
+                },
+            )
+    assert create_result.isError is False, create_result
+    payload = extract_payload(create_result)
+    if not payload.get("success"):
+        pytest.skip(
+            f"create_ai_automation failed (check AI on pipe / permissions): {payload!r}"
+        )
+    automation_id = str(payload.get("automation_id") or "").strip()
+    assert automation_id, f"Missing automation_id in payload: {payload!r}"
+
+    with patch("pipefy_mcp.server.settings", settings):
+        async with create_client_session(
+            mcp_server,
+            read_timeout_seconds=timedelta(seconds=120),
+            raise_exceptions=True,
+        ) as session:
+            delete_result = await session.call_tool(
+                "delete_automation",
+                {"automation_id": automation_id, "confirm": True},
+            )
+    assert delete_result.isError is False, delete_result
+    del_payload = extract_payload(delete_result)
+    assert del_payload.get("success") is True, del_payload

--- a/tests/tools/test_ai_automation_tools_live.py
+++ b/tests/tools/test_ai_automation_tools_live.py
@@ -78,10 +78,7 @@ async def test_live_create_ai_automation_omits_condition_uses_default_placeholde
             )
     assert create_result.isError is False, create_result
     payload = extract_payload(create_result)
-    if not payload.get("success"):
-        pytest.skip(
-            f"create_ai_automation failed (check AI on pipe / permissions): {payload!r}"
-        )
+    assert payload.get("success") is True, payload
     automation_id = str(payload.get("automation_id") or "").strip()
     assert automation_id, f"Missing automation_id in payload: {payload!r}"
 

--- a/tests/tools/test_ai_tool_helpers.py
+++ b/tests/tools/test_ai_tool_helpers.py
@@ -89,6 +89,29 @@ def test_enrich_with_empty_behaviors():
 
 
 @pytest.mark.unit
+def test_enrich_strips_internal_api_diagnostic_markers():
+    exc = ValueError(
+        "Invalid prompt [code=INVALID_PROMPT] [correlation_id=secret-correlation-uuid]"
+    )
+    behaviors = _make_behaviors(("B1", "card_created", "update_card"))
+    result = enrich_behavior_error(exc, behaviors)
+    assert "Invalid prompt" in result
+    assert "[code=" not in result
+    assert "[correlation_id=" not in result
+    assert "secret-correlation-uuid" not in result
+
+
+@pytest.mark.unit
+def test_enrich_only_diagnostic_markers_uses_generic_fallback():
+    exc = ValueError(" [code=X] [correlation_id=Y]")
+    behaviors = _make_behaviors(("B1", "card_created", "update_card"))
+    result = enrich_behavior_error(exc, behaviors)
+    assert "The AI behavior request failed" in result
+    assert "[code=" not in result
+    assert "Behaviors sent (1):" in result
+
+
+@pytest.mark.unit
 def test_enrich_handles_camel_case_behavior_keys():
     behaviors = [
         {

--- a/tests/tools/test_destructive_tool_guard.py
+++ b/tests/tools/test_destructive_tool_guard.py
@@ -10,23 +10,11 @@ from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmati
 RESOURCE = "phase 'Initial' (ID: 42)"
 
 
-def _make_ctx(*, can_elicit, elicit_result=None, elicit_side_effect=None):
+def _make_ctx(*, can_elicit):
     ctx = MagicMock()
     ctx.session.client_params.capabilities.elicitation = can_elicit
-    if elicit_side_effect:
-        ctx.elicit = AsyncMock(side_effect=elicit_side_effect)
-    elif elicit_result is not None:
-        ctx.elicit = AsyncMock(return_value=elicit_result)
-    else:
-        ctx.elicit = AsyncMock()
+    ctx.elicit = AsyncMock()
     return ctx
-
-
-def _elicit_result(action, confirm_value=True):
-    result = MagicMock()
-    result.action = action
-    result.data.model_dump.return_value = {"confirm": confirm_value}
-    return result
 
 
 @pytest.mark.anyio
@@ -41,6 +29,7 @@ class TestNoElicitation:
         assert payload["requires_confirmation"] is True
         assert payload["resource"] == RESOURCE
         assert "confirm=True" in payload["message"]
+        ctx.elicit.assert_not_called()
 
     async def test_confirm_true_returns_none(self):
         ctx = _make_ctx(can_elicit=False)
@@ -48,48 +37,15 @@ class TestNoElicitation:
             ctx, confirm=True, resource_descriptor=RESOURCE
         )
         assert result is None
+        ctx.elicit.assert_not_called()
 
 
 @pytest.mark.anyio
-class TestWithElicitation:
-    async def test_user_accepts_returns_none(self):
-        ctx = _make_ctx(
-            can_elicit=True,
-            elicit_result=_elicit_result(action="accept", confirm_value=True),
-        )
-        result = await check_destructive_confirmation(
-            ctx, confirm=False, resource_descriptor=RESOURCE
-        )
-        assert result is None
+class TestClientAdvertisesElicitation:
+    """Even when the client supports elicitation, only ``confirm=True`` authorizes deletion."""
 
-    async def test_user_declines_returns_cancel(self):
-        ctx = _make_ctx(
-            can_elicit=True,
-            elicit_result=_elicit_result(action="decline"),
-        )
-        payload = await check_destructive_confirmation(
-            ctx, confirm=False, resource_descriptor=RESOURCE
-        )
-        assert payload is not None
-        assert payload["success"] is False
-        assert "cancelled" in payload["error"].lower()
-
-    async def test_user_accepts_but_confirm_false_returns_cancel(self):
-        ctx = _make_ctx(
-            can_elicit=True,
-            elicit_result=_elicit_result(action="accept", confirm_value=False),
-        )
-        payload = await check_destructive_confirmation(
-            ctx, confirm=False, resource_descriptor=RESOURCE
-        )
-        assert payload is not None
-        assert payload["success"] is False
-
-    async def test_elicitation_raises_falls_back_to_preview(self):
-        ctx = _make_ctx(
-            can_elicit=True,
-            elicit_side_effect=RuntimeError("elicit broke"),
-        )
+    async def test_confirm_false_returns_preview_and_never_elicits(self):
+        ctx = _make_ctx(can_elicit=True)
         payload = await check_destructive_confirmation(
             ctx, confirm=False, resource_descriptor=RESOURCE
         )
@@ -97,13 +53,11 @@ class TestWithElicitation:
         assert payload["success"] is False
         assert payload["requires_confirmation"] is True
         assert payload["resource"] == RESOURCE
+        assert "confirm=True" in payload["message"]
+        ctx.elicit.assert_not_called()
 
-    async def test_confirm_true_bypasses_elicitation(self):
-        """When confirm=True, skip elicitation prompt and proceed immediately."""
-        ctx = _make_ctx(
-            can_elicit=True,
-            elicit_result=_elicit_result(action="accept", confirm_value=True),
-        )
+    async def test_confirm_true_returns_none_without_elicit(self):
+        ctx = _make_ctx(can_elicit=True)
         result = await check_destructive_confirmation(
             ctx, confirm=True, resource_descriptor=RESOURCE
         )

--- a/tests/tools/test_destructive_tool_guard.py
+++ b/tests/tools/test_destructive_tool_guard.py
@@ -1,5 +1,6 @@
 """Tests for the reusable destructive tool confirmation guard."""
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -107,4 +108,50 @@ class TestWithElicitation:
             ctx, confirm=True, resource_descriptor=RESOURCE
         )
         assert result is None
+        ctx.elicit.assert_not_called()
+
+
+@pytest.mark.anyio
+class TestMissingCapabilityMetadata:
+    async def test_no_client_params_returns_preview(self):
+        ctx = MagicMock()
+        ctx.session = SimpleNamespace()
+        ctx.elicit = AsyncMock()
+        payload = await check_destructive_confirmation(
+            ctx, confirm=False, resource_descriptor=RESOURCE
+        )
+        assert payload is not None
+        assert payload["success"] is False
+        assert payload["requires_confirmation"] is True
+        assert payload["resource"] == RESOURCE
+        assert "confirm=True" in payload["message"]
+        ctx.elicit.assert_not_called()
+
+    async def test_client_params_without_capabilities_returns_preview(self):
+        ctx = MagicMock()
+        ctx.session = SimpleNamespace(client_params=SimpleNamespace())
+        ctx.elicit = AsyncMock()
+        payload = await check_destructive_confirmation(
+            ctx, confirm=False, resource_descriptor=RESOURCE
+        )
+        assert payload is not None
+        assert payload["success"] is False
+        assert payload["requires_confirmation"] is True
+        assert payload["resource"] == RESOURCE
+        assert "confirm=True" in payload["message"]
+        ctx.elicit.assert_not_called()
+
+    async def test_capabilities_without_elicitation_attr_returns_preview(self):
+        ctx = MagicMock()
+        ctx.session = SimpleNamespace(
+            client_params=SimpleNamespace(capabilities=SimpleNamespace()),
+        )
+        ctx.elicit = AsyncMock()
+        payload = await check_destructive_confirmation(
+            ctx, confirm=False, resource_descriptor=RESOURCE
+        )
+        assert payload is not None
+        assert payload["success"] is False
+        assert payload["requires_confirmation"] is True
+        assert payload["resource"] == RESOURCE
         ctx.elicit.assert_not_called()

--- a/tests/tools/test_mcp_capabilities.py
+++ b/tests/tools/test_mcp_capabilities.py
@@ -1,0 +1,47 @@
+"""Tests for MCP client capability introspection helpers."""
+
+from types import SimpleNamespace
+
+from pipefy_mcp.tools.mcp_capabilities import supports_elicitation
+
+
+def test_no_session_returns_false():
+    ctx = SimpleNamespace()
+    assert supports_elicitation(ctx) is False
+
+
+def test_no_client_params_returns_false():
+    ctx = SimpleNamespace(session=SimpleNamespace())
+    assert supports_elicitation(ctx) is False
+
+
+def test_no_capabilities_returns_false():
+    session = SimpleNamespace(client_params=SimpleNamespace())
+    ctx = SimpleNamespace(session=session)
+    assert supports_elicitation(ctx) is False
+
+
+def test_elicitation_false_returns_false():
+    caps = SimpleNamespace(elicitation=False)
+    session = SimpleNamespace(
+        client_params=SimpleNamespace(capabilities=caps),
+    )
+    ctx = SimpleNamespace(session=session)
+    assert supports_elicitation(ctx) is False
+
+
+def test_elicitation_true_returns_true():
+    caps = SimpleNamespace(elicitation=True)
+    session = SimpleNamespace(
+        client_params=SimpleNamespace(capabilities=caps),
+    )
+    ctx = SimpleNamespace(session=session)
+    assert supports_elicitation(ctx) is True
+
+
+def test_capabilities_without_elicitation_attr_returns_false():
+    session = SimpleNamespace(
+        client_params=SimpleNamespace(capabilities=SimpleNamespace()),
+    )
+    ctx = SimpleNamespace(session=session)
+    assert supports_elicitation(ctx) is False

--- a/tests/tools/test_pipe_tools.py
+++ b/tests/tools/test_pipe_tools.py
@@ -1,6 +1,7 @@
 import json
 from datetime import timedelta
 from random import randint
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock
 
@@ -211,6 +212,37 @@ class TestCreateCardTool:
                 ),
             }
             assert response == expected_response
+
+    async def test_create_card_when_capabilities_missing_no_attribute_error(
+        self,
+        mock_pipefy_client,
+        pipe_id,
+    ):
+        """client_params without capabilities must not raise when gating elicitation."""
+        mock_pipefy_client.get_start_form_fields.return_value = {
+            "start_form_fields": []
+        }
+        mock_pipefy_client.create_card.return_value = {
+            "createCard": {"card": {"id": "789"}}
+        }
+
+        mcp = FastMCP("Pipefy MCP Test Server")
+        PipeTools.register(mcp, mock_pipefy_client)
+
+        ctx = MagicMock()
+        ctx.debug = AsyncMock()
+        ctx.session = SimpleNamespace(client_params=SimpleNamespace())
+
+        result = await mcp._tool_manager.call_tool(
+            "create_card",
+            {"pipe_id": pipe_id},
+            context=ctx,
+            convert_result=False,
+        )
+
+        mock_pipefy_client.create_card.assert_called_once_with(pipe_id, {})
+        assert result["createCard"]["card"]["id"] == "789"
+        assert "card_link" in result
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
     async def test_without_elicitation_filters_non_editable_fields(

--- a/tests/tools/test_pipe_tools.py
+++ b/tests/tools/test_pipe_tools.py
@@ -22,7 +22,6 @@ from pipefy_mcp.services.pipefy import PipefyClient
 from pipefy_mcp.tools.pipe_tool_helpers import (
     FIND_CARDS_EMPTY_MESSAGE,
     DeleteCardErrorPayload,
-    DeleteCardSuccessPayload,
 )
 from pipefy_mcp.tools.pipe_tools import FIND_CARDS_RESPONSE_KEY, PipeTools
 

--- a/tests/tools/test_pipe_tools.py
+++ b/tests/tools/test_pipe_tools.py
@@ -1395,7 +1395,7 @@ class TestDeleteCardTool:
         mock_pipefy_client,
         extract_payload,
     ) -> None:
-        """Test delete_card tool when user declines confirmation via elicitation."""
+        """Without confirm=True, deletion never runs—even if the client supports elicitation."""
         mock_pipefy_client.get_card.return_value = {
             "card": {"id": "12345", "title": "Test Card", "pipe": {"name": "Test Pipe"}}
         }
@@ -1413,7 +1413,13 @@ class TestDeleteCardTool:
             payload = extract_payload(result)
             assert payload == {
                 "success": False,
-                "error": "Action cancelled by user.",
+                "requires_confirmation": True,
+                "resource": "card 'Test Card' (ID: 12345) from pipe 'Test Pipe'",
+                "message": (
+                    "⚠️ You are about to permanently delete "
+                    "card 'Test Card' (ID: 12345) from pipe 'Test Pipe'. "
+                    "This action is irreversible. Set 'confirm=True' to proceed."
+                ),
             }
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
@@ -1593,13 +1599,13 @@ class TestDeleteCardTool:
         [elicitation_callback_for(action="accept", content={"confirm": True})],
         indirect=True,
     )
-    async def test_user_confirms_deletion(
+    async def test_elicitation_does_not_authorize_delete_without_confirm_true(
         self,
         client_session,
         mock_pipefy_client,
         extract_payload,
     ) -> None:
-        """Test delete_card tool when user confirms deletion via elicitation."""
+        """Elicitation accept must not delete; only confirm=True may run the mutation."""
         mock_pipefy_client.get_card.return_value = {
             "card": {"id": "12345", "title": "Test Card", "pipe": {"name": "Test Pipe"}}
         }
@@ -1612,30 +1618,24 @@ class TestDeleteCardTool:
             )
 
             assert result.isError is False
-            mock_pipefy_client.delete_card.assert_called_once_with("12345")
+            mock_pipefy_client.delete_card.assert_not_called()
 
             payload = extract_payload(result)
-            expected_payload: DeleteCardSuccessPayload = {
-                "success": True,
-                "card_id": "12345",
-                "card_title": "Test Card",
-                "pipe_name": "Test Pipe",
-                "message": "Card 'Test Card' (ID: 12345) from pipe 'Test Pipe' has been permanently deleted.",
-            }
-            assert payload == expected_payload
+            assert payload["success"] is False
+            assert payload["requires_confirmation"] is True
 
     @pytest.mark.parametrize(
         "client_session",
         [elicitation_callback_raises(RuntimeError("confirmation request failed"))],
         indirect=True,
     )
-    async def test_elicitation_raises_returns_failed_request_confirmation(
+    async def test_elicitation_callback_unused_for_delete_preview(
         self,
         client_session,
         mock_pipefy_client,
         extract_payload,
     ) -> None:
-        """When elicitation raises, the shared guard falls back to a preview payload."""
+        """Guard does not call elicit; a broken elicitation callback must not affect preview."""
         mock_pipefy_client.get_card.return_value = {
             "card": {"id": "12345", "title": "Test Card", "pipe": {"name": "Test Pipe"}}
         }

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -4,7 +4,7 @@ import pytest
 from mcp.server.fastmcp import FastMCP
 
 from pipefy_mcp.core.container import ServicesContainer
-from pipefy_mcp.tools.registry import ToolRegistry
+from pipefy_mcp.tools.registry import PIPEFY_TOOL_NAMES, ToolRegistry
 
 
 class TestToolRegistry:
@@ -19,7 +19,7 @@ class TestToolRegistry:
 
         assert registry.mcp is mock_mcp
         assert registry.services_container is mock_container
-        assert registry.pipefy_tool_names == frozenset()
+        assert registry.pipefy_tool_names == PIPEFY_TOOL_NAMES
 
     @patch("pipefy_mcp.tools.registry.ObservabilityTools.register")
     @patch("pipefy_mcp.tools.registry.IntrospectionTools.register")
@@ -72,7 +72,7 @@ class TestToolRegistry:
         mock_introspection_tools_register.assert_called_once_with(mock_mcp, mock_client)
         mock_observability_tools_register.assert_called_once_with(mock_mcp, mock_client)
         assert result is mock_mcp
-        assert registry.pipefy_tool_names == frozenset()
+        assert registry.pipefy_tool_names == PIPEFY_TOOL_NAMES
 
     def test_register_tools_raises_when_pipefy_client_is_none(self):
         """Test that register_tools raises ValueError when pipefy_client is None"""
@@ -144,7 +144,7 @@ class TestToolRegistry:
         mock_observability_tools_register.assert_called_once_with(mock_mcp, mock_client)
         mock_ai_automation_tools_register.assert_called_once_with(mock_mcp, mock_client)
         mock_ai_agent_tools_register.assert_called_once_with(mock_mcp, mock_client)
-        assert registry.pipefy_tool_names == frozenset()
+        assert registry.pipefy_tool_names == PIPEFY_TOOL_NAMES
 
     def test_register_tools_records_pipefy_tool_names_on_real_fastmcp(self):
         mcp = FastMCP("tool-registry-names")
@@ -153,5 +153,31 @@ class TestToolRegistry:
         registry = ToolRegistry(mcp=mcp, services_container=mock_container)
         registry.register_tools()
 
+        assert registry.pipefy_tool_names == PIPEFY_TOOL_NAMES
         assert "create_card" in registry.pipefy_tool_names
         assert len(registry.pipefy_tool_names) > 50
+
+    def test_check_for_name_collisions_raises_when_pipefy_name_already_registered(self):
+        mock_mcp = Mock(spec=FastMCP)
+        mock_container = Mock(spec=ServicesContainer)
+        registry = ToolRegistry(mcp=mock_mcp, services_container=mock_container)
+        with patch.object(
+            ToolRegistry,
+            "_snapshot_tool_names",
+            return_value={"create_card", "foreign_tool"},
+        ):
+            with pytest.raises(
+                RuntimeError, match="these names already exist: create_card"
+            ):
+                registry.check_for_name_collisions()
+
+    def test_check_for_name_collisions_ok_when_no_overlap(self):
+        mock_mcp = Mock(spec=FastMCP)
+        mock_container = Mock(spec=ServicesContainer)
+        registry = ToolRegistry(mcp=mock_mcp, services_container=mock_container)
+        with patch.object(
+            ToolRegistry,
+            "_snapshot_tool_names",
+            return_value={"foreign_tool"},
+        ):
+            registry.check_for_name_collisions()

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from mcp.server.fastmcp import FastMCP
@@ -19,6 +19,7 @@ class TestToolRegistry:
 
         assert registry.mcp is mock_mcp
         assert registry.services_container is mock_container
+        assert registry.pipefy_tool_names == frozenset()
 
     @patch("pipefy_mcp.tools.registry.ObservabilityTools.register")
     @patch("pipefy_mcp.tools.registry.IntrospectionTools.register")
@@ -71,6 +72,7 @@ class TestToolRegistry:
         mock_introspection_tools_register.assert_called_once_with(mock_mcp, mock_client)
         mock_observability_tools_register.assert_called_once_with(mock_mcp, mock_client)
         assert result is mock_mcp
+        assert registry.pipefy_tool_names == frozenset()
 
     def test_register_tools_raises_when_pipefy_client_is_none(self):
         """Test that register_tools raises ValueError when pipefy_client is None"""
@@ -142,3 +144,14 @@ class TestToolRegistry:
         mock_observability_tools_register.assert_called_once_with(mock_mcp, mock_client)
         mock_ai_automation_tools_register.assert_called_once_with(mock_mcp, mock_client)
         mock_ai_agent_tools_register.assert_called_once_with(mock_mcp, mock_client)
+        assert registry.pipefy_tool_names == frozenset()
+
+    def test_register_tools_records_pipefy_tool_names_on_real_fastmcp(self):
+        mcp = FastMCP("tool-registry-names")
+        mock_container = Mock(spec=ServicesContainer)
+        mock_container.pipefy_client = MagicMock()
+        registry = ToolRegistry(mcp=mcp, services_container=mock_container)
+        registry.register_tools()
+
+        assert "create_card" in registry.pipefy_tool_names
+        assert len(registry.pipefy_tool_names) > 50


### PR DESCRIPTION
## Summary
Merges `feat/mcp-elicitation-and-tool-lifecycle` into `pipe-full-toolset`.

### Highlights
- MCP tool lifecycle: explicit `PIPEFY_TOOL_NAMES`, collision preflight, cleanup on failed registration, idempotent rebind on repeat lifespan (`core/fastmcp_tool_lifecycle` / server lifespan).
- Destructive tools: preview/default `confirm=false`; only explicit `confirm=true` executes deletes.
- AI automation: typed condition/event params, optional condition contract aligned with API, sanitized error payloads + optional debug markers strip.
- Tests: AI automation MCP tools (incl. condition payload contract tests), lifecycle/repeat-lifespan coverage; opt-in integration for AI automation live.
- Docs: README MCP tools section cleanup (116 tools, Relations count fix), introspection doc tool count, dependency/agent guides, relations ID clarifications.

### Testing
- `uv run pytest -m "not integration"` — pass
- `uv run ruff check src/ tests/` — pass

### Notes
- Base branch: **pipe-full-toolset**.