### PR TITLE
feat: tool surface hardening (phase 1) e hardening de segurança

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,5 @@ PIPEFY_INTERNAL_API_URL=https://app.pipefy.com/internal_api
 PIPEFY_OAUTH_URL=https://app.pipefy.com/oauth/token
 PIPEFY_OAUTH_CLIENT=<YOUR_SERVICE_ACCOUNT_CLIENT_ID>
 PIPEFY_OAUTH_SECRET=<YOUR_SERVICE_ACCOUNT_CLIENT_SECRET>
+# Optional: comma-separated Pipefy user IDs blocked from remove_member_from_pipe (service accounts)
+# PIPEFY_SERVICE_ACCOUNT_IDS=

--- a/docs/tools/members-email-webhooks.md
+++ b/docs/tools/members-email-webhooks.md
@@ -12,6 +12,15 @@ Manage pipe membership, send emails from card inboxes, read inbox replies, and m
 | `remove_member_from_pipe` | No | Permanently remove one or more users from a pipe (`destructiveHint=True` — confirm with the user first). |
 | `set_role` | No | Set a member's role on a pipe (`member_id`, `role_name`). |
 
+### Service Account Protection
+
+When the optional environment variable **`PIPEFY_SERVICE_ACCOUNT_IDS`** is set to a comma-separated list of Pipefy user IDs, the server treats those IDs as **service accounts** for MCP safety:
+
+- **`remove_member_from_pipe`** — Removal is **blocked** if any requested `user_id` is in that list. The tool returns an error explaining that removing the service account would break write operations for the pipe; use the Pipefy UI if removal is intentional. If the env var is unset or empty, this check is skipped.
+- **`set_role`** — If `member_id` is a listed service account ID, the mutation still runs (role changes are reversible), but the success payload may include a **warning** reminding you to keep a role that preserves write permissions.
+
+Configure IDs in `.env` (see `.env.example`). Omit the variable when you do not need this guard.
+
 ## Email tools
 
 | Tool | Read-only | Role |

--- a/src/pipefy_mcp/services/pipefy/internal_api_client.py
+++ b/src/pipefy_mcp/services/pipefy/internal_api_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 from httpx import Timeout
@@ -33,10 +34,17 @@ class InternalApiClient:
             oauth_client: OAuth client ID.
             oauth_secret: OAuth client secret.
         """
-        if not url.strip().lower().startswith("https://"):
-            raise ValueError("internal_api URL must use HTTPS")
-        if not oauth_url.strip().lower().startswith("https://"):
-            raise ValueError("OAuth URL must use HTTPS")
+        for label, val in (("internal_api URL", url), ("OAuth URL", oauth_url)):
+            stripped = val.strip().lower()
+            if not stripped.startswith("https://"):
+                raise ValueError(f"{label} must use HTTPS")
+            parsed = urlparse(val.strip())
+            if not parsed.hostname:
+                raise ValueError(f"{label} must include a hostname")
+            if parsed.hostname in ("localhost", "127.0.0.1", "::1"):
+                raise ValueError(
+                    f"{label} must not point to localhost ({parsed.hostname})"
+                )
         self._url = url
         self._auth = OAuth2ClientCredentials(
             token_url=oauth_url,

--- a/src/pipefy_mcp/services/pipefy/queries/ai_automation_queries.py
+++ b/src/pipefy_mcp/services/pipefy/queries/ai_automation_queries.py
@@ -1,6 +1,9 @@
 """GraphQL mutation strings for AI Automation (internal_api endpoint).
 
-Plain strings (not gql()) since internal_api does not support schema validation.
+Mutations are plain strings (not ``gql()``) because ``InternalApiClient``
+sends raw GraphQL text via JSON POST — the internal_api endpoint does not
+support schema validation that ``gql()`` provides via graphql-core. All
+other query files use ``gql()`` constants.
 """
 
 from __future__ import annotations

--- a/src/pipefy_mcp/settings.py
+++ b/src/pipefy_mcp/settings.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from typing import Annotated
+
+from pydantic import BaseModel, Field, field_validator
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 
 class PipefySettings(BaseModel):
@@ -29,6 +31,23 @@ class PipefySettings(BaseModel):
         default=None,
         description="OAuth client secret for Pipefy",
     )
+
+    service_account_ids: Annotated[list[str], NoDecode] = Field(
+        default_factory=list,
+        description="Comma-separated user IDs protected from removal via MCP tools.",
+    )
+
+    @field_validator("service_account_ids", mode="before")
+    @classmethod
+    def _coerce_service_account_ids(cls, value: object) -> list[str]:
+        if value is None or value == "":
+            return []
+        if isinstance(value, list):
+            return [str(item).strip() for item in value if str(item).strip()]
+        if isinstance(value, str):
+            return [part.strip() for part in value.split(",") if part.strip()]
+        msg = "service_account_ids must be a list or a comma-separated string"
+        raise ValueError(msg)
 
 
 class Settings(BaseSettings):

--- a/src/pipefy_mcp/tools/attachment_tools.py
+++ b/src/pipefy_mcp/tools/attachment_tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import binascii
 import ipaddress
@@ -44,8 +45,11 @@ _PRIVATE_NETWORKS = (
 )
 
 
-def _validate_url_safe(url: str) -> None:
+async def _validate_url_safe(url: str) -> None:
     """Reject URLs that target private/internal networks or non-HTTP schemes.
+
+    DNS resolution is offloaded to a thread executor so it does not block the
+    async event loop.
 
     Raises:
         ValueError: When the URL is unsafe for server-side fetch.
@@ -61,7 +65,10 @@ def _validate_url_safe(url: str) -> None:
         raise ValueError(msg)
 
     try:
-        addr_info = socket.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP)
+        loop = asyncio.get_event_loop()
+        addr_info = await loop.run_in_executor(
+            None, socket.getaddrinfo, hostname, None, 0, socket.SOCK_STREAM
+        )
     except socket.gaierror as exc:
         msg = f"Could not resolve hostname '{hostname}': {exc}"
         raise ValueError(msg) from exc
@@ -74,47 +81,67 @@ def _validate_url_safe(url: str) -> None:
                 raise ValueError(msg)
 
 
+_MAX_REDIRECTS = 3
+
+
 async def _download_file_bytes(url: str) -> bytes:
     """Fetch file body from an HTTP(S) URL with SSRF protection and size limit.
+
+    Redirects are followed manually (up to ``_MAX_REDIRECTS``) so that each
+    intermediate URL is validated against private-network rules — preventing
+    redirect-based SSRF bypass.
 
     Args:
         url: Location to download. Must be http/https and resolve to a public IP.
 
     Raises:
-        ValueError: When the URL targets a private network or exceeds size limit.
+        ValueError: When the URL targets a private network, exceeds size limit,
+            or the redirect chain is too long.
         httpx.HTTPError: On transport/HTTP failures.
     """
-    _validate_url_safe(url)
+    await _validate_url_safe(url)
+    current_url = url
 
     async with httpx.AsyncClient() as http:
-        async with http.stream(
-            "GET",
-            url,
-            follow_redirects=True,
-            timeout=_FILE_DOWNLOAD_TIMEOUT_SEC,
-        ) as response:
-            response.raise_for_status()
+        for _ in range(_MAX_REDIRECTS + 1):
+            async with http.stream(
+                "GET",
+                current_url,
+                follow_redirects=False,
+                timeout=_FILE_DOWNLOAD_TIMEOUT_SEC,
+            ) as response:
+                if response.status_code in (301, 302, 303, 307, 308):
+                    location = response.headers.get("location")
+                    if not location:
+                        raise ValueError("Redirect without Location header")
+                    await _validate_url_safe(location)
+                    current_url = location
+                    continue
 
-            content_length = response.headers.get("content-length")
-            if content_length and int(content_length) > _MAX_DOWNLOAD_SIZE_BYTES:
-                msg = (
-                    f"File too large: Content-Length {content_length} bytes "
-                    f"exceeds the {_MAX_DOWNLOAD_SIZE_BYTES // (1024 * 1024)} MiB limit."
-                )
-                raise ValueError(msg)
+                response.raise_for_status()
 
-            chunks: list[bytes] = []
-            total = 0
-            async for chunk in response.aiter_bytes():
-                total += len(chunk)
-                if total > _MAX_DOWNLOAD_SIZE_BYTES:
+                content_length = response.headers.get("content-length")
+                if content_length and int(content_length) > _MAX_DOWNLOAD_SIZE_BYTES:
                     msg = (
-                        f"File too large: downloaded {total} bytes, "
-                        f"exceeding the {_MAX_DOWNLOAD_SIZE_BYTES // (1024 * 1024)} MiB limit."
+                        f"File too large: Content-Length {content_length} bytes "
+                        f"exceeds the {_MAX_DOWNLOAD_SIZE_BYTES // (1024 * 1024)} MiB limit."
                     )
                     raise ValueError(msg)
-                chunks.append(chunk)
-            return b"".join(chunks)
+
+                chunks: list[bytes] = []
+                total = 0
+                async for chunk in response.aiter_bytes():
+                    total += len(chunk)
+                    if total > _MAX_DOWNLOAD_SIZE_BYTES:
+                        msg = (
+                            f"File too large: downloaded {total} bytes, "
+                            f"exceeding the {_MAX_DOWNLOAD_SIZE_BYTES // (1024 * 1024)} MiB limit."
+                        )
+                        raise ValueError(msg)
+                    chunks.append(chunk)
+                return b"".join(chunks)
+
+        raise ValueError(f"Too many redirects (max {_MAX_REDIRECTS})")
 
 
 def _decode_base64_file(payload: str) -> bytes:

--- a/src/pipefy_mcp/tools/automation_tools.py
+++ b/src/pipefy_mcp/tools/automation_tools.py
@@ -70,18 +70,20 @@ class AutomationTools:
         ) -> dict[str, Any]:
             """Load one automation rule by ID, including trigger and action payloads.
 
-            Returns ``event_params`` and ``action_params`` (e.g. ``aiParams`` with
-            ``value`` / ``fieldIds`` / ``skillsIds``) for inspection, debugging, and parity
-            with ``simulate_automation`` / ``create_automation`` inputs. Use this before
-            ``update_automation`` to inspect the stored configuration; when cloning a rule,
-            copy these objects into the matching optional JSON args on create/update or
-            simulation.
-
-            For new rules, discover ``event_id`` / ``action_id`` via ``get_automation_events``
-            and ``get_automation_actions`` on the target pipe, then call ``create_automation``.
+            Use this to inspect or debug a specific rule, or before ``update_automation`` /
+            ``delete_automation``. Returned ``event_params`` and ``action_params`` (e.g.
+            ``aiParams`` with ``value`` / ``fieldIds`` / ``skillsIds``) align with
+            ``simulate_automation`` and ``create_automation`` inputs. For new rules, discover
+            ``event_id`` / ``action_id`` via ``get_automation_events`` and ``get_automation_actions``
+            on the target pipe, then call ``create_automation``.
 
             Args:
-                automation_id: Automation rule ID.
+                automation_id: Automation rule ID (non-empty string or positive integer).
+
+            Returns:
+                On success, ``success``, ``message``, and ``data`` with the automation row (or
+                ``None`` when not found). On validation or GraphQL errors, ``success: False`` with
+                ``error``.
             """
             aid = _normalize_required_id(automation_id)
             if aid is None:
@@ -112,16 +114,23 @@ class AutomationTools:
         ) -> dict[str, Any]:
             """List traditional automation rules, optionally filtered by organization and/or pipe.
 
-            Combine with ``get_automation`` for full detail. Use pipe-scoped listings to plan
-            ``create_automation`` / ``update_automation`` without pulling every org rule.
+            Use this to discover automation IDs in a pipe or org before calling ``get_automation``
+            for full payloads, or to plan ``create_automation`` / ``update_automation`` without
+            listing unrelated rules.
 
-            When only ``pipe_id`` is set (no ``organization_id``), the server resolves the org from
-            the pipe first, then lists automations — two sequential API calls vs. one when you pass
-            ``organization_id`` directly.
+            Combine with ``get_automation`` for full detail. When only ``pipe_id`` is set (no
+            ``organization_id``), the server resolves the org from the pipe first, then lists
+            automations — two sequential API calls vs. one when you pass ``organization_id``
+            directly.
 
             Args:
-                organization_id: When set, restrict to this organization.
-                pipe_id: When set, restrict to this pipe.
+                organization_id: When set, restrict to this organization; omit for no org filter.
+                pipe_id: When set, restrict to this pipe; omit for no pipe filter.
+
+            Returns:
+                On success, ``success``, ``message``, and ``data`` with the list of automation
+                summaries returned by the API. On validation or GraphQL errors, ``success: False``
+                with ``error``.
             """
             ok_o, org = _normalize_optional_filter(organization_id)
             ok_p, pipe = _normalize_optional_filter(pipe_id)

--- a/src/pipefy_mcp/tools/member_tools.py
+++ b/src/pipefy_mcp/tools/member_tools.py
@@ -9,6 +9,7 @@ from mcp.server.session import ServerSession
 from mcp.types import ToolAnnotations
 
 from pipefy_mcp.services.pipefy import PipefyClient
+from pipefy_mcp.settings import settings
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.member_tool_helpers import (
     build_member_error_payload,
@@ -88,6 +89,10 @@ class MemberTools:
             ``confirm=True`` after explicit human approval. Elicitation does not authorize
             deletion (only ``confirm=True`` does).
 
+            Service account guard: when ``PIPEFY_SERVICE_ACCOUNT_IDS`` is set, user IDs in
+            that list cannot be removed via this tool (returns an error); use the Pipefy UI
+            if intentional. When the env var is unset or empty, the guard is not applied.
+
             Args:
                 pipe_id: ID of the pipe.
                 user_ids: List of user IDs to remove.
@@ -109,6 +114,25 @@ class MemberTools:
                 return build_member_error_payload(
                     message="Invalid 'user_ids': each ID must be a non-empty string.",
                 )
+
+            protected_ids = settings.pipefy.service_account_ids
+            if protected_ids:
+                protected_set = set(protected_ids)
+                blocked = [uid for uid in user_ids if uid in protected_set]
+                if blocked:
+                    if len(blocked) == 1:
+                        msg = (
+                            f"Cannot remove service account {blocked[0]} — "
+                            "this would break all write operations for this pipe. "
+                            "Remove it via the Pipefy UI if intentional."
+                        )
+                    else:
+                        msg = (
+                            f"Cannot remove service accounts {', '.join(blocked)} — "
+                            "this would break all write operations for this pipe. "
+                            "Remove it via the Pipefy UI if intentional."
+                        )
+                    return build_member_error_payload(message=msg)
 
             guard = await check_destructive_confirmation(
                 ctx,
@@ -156,6 +180,10 @@ class MemberTools:
         ) -> dict[str, Any]:
             """Set a member's role on a pipe.
 
+            Service account warning: when ``PIPEFY_SERVICE_ACCOUNT_IDS`` includes ``member_id``,
+            the success payload may include a ``warning`` field reminding you to keep write
+            permissions for that account. When the env var is unset or empty, no warning is added.
+
             Args:
                 pipe_id: ID of the pipe.
                 member_id: User ID of the member.
@@ -176,17 +204,26 @@ class MemberTools:
                 return build_member_error_payload(
                     message="Invalid 'role_name': provide a non-empty string.",
                 )
+            trimmed_member_id = member_id.strip()
             try:
                 raw = await client.set_role(
-                    pipe_id, member_id.strip(), role_name.strip()
+                    pipe_id, trimmed_member_id, role_name.strip()
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_member_tool_graphql_error(
                     exc, "Set role failed.", debug=debug
                 )
+            warning: str | None = None
+            protected_ids = settings.pipefy.service_account_ids
+            if protected_ids and trimmed_member_id in protected_ids:
+                warning = (
+                    "Warning: you changed the role of a service account. "
+                    "Ensure the new role retains write permissions."
+                )
             return build_member_success_payload(
                 message="Role updated.",
                 data=raw,
+                warning=warning,
             )
 
 

--- a/src/pipefy_mcp/tools/pipe_tool_helpers.py
+++ b/src/pipefy_mcp/tools/pipe_tool_helpers.py
@@ -50,7 +50,9 @@ class DeleteCommentErrorPayload(TypedDict):
     error: str
 
 
-DeleteCommentPayload = DeleteCommentSuccessPayload | DeleteCommentErrorPayload
+DeleteCommentPayload = (
+    DestructivePreviewPayload | DeleteCommentSuccessPayload | DeleteCommentErrorPayload
+)
 
 
 class DeleteCardSuccessPayload(TypedDict):

--- a/src/pipefy_mcp/tools/pipe_tools.py
+++ b/src/pipefy_mcp/tools/pipe_tools.py
@@ -32,8 +32,7 @@ from pipefy_mcp.tools.pipe_tool_helpers import (
     FIND_CARDS_EMPTY_MESSAGE,
     AddCardCommentPayload,
     DeleteCardPayload,
-    DeleteCommentErrorPayload,
-    DeleteCommentSuccessPayload,
+    DeleteCommentPayload,
     UpdateCommentErrorPayload,
     UpdateCommentSuccessPayload,
     UserCancelledError,
@@ -151,11 +150,19 @@ class PipeTools:
             card_id: str | int,
             include_fields: bool = False,
         ) -> dict:
-            """Get a card by its ID.
+            """Load one card by ID for title, phase, assignees, labels, and optional field values.
+
+            Use this to inspect a card before updates, after ``find_cards`` / ``get_cards``,
+            or when the user references a card by ID. Set ``include_fields`` when you need
+            custom field ``name``/``value`` pairs for forms or automation.
 
             Args:
-                card_id: The ID of the card.
-                include_fields: If True, include the card's custom fields (name, value) in the response.
+                card_id: Pipefy card ID (string or positive integer).
+                include_fields: If True, include each custom field's name and value on the card node.
+
+            Returns:
+                dict: GraphQL ``card`` query payload (typically ``card`` with ``id``, ``title``,
+                ``phase``, ``assignees``, ``labels``, and—when requested—``fields``).
             """
             return await client.get_card(card_id, include_fields=include_fields)
 
@@ -224,15 +231,27 @@ class PipeTools:
             return build_update_comment_success_payload(comment_id=comment_id_out)
 
         @mcp.tool(
-            annotations=ToolAnnotations(readOnlyHint=False),
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=True,
+            ),
         )
         async def delete_comment(
+            ctx: Context[ServerSession, None],
             comment_id: str | int,
-        ) -> DeleteCommentSuccessPayload | DeleteCommentErrorPayload:
-            """Delete a comment by its ID.
+            confirm: bool = False,
+        ) -> DeleteCommentPayload:
+            """Delete a comment from Pipefy.
+
+            Two-step operation:
+
+            1. **Preview** — call with ``confirm=False`` (default). Returns a preview payload;
+               nothing is deleted. Elicitation is **not** used to authorize deletion.
+            2. **Execute** — call again with ``confirm=True`` after explicit human approval.
 
             Args:
                 comment_id: The ID of the comment to delete.
+                confirm: Must be ``True`` to run the delete mutation.
             """
             try:
                 delete_input = DeleteCommentInput(comment_id=comment_id)
@@ -240,6 +259,14 @@ class PipeTools:
                 return build_delete_comment_error_payload(
                     message="Invalid input. Please provide a valid 'comment_id'."
                 )
+
+            guard = await check_destructive_confirmation(
+                ctx,
+                confirm=confirm,
+                resource_descriptor=f"comment (ID: {delete_input.comment_id})",
+            )
+            if guard is not None:
+                return guard
 
             try:
                 await client.delete_comment(delete_input.comment_id)
@@ -358,8 +385,19 @@ class PipeTools:
             ),
         )
         async def get_pipe(pipe_id: str | int) -> dict:
-            """Get a pipe by its ID."""
+            """Load a pipe by ID: name, phases, labels, and start-form field definitions.
 
+            Use this after resolving ``pipe_id`` (e.g. from ``search_pipes``) to inspect workflow
+            structure, obtain phase IDs for ``move_card_to_phase``, or read start-form fields
+            before ``create_card``.
+
+            Args:
+                pipe_id: Pipe identifier (string or positive integer).
+
+            Returns:
+                dict: GraphQL response containing a ``pipe`` object with ``id``, ``name``,
+                ``phases``, ``labels``, ``start_form_fields``, and related metadata from the API.
+            """
             return await client.get_pipe(pipe_id)
 
         @mcp.tool(
@@ -368,8 +406,18 @@ class PipeTools:
             ),
         )
         async def get_pipe_members(pipe_id: str | int) -> dict:
-            """Get the members of a pipe."""
+            """List members of a pipe with roles and basic user profile fields.
 
+            Use this to audit who has access, resolve user IDs for assignments, or before
+            changing membership with invite/remove/role tools.
+
+            Args:
+                pipe_id: Pipe identifier (string or positive integer).
+
+            Returns:
+                dict: GraphQL payload whose ``pipe.members`` entries include ``user``
+                (``id``, ``uuid``, ``name``, ``email``) and ``role_name`` per member.
+            """
             return await client.get_pipe_members(pipe_id)
 
         @mcp.tool(
@@ -378,11 +426,21 @@ class PipeTools:
         async def move_card_to_phase(
             card_id: str | int, destination_phase_id: str | int
         ) -> dict:
-            """Move a card to a specific phase.
+            """Move a card to a target phase (Kanban column) within the same pipe.
 
-            On failure, if the destination is not among ``cards_can_be_moved_to_phases`` for the
-            card's current phase, returns ``success: false`` with ``valid_destinations`` instead of
-            only the raw API error.
+            Use this when the workflow should advance or regress a card; pair with ``get_pipe``
+            or ``get_card`` to resolve valid phase IDs. On failure, if the destination is not
+            among ``cards_can_be_moved_to_phases`` for the card's current phase, the tool may
+            return ``success: false`` with ``valid_destinations`` instead of only the raw API error.
+
+            Args:
+                card_id: The card to move.
+                destination_phase_id: Target phase ID (must be allowed for the current phase).
+
+            Returns:
+                dict: Pipefy move mutation response on success. On some validation failures,
+                a structured payload with ``success: false`` and ``valid_destinations`` when the
+                destination phase is not allowed from the current phase.
             """
 
             try:

--- a/src/pipefy_mcp/tools/table_tools.py
+++ b/src/pipefy_mcp/tools/table_tools.py
@@ -89,12 +89,21 @@ class TableTools:
         async def get_table(table_id: str | int) -> dict[str, Any]:
             """Load one database table: name, description, fields, and authorization.
 
+            Use this after ``search_tables`` (or when you already have a table ID) to inspect
+            schema, field types, and permissions before creating or updating records.
+
             ``table_id`` is the **database table** id (from ``search_tables`` / ``get_tables``).
             For **table-to-table relation link** metadata, use ``get_table_relations`` with
             table-**relation** ids — not this argument.
 
             Args:
                 table_id: Pipefy database table ID.
+
+            Returns:
+                On success, a structured payload with ``success``, ``message``, and ``data``
+                (GraphQL ``table`` object: ``id``, ``name``, ``description``, ``table_fields``,
+                ``authorization``). On validation or GraphQL errors, ``success: False`` with an
+                ``error`` message.
             """
             if not valid_repo_id(table_id):
                 return build_table_read_error_payload(
@@ -196,8 +205,16 @@ class TableTools:
         async def get_table_record(record_id: str | int) -> dict[str, Any]:
             """Load a single database table record with its field values.
 
+            Use this when you have a record ID (e.g. from ``get_table_records`` or ``find_records``)
+            and need the full row: title and ``record_fields`` name/value pairs.
+
             Args:
-                record_id: Table record ID.
+                record_id: Table record ID (string or positive integer).
+
+            Returns:
+                On success, ``success``, ``message``, and ``data`` containing the GraphQL
+                ``table_record`` (``id``, ``title``, ``record_fields``). On errors,
+                ``success: False`` with ``error``.
             """
             if not valid_repo_id(record_id):
                 return build_table_read_error_payload(

--- a/tests/services/test_internal_api_client.py
+++ b/tests/services/test_internal_api_client.py
@@ -353,3 +353,25 @@ def test_internal_api_client_rejects_http_oauth_url():
             oauth_client="id",
             oauth_secret="secret",
         )
+
+
+@pytest.mark.unit
+def test_internal_api_client_rejects_empty_hostname():
+    with pytest.raises(ValueError, match="hostname"):
+        InternalApiClient(
+            url="https://",
+            oauth_url="https://auth.pipefy.com/oauth/token",
+            oauth_client="id",
+            oauth_secret="secret",
+        )
+
+
+@pytest.mark.unit
+def test_internal_api_client_rejects_localhost():
+    with pytest.raises(ValueError, match="localhost"):
+        InternalApiClient(
+            url="https://localhost/internal_api",
+            oauth_url="https://auth.pipefy.com/oauth/token",
+            oauth_client="id",
+            oauth_secret="secret",
+        )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -47,15 +47,11 @@ async def test_register_tools(client_session):
 
 
 @pytest.mark.unit
-def test_run_server_calls_logger_and_mcp_run():
-    """run_server logs and calls mcp.run()."""
-    with (
-        patch("pipefy_mcp.server.logger") as mock_logger,
-        patch("pipefy_mcp.server.mcp") as mock_mcp,
-    ):
+def test_run_server_starts_mcp_with_no_arguments():
+    """run_server delegates to mcp.run() without extra arguments."""
+    with patch("pipefy_mcp.server.mcp") as mock_mcp:
         run_server()
-        mock_logger.info.assert_called()
-        mock_mcp.run.assert_called_once()
+        mock_mcp.run.assert_called_once_with()
 
 
 @pytest.mark.anyio

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,36 @@
+"""Tests for ``Settings`` / ``PipefySettings`` (env loading and coercion)."""
+
+import pytest
+
+from pipefy_mcp.settings import PipefySettings, Settings
+
+
+@pytest.mark.unit
+def test_service_account_ids_defaults_to_empty_list():
+    assert PipefySettings().service_account_ids == []
+
+
+@pytest.mark.unit
+def test_service_account_ids_accepts_list_and_strips_whitespace():
+    settings = PipefySettings(service_account_ids=["  id1  ", "id2"])
+    assert settings.service_account_ids == ["id1", "id2"]
+
+
+@pytest.mark.unit
+def test_service_account_ids_accepts_comma_separated_string():
+    settings = PipefySettings(service_account_ids="alpha, beta ,gamma")
+    assert settings.service_account_ids == ["alpha", "beta", "gamma"]
+
+
+@pytest.mark.unit
+def test_service_account_ids_from_env_comma_separated(monkeypatch):
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_IDS", "user-1,user-2, user-3 ")
+    settings = Settings()
+    assert settings.pipefy.service_account_ids == ["user-1", "user-2", "user-3"]
+
+
+@pytest.mark.unit
+def test_service_account_ids_empty_env_is_empty_list(monkeypatch):
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_IDS", "")
+    settings = Settings()
+    assert settings.pipefy.service_account_ids == []

--- a/tests/tools/test_attachment_tools.py
+++ b/tests/tools/test_attachment_tools.py
@@ -87,61 +87,62 @@ def _httpx_stream_cm_mock(content=b"hello-bytes", headers=None):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.anyio
 class TestValidateUrlSafe:
-    def test_rejects_file_scheme(self):
+    async def test_rejects_file_scheme(self):
         with pytest.raises(ValueError, match="Only http and https"):
-            _validate_url_safe("file:///etc/passwd")
+            await _validate_url_safe("file:///etc/passwd")
 
-    def test_rejects_ftp_scheme(self):
+    async def test_rejects_ftp_scheme(self):
         with pytest.raises(ValueError, match="Only http and https"):
-            _validate_url_safe("ftp://internal/data")
+            await _validate_url_safe("ftp://internal/data")
 
-    def test_rejects_no_hostname(self):
+    async def test_rejects_no_hostname(self):
         with pytest.raises(ValueError, match="no hostname"):
-            _validate_url_safe("https://")
+            await _validate_url_safe("https://")
 
     @patch("pipefy_mcp.tools.attachment_tools.socket.getaddrinfo")
-    def test_rejects_localhost(self, mock_getaddrinfo):
+    async def test_rejects_localhost(self, mock_getaddrinfo):
         mock_getaddrinfo.return_value = [(None, None, None, None, ("127.0.0.1", 0))]
         with pytest.raises(ValueError, match="private/internal"):
-            _validate_url_safe("https://localhost/secret")
+            await _validate_url_safe("https://localhost/secret")
 
     @patch("pipefy_mcp.tools.attachment_tools.socket.getaddrinfo")
-    def test_rejects_metadata_endpoint(self, mock_getaddrinfo):
+    async def test_rejects_metadata_endpoint(self, mock_getaddrinfo):
         mock_getaddrinfo.return_value = [
             (None, None, None, None, ("169.254.169.254", 0))
         ]
         with pytest.raises(ValueError, match="private/internal"):
-            _validate_url_safe("http://169.254.169.254/latest/meta-data/")
+            await _validate_url_safe("http://169.254.169.254/latest/meta-data/")
 
     @patch("pipefy_mcp.tools.attachment_tools.socket.getaddrinfo")
-    def test_rejects_private_10_range(self, mock_getaddrinfo):
+    async def test_rejects_private_10_range(self, mock_getaddrinfo):
         mock_getaddrinfo.return_value = [(None, None, None, None, ("10.0.0.1", 0))]
         with pytest.raises(ValueError, match="private/internal"):
-            _validate_url_safe("https://internal.corp/file.pdf")
+            await _validate_url_safe("https://internal.corp/file.pdf")
 
     @patch("pipefy_mcp.tools.attachment_tools.socket.getaddrinfo")
-    def test_rejects_private_172_range(self, mock_getaddrinfo):
+    async def test_rejects_private_172_range(self, mock_getaddrinfo):
         mock_getaddrinfo.return_value = [(None, None, None, None, ("172.16.0.1", 0))]
         with pytest.raises(ValueError, match="private/internal"):
-            _validate_url_safe("https://internal.corp/file.pdf")
+            await _validate_url_safe("https://internal.corp/file.pdf")
 
     @patch("pipefy_mcp.tools.attachment_tools.socket.getaddrinfo")
-    def test_rejects_private_192_range(self, mock_getaddrinfo):
+    async def test_rejects_private_192_range(self, mock_getaddrinfo):
         mock_getaddrinfo.return_value = [(None, None, None, None, ("192.168.1.1", 0))]
         with pytest.raises(ValueError, match="private/internal"):
-            _validate_url_safe("https://home.lan/file.pdf")
+            await _validate_url_safe("https://home.lan/file.pdf")
 
     @patch("pipefy_mcp.tools.attachment_tools.socket.getaddrinfo")
-    def test_rejects_ipv6_loopback(self, mock_getaddrinfo):
+    async def test_rejects_ipv6_loopback(self, mock_getaddrinfo):
         mock_getaddrinfo.return_value = [(None, None, None, None, ("::1", 0, 0, 0))]
         with pytest.raises(ValueError, match="private/internal"):
-            _validate_url_safe("https://[::1]/file.pdf")
+            await _validate_url_safe("https://[::1]/file.pdf")
 
     @patch("pipefy_mcp.tools.attachment_tools.socket.getaddrinfo")
-    def test_accepts_public_ip(self, mock_getaddrinfo):
+    async def test_accepts_public_ip(self, mock_getaddrinfo):
         mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
-        _validate_url_safe("https://example.com/file.pdf")  # should not raise
+        await _validate_url_safe("https://example.com/file.pdf")  # should not raise
 
 
 @pytest.mark.anyio

--- a/tests/tools/test_member_tools.py
+++ b/tests/tools/test_member_tools.py
@@ -1,7 +1,7 @@
 """Tests for member MCP tools (mocked PipefyClient)."""
 
 from datetime import timedelta
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from gql.transport.exceptions import TransportQueryError
@@ -126,6 +126,97 @@ async def test_invite_members_graphql_error(
     payload = extract_payload(result)
     assert payload["success"] is False
     assert "invalid email" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("member_session", [None], indirect=True)
+async def test_remove_member_from_pipe_blocks_protected_service_account(
+    member_session, mock_member_client, extract_payload
+):
+    """FR-1: IDs in PIPEFY_SERVICE_ACCOUNT_IDS cannot be removed via MCP."""
+    mock_member_client.remove_members_from_pipe.return_value = {
+        "removeMembersFromPipe": {"success": True}
+    }
+
+    with patch("pipefy_mcp.tools.member_tools.settings") as mock_settings:
+        mock_settings.pipefy.service_account_ids = ["sa-user-1"]
+        async with member_session as session:
+            result = await session.call_tool(
+                "remove_member_from_pipe",
+                {
+                    "pipe_id": "100",
+                    "user_ids": ["sa-user-1", "regular-user"],
+                    "confirm": True,
+                },
+            )
+
+    mock_member_client.remove_members_from_pipe.assert_not_awaited()
+    assert result.isError is False
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "sa-user-1" in payload["error"]
+    assert "service account" in payload["error"].lower()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("member_session", [None], indirect=True)
+async def test_remove_member_from_pipe_allows_non_service_account_when_list_configured(
+    member_session, mock_member_client, extract_payload
+):
+    mock_member_client.remove_members_from_pipe.return_value = {
+        "removeMembersFromPipe": {"success": True}
+    }
+    mock_member_client.get_pipe_members.return_value = {"pipe": {"members": []}}
+
+    with patch("pipefy_mcp.tools.member_tools.settings") as mock_settings:
+        mock_settings.pipefy.service_account_ids = ["sa-user-1"]
+        async with member_session as session:
+            result = await session.call_tool(
+                "remove_member_from_pipe",
+                {
+                    "pipe_id": "100",
+                    "user_ids": ["regular-user"],
+                    "confirm": True,
+                },
+            )
+
+    mock_member_client.remove_members_from_pipe.assert_awaited_once_with(
+        "100", ["regular-user"]
+    )
+    assert result.isError is False
+    payload = extract_payload(result)
+    assert payload["success"] is True
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("member_session", [None], indirect=True)
+async def test_remove_member_from_pipe_skips_sa_guard_when_list_empty(
+    member_session, mock_member_client, extract_payload
+):
+    """Unset / empty PIPEFY_SERVICE_ACCOUNT_IDS must not block removals."""
+    mock_member_client.remove_members_from_pipe.return_value = {
+        "removeMembersFromPipe": {"success": True}
+    }
+    mock_member_client.get_pipe_members.return_value = {"pipe": {"members": []}}
+
+    with patch("pipefy_mcp.tools.member_tools.settings") as mock_settings:
+        mock_settings.pipefy.service_account_ids = []
+        async with member_session as session:
+            result = await session.call_tool(
+                "remove_member_from_pipe",
+                {
+                    "pipe_id": "100",
+                    "user_ids": ["would-be-sa-id"],
+                    "confirm": True,
+                },
+            )
+
+    mock_member_client.remove_members_from_pipe.assert_awaited_once_with(
+        "100", ["would-be-sa-id"]
+    )
+    assert result.isError is False
+    payload = extract_payload(result)
+    assert payload["success"] is True
 
 
 @pytest.mark.anyio
@@ -397,6 +488,106 @@ async def test_set_role_success(member_session, mock_member_client, extract_payl
     payload = extract_payload(result)
     assert payload["success"] is True
     assert payload["result"]["setRole"]["member"]["role_name"] == "admin"
+    assert "warning" not in payload
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("member_session", [None], indirect=True)
+async def test_set_role_warns_when_target_is_protected_service_account(
+    member_session, mock_member_client, extract_payload
+):
+    mock_member_client.set_role.return_value = {
+        "setRole": {
+            "member": {
+                "role_name": "admin",
+                "user": {"id": "sa-42", "email": "bot@x.com"},
+            }
+        }
+    }
+
+    with patch("pipefy_mcp.tools.member_tools.settings") as mock_settings:
+        mock_settings.pipefy.service_account_ids = ["sa-42"]
+        async with member_session as session:
+            result = await session.call_tool(
+                "set_role",
+                {
+                    "pipe_id": "pipe-1",
+                    "member_id": "sa-42",
+                    "role_name": "admin",
+                },
+            )
+
+    assert result.isError is False
+    mock_member_client.set_role.assert_awaited_once_with("pipe-1", "sa-42", "admin")
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    assert "warning" in payload
+    assert "service account" in payload["warning"].lower()
+    assert "write permissions" in payload["warning"].lower()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("member_session", [None], indirect=True)
+async def test_set_role_no_warning_for_non_service_account_when_list_configured(
+    member_session, mock_member_client, extract_payload
+):
+    mock_member_client.set_role.return_value = {
+        "setRole": {
+            "member": {
+                "role_name": "member",
+                "user": {"id": "user-9", "email": "human@x.com"},
+            }
+        }
+    }
+
+    with patch("pipefy_mcp.tools.member_tools.settings") as mock_settings:
+        mock_settings.pipefy.service_account_ids = ["sa-only"]
+        async with member_session as session:
+            result = await session.call_tool(
+                "set_role",
+                {
+                    "pipe_id": "pipe-1",
+                    "member_id": "user-9",
+                    "role_name": "member",
+                },
+            )
+
+    assert result.isError is False
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    assert "warning" not in payload
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("member_session", [None], indirect=True)
+async def test_set_role_no_warning_when_protected_list_empty(
+    member_session, mock_member_client, extract_payload
+):
+    mock_member_client.set_role.return_value = {
+        "setRole": {
+            "member": {
+                "role_name": "admin",
+                "user": {"id": "could-be-sa", "email": "x@x.com"},
+            }
+        }
+    }
+
+    with patch("pipefy_mcp.tools.member_tools.settings") as mock_settings:
+        mock_settings.pipefy.service_account_ids = []
+        async with member_session as session:
+            result = await session.call_tool(
+                "set_role",
+                {
+                    "pipe_id": "pipe-1",
+                    "member_id": "could-be-sa",
+                    "role_name": "admin",
+                },
+            )
+
+    assert result.isError is False
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    assert "warning" not in payload
 
 
 @pytest.mark.anyio

--- a/tests/tools/test_pipe_tools.py
+++ b/tests/tools/test_pipe_tools.py
@@ -645,7 +645,7 @@ class TestDirectToolCalls:
         async with client_session as session:
             result = await session.call_tool(
                 "delete_comment",
-                {"comment_id": 456},
+                {"comment_id": 456, "confirm": True},
             )
         assert result.isError is False
         mock_pipefy_client.delete_comment.assert_called_once_with("456")
@@ -663,7 +663,7 @@ class TestDirectToolCalls:
         async with client_session as session:
             result = await session.call_tool(
                 "delete_comment",
-                {"comment_id": 0},
+                {"comment_id": 0, "confirm": True},
             )
         assert result.isError is False
         mock_pipefy_client.delete_comment.assert_called_once_with("0")
@@ -692,7 +692,7 @@ class TestDirectToolCalls:
         async with client_session as session:
             result = await session.call_tool(
                 "delete_comment",
-                {"comment_id": 12345},
+                {"comment_id": 12345, "confirm": True},
             )
         assert result.isError is False
         mock_pipefy_client.delete_comment.assert_called_once_with("12345")
@@ -718,7 +718,7 @@ class TestDirectToolCalls:
         async with client_session as session:
             result = await session.call_tool(
                 "delete_comment",
-                {"comment_id": 99999},
+                {"comment_id": 99999, "confirm": True},
             )
         assert result.isError is False
         mock_pipefy_client.delete_comment.assert_called_once_with("99999")
@@ -726,6 +726,43 @@ class TestDirectToolCalls:
         assert payload["success"] is False
         assert "error" in payload
         assert "comment" in payload["error"].lower() or "not found" in payload["error"]
+
+    @pytest.mark.parametrize("client_session", [None], indirect=True)
+    async def test_delete_comment_preview_then_confirm_true_runs_mutation(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        """Destructive guard: default returns preview; confirm=True runs delete (step 2)."""
+        comment_id = 42
+        resource = f"comment (ID: {comment_id})"
+        expected_preview = {
+            "success": False,
+            "requires_confirmation": True,
+            "resource": resource,
+            "message": (
+                f"⚠️ You are about to permanently delete {resource}. "
+                "This action is irreversible. Set 'confirm=True' to proceed."
+            ),
+        }
+
+        async with client_session as session:
+            preview = await session.call_tool(
+                "delete_comment",
+                {"comment_id": comment_id},
+            )
+            assert preview.isError is False
+            mock_pipefy_client.delete_comment.assert_not_called()
+            assert extract_payload(preview) == expected_preview
+
+            result = await session.call_tool(
+                "delete_comment",
+                {"comment_id": comment_id, "confirm": True},
+            )
+        assert result.isError is False
+        mock_pipefy_client.delete_comment.assert_called_once_with(str(comment_id))
+        assert extract_payload(result) == {"success": True}
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Objetivo

Entregar a **fase 1.0** do plano [tasks-tool-surface-hardening](.cursor/dev-planning/specs/tool-surface-hardening/tasks/tasks-tool-surface-hardening.md): proteção de service accounts, `delete_comment` destrutivo em dois passos, docstrings e documentação operacional, mais correções de segurança (internal API, attachments).

**Base:** `pipe-full-toolset` ← **Head:** `feat/tool-surface-hardening-phase-1`

## Commits

1. `feat(settings): add PIPEFY_SERVICE_ACCOUNT_IDS for member tool guards`
2. `feat(members): block SA removal and warn on set_role for protected IDs`
3. `feat(pipe-tools): destructive delete_comment guard and expand read tool docstrings`
4. `docs(tools): expand get_table, get_table_record, and automation read docstrings`
5. `fix(security): validate internal API and OAuth URLs reject localhost`
6. `fix(attachment): async-safe URL checks and redirect-safe SSRF validation`
7. `docs(queries): clarify why AI automation mutations omit gql()`
8. `test(server): assert mcp.run() is called with no arguments`

## Verificação

- `uv run pytest -m "not integration"`
- `uv run ruff check src/ tests/` + `ruff format --check`