### PR TITLE
feat(tools): Phase 3 agent UX — prompt validation, permission enrichment, membership checks

### DIFF
--- a/.cursor/dev-planning/code-review/pipe-full-toolset-vs-main-phase-3.md
+++ b/.cursor/dev-planning/code-review/pipe-full-toolset-vs-main-phase-3.md
@@ -1,0 +1,396 @@
+# Code Review: feat/tool-surface-hardening-phase-3 vs pipe-full-toolset
+
+## Document meta
+
+| Field | Value |
+| :--- | :--- |
+| **Review date** | 2026-04-14 |
+| **Diff scope** | `pipe-full-toolset...feat/tool-surface-hardening-phase-3` |
+| **Branch tip** | `2e59a5f` |
+| **pipe-full-toolset tip** | `76c1247` |
+| **Diff size** | 14 files changed, 1047 insertions(+), 12 deletions(-) |
+
+## How to use this document (for humans + fix agents)
+
+1. Work through **S5 Required fixes** in **ID order** (`RF-01`, `RF-02`, ...) before **S7 Improvements**.
+2. Each finding has **Location**, **Snippet**, and **Suggested direction** -- open the file at that line; do not rely on memory.
+3. After each fix (or small batch), run the **Verify** commands for that finding.
+4. **Depends on** prevents ordering mistakes when fixes interact.
+
+---
+
+## 0. Context read (checklist)
+
+- [x] PRD: `.cursor/dev-planning/specs/tool-surface-hardening/prd-tool-surface-hardening.md` (FR-10, FR-11, FR-12)
+- [x] Tasks: `.cursor/dev-planning/specs/tool-surface-hardening/tasks/tasks-tool-surface-hardening.md` (section 4.0, sub-tasks 4.1-4.10)
+- [x] `CLAUDE.md` (architecture, code quality, no-ai-slop, testing rules)
+- [x] `.claude/commands/testing-anti-patterns.md` (mock gates, behavior-not-mocks, completeness)
+
+---
+
+## 1. Executive summary
+
+| Category | Status | Summary |
+| :--- | :--- | :--- |
+| Architecture | pass | Clean layer separation: query in `queries/`, service in `pipe_service.py`, facade delegation in `client.py`, tool in `ai_automation_tools.py`. New helper in `graphql_error_helpers.py` follows existing patterns. |
+| Security | pass | No credentials in logs/errors. `ctx.debug()` used for internal diagnostics. Enrichment helper returns `None` on failure (never masks original error). Timeout bounds on all async gather calls. |
+| Correctness | warn | Two issues: (1) `create_card` re-raise via `type(exc)(...)` loses `.errors` attribute of `TransportQueryError`; (2) read-only field warnings are unfiltered (noisy on pipes with many non-editable fields). |
+| Tests | warn | New features have solid coverage (24 new tests). However: no integration tests for FR-11 enrichment at the tool level (only the helper is unit-tested), and one test helper has unused parameters. |
+| Docs / MCP tool UX | pass | Tool docstring is clear with `Args:` block. `readOnlyHint=True` annotation set. Return shape documented. |
+
+**Merge recommendation:** `ready with fixes` -- RF-01 and RF-02 should be addressed before merge. DD findings are non-blocking but should be tracked.
+
+**Counts:** Required fixes: 2 -- Deep dive: 4 -- Improvements: 3 -- Nits: 2
+
+---
+
+## 2. Diff inventory
+
+| Area | Files | PRD / Task |
+| :--- | :--- | :--- |
+| Pipe preferences query | `queries/pipe_queries.py`, `pipe_service.py`, `client.py` | FR-10 / 4.1 |
+| Prompt validation tool | `ai_automation_tools.py`, `ai_tool_helpers.py` | FR-10 / 4.2 |
+| Prompt validation tests | `test_ai_automation_tools.py` | FR-10 / 4.3 |
+| Permission enrichment helper | `graphql_error_helpers.py` | FR-11 / 4.4 |
+| Permission enrichment tests | `test_graphql_error_helpers.py` | FR-11 / 4.5 |
+| Cross-pipe enrichment wiring | `ai_agent_tools.py`, `automation_tools.py`, `pipe_tools.py` | FR-11 / 4.6 |
+| Proactive membership check | `ai_agent_tools.py` | FR-12 / 4.7 |
+| Membership check tests | `test_ai_agent_tools.py` | FR-12 / 4.8 |
+| Registry update | `registry.py` | 4.9 |
+| Facade delegation test | `test_pipefy_facade.py` | 4.1 (supplementary) |
+
+---
+
+## 3. PRD / spec alignment
+
+| Topic | Expected (doc + section) | Observed in code | Finding ID |
+| :--- | :--- | :--- | :--- |
+| FR-10: validate_ai_automation_prompt | 5 validations + return `{valid, problems, warnings, field_map}` | All 5 validations present; return shape correct; `readOnlyHint=True` | -- (pass) |
+| FR-11: Cross-pipe enrichment | Apply to `create_card`, `create_ai_agent`, `update_ai_agent`, `create_automation` | All four applied; `create_connected_card` flows through `create_ai_agent` behaviors | -- (pass) |
+| FR-11: Enrichment graceful failure | "If enrichment fails, return original error unchanged" | Helper returns `None` on timeout/error; callers fall through to original path | -- (pass) |
+| FR-11: Always-on (not behind debug) | "Always-on (not behind debug flag)" | Enrichment runs unconditionally in error paths | -- (pass) |
+| FR-12: Proactive SA check | Check SA membership on cross-pipe target pipes; add to `problems` | Implemented; adds to `membership_problems` merged into `problems` | -- (pass) |
+| FR-12: Skip when SA IDs not configured | "If SA IDs not configured, skip" | Guarded by `if sa_ids and target_pipe_ids` | -- (pass) |
+| FR-11: Error message format | `"Service account is not a member of pipe <pipe_id> (<pipe_name>). Use invite_members to add it."` | When `get_pipe_members` raises, message uses `pipe {pid}` (no name); when empty members, includes pipe name | DD-02 |
+
+---
+
+## 4. Prioritized work queue
+
+| Order | ID | Severity | Title | Location |
+| :---: | :--- | :--- | :--- | :--- |
+| 1 | RF-01 | high | `_pipe_ids_from_behavior` imported as private function across modules | `ai_agent_tools.py:14` |
+| 2 | RF-02 | high | `create_card` re-raise via `type(exc)(...)` loses `.errors` attribute | `pipe_tools.py:141` |
+| 3 | DD-01 | medium | Read-only field warnings unfiltered -- noisy on pipes with many non-editable fields | `ai_automation_tools.py:178-187` |
+| 4 | DD-02 | medium | `enrich_permission_denied_error` asserts "not a member" when `get_pipe_members` raises for any reason | `graphql_error_helpers.py:196-202` |
+| 5 | DD-03 | low | Iterating `set[str]` twice for `asyncio.gather` + `zip` is order-dependent | `ai_agent_tools.py:727-735` |
+| 6 | DD-04 | low | Deferred import of `settings` inside function body | `ai_agent_tools.py:718` |
+| 7 | IM-01 | medium | No integration tests for FR-11 enrichment at tool level | `test_ai_agent_tools.py`, `test_automation_tools.py`, `test_pipe_tools.py` |
+| 8 | IM-02 | low | `_pipe_graph_with_fields_for_both` has unused parameters | `test_ai_agent_tools.py:1994` |
+| 9 | IM-03 | low | `_cross_pipe_behavior` has unused `source_pipe_id` parameter | `test_ai_agent_tools.py:1968` |
+
+---
+
+## 5. Required fixes (before merge)
+
+### RF-01 -- Private function `_pipe_ids_from_behavior` imported across module boundary
+
+- **Severity:** high
+- **Location:** `src/pipefy_mcp/tools/ai_agent_tools.py:14`
+- **Snippet:**
+
+```python
+from pipefy_mcp.tools.ai_tool_helpers import (
+    _pipe_ids_from_behavior,
+    build_ai_tool_error,
+    ...
+)
+```
+
+- **Problem:** `_pipe_ids_from_behavior` is a private function (prefixed with `_`) in `ai_tool_helpers.py`. Importing it in `ai_agent_tools.py` crosses the module abstraction boundary. Python convention: `_`-prefixed names are internal to their module. Linters like pyright/pylance flag this, and it signals to other developers that the function's contract is not stable.
+- **Trigger / scenario:** Future refactoring of `ai_tool_helpers.py` could rename or change `_pipe_ids_from_behavior` without considering external callers, breaking `ai_agent_tools.py`.
+- **Rationale:** CLAUDE.md: "Hide implementation details; expose clear interfaces." The underscore prefix explicitly marks this as internal.
+- **PRD / spec link:** Task 4.7 (proactive membership check uses pipe IDs from behaviors).
+- **Suggested direction:**
+  1. Rename `_pipe_ids_from_behavior` to `pipe_ids_from_behavior` (remove underscore) in `ai_tool_helpers.py`.
+  2. Update the import in `ai_agent_tools.py` accordingly.
+  3. Alternatively, move `_collect_pipe_ids_from_behaviors` (which wraps it) into `ai_tool_helpers.py` as a public function and import that instead, keeping `_pipe_ids_from_behavior` private.
+- **Tests:** Existing tests pass unchanged -- function behavior doesn't change.
+- **Verify:**
+
+```bash
+uv run ruff check src/pipefy_mcp/tools/ai_tool_helpers.py src/pipefy_mcp/tools/ai_agent_tools.py
+uv run pytest tests/tools/test_ai_agent_tools.py -v
+```
+
+- **Depends on:** none
+
+---
+
+### RF-02 -- `create_card` re-raise via `type(exc)(...)` loses `.errors` attribute
+
+- **Severity:** high
+- **Location:** `src/pipefy_mcp/tools/pipe_tools.py:134-142`
+- **Snippet:**
+
+```python
+try:
+    result = await client.create_card(pipe_id, card_data)
+except Exception as exc:  # noqa: BLE001
+    perm_msg = await enrich_permission_denied_error(
+        exc, [str(pipe_id)], client
+    )
+    if perm_msg:
+        raise type(exc)(f"{perm_msg}\n{exc}") from exc
+    raise
+```
+
+- **Problem:** `type(exc)(f"{perm_msg}\n{exc}")` creates a new `TransportQueryError` with only the `msg` argument. The original `.errors` list (containing GraphQL error details, extensions, codes) is lost. This also differs from the enrichment pattern used in `ai_agent_tools.py` and `automation_tools.py`, where enrichment is prepended to a returned error payload rather than re-raised.
+- **Trigger / scenario:** Any `PERMISSION_DENIED` error from `create_card` where enrichment succeeds. The re-raised exception lacks `.errors`, so any downstream code calling `extract_graphql_error_codes()` or `extract_error_strings()` on the re-raised exception will get incomplete results.
+- **Rationale:** Inconsistent error handling pattern across tools; potential data loss in exception attributes. The other enrichment sites (ai_agent_tools, automation_tools) return error payloads directly, which is safer.
+- **PRD / spec link:** FR-11 / Task 4.6.
+- **Suggested direction:**
+  1. Wrap the `client.create_card` call in a try/except that catches `Exception`, calls enrichment, and returns an error dict (consistent with other tools).
+  2. Use the existing `handle_tool_graphql_error` or `build_ai_tool_error` pattern to return a structured error payload with the enrichment prepended.
+- **Proposed fix:**
+
+```python
+try:
+    result = await client.create_card(pipe_id, card_data)
+except Exception as exc:  # noqa: BLE001
+    perm_msg = await enrich_permission_denied_error(
+        exc, [str(pipe_id)], client
+    )
+    error_text = str(exc)
+    if perm_msg:
+        error_text = f"{perm_msg}\n{error_text}"
+    return {"success": False, "error": error_text}
+```
+
+- **Tests:** Add a test in `test_pipe_tools.py` for `create_card` with a `PERMISSION_DENIED` error to verify the enriched error payload structure.
+- **Verify:**
+
+```bash
+uv run pytest tests/tools/test_pipe_tools.py -v
+uv run pytest tests/tools/test_ai_automation_tools.py -k validate -v
+```
+
+- **Depends on:** none
+
+---
+
+## 6. Deep dive findings (non-blocking but should track)
+
+### DD-01 -- Read-only field warnings unfiltered
+
+- **Severity:** medium
+- **Location:** `src/pipefy_mcp/tools/ai_automation_tools.py:178-187`
+- **Snippet:**
+
+```python
+for field in phase.get("fields") or []:
+    fid = str(field.get("internal_id") or field.get("id", ""))
+    label = field.get("label", "")
+    if fid:
+        all_field_ids.add(fid)
+        field_map[fid] = label
+    if field.get("editable") is False:
+        warnings.append(f"Field {fid} ({label}) is read-only.")
+```
+
+- **Problem:** ALL read-only fields in the pipe generate a warning, regardless of whether the prompt or `field_ids` reference them. A pipe with 20 non-editable fields produces 20 warnings even when the prompt uses only one editable field.
+- **Trigger / scenario:** Any pipe with system fields (created_at, updated_at, etc.) or locked fields.
+- **Rationale:** Noisy warnings reduce signal-to-noise ratio and may cause agents to waste time investigating irrelevant warnings.
+- **Suggested direction:** Defer the read-only check until after all field IDs are collected. Only warn for fields that appear in `prompt_tokens` or `field_ids`:
+
+```python
+# After building all_field_ids and field_map:
+for fid in set(prompt_tokens) | set(str(f) for f in field_ids):
+    if fid in all_field_ids and fid in readonly_fields:
+        warnings.append(f"Field {fid} ({field_map.get(fid, '')}) is read-only.")
+```
+
+- **Tests:** Update `test_read_only_field_warning` to also assert that unreferenced read-only fields do NOT produce warnings.
+- **Verify:** `uv run pytest tests/tools/test_ai_automation_tools.py -k "read_only" -v`
+- **Depends on:** none
+
+---
+
+### DD-02 -- False positive in enrichment when `get_pipe_members` raises
+
+- **Severity:** medium
+- **Location:** `src/pipefy_mcp/tools/graphql_error_helpers.py:196-202`
+- **Snippet:**
+
+```python
+if isinstance(result, BaseException):
+    # Could not fetch members for this pipe -- likely the pipe we lack access to
+    pipe_name = f"pipe {pid}"
+    missing_pipes.append(
+        f"Service account is not a member of {pipe_name}. "
+        f"Use invite_members to add it."
+    )
+    continue
+```
+
+- **Problem:** When `get_pipe_members` raises for a pipe, the code assumes "not a member" and reports it. But the exception could be a network timeout, a transient API error, or the pipe not existing. The message asserts a definitive cause ("is not a member") when the actual cause is uncertain.
+- **Trigger / scenario:** Transient network error on `get_pipe_members` during a PERMISSION_DENIED enrichment attempt.
+- **Rationale:** Could mislead agents into adding members to pipes where the real issue is network instability. The PRD says enrichment message should identify "which pipe lacks membership" -- but only when we actually know membership is the issue.
+- **Suggested direction:** Soften the message for exception cases to indicate uncertainty:
+
+```python
+if isinstance(result, BaseException):
+    missing_pipes.append(
+        f"Could not verify membership for pipe {pid} ({result}). "
+        f"Check if the service account is a member — use invite_members if not."
+    )
+```
+
+- **Tests:** Update `test_permission_denied_missing_member_returns_enrichment` assertion to match new message.
+- **Verify:** `uv run pytest tests/tools/test_graphql_error_helpers.py -v`
+- **Depends on:** none
+
+---
+
+### DD-03 -- Set iteration order relied upon for `asyncio.gather` + `zip`
+
+- **Severity:** low
+- **Location:** `src/pipefy_mcp/tools/ai_agent_tools.py:727-735`
+- **Snippet:**
+
+```python
+member_results = await asyncio.wait_for(
+    asyncio.gather(
+        *(client.get_pipe_members(tpid) for tpid in target_pipe_ids),
+        return_exceptions=True,
+    ),
+    timeout=MEMBERSHIP_CHECK_TIMEOUT_SECONDS,
+)
+for tpid, mresult in zip(target_pipe_ids, member_results):
+```
+
+- **Problem:** `target_pipe_ids` is a `set[str]`. The code relies on iterating it twice in the same order (once for `gather`, once for `zip`). Python guarantees this for an unmodified set object, but the intent is not obvious and fragile under refactoring.
+- **Suggested direction:** Convert to a list before the first use: `target_list = list(target_pipe_ids)` and use `target_list` for both `gather` and `zip`.
+- **Depends on:** none
+
+---
+
+### DD-04 -- Deferred import of `settings` inside function body
+
+- **Severity:** low
+- **Location:** `src/pipefy_mcp/tools/ai_agent_tools.py:718`
+- **Snippet:**
+
+```python
+# Inside validate_ai_agent_behaviors tool function:
+from pipefy_mcp.settings import settings
+```
+
+- **Problem:** Import inside function body rather than at module level. This pattern is sometimes used to avoid circular imports, but `pipefy_mcp.settings` has no circular dependency with `ai_agent_tools.py`. Other tools (e.g. `member_tools.py:12`) import it at module level.
+- **Suggested direction:** Move to module-level imports for consistency with the rest of the codebase.
+- **Depends on:** none
+
+---
+
+## 7. Improvements (recommended)
+
+### IM-01 -- Missing integration tests for FR-11 enrichment at tool level
+
+- **Severity:** medium
+- **Location:** `tests/tools/test_ai_agent_tools.py`, `tests/tools/test_automation_tools.py`, `tests/tools/test_pipe_tools.py`
+- **Problem:** The `enrich_permission_denied_error` helper has 7 unit tests (test_graphql_error_helpers.py), but the wiring in `create_ai_agent`, `update_ai_agent`, `create_automation`, and `create_card` has no tests that verify the enriched message appears in the tool's error payload when a PERMISSION_DENIED error occurs.
+- **Rationale:** Testing anti-patterns doc: "New logic paths have sad path tests, not only happy path." The integration between helper and tool error paths is untested.
+- **Suggested direction:** Add at least one test per enriched tool that:
+  1. Mocks the service call to raise a `TransportQueryError` with `PERMISSION_DENIED`
+  2. Mocks `get_pipe_members` to return members for one pipe but raise for another
+  3. Asserts the enriched message appears in the error payload
+- **Depends on:** RF-02 (create_card pattern must be decided first)
+
+---
+
+### IM-02 -- `_pipe_graph_with_fields_for_both` has unused parameters
+
+- **Severity:** low
+- **Location:** `tests/tools/test_ai_agent_tools.py:1994`
+- **Snippet:**
+
+```python
+def _pipe_graph_with_fields_for_both(source_pipe_id="1", target_pipe_id="999"):
+    """Pipe graph and relations enabling cross-pipe validation."""
+    return {
+        "pipe": {
+            "phases": [{"id": "ph-1", "fields": [{"id": "100"}]}],
+            "start_form_fields": [],
+        }
+    }
+```
+
+- **Problem:** Both `source_pipe_id` and `target_pipe_id` parameters are declared but never used in the function body. This is dead code in tests.
+- **Suggested direction:** Remove the unused parameters: `def _pipe_graph_with_fields_for_both():`.
+- **Depends on:** none
+
+---
+
+### IM-03 -- `_cross_pipe_behavior` has unused `source_pipe_id` parameter
+
+- **Severity:** low
+- **Location:** `tests/tools/test_ai_agent_tools.py:1968`
+- **Snippet:**
+
+```python
+def _cross_pipe_behavior(source_pipe_id="1", target_pipe_id="999"):
+```
+
+- **Problem:** `source_pipe_id` is never used in the function body (only `target_pipe_id` is used in `"pipeId": target_pipe_id`).
+- **Suggested direction:** Remove: `def _cross_pipe_behavior(target_pipe_id="999"):`.
+- **Depends on:** none
+
+---
+
+## 8. Nits
+
+| ID | Location | Note |
+| :--- | :--- | :--- |
+| NIT-01 | `ai_agent_tools.py:39` | `MEMBERSHIP_CHECK_TIMEOUT_SECONDS = 5` placed before `VALIDATE_FETCH_TIMEOUT_SECONDS = 30` -- reverse alphabetical and conceptual grouping. Consider placing after `VALIDATE_FETCH_TIMEOUT_SECONDS` since membership check runs inside the validation tool flow. |
+| NIT-02 | `graphql_error_helpers.py:208` | `" | ".join(missing_pipes)` uses pipe character as separator. When multiple pipes are missing, this produces a single-line message that's harder to parse. Consider `"\n"` for multi-pipe cases. |
+
+---
+
+## 9. Verification (full suite)
+
+Commands run during review:
+
+```bash
+git diff pipe-full-toolset...HEAD --stat
+# 14 files changed, 1047 insertions(+), 12 deletions(-)
+
+uv run pytest -m "not integration" -v
+# 1458 passed, 29 deselected in 27.10s
+
+uv run ruff check src/ tests/
+# All checks passed!
+
+uv run ruff format --check src/ tests/
+# 162 files already formatted
+```
+
+---
+
+## 10. Appendix -- Files touched in diff
+
+```
+src/pipefy_mcp/services/pipefy/client.py                     (+4)
+src/pipefy_mcp/services/pipefy/pipe_service.py                (+10)
+src/pipefy_mcp/services/pipefy/queries/pipe_queries.py        (+34)
+src/pipefy_mcp/tools/ai_agent_tools.py                        (+86, -1)
+src/pipefy_mcp/tools/ai_automation_tools.py                   (+140, -1)
+src/pipefy_mcp/tools/ai_tool_helpers.py                       (+30)
+src/pipefy_mcp/tools/automation_tools.py                      (+11)
+src/pipefy_mcp/tools/graphql_error_helpers.py                 (+75, -1)
+src/pipefy_mcp/tools/pipe_tools.py                            (+11, -1)
+src/pipefy_mcp/tools/registry.py                              (+1)
+tests/services/test_pipefy_facade.py                          (+6)
+tests/tools/test_ai_agent_tools.py                            (+209)
+tests/tools/test_ai_automation_tools.py                       (+325)
+tests/tools/test_graphql_error_helpers.py                     (+117, new file)
+```

--- a/.env.example
+++ b/.env.example
@@ -7,5 +7,8 @@ PIPEFY_INTERNAL_API_URL=https://app.pipefy.com/internal_api
 PIPEFY_OAUTH_URL=https://app.pipefy.com/oauth/token
 PIPEFY_OAUTH_CLIENT=<YOUR_SERVICE_ACCOUNT_CLIENT_ID>
 PIPEFY_OAUTH_SECRET=<YOUR_SERVICE_ACCOUNT_CLIENT_SECRET>
-# Optional: comma-separated Pipefy user IDs blocked from remove_member_from_pipe (service accounts)
+# Optional: comma-separated Pipefy user IDs for service accounts (same env var).
+# - Blocks remove_member_from_pipe from removing these users (when configured).
+# - Enables proactive membership checks in validate_ai_agent_behaviors (cross-pipe targets).
+# Discover IDs via get_pipe_members (emails like *@service-account.pipefy.com) or Pipefy Admin.
 # PIPEFY_SERVICE_ACCOUNT_IDS=

--- a/README.md
+++ b/README.md
@@ -58,8 +58,6 @@ The server exposes **128 tools**, grouped below into **nine** surface areas. Can
 | **Organization** | 1 | Fetch organization details (plan, members, pipes count). | [Details](docs/tools/organization.md) |
 | **Introspection** | 5 | Schema discovery, depth-controlled type resolution, and raw GraphQL execution. | [Details](docs/tools/introspection.md) |
 
-**Sanity check:** 37 + 17 + 8 + 17 + 22 + 10 + 11 + 1 + 5 = **128** (matches `len(PIPEFY_TOOL_NAMES)`).
-
 ---
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MCP server for Pipefy
 
 <p align="center">
-  <strong>Open-source MCP for Pipefy: 116 tools across pipes, cards, tables, relations, reports, automations, AI agents and observability — built for your IDE, with pagination, introspection and safe deletes.</strong>
+  <strong>Open-source MCP for Pipefy: 128 tools across pipes, cards, tables, relations, reports, automations, AI agents and observability — built for your IDE, with pagination, introspection and safe deletes.</strong>
 </p>
 
 <p align="center">
@@ -33,7 +33,7 @@
 
 ## MCP tools
 
-The server exposes **116 tools**, grouped below into **nine** surface areas. Canonical names live in `PIPEFY_TOOL_NAMES` (`src/pipefy_mcp/tools/registry.py`).
+The server exposes **128 tools**, grouped below into **nine** surface areas. Canonical names live in `PIPEFY_TOOL_NAMES` (`src/pipefy_mcp/tools/registry.py`).
 
 **Documentation for agents:** each tool’s description and `Args:` come from its Python docstring—MCP clients show that text to LLMs for routing. Use the docstrings (and the per-area docs linked in the table) as the authority on parameters and edge cases.
 
@@ -48,15 +48,17 @@ The server exposes **116 tools**, grouped below into **nine** surface areas. Can
 
 | Category | Tools | Description | Docs |
 |----------|:-----:|-------------|------|
-| **Pipes & cards** | 34 | Pipes, phases, fields, labels, cards, field conditions, and card-level attachments—read/write/delete as documented per tool. | [Details](docs/tools/pipes-and-cards.md) |
-| **Database tables** | 18 | Tables, records (rows), schema columns (table fields), org-wide table discovery, and table-record attachment uploads. | [Details](docs/tools/database-tables.md) |
+| **Pipes & cards** | 37 | Pipes, phases, fields, labels, cards, field conditions, and card-level attachments—read/write/delete as documented per tool (card-to-card relation list/delete live under **Relations**). | [Details](docs/tools/pipes-and-cards.md) |
+| **Database tables** | 17 | Tables, records (rows), schema columns (table fields), org-wide table discovery, and table-record attachment uploads. | [Details](docs/tools/database-tables.md) |
 | **Relations** | 8 | Pipe relations, table relations by ID, card links, list/delete card-level relations. | [Details](docs/tools/relations.md) |
-| **Reports** | 16 | Pipe and organization reports: discovery, CRUD, and async exports. | [Details](docs/tools/reports.md) |
-| **Automations & AI** | 17 | Traditional automations (rules engine) and AI-powered automations and agents. | [Details](docs/tools/automations-and-ai.md) |
+| **Reports** | 17 | Pipe and organization reports: discovery, CRUD, single pipe report read, and async exports. | [Details](docs/tools/reports.md) |
+| **Automations & AI** | 22 | Traditional automations (rules engine), AI automations (including read/delete/validate), and AI agents. | [Details](docs/tools/automations-and-ai.md) |
 | **Observability** | 10 | AI agent and automation logs, usage stats, credits, job exports, status polling, and CSV fetch for finished exports. | [Details](docs/tools/observability.md) |
-| **Members, email & webhooks** | 9 | Pipe membership, card inbox emails, and webhook management. | [Details](docs/tools/members-email-webhooks.md) |
+| **Members, email & webhooks** | 11 | Pipe membership, card inbox emails, webhooks (list/update/create/delete), and transactional email sends. | [Details](docs/tools/members-email-webhooks.md) |
 | **Organization** | 1 | Fetch organization details (plan, members, pipes count). | [Details](docs/tools/organization.md) |
 | **Introspection** | 5 | Schema discovery, depth-controlled type resolution, and raw GraphQL execution. | [Details](docs/tools/introspection.md) |
+
+**Sanity check:** 37 + 17 + 8 + 17 + 22 + 10 + 11 + 1 + 5 = **128** (matches `len(PIPEFY_TOOL_NAMES)`).
 
 ---
 

--- a/docs/tools/automations-and-ai.md
+++ b/docs/tools/automations-and-ai.md
@@ -1,12 +1,12 @@
 # Automations & AI
 
-Traditional automations (if/then rules) and AI-powered automations and agents. **17 tools.**
+Traditional automations (if/then rules) and AI-powered automations and agents. **22 tools.** (Execution logs, usage exports, and credit dashboards are in [Observability](observability.md).)
 
 ---
 
 ## Traditional automations (rules engine)
 
-Eight tools manage Pipefy traditional automations: if/then rules bound to a pipe via the standard GraphQL API.
+Nine tools manage Pipefy traditional automations: if/then rules bound to a pipe via the standard GraphQL API.
 
 **Tip:** For **send-a-task** rules (`send_a_task` action), use `create_send_task_automation` (pipe, trigger, task title, recipients) instead of hand-building `action_params.taskParams` on `create_automation`. For other actions, call `get_automation_events` (global event catalog) and `get_automation_actions` with the target pipe (`repoId`) before `create_automation` to pick valid `trigger_id` / `action_id` values. Writes accept optional `extra_input` (camelCase API keys) and `debug=true` on errors.
 
@@ -16,6 +16,7 @@ Eight tools manage Pipefy traditional automations: if/then rules bound to a pipe
 | `get_automations` | Yes | Lists rules; optional `organization_id` and/or `pipe_id`. |
 | `get_automation_actions` | Yes | Catalog of action types for a pipe (IDs and field metadata). |
 | `get_automation_events` | Yes | Catalog of trigger event definitions (global list; tool still takes `pipe_id` for context). |
+| `simulate_automation` | Yes | Runs a dry-run simulation for an automation with a payload (see tool docstring). |
 | `create_automation` | No | Creates a rule: `pipe_id`, `name`, `trigger_id`, `action_id`; `active` defaults to true. Set `active: false` to create disabled. |
 | `create_send_task_automation` | No | Creates a send-a-task automation (`pipe_id`, trigger, task title, recipients). Created active; disable via `update_automation`. |
 | `update_automation` | No | Patches a rule via `extra_input` (`UpdateAutomationInput` fields). |
@@ -23,21 +24,30 @@ Eight tools manage Pipefy traditional automations: if/then rules bound to a pipe
 
 ---
 
-## AI automations & agents
+## AI automations
 
 AI automations are separate from traditional rules above. They are prompt-driven and use the internal API.
 
-| Tool | Role |
-|------|------|
-| `create_ai_automation` | Prompt-driven automation writing to one or more card fields (AI must be enabled on the pipe). |
-| `update_ai_automation` | Change name, `active`, prompt, `field_ids`, or `condition`. |
+| Tool | Read-only | Role |
+|------|-----------|------|
+| `create_ai_automation` | No | Prompt-driven automation writing to one or more card fields (AI must be enabled on the pipe). |
+| `update_ai_automation` | No | Change name, `active`, prompt, `field_ids`, or `condition`. |
+| `get_ai_automation` | Yes | Loads one AI automation by id (same GraphQL read path as `get_automation`). |
+| `get_ai_automations` | Yes | Lists **only** `generate_with_ai` automations for the pipe (optional org resolution). |
+| `delete_ai_automation` | No | Permanently deletes an AI automation (`destructiveHint=True` — two-step confirm). |
+| `validate_ai_automation_prompt` | Yes | Pre-flight validation: field refs in the prompt, `field_ids`, optional `event_id`, and `pipe.preferences.aiAgentsEnabled`. |
 
 ### `create_ai_automation`: `condition` (contract)
 
 **Source of truth:** **Required-on-wire via default (branch B).** If the tool caller omits `condition`, the MCP layer applies `DEFAULT_CONDITION` in code (`CreateAiAutomationInput`): an empty-expression structure meaning “no extra trigger conditions” in Pipefy. The internal API **always** receives a `condition` key on create, avoiding ambiguous “key absent” behavior. Pass an explicit `condition` dict to override. **`update_ai_automation`:** omit `condition` to leave the existing rule unchanged; pass a dict to replace it.
-| `create_ai_agent` | Creates and configures an AI agent with `instruction` (= Pipefy UI "Description") and 1–5 `behaviors` in one call. `repo_uuid` is the pipe UUID from `get_pipe`. Optional: `data_source_ids`. |
-| `update_ai_agent` | Replaces full agent config; send the complete `behaviors` list (1-5). |
-| `toggle_ai_agent_status` | Enable/disable without resending configuration. |
+
+## AI agents
+
+| Tool | Read-only | Role |
+|------|-----------|------|
+| `create_ai_agent` | No | Creates and configures an AI agent with `instruction` (= Pipefy UI "Description") and 1–5 `behaviors` in one call. `repo_uuid` is the pipe UUID from `get_pipe`. Optional: `data_source_ids`. |
+| `update_ai_agent` | No | Replaces full agent config; send the complete `behaviors` list (1-5). |
+| `toggle_ai_agent_status` | No | Enable/disable without resending configuration. |
 
 **Tip:** Pipefy UI **Description** maps to the API/tool field `instruction` (agent-level purpose). The per-behavior prompt in the UI maps to `actionParams.aiBehaviorParams.instruction` on each behavior (behavior-level).
 

--- a/docs/tools/automations-and-ai.md
+++ b/docs/tools/automations-and-ai.md
@@ -39,7 +39,7 @@ AI automations are separate from traditional rules above. They are prompt-driven
 
 ### `create_ai_automation`: `condition` (contract)
 
-**Source of truth:** **Required-on-wire via default (branch B).** If the tool caller omits `condition`, the MCP layer applies `DEFAULT_CONDITION` in code (`CreateAiAutomationInput`): an empty-expression structure meaning “no extra trigger conditions” in Pipefy. The internal API **always** receives a `condition` key on create, avoiding ambiguous “key absent” behavior. Pass an explicit `condition` dict to override. **`update_ai_automation`:** omit `condition` to leave the existing rule unchanged; pass a dict to replace it.
+On **create**, if the caller omits `condition`, the MCP layer supplies `DEFAULT_CONDITION` (see `CreateAiAutomationInput` in `pipefy_mcp.models.ai_automation`) so Pipefy always receives an explicit condition object. Pass a `condition` dict to override. On **`update_ai_automation`**, omit `condition` to leave the existing rule unchanged; pass a dict to replace it.
 
 ## AI agents
 

--- a/docs/tools/database-tables.md
+++ b/docs/tools/database-tables.md
@@ -1,6 +1,6 @@
 # Database Tables
 
-Tables, records (rows), and schema columns (table fields) for org Database Tables. **18 tools.**
+Tables, records (rows), and schema columns (table fields) for org Database Tables. **17 tools.**
 
 ## Cross-cutting patterns
 

--- a/docs/tools/members-email-webhooks.md
+++ b/docs/tools/members-email-webhooks.md
@@ -1,6 +1,6 @@
 # Members, Email & Webhooks
 
-Manage pipe membership, send emails from card inboxes, read inbox replies, and manage webhooks. **9 tools.**
+Manage pipe membership, send emails from card inboxes, read inbox replies, and manage webhooks (list, create, update, delete). **11 tools.**
 
 ---
 
@@ -34,5 +34,7 @@ Configure IDs in `.env` (see `.env.example`). Omit the variable when you do not 
 
 | Tool | Read-only | Role |
 |------|-----------|------|
+| `get_webhooks` | Yes | Lists webhooks for a pipe (`id`, `name`, `url`, `actions`, `headers`, `email`). |
 | `create_webhook` | No | Register a webhook for pipe events; `url` must be HTTPS; `actions` is a list of event names (e.g. `['card.move', 'card.create']`). Use `introspect_type('WebhookActions')` for valid actions. |
+| `update_webhook` | No | Patch an existing webhook (`webhook_id`, optional `name`, `url`, `actions`, `headers`). |
 | `delete_webhook` | No | Permanently delete a webhook by ID (`destructiveHint=True` — confirm with the user first). |

--- a/docs/tools/pipes-and-cards.md
+++ b/docs/tools/pipes-and-cards.md
@@ -1,6 +1,6 @@
 # Pipes & Cards
 
-Read, create, update, and delete pipes, phases, phase fields, labels, cards, and field conditions. **34 tools.**
+Read, create, update, and delete pipes, phases, phase fields, labels, cards, and field conditions. **37 tools.** (Card-to-card relation tools `get_card_relations` / `delete_card_relation` / `create_card_relation` are documented in [Connections & Relations](relations.md).)
 
 ## Cross-cutting patterns
 
@@ -29,6 +29,7 @@ Pipefy’s GraphQL API uses **string** IDs for pipes, phases, cards, and most ot
 | `get_start_form_fields` | Start-form fields for a pipe. |
 | `get_phase_fields` | Fields for a phase — each includes `id`, `internal_id`, `uuid`. |
 | `get_pipe_members` | List pipe members. |
+| `get_labels` | List labels configured on the pipe (`id`, `name`). |
 | `search_pipes` | Search pipes by name. |
 
 ## Card reads
@@ -55,7 +56,7 @@ Pipefy’s GraphQL API uses **string** IDs for pipes, phases, cards, and most ot
 | `create_card` | Create a card; may use elicitation to ask the user for required fields mid-call. |
 | `add_card_comment` | Add a comment to a card. |
 | `update_comment` | Update an existing comment. |
-| `delete_comment` | Delete a comment. |
+| `delete_comment` | Delete a comment (two-step: preview with `confirm=false`, then `confirm=true` after approval; `destructiveHint=True`). |
 | `move_card_to_phase` | Move card to another phase. |
 | `update_card_field` | Single-field update (`updateCardField`). |
 | `update_card` | Metadata (title, assignees, labels, due date) and/or multiple custom fields via `field_updates`. |
@@ -66,10 +67,12 @@ Pipefy’s GraphQL API uses **string** IDs for pipes, phases, cards, and most ot
 
 ## Field condition tools
 
-Three tools configure conditional visibility on phase fields.
+Five tools read and configure conditional visibility on phase fields.
 
 | Tool | Read-only | Role |
 |------|-----------|------|
+| `get_field_conditions` | Yes | Lists conditions for a phase (expressions, actions). |
+| `get_field_condition` | Yes | Loads one condition by ID. |
 | `create_field_condition` | No | Creates a rule: `phase_id`, `condition` (dict), `actions` (list of dicts), optional `extra_input`. |
 | `update_field_condition` | No | Patches an existing rule: `condition_id` and at least one of `condition`, `actions`, or `extra_input`. |
 | `delete_field_condition` | No | Deletes a rule (`destructiveHint=True` — confirm with the user first). |

--- a/docs/tools/reports.md
+++ b/docs/tools/reports.md
@@ -1,6 +1,6 @@
 # Reports
 
-Pipe reports and organization reports: discovery, CRUD, and async exports. **16 tools.**
+Pipe reports and organization reports: discovery, CRUD, single pipe report fetch, and async exports. **17 tools.**
 
 ## Cross-cutting patterns
 
@@ -16,6 +16,7 @@ Pipe reports and organization reports: discovery, CRUD, and async exports. **16 
 | Tool | Role |
 |------|------|
 | `get_pipe_reports` | Lists pipe reports with pagination and optional search. |
+| `get_pipe_report` | Loads **one** pipe report by id (filtered list under the hood — no dedicated single-report endpoint). |
 | `get_pipe_report_columns` | Returns columns (`name`, `label`, `type`, ...) for building `fields` on create/update. |
 | `get_pipe_report_filterable_fields` | Returns filterable fields grouped by section/phase for `filter`. |
 | `get_organization_report` | Loads one organization report by ID. |

--- a/src/pipefy_mcp/services/pipefy/client.py
+++ b/src/pipefy_mcp/services/pipefy/client.py
@@ -118,6 +118,10 @@ class PipefyClient:
         """Get a pipe by ID, including phases, labels, and start form fields."""
         return await self._pipe_service.get_pipe(pipe_id)
 
+    async def get_pipe_with_preferences(self, pipe_id: str | int) -> dict:
+        """Get a pipe with AI preferences, phases with fields, and start form fields."""
+        return await self._pipe_service.get_pipe_with_preferences(pipe_id)
+
     async def create_pipe(self, name: str, organization_id: str | int) -> dict:
         """Create a new pipe in the organization."""
         return await self._pipe_config_service.create_pipe(name, organization_id)

--- a/src/pipefy_mcp/services/pipefy/pipe_service.py
+++ b/src/pipefy_mcp/services/pipefy/pipe_service.py
@@ -9,6 +9,7 @@ from pipefy_mcp.services.pipefy.queries.pipe_queries import (
     GET_PHASE_FIELDS_QUERY,
     GET_PIPE_MEMBERS_QUERY,
     GET_PIPE_QUERY,
+    GET_PIPE_WITH_PREFERENCES_QUERY,
     GET_START_FORM_FIELDS_QUERY,
     SEARCH_PIPES_QUERY,
 )
@@ -29,6 +30,15 @@ class PipeService(BasePipefyClient):
         """Get a pipe by its ID, including phases, labels, and start form fields."""
         variables = {"pipe_id": str(pipe_id)}
         return await self.execute_query(GET_PIPE_QUERY, variables)
+
+    async def get_pipe_with_preferences(self, pipe_id: str | int) -> dict:
+        """Get a pipe including AI preferences, phases with fields, and start form fields.
+
+        Args:
+            pipe_id: Pipe ID.
+        """
+        variables = {"pipe_id": str(pipe_id)}
+        return await self.execute_query(GET_PIPE_WITH_PREFERENCES_QUERY, variables)
 
     async def get_pipe_members(self, pipe_id: str | int) -> dict:
         """Get the members of a pipe."""

--- a/src/pipefy_mcp/services/pipefy/queries/pipe_queries.py
+++ b/src/pipefy_mcp/services/pipefy/queries/pipe_queries.py
@@ -123,11 +123,45 @@ GET_PHASE_FIELDS_QUERY = gql(
     """
 )
 
+GET_PIPE_WITH_PREFERENCES_QUERY = gql(
+    """
+    query ($pipe_id: ID!) {
+        pipe(id: $pipe_id) {
+            id
+            uuid
+            name
+            preferences {
+                aiAgentsEnabled
+            }
+            phases {
+                id
+                name
+                fields {
+                    id
+                    internal_id
+                    label
+                    type
+                    editable
+                }
+            }
+            start_form_fields {
+                id
+                internal_id
+                label
+                type
+                editable
+            }
+        }
+    }
+    """
+)
+
 __all__ = [
     "GET_PHASE_ALLOWED_MOVES_QUERY",
     "GET_PHASE_FIELDS_QUERY",
     "GET_PIPE_MEMBERS_QUERY",
     "GET_PIPE_QUERY",
+    "GET_PIPE_WITH_PREFERENCES_QUERY",
     "GET_START_FORM_FIELDS_QUERY",
     "SEARCH_PIPES_QUERY",
 ]

--- a/src/pipefy_mcp/settings.py
+++ b/src/pipefy_mcp/settings.py
@@ -34,7 +34,10 @@ class PipefySettings(BaseModel):
 
     service_account_ids: Annotated[list[str], NoDecode] = Field(
         default_factory=list,
-        description="Comma-separated user IDs protected from removal via MCP tools.",
+        description=(
+            "Pipefy user IDs for service accounts: protected from removal in member tools; "
+            "used for proactive cross-pipe membership checks in validate_ai_agent_behaviors."
+        ),
     )
 
     @field_validator("service_account_ids", mode="before")

--- a/src/pipefy_mcp/tools/ai_agent_tools.py
+++ b/src/pipefy_mcp/tools/ai_agent_tools.py
@@ -704,8 +704,7 @@ class AiAgentTools:
                         f"fieldIds targeting it were not verified."
                     )
 
-            # Proactive membership check for cross-pipe target pipes (FR-12).
-            # Only runs when service_account_ids are configured.
+            # Optional: verify service account membership on cross-pipe targets.
             membership_problems: list[str] = []
             sa_ids = settings.pipefy.service_account_ids
             target_pipe_list = list(target_pipe_ids)

--- a/src/pipefy_mcp/tools/ai_agent_tools.py
+++ b/src/pipefy_mcp/tools/ai_agent_tools.py
@@ -37,6 +37,8 @@ from pipefy_mcp.tools.phase_transition_helpers import (
     collect_ai_behavior_move_transition_problems,
 )
 
+MEMBERSHIP_CHECK_TIMEOUT_SECONDS = 5
+
 VALIDATE_FETCH_TIMEOUT_SECONDS = 30
 
 
@@ -721,6 +723,48 @@ class AiAgentTools:
                         f"fieldIds targeting it were not verified."
                     )
 
+            # Proactive membership check for cross-pipe target pipes (FR-12).
+            # Only runs when service_account_ids are configured.
+            from pipefy_mcp.settings import settings
+
+            membership_problems: list[str] = []
+            sa_ids = settings.pipefy.service_account_ids
+            if sa_ids and target_pipe_ids:
+                sa_set = set(sa_ids)
+                try:
+                    member_results = await asyncio.wait_for(
+                        asyncio.gather(
+                            *(
+                                client.get_pipe_members(tpid)
+                                for tpid in target_pipe_ids
+                            ),
+                            return_exceptions=True,
+                        ),
+                        timeout=MEMBERSHIP_CHECK_TIMEOUT_SECONDS,
+                    )
+                    for tpid, mresult in zip(target_pipe_ids, member_results):
+                        if isinstance(mresult, BaseException):
+                            await ctx.debug(
+                                f"Could not check membership for pipe {tpid}: {mresult}"
+                            )
+                            continue
+                        members = mresult.get("pipe", {}).get("members") or []
+                        member_ids = {
+                            str(m.get("user", {}).get("id", ""))
+                            for m in members
+                            if isinstance(m, dict)
+                        }
+                        if not sa_set & member_ids:
+                            membership_problems.append(
+                                f"Service account is not a member of target pipe "
+                                f"{tpid}. Use invite_members to add it before "
+                                f"creating the agent."
+                            )
+                except (TimeoutError, asyncio.TimeoutError):
+                    await ctx.debug(
+                        "Membership check timed out; skipping SA verification"
+                    )
+
             unknown_action_types = "error" if strict_unknown_action_types else "warning"
             problems, helper_warnings = validate_behaviors_against_pipe(
                 behaviors,
@@ -734,7 +778,7 @@ class AiAgentTools:
             transition_problems = await collect_ai_behavior_move_transition_problems(
                 client, behaviors
             )
-            problems = [*problems, *transition_problems]
+            problems = [*problems, *transition_problems, *membership_problems]
             warnings = [*tool_warnings, *helper_warnings]
 
             if problems:

--- a/src/pipefy_mcp/tools/ai_agent_tools.py
+++ b/src/pipefy_mcp/tools/ai_agent_tools.py
@@ -11,6 +11,7 @@ from pydantic import ValidationError
 from pipefy_mcp.models.ai_agent import CreateAiAgentInput, UpdateAiAgentInput
 from pipefy_mcp.services.pipefy import PipefyClient
 from pipefy_mcp.tools.ai_tool_helpers import (
+    _pipe_ids_from_behavior,
     build_ai_tool_error,
     build_create_agent_partial_failure,
     build_create_agent_success,
@@ -28,7 +29,10 @@ from pipefy_mcp.tools.behavior_placeholder_interpolation import (
     expand_behaviors_placeholders,
 )
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
-from pipefy_mcp.tools.graphql_error_helpers import extract_error_strings
+from pipefy_mcp.tools.graphql_error_helpers import (
+    enrich_permission_denied_error,
+    extract_error_strings,
+)
 from pipefy_mcp.tools.phase_transition_helpers import (
     collect_ai_behavior_move_transition_problems,
 )
@@ -46,6 +50,15 @@ _PAYLOAD_OK_SUFFIX = (
     "Try the same behaviors on a different pipe to confirm. "
     "Do NOT retry with modified payload — the issue is the pipe, not the behaviors."
 )
+
+
+def _collect_pipe_ids_from_behaviors(behaviors: list[dict]) -> list[str]:
+    """Collect all unique pipe IDs referenced in behavior metadata."""
+    ids: set[str] = set()
+    for b in behaviors:
+        if isinstance(b, dict):
+            ids.update(_pipe_ids_from_behavior(b))
+    return list(ids)
 
 
 def _extract_pipe_id_from_behaviors(behaviors: list[dict]) -> str | None:
@@ -290,9 +303,14 @@ class AiAgentTools:
             try:
                 create_result = await client.create_ai_agent(validated)
             except Exception as exc:  # noqa: BLE001
-                return build_ai_tool_error(
-                    enrich_behavior_error(exc, behaviors_expanded)
+                pipe_ids = _collect_pipe_ids_from_behaviors(behaviors_expanded)
+                perm_msg = await enrich_permission_denied_error(
+                    exc, pipe_ids, client
                 )
+                error_text = enrich_behavior_error(exc, behaviors_expanded)
+                if perm_msg:
+                    error_text = f"{perm_msg}\n{error_text}"
+                return build_ai_tool_error(error_text)
 
             agent_uuid = create_result["agent_uuid"]
 
@@ -311,9 +329,18 @@ class AiAgentTools:
             try:
                 await client.update_ai_agent(update_input)
             except Exception as exc:  # noqa: BLE001
+                pipe_ids = _collect_pipe_ids_from_behaviors(behaviors_expanded)
+                perm_msg = await enrich_permission_denied_error(
+                    exc, pipe_ids, client
+                )
+                error_text = await _enrich_with_validation(
+                    exc, behaviors_expanded
+                )
+                if perm_msg:
+                    error_text = f"{perm_msg}\n{error_text}"
                 return build_create_agent_partial_failure(
                     agent_uuid=agent_uuid,
-                    error=await _enrich_with_validation(exc, behaviors_expanded),
+                    error=error_text,
                 )
 
             msg = f"AI Agent created and configured successfully. UUID: {agent_uuid}"
@@ -399,9 +426,16 @@ class AiAgentTools:
             try:
                 result = await client.update_ai_agent(validated)
             except Exception as exc:  # noqa: BLE001
-                return build_ai_tool_error(
-                    await _enrich_with_validation(exc, resolved_behaviors)
+                pipe_ids = _collect_pipe_ids_from_behaviors(resolved_behaviors)
+                perm_msg = await enrich_permission_denied_error(
+                    exc, pipe_ids, client
                 )
+                error_text = await _enrich_with_validation(
+                    exc, resolved_behaviors
+                )
+                if perm_msg:
+                    error_text = f"{perm_msg}\n{error_text}"
+                return build_ai_tool_error(error_text)
 
             return build_update_agent_success(
                 agent_uuid=result["agent_uuid"],

--- a/src/pipefy_mcp/tools/ai_agent_tools.py
+++ b/src/pipefy_mcp/tools/ai_agent_tools.py
@@ -10,8 +10,8 @@ from pydantic import ValidationError
 
 from pipefy_mcp.models.ai_agent import CreateAiAgentInput, UpdateAiAgentInput
 from pipefy_mcp.services.pipefy import PipefyClient
+from pipefy_mcp.settings import settings
 from pipefy_mcp.tools.ai_tool_helpers import (
-    _pipe_ids_from_behavior,
     build_ai_tool_error,
     build_create_agent_partial_failure,
     build_create_agent_success,
@@ -20,6 +20,7 @@ from pipefy_mcp.tools.ai_tool_helpers import (
     build_get_agents_success,
     build_toggle_agent_status_success,
     build_update_agent_success,
+    collect_pipe_ids_from_behaviors,
     enrich_behavior_error,
     fetch_pipe_validation_context,
     resolve_field_slugs_to_numeric,
@@ -37,9 +38,8 @@ from pipefy_mcp.tools.phase_transition_helpers import (
     collect_ai_behavior_move_transition_problems,
 )
 
-MEMBERSHIP_CHECK_TIMEOUT_SECONDS = 5
-
 VALIDATE_FETCH_TIMEOUT_SECONDS = 30
+MEMBERSHIP_CHECK_TIMEOUT_SECONDS = 5
 
 
 _RECORD_NOT_SAVED_PATTERN = "RECORD_NOT_SAVED"
@@ -52,15 +52,6 @@ _PAYLOAD_OK_SUFFIX = (
     "Try the same behaviors on a different pipe to confirm. "
     "Do NOT retry with modified payload — the issue is the pipe, not the behaviors."
 )
-
-
-def _collect_pipe_ids_from_behaviors(behaviors: list[dict]) -> list[str]:
-    """Collect all unique pipe IDs referenced in behavior metadata."""
-    ids: set[str] = set()
-    for b in behaviors:
-        if isinstance(b, dict):
-            ids.update(_pipe_ids_from_behavior(b))
-    return list(ids)
 
 
 def _extract_pipe_id_from_behaviors(behaviors: list[dict]) -> str | None:
@@ -305,7 +296,7 @@ class AiAgentTools:
             try:
                 create_result = await client.create_ai_agent(validated)
             except Exception as exc:  # noqa: BLE001
-                pipe_ids = _collect_pipe_ids_from_behaviors(behaviors_expanded)
+                pipe_ids = collect_pipe_ids_from_behaviors(behaviors_expanded)
                 perm_msg = await enrich_permission_denied_error(exc, pipe_ids, client)
                 error_text = enrich_behavior_error(exc, behaviors_expanded)
                 if perm_msg:
@@ -329,7 +320,7 @@ class AiAgentTools:
             try:
                 await client.update_ai_agent(update_input)
             except Exception as exc:  # noqa: BLE001
-                pipe_ids = _collect_pipe_ids_from_behaviors(behaviors_expanded)
+                pipe_ids = collect_pipe_ids_from_behaviors(behaviors_expanded)
                 perm_msg = await enrich_permission_denied_error(exc, pipe_ids, client)
                 error_text = await _enrich_with_validation(exc, behaviors_expanded)
                 if perm_msg:
@@ -422,7 +413,7 @@ class AiAgentTools:
             try:
                 result = await client.update_ai_agent(validated)
             except Exception as exc:  # noqa: BLE001
-                pipe_ids = _collect_pipe_ids_from_behaviors(resolved_behaviors)
+                pipe_ids = collect_pipe_ids_from_behaviors(resolved_behaviors)
                 perm_msg = await enrich_permission_denied_error(exc, pipe_ids, client)
                 error_text = await _enrich_with_validation(exc, resolved_behaviors)
                 if perm_msg:
@@ -715,24 +706,23 @@ class AiAgentTools:
 
             # Proactive membership check for cross-pipe target pipes (FR-12).
             # Only runs when service_account_ids are configured.
-            from pipefy_mcp.settings import settings
-
             membership_problems: list[str] = []
             sa_ids = settings.pipefy.service_account_ids
-            if sa_ids and target_pipe_ids:
+            target_pipe_list = list(target_pipe_ids)
+            if sa_ids and target_pipe_list:
                 sa_set = set(sa_ids)
                 try:
                     member_results = await asyncio.wait_for(
                         asyncio.gather(
                             *(
                                 client.get_pipe_members(tpid)
-                                for tpid in target_pipe_ids
+                                for tpid in target_pipe_list
                             ),
                             return_exceptions=True,
                         ),
                         timeout=MEMBERSHIP_CHECK_TIMEOUT_SECONDS,
                     )
-                    for tpid, mresult in zip(target_pipe_ids, member_results):
+                    for tpid, mresult in zip(target_pipe_list, member_results):
                         if isinstance(mresult, BaseException):
                             await ctx.debug(
                                 f"Could not check membership for pipe {tpid}: {mresult}"

--- a/src/pipefy_mcp/tools/ai_agent_tools.py
+++ b/src/pipefy_mcp/tools/ai_agent_tools.py
@@ -306,9 +306,7 @@ class AiAgentTools:
                 create_result = await client.create_ai_agent(validated)
             except Exception as exc:  # noqa: BLE001
                 pipe_ids = _collect_pipe_ids_from_behaviors(behaviors_expanded)
-                perm_msg = await enrich_permission_denied_error(
-                    exc, pipe_ids, client
-                )
+                perm_msg = await enrich_permission_denied_error(exc, pipe_ids, client)
                 error_text = enrich_behavior_error(exc, behaviors_expanded)
                 if perm_msg:
                     error_text = f"{perm_msg}\n{error_text}"
@@ -332,12 +330,8 @@ class AiAgentTools:
                 await client.update_ai_agent(update_input)
             except Exception as exc:  # noqa: BLE001
                 pipe_ids = _collect_pipe_ids_from_behaviors(behaviors_expanded)
-                perm_msg = await enrich_permission_denied_error(
-                    exc, pipe_ids, client
-                )
-                error_text = await _enrich_with_validation(
-                    exc, behaviors_expanded
-                )
+                perm_msg = await enrich_permission_denied_error(exc, pipe_ids, client)
+                error_text = await _enrich_with_validation(exc, behaviors_expanded)
                 if perm_msg:
                     error_text = f"{perm_msg}\n{error_text}"
                 return build_create_agent_partial_failure(
@@ -429,12 +423,8 @@ class AiAgentTools:
                 result = await client.update_ai_agent(validated)
             except Exception as exc:  # noqa: BLE001
                 pipe_ids = _collect_pipe_ids_from_behaviors(resolved_behaviors)
-                perm_msg = await enrich_permission_denied_error(
-                    exc, pipe_ids, client
-                )
-                error_text = await _enrich_with_validation(
-                    exc, resolved_behaviors
-                )
+                perm_msg = await enrich_permission_denied_error(exc, pipe_ids, client)
+                error_text = await _enrich_with_validation(exc, resolved_behaviors)
                 if perm_msg:
                     error_text = f"{perm_msg}\n{error_text}"
                 return build_ai_tool_error(error_text)

--- a/src/pipefy_mcp/tools/ai_automation_tools.py
+++ b/src/pipefy_mcp/tools/ai_automation_tools.py
@@ -162,9 +162,7 @@ class AiAutomationTools:
             try:
                 pipe_data = await client.get_pipe_with_preferences(pid)
             except Exception as exc:  # noqa: BLE001
-                return build_ai_tool_error(
-                    f"Failed to fetch pipe {pid}: {exc}"
-                )
+                return build_ai_tool_error(f"Failed to fetch pipe {pid}: {exc}")
 
             pipe_info = pipe_data.get("pipe", {})
 
@@ -178,9 +176,7 @@ class AiAutomationTools:
                         all_field_ids.add(fid)
                         field_map[fid] = label
                     if field.get("editable") is False:
-                        warnings.append(
-                            f"Field {fid} ({label}) is read-only."
-                        )
+                        warnings.append(f"Field {fid} ({label}) is read-only.")
             for field in pipe_info.get("start_form_fields") or []:
                 fid = str(field.get("internal_id") or field.get("id", ""))
                 label = field.get("label", "")
@@ -188,9 +184,7 @@ class AiAutomationTools:
                     all_field_ids.add(fid)
                     field_map[fid] = label
                 if field.get("editable") is False:
-                    warnings.append(
-                        f"Field {fid} ({label}) is read-only."
-                    )
+                    warnings.append(f"Field {fid} ({label}) is read-only.")
 
             # 3. Validate prompt token IDs exist in the pipe
             for token_id in prompt_tokens:
@@ -225,9 +219,7 @@ class AiAutomationTools:
                                 f"{sorted(valid_event_ids)}."
                             )
                     except Exception as exc:  # noqa: BLE001
-                        await ctx.debug(
-                            f"Could not fetch automation events: {exc}"
-                        )
+                        await ctx.debug(f"Could not fetch automation events: {exc}")
                         warnings.append(
                             "Could not verify event_id — automation events "
                             "endpoint returned an error."
@@ -244,9 +236,7 @@ class AiAutomationTools:
 
             # Only include referenced fields in the returned field_map
             referenced_ids = set(prompt_tokens) | set(str(f) for f in field_ids)
-            filtered_map = {
-                k: v for k, v in field_map.items() if k in referenced_ids
-            }
+            filtered_map = {k: v for k, v in field_map.items() if k in referenced_ids}
 
             return build_validate_prompt_payload(
                 problems=problems,

--- a/src/pipefy_mcp/tools/ai_automation_tools.py
+++ b/src/pipefy_mcp/tools/ai_automation_tools.py
@@ -1,7 +1,8 @@
-"""MCP tools for AI Automation operations (create, update, read, delete)."""
+"""MCP tools for AI Automation operations (create, update, read, delete, validate)."""
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from mcp.server.fastmcp import Context, FastMCP
@@ -19,6 +20,7 @@ from pipefy_mcp.tools.ai_tool_helpers import (
     build_ai_tool_error,
     build_create_automation_success,
     build_update_automation_success,
+    build_validate_prompt_payload,
 )
 from pipefy_mcp.tools.automation_tool_helpers import (
     build_automation_error_payload,
@@ -53,6 +55,9 @@ AI_AUTOMATION_NOT_CONFIGURED = (
 )
 
 GENERATE_WITH_AI_ACTION_ID = "generate_with_ai"
+
+# Regex to extract numeric IDs from %{<id>} tokens in AI automation prompts.
+_PROMPT_FIELD_TOKEN_RE = re.compile(r"%\{(\d+)\}")
 
 
 def _is_ai_automation_summary_row(row: Any) -> bool:
@@ -105,6 +110,149 @@ class AiAutomationTools:
     @staticmethod
     def register(mcp: FastMCP, client: PipefyClient) -> None:
         """Register AI Automation tools on the MCP server."""
+
+        @mcp.tool(
+            annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+        )
+        async def validate_ai_automation_prompt(
+            ctx: Context,
+            pipe_id: PipefyId,
+            prompt: str,
+            field_ids: list[str],
+            event_id: PipefyId | None = None,
+        ) -> dict:
+            """Pre-flight validation for AI automation prompts before calling ``create_ai_automation``.
+
+            Checks that the prompt references valid pipe fields, output field IDs exist,
+            the optional event ID is valid, and AI is enabled on the pipe. Catches common
+            mistakes in a single read-only call instead of 2-3 failed mutation roundtrips.
+
+            Args:
+                pipe_id: Pipe where the AI automation will run.
+                prompt: AI prompt text with ``%{internal_id}`` field references.
+                field_ids: Output field internal IDs where the AI writes results.
+                event_id: Optional trigger event ID to validate (e.g. ``card_created``).
+
+            Returns:
+                ``valid`` is True when no problems found. ``problems`` lists blocking
+                issues, ``warnings`` lists non-blocking notices, ``field_map`` maps
+                referenced numeric IDs to field labels.
+            """
+            await ctx.debug(
+                f"validate_ai_automation_prompt: pipe_id={pipe_id}, "
+                f"field_ids={field_ids}, event_id={event_id}"
+            )
+            pid, pid_err = validate_tool_id(pipe_id, "pipe_id")
+            if pid_err is not None:
+                return build_ai_tool_error(pid_err["error"])
+
+            problems: list[str] = []
+            warnings: list[str] = []
+            field_map: dict[str, str] = {}
+
+            # 1. Check prompt contains at least one %{numeric_id} token
+            prompt_tokens = _PROMPT_FIELD_TOKEN_RE.findall(prompt)
+            if not prompt_tokens:
+                problems.append(
+                    "Prompt must reference at least one pipe field using "
+                    "%{internal_id} syntax (e.g. 'Summarize: %{425829426}')."
+                )
+
+            # 2. Fetch pipe with preferences and fields
+            try:
+                pipe_data = await client.get_pipe_with_preferences(pid)
+            except Exception as exc:  # noqa: BLE001
+                return build_ai_tool_error(
+                    f"Failed to fetch pipe {pid}: {exc}"
+                )
+
+            pipe_info = pipe_data.get("pipe", {})
+
+            # Build a map of internal_id → label for all pipe fields
+            all_field_ids: set[str] = set()
+            for phase in pipe_info.get("phases") or []:
+                for field in phase.get("fields") or []:
+                    fid = str(field.get("internal_id") or field.get("id", ""))
+                    label = field.get("label", "")
+                    if fid:
+                        all_field_ids.add(fid)
+                        field_map[fid] = label
+                    if field.get("editable") is False:
+                        warnings.append(
+                            f"Field {fid} ({label}) is read-only."
+                        )
+            for field in pipe_info.get("start_form_fields") or []:
+                fid = str(field.get("internal_id") or field.get("id", ""))
+                label = field.get("label", "")
+                if fid:
+                    all_field_ids.add(fid)
+                    field_map[fid] = label
+                if field.get("editable") is False:
+                    warnings.append(
+                        f"Field {fid} ({label}) is read-only."
+                    )
+
+            # 3. Validate prompt token IDs exist in the pipe
+            for token_id in prompt_tokens:
+                if token_id not in all_field_ids:
+                    problems.append(
+                        f"Prompt references field %{{{token_id}}} but it does not "
+                        f"exist in pipe {pid}."
+                    )
+
+            # 4. Validate output field_ids exist in the pipe
+            for fid in field_ids:
+                if str(fid) not in all_field_ids:
+                    problems.append(
+                        f"Output field_id '{fid}' does not exist in pipe {pid}."
+                    )
+
+            # 5. Validate event_id if provided
+            if event_id is not None:
+                ok_e, eid, eid_err = validate_optional_tool_id(event_id, "event_id")
+                if not ok_e:
+                    problems.append(eid_err["error"])
+                elif eid:
+                    try:
+                        events = await client.get_automation_events(pid)
+                        valid_event_ids = {
+                            str(e.get("id", "")) for e in events if isinstance(e, dict)
+                        }
+                        if eid not in valid_event_ids:
+                            problems.append(
+                                f"event_id '{eid}' is not a valid automation event "
+                                f"for pipe {pid}. Valid events: "
+                                f"{sorted(valid_event_ids)}."
+                            )
+                    except Exception as exc:  # noqa: BLE001
+                        await ctx.debug(
+                            f"Could not fetch automation events: {exc}"
+                        )
+                        warnings.append(
+                            "Could not verify event_id — automation events "
+                            "endpoint returned an error."
+                        )
+
+            # 6. Check pipe.preferences.aiAgentsEnabled
+            preferences = pipe_info.get("preferences") or {}
+            ai_enabled = preferences.get("aiAgentsEnabled")
+            if ai_enabled is False:
+                problems.append(
+                    "AI is not enabled for this pipe. Enable it in "
+                    "Pipefy UI > Pipe Settings > AI."
+                )
+
+            # Only include referenced fields in the returned field_map
+            referenced_ids = set(prompt_tokens) | set(str(f) for f in field_ids)
+            filtered_map = {
+                k: v for k, v in field_map.items() if k in referenced_ids
+            }
+
+            return build_validate_prompt_payload(
+                problems=problems,
+                warnings=warnings,
+                field_map=filtered_map,
+            )
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),

--- a/src/pipefy_mcp/tools/ai_automation_tools.py
+++ b/src/pipefy_mcp/tools/ai_automation_tools.py
@@ -168,6 +168,7 @@ class AiAutomationTools:
 
             # Build a map of internal_id → label for all pipe fields
             all_field_ids: set[str] = set()
+            readonly_field_ids: set[str] = set()
             for phase in pipe_info.get("phases") or []:
                 for field in phase.get("fields") or []:
                     fid = str(field.get("internal_id") or field.get("id", ""))
@@ -175,16 +176,16 @@ class AiAutomationTools:
                     if fid:
                         all_field_ids.add(fid)
                         field_map[fid] = label
-                    if field.get("editable") is False:
-                        warnings.append(f"Field {fid} ({label}) is read-only.")
+                    if fid and field.get("editable") is False:
+                        readonly_field_ids.add(fid)
             for field in pipe_info.get("start_form_fields") or []:
                 fid = str(field.get("internal_id") or field.get("id", ""))
                 label = field.get("label", "")
                 if fid:
                     all_field_ids.add(fid)
                     field_map[fid] = label
-                if field.get("editable") is False:
-                    warnings.append(f"Field {fid} ({label}) is read-only.")
+                if fid and field.get("editable") is False:
+                    readonly_field_ids.add(fid)
 
             # 3. Validate prompt token IDs exist in the pipe
             for token_id in prompt_tokens:
@@ -234,8 +235,10 @@ class AiAutomationTools:
                     "Pipefy UI > Pipe Settings > AI."
                 )
 
-            # Only include referenced fields in the returned field_map
+            # Only include referenced fields in the returned field_map and warnings
             referenced_ids = set(prompt_tokens) | set(str(f) for f in field_ids)
+            for fid in referenced_ids & readonly_field_ids:
+                warnings.append(f"Field {fid} ({field_map.get(fid, '')}) is read-only.")
             filtered_map = {k: v for k, v in field_map.items() if k in referenced_ids}
 
             return build_validate_prompt_payload(

--- a/src/pipefy_mcp/tools/ai_tool_helpers.py
+++ b/src/pipefy_mcp/tools/ai_tool_helpers.py
@@ -21,6 +21,14 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class ValidateAiAutomationPromptPayload(TypedDict):
+    success: Literal[True]
+    valid: bool
+    problems: list[str]
+    warnings: list[str]
+    field_map: dict[str, str]
+
+
 class CreateAiAutomationSuccessPayload(TypedDict):
     success: Literal[True]
     automation_id: str
@@ -174,6 +182,28 @@ def build_ai_tool_error(message: str) -> AiToolErrorPayload:
         message: User-visible failure reason.
     """
     return {"success": False, "error": message}
+
+
+def build_validate_prompt_payload(
+    *,
+    problems: list[str],
+    warnings: list[str],
+    field_map: dict[str, str],
+) -> ValidateAiAutomationPromptPayload:
+    """Build the response for ``validate_ai_automation_prompt``.
+
+    Args:
+        problems: Blocking issues found during validation.
+        warnings: Non-blocking notices.
+        field_map: Mapping of numeric field ID to field slug/label.
+    """
+    return {
+        "success": True,
+        "valid": len(problems) == 0,
+        "problems": problems,
+        "warnings": warnings,
+        "field_map": field_map,
+    }
 
 
 def build_create_agent_partial_failure(

--- a/src/pipefy_mcp/tools/ai_tool_helpers.py
+++ b/src/pipefy_mcp/tools/ai_tool_helpers.py
@@ -373,9 +373,8 @@ def validate_behaviors_against_pipe(
             # Check fieldsAttributes fieldId references.
             # Same-pipe actions check against pipe_field_ids; cross-pipe actions
             # check against cross_pipe_field_ids when available.
-            # create_table_record: table field IDs, not pipe fields (FR-6).
-            # send_email_template: no pipe-scoped field metadata (FR-6); missing pipeId
-            # would otherwise make targets_source True and mis-validate stray fieldsAttributes.
+            # Skip fieldId validation for create_table_record (table fields) and
+            # send_email_template (no pipe field list; pipeId omission would mis-route checks).
             if action_type not in ("create_table_record", "send_email_template"):
                 action_pipe = str(metadata.get("pipeId", ""))
                 targets_source = not action_pipe or action_pipe == pipe_id

--- a/src/pipefy_mcp/tools/ai_tool_helpers.py
+++ b/src/pipefy_mcp/tools/ai_tool_helpers.py
@@ -479,7 +479,15 @@ def _instruction_has_non_numeric_field_tokens(instruction: str) -> bool:
     return False
 
 
-def _pipe_ids_from_behavior(behavior: dict[str, Any]) -> set[str]:
+def pipe_ids_from_behavior(behavior: dict[str, Any]) -> set[str]:
+    """Extract target pipe IDs from a single behavior's action metadata.
+
+    Args:
+        behavior: Raw behavior dict (supports both camelCase and snake_case keys).
+
+    Returns:
+        Set of pipe ID strings found in ``metadata.pipeId`` across all actions.
+    """
     pids: set[str] = set()
     ap = behavior.get("actionParams") or behavior.get("action_params") or {}
     if not isinstance(ap, dict):
@@ -494,6 +502,22 @@ def _pipe_ids_from_behavior(behavior: dict[str, Any]) -> set[str]:
         if pid:
             pids.add(pid)
     return pids
+
+
+def collect_pipe_ids_from_behaviors(behaviors: list[dict[str, Any]]) -> list[str]:
+    """Collect all unique pipe IDs referenced in behavior metadata.
+
+    Args:
+        behaviors: List of raw behavior dicts.
+
+    Returns:
+        Deduplicated list of pipe ID strings.
+    """
+    ids: set[str] = set()
+    for b in behaviors:
+        if isinstance(b, dict):
+            ids.update(pipe_ids_from_behavior(b))
+    return list(ids)
 
 
 def _rewrite_instruction_field_tokens(
@@ -581,7 +605,7 @@ async def resolve_field_slugs_to_numeric(
             continue
         instr = abp.get("instruction")
         if isinstance(instr, str) and _instruction_has_non_numeric_field_tokens(instr):
-            pipes_needed.update(_pipe_ids_from_behavior(b))
+            pipes_needed.update(pipe_ids_from_behavior(b))
 
     if not pipes_needed:
         return behaviors

--- a/src/pipefy_mcp/tools/attachment_tool_helpers.py
+++ b/src/pipefy_mcp/tools/attachment_tool_helpers.py
@@ -29,7 +29,7 @@ def build_upload_success_payload(
     card_id: str | int | None = None,
     table_record_id: str | None = None,
 ) -> dict[str, Any]:
-    """Structured success payload (FR-8).
+    """Structured success payload for a completed upload.
 
     Args:
         download_url: Permanent/signed download URL from Pipefy (may be None if API omits it).
@@ -102,7 +102,7 @@ def format_s3_upload_failure(upload_result: dict[str, Any]) -> str:
 
 
 def map_upload_error_to_message(exc: BaseException, step: UploadFlowStep) -> str:
-    """Map an exception to a short, actionable message (FR-9).
+    """Map an exception to a short, actionable message.
 
     Args:
         exc: Failure from transport, GraphQL, or validation.

--- a/src/pipefy_mcp/tools/automation_tools.py
+++ b/src/pipefy_mcp/tools/automation_tools.py
@@ -18,8 +18,8 @@ from pipefy_mcp.tools.automation_tool_helpers import (
     build_automation_simulation_success_payload,
     handle_automation_tool_graphql_error,
 )
-from pipefy_mcp.tools.graphql_error_helpers import enrich_permission_denied_error
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
+from pipefy_mcp.tools.graphql_error_helpers import enrich_permission_denied_error
 from pipefy_mcp.tools.phase_transition_helpers import (
     validate_traditional_automation_move_transition_or_none,
 )

--- a/src/pipefy_mcp/tools/automation_tools.py
+++ b/src/pipefy_mcp/tools/automation_tools.py
@@ -18,6 +18,7 @@ from pipefy_mcp.tools.automation_tool_helpers import (
     build_automation_simulation_success_payload,
     handle_automation_tool_graphql_error,
 )
+from pipefy_mcp.tools.graphql_error_helpers import enrich_permission_denied_error
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.phase_transition_helpers import (
     validate_traditional_automation_move_transition_or_none,
@@ -411,6 +412,16 @@ class AutomationTools:
                     extra_input=extra_input,
                 )
             except Exception as exc:  # noqa: BLE001
+                if arid and arid != pid:
+                    perm_msg = await enrich_permission_denied_error(
+                        exc, [pid, arid], client
+                    )
+                    if perm_msg:
+                        base = await handle_automation_tool_graphql_error(
+                            exc, ctx, debug
+                        )
+                        base["error"] = f"{perm_msg}\n{base.get('error', '')}"
+                        return base
                 return await handle_automation_tool_graphql_error(exc, ctx, debug)
             block = raw.get("createAutomation") or {}
             automation = block.get("automation") or {}

--- a/src/pipefy_mcp/tools/graphql_error_helpers.py
+++ b/src/pipefy_mcp/tools/graphql_error_helpers.py
@@ -217,17 +217,14 @@ async def enrich_permission_denied_error(
     missing_pipes: list[str] = []
     for pid, result in zip(unique_ids, results):
         if isinstance(result, BaseException):
-            # Could not fetch members for this pipe — likely the pipe we lack access to
-            pipe_name = f"pipe {pid}"
+            # Could not fetch members — could be access denied, network, or pipe not found
             missing_pipes.append(
-                f"Service account is not a member of {pipe_name}. "
-                f"Use invite_members to add it."
+                f"Could not verify membership for pipe {pid}. "
+                f"Check if the service account is a member — use invite_members if not."
             )
             continue
         members = result.get("pipe", {}).get("members") or []
         if not members:
-            # Empty members list means we got a response but no members visible
-            # (which can happen when we lack access)
             pipe_name = result.get("pipe", {}).get("name") or f"pipe {pid}"
             missing_pipes.append(
                 f"Service account may not be a member of {pipe_name} (ID: {pid}). "
@@ -237,4 +234,4 @@ async def enrich_permission_denied_error(
     if not missing_pipes:
         return None
 
-    return " | ".join(missing_pipes)
+    return "\n".join(missing_pipes)

--- a/src/pipefy_mcp/tools/graphql_error_helpers.py
+++ b/src/pipefy_mcp/tools/graphql_error_helpers.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 import pipefy_mcp.settings as _settings_mod
 
 # Suffixes appended by InternalApiClient for service-layer diagnostics; MCP tools
-# should strip these from default user-visible errors (see task 4.2).
+# strip these from default user-visible errors.
 _INTERNAL_API_CODE_SUFFIX_RE = re.compile(r"\s*\[code=[^\]]*\]")
 _INTERNAL_API_CORRELATION_SUFFIX_RE = re.compile(r"\s*\[correlation_id=[^\]]*\]")
 _INTERNAL_API_CODE_BRACKET_CAPTURE_RE = re.compile(r"\[code=([^\]]*)\]")
@@ -151,10 +151,7 @@ def handle_tool_graphql_error(
     *,
     debug: bool = False,
 ) -> dict[str, Any]:
-    """Turn transport/GraphQL failures into a standard error payload.
-
-    Consolidates the repeated ``handle_*_tool_graphql_error`` pattern used across
-    domain helper modules. Returns ``{"success": False, "error": message}``.
+    """Turn transport/GraphQL failures into ``{"success": False, "error": message}``.
 
     Args:
         exc: Root exception from gql/httpx.

--- a/src/pipefy_mcp/tools/graphql_error_helpers.py
+++ b/src/pipefy_mcp/tools/graphql_error_helpers.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from pipefy_mcp.services.pipefy import PipefyClient
 
+import pipefy_mcp.settings as _settings_mod
+
 # Suffixes appended by InternalApiClient for service-layer diagnostics; MCP tools
 # should strip these from default user-visible errors (see task 4.2).
 _INTERNAL_API_CODE_SUFFIX_RE = re.compile(r"\s*\[code=[^\]]*\]")
@@ -214,22 +216,34 @@ async def enrich_permission_denied_error(
     except (TimeoutError, asyncio.TimeoutError):
         return None
 
+    sa_ids = set(_settings_mod.settings.pipefy.service_account_ids)
+
     missing_pipes: list[str] = []
     for pid, result in zip(unique_ids, results):
         if isinstance(result, BaseException):
-            # Could not fetch members — could be access denied, network, or pipe not found
             missing_pipes.append(
                 f"Could not verify membership for pipe {pid}. "
                 f"Check if the service account is a member — use invite_members if not."
             )
             continue
         members = result.get("pipe", {}).get("members") or []
+        pipe_name = result.get("pipe", {}).get("name") or f"pipe {pid}"
         if not members:
-            pipe_name = result.get("pipe", {}).get("name") or f"pipe {pid}"
             missing_pipes.append(
                 f"Service account may not be a member of {pipe_name} (ID: {pid}). "
                 f"Use invite_members to add it."
             )
+        elif sa_ids:
+            member_ids = {
+                str(m.get("user", {}).get("id", ""))
+                for m in members
+                if isinstance(m, dict)
+            }
+            if not sa_ids & member_ids:
+                missing_pipes.append(
+                    f"Service account is not a member of {pipe_name} (ID: {pid}). "
+                    f"Use invite_members to add it."
+                )
 
     if not missing_pipes:
         return None

--- a/src/pipefy_mcp/tools/graphql_error_helpers.py
+++ b/src/pipefy_mcp/tools/graphql_error_helpers.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 import re
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pipefy_mcp.services.pipefy import PipefyClient
 
 # Suffixes appended by InternalApiClient for service-layer diagnostics; MCP tools
 # should strip these from default user-visible errors (see task 4.2).
@@ -165,3 +169,72 @@ def handle_tool_graphql_error(
         "success": False,
         "error": with_debug_suffix(base, debug=True, codes=codes, correlation_id=cid),
     }
+
+
+_PERMISSION_DENIED_CODE = "PERMISSION_DENIED"
+_ENRICHMENT_TIMEOUT_SECONDS = 5
+
+
+async def enrich_permission_denied_error(
+    exc: BaseException,
+    pipe_ids: list[str],
+    client: PipefyClient,
+) -> str | None:
+    """Enrich PERMISSION_DENIED errors with membership guidance.
+
+    When the exception contains a ``PERMISSION_DENIED`` GraphQL error code,
+    checks each ``pipe_id`` for membership and returns an actionable message
+    identifying which pipe(s) the service account is not a member of.
+
+    Returns ``None`` when the error is not PERMISSION_DENIED, when the service
+    account is already a member, or when enrichment itself fails (timeout,
+    network error). The caller falls back to its standard error path.
+
+    Args:
+        exc: GraphQL exception from a cross-pipe operation.
+        pipe_ids: Pipe IDs involved in the operation (source + target).
+        client: PipefyClient for membership lookups.
+    """
+    codes = extract_graphql_error_codes(exc)
+    if _PERMISSION_DENIED_CODE not in codes:
+        return None
+
+    unique_ids = list(dict.fromkeys(pid for pid in pipe_ids if pid))
+    if not unique_ids:
+        return None
+
+    try:
+        results = await asyncio.wait_for(
+            asyncio.gather(
+                *(client.get_pipe_members(pid) for pid in unique_ids),
+                return_exceptions=True,
+            ),
+            timeout=_ENRICHMENT_TIMEOUT_SECONDS,
+        )
+    except (TimeoutError, asyncio.TimeoutError):
+        return None
+
+    missing_pipes: list[str] = []
+    for pid, result in zip(unique_ids, results):
+        if isinstance(result, BaseException):
+            # Could not fetch members for this pipe — likely the pipe we lack access to
+            pipe_name = f"pipe {pid}"
+            missing_pipes.append(
+                f"Service account is not a member of {pipe_name}. "
+                f"Use invite_members to add it."
+            )
+            continue
+        members = result.get("pipe", {}).get("members") or []
+        if not members:
+            # Empty members list means we got a response but no members visible
+            # (which can happen when we lack access)
+            pipe_name = result.get("pipe", {}).get("name") or f"pipe {pid}"
+            missing_pipes.append(
+                f"Service account may not be a member of {pipe_name} (ID: {pid}). "
+                f"Use invite_members to add it."
+            )
+
+    if not missing_pipes:
+        return None
+
+    return " | ".join(missing_pipes)

--- a/src/pipefy_mcp/tools/pipe_tools.py
+++ b/src/pipefy_mcp/tools/pipe_tools.py
@@ -137,9 +137,10 @@ class PipeTools:
                 perm_msg = await enrich_permission_denied_error(
                     exc, [str(pipe_id)], client
                 )
+                error_text = str(exc)
                 if perm_msg:
-                    raise type(exc)(f"{perm_msg}\n{exc}") from exc
-                raise
+                    error_text = f"{perm_msg}\n{error_text}"
+                return {"success": False, "error": error_text}
             card_id = result.get("createCard", {}).get("card", {}).get("id")
             if card_id:
                 if title:

--- a/src/pipefy_mcp/tools/pipe_tools.py
+++ b/src/pipefy_mcp/tools/pipe_tools.py
@@ -20,6 +20,7 @@ from pipefy_mcp.services.pipefy import PipefyClient
 from pipefy_mcp.services.pipefy.types import CardSearch
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.graphql_error_helpers import (
+    enrich_permission_denied_error,
     extract_graphql_correlation_id,
     extract_graphql_error_codes,
     handle_tool_graphql_error,
@@ -130,7 +131,15 @@ class PipeTools:
             elif expected_fields:
                 card_data = _filter_fields_by_definitions(card_data, expected_fields)
 
-            result = await client.create_card(pipe_id, card_data)
+            try:
+                result = await client.create_card(pipe_id, card_data)
+            except Exception as exc:  # noqa: BLE001
+                perm_msg = await enrich_permission_denied_error(
+                    exc, [str(pipe_id)], client
+                )
+                if perm_msg:
+                    raise type(exc)(f"{perm_msg}\n{exc}") from exc
+                raise
             card_id = result.get("createCard", {}).get("card", {}).get("id")
             if card_id:
                 if title:

--- a/src/pipefy_mcp/tools/registry.py
+++ b/src/pipefy_mcp/tools/registry.py
@@ -148,6 +148,7 @@ PIPEFY_TOOL_NAMES = frozenset(
         "upload_attachment_to_card",
         "upload_attachment_to_table_record",
         "validate_ai_agent_behaviors",
+        "validate_ai_automation_prompt",
     }
 )
 

--- a/tests/services/test_pipefy_facade.py
+++ b/tests/services/test_pipefy_facade.py
@@ -39,6 +39,9 @@ async def test_pipefy_client_facade_delegates_to_services_without_modifying_args
     table_service = AsyncMock()
 
     pipe_service.get_pipe = AsyncMock(return_value={"ok": "pipe"})
+    pipe_service.get_pipe_with_preferences = AsyncMock(
+        return_value={"ok": "pipe_prefs"}
+    )
     pipe_service.get_start_form_fields = AsyncMock(return_value={"ok": "fields"})
 
     card_service.create_card = AsyncMock(return_value={"ok": "create"})
@@ -183,6 +186,9 @@ async def test_pipefy_client_facade_delegates_to_services_without_modifying_args
 
     assert await client.get_pipe(1) == {"ok": "pipe"}
     pipe_service.get_pipe.assert_awaited_once_with(1)
+
+    assert await client.get_pipe_with_preferences(1) == {"ok": "pipe_prefs"}
+    pipe_service.get_pipe_with_preferences.assert_awaited_once_with(1)
 
     assert await client.get_start_form_fields(2, True) == {"ok": "fields"}
     pipe_service.get_start_form_fields.assert_awaited_once_with(2, True)

--- a/tests/tools/test_ai_agent_tools.py
+++ b/tests/tools/test_ai_agent_tools.py
@@ -1944,7 +1944,7 @@ class TestFetchPipeValidationContext:
 
 
 ## ---------------------------------------------------------------------------
-## Proactive membership check in validate_ai_agent_behaviors (FR-12)
+## Proactive membership check in validate_ai_agent_behaviors
 ## ---------------------------------------------------------------------------
 
 
@@ -2152,7 +2152,7 @@ class TestValidateAiAgentBehaviorsMembership:
 
 
 ## ---------------------------------------------------------------------------
-## FR-11: Cross-pipe PERMISSION_DENIED enrichment at tool level
+## Cross-pipe PERMISSION_DENIED enrichment at tool level
 ## ---------------------------------------------------------------------------
 
 

--- a/tests/tools/test_ai_agent_tools.py
+++ b/tests/tools/test_ai_agent_tools.py
@@ -27,6 +27,7 @@ def mock_pipefy_client():
     client.delete_ai_agent = AsyncMock()
     client.get_pipe = AsyncMock()
     client.get_pipe_relations = AsyncMock()
+    client.get_pipe_members = AsyncMock()
     client.get_phase_allowed_move_targets = AsyncMock()
     return client
 
@@ -1933,3 +1934,219 @@ class TestFetchPipeValidationContext:
         assert field_ids == set()
         assert phase_ids == set()
         assert related_pipe_ids == set()
+
+
+## ---------------------------------------------------------------------------
+## Proactive membership check in validate_ai_agent_behaviors (FR-12)
+## ---------------------------------------------------------------------------
+
+
+def _cross_pipe_behavior(source_pipe_id="1", target_pipe_id="999"):
+    return {
+        "name": "Cross-pipe create",
+        "event_id": "card_created",
+        "actionParams": {
+            "aiBehaviorParams": {
+                "instruction": "Create card in target pipe",
+                "actionsAttributes": [
+                    {
+                        "name": "create in target",
+                        "actionType": "create_card",
+                        "metadata": {
+                            "pipeId": target_pipe_id,
+                            "fieldsAttributes": [
+                                {
+                                    "fieldId": "f1",
+                                    "inputMode": "fill_with_ai",
+                                    "value": "",
+                                },
+                            ],
+                        },
+                    },
+                ],
+            }
+        },
+    }
+
+
+def _pipe_graph_with_fields_for_both(source_pipe_id="1", target_pipe_id="999"):
+    """Pipe graph and relations enabling cross-pipe validation."""
+    return {
+        "pipe": {
+            "phases": [
+                {
+                    "id": "ph-1",
+                    "fields": [{"id": "100"}],
+                }
+            ],
+            "start_form_fields": [],
+        }
+    }
+
+
+@pytest.mark.anyio
+class TestValidateAiAgentBehaviorsMembership:
+    async def test_sa_not_member_reports_problem(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+        monkeypatch,
+    ):
+        mock_pipefy_client.get_pipe.return_value = _pipe_graph_with_fields_for_both()
+        mock_pipefy_client.get_pipe_relations.return_value = {
+            "children": [{"child": {"id": "999"}}],
+            "parents": [],
+        }
+        # Target pipe returns members that do NOT include the SA
+        mock_pipefy_client.get_pipe_members.return_value = {
+            "pipe": {
+                "name": "Target Pipe",
+                "members": [{"user": {"id": "other-user"}, "role_name": "member"}],
+            }
+        }
+
+        from pipefy_mcp import settings as settings_mod
+
+        monkeypatch.setattr(
+            settings_mod.settings.pipefy,
+            "service_account_ids",
+            ["sa-123"],
+        )
+
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_agent_behaviors",
+                {
+                    "pipe_id": "1",
+                    "behaviors": [_cross_pipe_behavior()],
+                },
+            )
+        payload = extract_payload(result)
+        assert payload["success"] is True
+        assert any(
+            "not a member of target pipe 999" in p for p in payload["problems"]
+        )
+
+    async def test_sa_is_member_no_extra_problem(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+        monkeypatch,
+    ):
+        mock_pipefy_client.get_pipe.return_value = _pipe_graph_with_fields_for_both()
+        mock_pipefy_client.get_pipe_relations.return_value = {
+            "children": [{"child": {"id": "999"}}],
+            "parents": [],
+        }
+        # Target pipe includes SA as a member
+        mock_pipefy_client.get_pipe_members.return_value = {
+            "pipe": {
+                "name": "Target Pipe",
+                "members": [{"user": {"id": "sa-123"}, "role_name": "admin"}],
+            }
+        }
+
+        from pipefy_mcp import settings as settings_mod
+
+        monkeypatch.setattr(
+            settings_mod.settings.pipefy,
+            "service_account_ids",
+            ["sa-123"],
+        )
+
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_agent_behaviors",
+                {
+                    "pipe_id": "1",
+                    "behaviors": [_cross_pipe_behavior()],
+                },
+            )
+        payload = extract_payload(result)
+        # No membership problem
+        membership_problems = [
+            p for p in payload["problems"] if "not a member" in p
+        ]
+        assert membership_problems == []
+
+    async def test_sa_not_configured_skips_check(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+        monkeypatch,
+    ):
+        mock_pipefy_client.get_pipe.return_value = _pipe_graph_with_fields_for_both()
+        mock_pipefy_client.get_pipe_relations.return_value = {
+            "children": [{"child": {"id": "999"}}],
+            "parents": [],
+        }
+
+        from pipefy_mcp import settings as settings_mod
+
+        monkeypatch.setattr(
+            settings_mod.settings.pipefy,
+            "service_account_ids",
+            [],
+        )
+
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_agent_behaviors",
+                {
+                    "pipe_id": "1",
+                    "behaviors": [_cross_pipe_behavior()],
+                },
+            )
+        payload = extract_payload(result)
+        # No membership check ran, so no membership problems
+        membership_problems = [
+            p for p in payload["problems"] if "not a member" in p
+        ]
+        assert membership_problems == []
+        mock_pipefy_client.get_pipe_members.assert_not_called()
+
+    async def test_membership_timeout_graceful(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+        monkeypatch,
+    ):
+        mock_pipefy_client.get_pipe.return_value = _pipe_graph_with_fields_for_both()
+        mock_pipefy_client.get_pipe_relations.return_value = {
+            "children": [{"child": {"id": "999"}}],
+            "parents": [],
+        }
+
+        async def slow_members(*args, **kwargs):
+            await asyncio.sleep(10)
+            return {}
+
+        mock_pipefy_client.get_pipe_members.side_effect = slow_members
+
+        from pipefy_mcp import settings as settings_mod
+
+        monkeypatch.setattr(
+            settings_mod.settings.pipefy,
+            "service_account_ids",
+            ["sa-123"],
+        )
+
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_agent_behaviors",
+                {
+                    "pipe_id": "1",
+                    "behaviors": [_cross_pipe_behavior()],
+                },
+            )
+        payload = extract_payload(result)
+        # Timeout doesn't cause a problem — tool still succeeds
+        assert payload["success"] is True
+        membership_problems = [
+            p for p in payload["problems"] if "not a member" in p
+        ]
+        assert membership_problems == []

--- a/tests/tools/test_ai_agent_tools.py
+++ b/tests/tools/test_ai_agent_tools.py
@@ -2024,9 +2024,7 @@ class TestValidateAiAgentBehaviorsMembership:
             )
         payload = extract_payload(result)
         assert payload["success"] is True
-        assert any(
-            "not a member of target pipe 999" in p for p in payload["problems"]
-        )
+        assert any("not a member of target pipe 999" in p for p in payload["problems"])
 
     async def test_sa_is_member_no_extra_problem(
         self,
@@ -2066,9 +2064,7 @@ class TestValidateAiAgentBehaviorsMembership:
             )
         payload = extract_payload(result)
         # No membership problem
-        membership_problems = [
-            p for p in payload["problems"] if "not a member" in p
-        ]
+        membership_problems = [p for p in payload["problems"] if "not a member" in p]
         assert membership_problems == []
 
     async def test_sa_not_configured_skips_check(
@@ -2102,9 +2098,7 @@ class TestValidateAiAgentBehaviorsMembership:
             )
         payload = extract_payload(result)
         # No membership check ran, so no membership problems
-        membership_problems = [
-            p for p in payload["problems"] if "not a member" in p
-        ]
+        membership_problems = [p for p in payload["problems"] if "not a member" in p]
         assert membership_problems == []
         mock_pipefy_client.get_pipe_members.assert_not_called()
 
@@ -2146,7 +2140,5 @@ class TestValidateAiAgentBehaviorsMembership:
         payload = extract_payload(result)
         # Timeout doesn't cause a problem — tool still succeeds
         assert payload["success"] is True
-        membership_problems = [
-            p for p in payload["problems"] if "not a member" in p
-        ]
+        membership_problems = [p for p in payload["problems"] if "not a member" in p]
         assert membership_problems == []

--- a/tests/tools/test_ai_agent_tools.py
+++ b/tests/tools/test_ai_agent_tools.py
@@ -11,9 +11,16 @@ from mcp.shared.memory import (
     create_connected_server_and_client_session as create_client_session,
 )
 
+import pipefy_mcp.settings as _settings_mod
 from pipefy_mcp.models.ai_agent import UpdateAiAgentInput
 from pipefy_mcp.tools.ai_agent_tools import AiAgentTools
 from tests.ai_agent_test_payloads import behavior_with_action, minimal_behavior_dict
+
+
+@pytest.fixture(autouse=True)
+def _isolate_sa_ids(monkeypatch):
+    """Ensure service_account_ids is empty so .env values don't leak into tests."""
+    monkeypatch.setattr(_settings_mod.settings.pipefy, "service_account_ids", [])
 
 
 @pytest.fixture
@@ -27,7 +34,7 @@ def mock_pipefy_client():
     client.delete_ai_agent = AsyncMock()
     client.get_pipe = AsyncMock()
     client.get_pipe_relations = AsyncMock()
-    client.get_pipe_members = AsyncMock()
+    client.get_pipe_members = AsyncMock(return_value={"pipe": {"members": []}})
     client.get_phase_allowed_move_targets = AsyncMock()
     return client
 

--- a/tests/tools/test_ai_agent_tools.py
+++ b/tests/tools/test_ai_agent_tools.py
@@ -1941,7 +1941,7 @@ class TestFetchPipeValidationContext:
 ## ---------------------------------------------------------------------------
 
 
-def _cross_pipe_behavior(source_pipe_id="1", target_pipe_id="999"):
+def _cross_pipe_behavior(target_pipe_id="999"):
     return {
         "name": "Cross-pipe create",
         "event_id": "card_created",
@@ -1969,8 +1969,8 @@ def _cross_pipe_behavior(source_pipe_id="1", target_pipe_id="999"):
     }
 
 
-def _pipe_graph_with_fields_for_both(source_pipe_id="1", target_pipe_id="999"):
-    """Pipe graph and relations enabling cross-pipe validation."""
+def _pipe_graph_with_fields_for_both():
+    """Pipe graph for cross-pipe validation tests."""
     return {
         "pipe": {
             "phases": [
@@ -2142,3 +2142,44 @@ class TestValidateAiAgentBehaviorsMembership:
         assert payload["success"] is True
         membership_problems = [p for p in payload["problems"] if "not a member" in p]
         assert membership_problems == []
+
+
+## ---------------------------------------------------------------------------
+## FR-11: Cross-pipe PERMISSION_DENIED enrichment at tool level
+## ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+class TestCreateAiAgentPermissionEnrichment:
+    async def test_permission_denied_enriches_error_with_membership_guidance(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.create_ai_agent.side_effect = TransportQueryError(
+            "forbidden",
+            errors=[
+                {
+                    "message": "forbidden",
+                    "extensions": {"code": "PERMISSION_DENIED"},
+                }
+            ],
+        )
+        # get_pipe_members fails for the target pipe (no access)
+        mock_pipefy_client.get_pipe_members.side_effect = RuntimeError("no access")
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_ai_agent",
+                {
+                    "name": "Agent",
+                    "repo_uuid": "uuid-1",
+                    "instruction": "Do stuff",
+                    "behaviors": [minimal_behavior_dict()],
+                },
+            )
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        # Enrichment message is prepended to the error
+        assert "invite_members" in payload["error"]
+        assert "forbidden" in payload["error"]

--- a/tests/tools/test_ai_automation_tools.py
+++ b/tests/tools/test_ai_automation_tools.py
@@ -22,6 +22,8 @@ def mock_pipefy_client():
     client.get_automation = AsyncMock()
     client.get_automations = AsyncMock()
     client.delete_automation = AsyncMock()
+    client.get_pipe_with_preferences = AsyncMock()
+    client.get_automation_events = AsyncMock()
     client.ai_automation_available = True
     return client
 
@@ -1002,3 +1004,326 @@ class TestPipefyIdCoercion:
             )
         assert extract_payload(result)["success"] is True
         mock_pipefy_client.delete_automation.assert_awaited_once_with("501")
+
+
+## ---------------------------------------------------------------------------
+## validate_ai_automation_prompt
+## ---------------------------------------------------------------------------
+
+MOCK_PIPE_WITH_PREFS = {
+    "pipe": {
+        "id": "303",
+        "uuid": "pipe-uuid-303",
+        "name": "Test Pipe",
+        "preferences": {"aiAgentsEnabled": True},
+        "phases": [
+            {
+                "id": "1",
+                "name": "Start",
+                "fields": [
+                    {
+                        "id": "slug_a",
+                        "internal_id": "100",
+                        "label": "Summary",
+                        "type": "short_text",
+                        "editable": True,
+                    },
+                    {
+                        "id": "slug_b",
+                        "internal_id": "200",
+                        "label": "Status",
+                        "type": "short_text",
+                        "editable": False,
+                    },
+                ],
+            },
+        ],
+        "start_form_fields": [
+            {
+                "id": "slug_c",
+                "internal_id": "300",
+                "label": "Title",
+                "type": "short_text",
+                "editable": True,
+            },
+        ],
+    },
+}
+
+MOCK_EVENTS = [
+    {"id": "card_created"},
+    {"id": "card_moved"},
+    {"id": "field_updated"},
+]
+
+
+@pytest.mark.anyio
+class TestValidateAiAutomationPrompt:
+    async def test_valid_prompt(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.get_pipe_with_preferences.return_value = MOCK_PIPE_WITH_PREFS
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_automation_prompt",
+                {
+                    "pipe_id": "303",
+                    "prompt": "Summarize: %{100}",
+                    "field_ids": ["100"],
+                },
+            )
+        assert result.isError is False
+        payload = extract_payload(result)
+        assert payload["success"] is True
+        assert payload["valid"] is True
+        assert payload["problems"] == []
+        assert payload["field_map"]["100"] == "Summary"
+
+    async def test_missing_field_ref_in_prompt(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.get_pipe_with_preferences.return_value = MOCK_PIPE_WITH_PREFS
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_automation_prompt",
+                {
+                    "pipe_id": "303",
+                    "prompt": "Just a plain prompt with no references",
+                    "field_ids": ["100"],
+                },
+            )
+        payload = extract_payload(result)
+        assert payload["success"] is True
+        assert payload["valid"] is False
+        assert any("%{internal_id}" in p for p in payload["problems"])
+
+    async def test_invalid_field_id_in_prompt_token(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.get_pipe_with_preferences.return_value = MOCK_PIPE_WITH_PREFS
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_automation_prompt",
+                {
+                    "pipe_id": "303",
+                    "prompt": "Summarize: %{999999}",
+                    "field_ids": ["100"],
+                },
+            )
+        payload = extract_payload(result)
+        assert payload["valid"] is False
+        assert any("999999" in p for p in payload["problems"])
+
+    async def test_invalid_output_field_id(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.get_pipe_with_preferences.return_value = MOCK_PIPE_WITH_PREFS
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_automation_prompt",
+                {
+                    "pipe_id": "303",
+                    "prompt": "Summarize: %{100}",
+                    "field_ids": ["888888"],
+                },
+            )
+        payload = extract_payload(result)
+        assert payload["valid"] is False
+        assert any("888888" in p for p in payload["problems"])
+
+    async def test_ai_disabled_on_pipe(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        disabled_pipe = {
+            "pipe": {
+                **MOCK_PIPE_WITH_PREFS["pipe"],
+                "preferences": {"aiAgentsEnabled": False},
+            }
+        }
+        mock_pipefy_client.get_pipe_with_preferences.return_value = disabled_pipe
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_automation_prompt",
+                {
+                    "pipe_id": "303",
+                    "prompt": "Summarize: %{100}",
+                    "field_ids": ["100"],
+                },
+            )
+        payload = extract_payload(result)
+        assert payload["valid"] is False
+        assert any("AI is not enabled" in p for p in payload["problems"])
+
+    async def test_valid_event_id(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.get_pipe_with_preferences.return_value = MOCK_PIPE_WITH_PREFS
+        mock_pipefy_client.get_automation_events.return_value = MOCK_EVENTS
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_automation_prompt",
+                {
+                    "pipe_id": "303",
+                    "prompt": "Summarize: %{100}",
+                    "field_ids": ["100"],
+                    "event_id": "card_created",
+                },
+            )
+        payload = extract_payload(result)
+        assert payload["valid"] is True
+        assert payload["problems"] == []
+
+    async def test_invalid_event_id(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.get_pipe_with_preferences.return_value = MOCK_PIPE_WITH_PREFS
+        mock_pipefy_client.get_automation_events.return_value = MOCK_EVENTS
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_automation_prompt",
+                {
+                    "pipe_id": "303",
+                    "prompt": "Summarize: %{100}",
+                    "field_ids": ["100"],
+                    "event_id": "nonexistent_event",
+                },
+            )
+        payload = extract_payload(result)
+        assert payload["valid"] is False
+        assert any("nonexistent_event" in p for p in payload["problems"])
+
+    async def test_read_only_field_warning(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.get_pipe_with_preferences.return_value = MOCK_PIPE_WITH_PREFS
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_automation_prompt",
+                {
+                    "pipe_id": "303",
+                    "prompt": "Check: %{200}",
+                    "field_ids": ["200"],
+                },
+            )
+        payload = extract_payload(result)
+        # read-only field appears in warnings, not problems
+        assert any("read-only" in w for w in payload["warnings"])
+
+    async def test_pipe_fetch_failure(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.get_pipe_with_preferences.side_effect = RuntimeError(
+            "network error"
+        )
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_automation_prompt",
+                {
+                    "pipe_id": "303",
+                    "prompt": "Summarize: %{100}",
+                    "field_ids": ["100"],
+                },
+            )
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "network error" in payload["error"]
+
+    async def test_rejects_invalid_pipe_id(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_automation_prompt",
+                {
+                    "pipe_id": "",
+                    "prompt": "Summarize: %{100}",
+                    "field_ids": ["100"],
+                },
+            )
+        mock_pipefy_client.get_pipe_with_preferences.assert_not_called()
+        payload = extract_payload(result)
+        assert payload["success"] is False
+
+    async def test_event_fetch_failure_adds_warning(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.get_pipe_with_preferences.return_value = MOCK_PIPE_WITH_PREFS
+        mock_pipefy_client.get_automation_events.side_effect = RuntimeError("fail")
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_automation_prompt",
+                {
+                    "pipe_id": "303",
+                    "prompt": "Summarize: %{100}",
+                    "field_ids": ["100"],
+                    "event_id": "card_created",
+                },
+            )
+        payload = extract_payload(result)
+        # Event fetch failure is a warning, not a problem
+        assert payload["valid"] is True
+        assert any("Could not verify event_id" in w for w in payload["warnings"])
+
+    async def test_has_read_only_annotation(self, client_session):
+        async with client_session as session:
+            listed = await session.list_tools()
+        tool = next(
+            t for t in listed.tools if t.name == "validate_ai_automation_prompt"
+        )
+        assert tool.annotations is not None
+        assert tool.annotations.readOnlyHint is True
+
+    async def test_field_map_contains_only_referenced_fields(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.get_pipe_with_preferences.return_value = MOCK_PIPE_WITH_PREFS
+        async with client_session as session:
+            result = await session.call_tool(
+                "validate_ai_automation_prompt",
+                {
+                    "pipe_id": "303",
+                    "prompt": "Summarize: %{100}",
+                    "field_ids": ["300"],
+                },
+            )
+        payload = extract_payload(result)
+        # field_map only includes referenced fields (100 from prompt, 300 from field_ids)
+        assert "100" in payload["field_map"]
+        assert "300" in payload["field_map"]
+        assert "200" not in payload["field_map"]

--- a/tests/tools/test_ai_tool_helpers.py
+++ b/tests/tools/test_ai_tool_helpers.py
@@ -391,7 +391,7 @@ def test_validate_create_connected_card_skipped_when_relations_not_loaded():
 
 @pytest.mark.unit
 def test_validate_create_table_record_skips_pipe_field_id_check():
-    """Table field IDs are not validated against the source pipe (FR-6)."""
+    """Table field IDs are not validated against the source pipe."""
     problems, warnings = validate_behaviors_against_pipe(
         [_create_table_record_behavior(field_id="999")],
         pipe_id="1",
@@ -407,7 +407,7 @@ def test_validate_create_table_record_skips_pipe_field_id_check():
 
 @pytest.mark.unit
 def test_validate_send_email_template_skips_pipe_field_checks():
-    """Email template actions do not cross-validate fieldIds against the pipe (FR-6)."""
+    """Email template actions do not cross-validate fieldIds against the pipe."""
     problems, warnings = validate_behaviors_against_pipe(
         [_send_email_template_behavior(include_stray_fields_attributes=True)],
         pipe_id="1",

--- a/tests/tools/test_automation_tools.py
+++ b/tests/tools/test_automation_tools.py
@@ -885,7 +885,7 @@ async def test_create_send_task_automation_listed_not_read_only(automation_sessi
 
 
 ## ---------------------------------------------------------------------------
-## FR-11: Cross-pipe PERMISSION_DENIED enrichment
+## Cross-pipe PERMISSION_DENIED enrichment
 ## ---------------------------------------------------------------------------
 
 

--- a/tests/tools/test_automation_tools.py
+++ b/tests/tools/test_automation_tools.py
@@ -26,6 +26,7 @@ def mock_automation_client():
     client.simulate_automation = AsyncMock()
     client.delete_automation = AsyncMock()
     client.get_phase_allowed_move_targets = AsyncMock()
+    client.get_pipe_members = AsyncMock()
     return client
 
 
@@ -881,3 +882,41 @@ async def test_create_send_task_automation_listed_not_read_only(automation_sessi
     assert tool.annotations is not None
     assert tool.annotations.readOnlyHint is False
     assert tool.annotations.destructiveHint is not True
+
+
+## ---------------------------------------------------------------------------
+## FR-11: Cross-pipe PERMISSION_DENIED enrichment
+## ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("automation_session", [None], indirect=True)
+async def test_create_automation_cross_pipe_permission_denied_enriches_error(
+    automation_session, mock_automation_client, extract_payload
+):
+    mock_automation_client.create_automation.side_effect = TransportQueryError(
+        "forbidden",
+        errors=[
+            {
+                "message": "forbidden",
+                "extensions": {"code": "PERMISSION_DENIED"},
+            }
+        ],
+    )
+    # get_pipe_members fails for the target pipe
+    mock_automation_client.get_pipe_members.side_effect = RuntimeError("no access")
+    async with automation_session as session:
+        result = await session.call_tool(
+            "create_automation",
+            {
+                "pipe_id": "100",
+                "name": "Cross-pipe rule",
+                "trigger_id": "card_created",
+                "action_id": "move_card",
+                "action_repo_id": "200",
+            },
+        )
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "invite_members" in payload["error"]
+    assert "forbidden" in payload["error"]

--- a/tests/tools/test_graphql_error_helpers.py
+++ b/tests/tools/test_graphql_error_helpers.py
@@ -1,0 +1,117 @@
+"""Tests for enrich_permission_denied_error helper."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from gql.transport.exceptions import TransportQueryError
+
+from pipefy_mcp.services.pipefy import PipefyClient
+from pipefy_mcp.tools.graphql_error_helpers import enrich_permission_denied_error
+
+
+def _make_permission_denied_exc(message="forbidden"):
+    return TransportQueryError(
+        message,
+        errors=[
+            {
+                "message": message,
+                "extensions": {"code": "PERMISSION_DENIED"},
+            }
+        ],
+    )
+
+
+def _make_non_permission_exc(message="not found"):
+    return TransportQueryError(
+        message,
+        errors=[
+            {
+                "message": message,
+                "extensions": {"code": "NOT_FOUND"},
+            }
+        ],
+    )
+
+
+@pytest.fixture
+def mock_client():
+    client = MagicMock(spec=PipefyClient)
+    client.get_pipe_members = AsyncMock()
+    return client
+
+
+@pytest.mark.anyio
+class TestEnrichPermissionDeniedError:
+    async def test_permission_denied_missing_member_returns_enrichment(
+        self, mock_client
+    ):
+        exc = _make_permission_denied_exc()
+        # Fetching members for the target pipe fails (no access)
+        mock_client.get_pipe_members.side_effect = [
+            # Source pipe — accessible
+            {"pipe": {"name": "Source Pipe", "members": [{"user": {"id": "u1"}}]}},
+            # Target pipe — raises (no access)
+            RuntimeError("no access to pipe"),
+        ]
+        result = await enrich_permission_denied_error(exc, ["100", "200"], mock_client)
+        assert result is not None
+        assert "pipe 200" in result
+        assert "invite_members" in result
+
+    async def test_permission_denied_is_member_returns_none(self, mock_client):
+        exc = _make_permission_denied_exc()
+        mock_client.get_pipe_members.return_value = {
+            "pipe": {
+                "name": "Pipe",
+                "members": [{"user": {"id": "u1"}, "role_name": "admin"}],
+            }
+        }
+        result = await enrich_permission_denied_error(exc, ["100", "200"], mock_client)
+        assert result is None
+
+    async def test_non_permission_denied_returns_none(self, mock_client):
+        exc = _make_non_permission_exc()
+        result = await enrich_permission_denied_error(exc, ["100"], mock_client)
+        assert result is None
+        mock_client.get_pipe_members.assert_not_called()
+
+    async def test_timeout_returns_none(self, mock_client):
+        import asyncio
+
+        exc = _make_permission_denied_exc()
+
+        async def slow_fetch(*args, **kwargs):
+            await asyncio.sleep(10)
+            return {}
+
+        mock_client.get_pipe_members.side_effect = slow_fetch
+        result = await enrich_permission_denied_error(exc, ["100"], mock_client)
+        assert result is None
+
+    async def test_empty_pipe_ids_returns_none(self, mock_client):
+        exc = _make_permission_denied_exc()
+        result = await enrich_permission_denied_error(exc, [], mock_client)
+        assert result is None
+        mock_client.get_pipe_members.assert_not_called()
+
+    async def test_deduplicates_pipe_ids(self, mock_client):
+        exc = _make_permission_denied_exc()
+        mock_client.get_pipe_members.return_value = {
+            "pipe": {
+                "name": "Pipe",
+                "members": [{"user": {"id": "u1"}}],
+            }
+        }
+        await enrich_permission_denied_error(exc, ["100", "100"], mock_client)
+        # Should only call once despite duplicate IDs
+        assert mock_client.get_pipe_members.call_count == 1
+
+    async def test_empty_members_list_reports_missing(self, mock_client):
+        exc = _make_permission_denied_exc()
+        mock_client.get_pipe_members.return_value = {
+            "pipe": {"name": "Target Pipe", "members": []}
+        }
+        result = await enrich_permission_denied_error(exc, ["100"], mock_client)
+        assert result is not None
+        assert "Target Pipe" in result
+        assert "invite_members" in result

--- a/tests/tools/test_graphql_error_helpers.py
+++ b/tests/tools/test_graphql_error_helpers.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from gql.transport.exceptions import TransportQueryError
 
+import pipefy_mcp.settings as settings_mod
 from pipefy_mcp.services.pipefy import PipefyClient
 from pipefy_mcp.tools.graphql_error_helpers import enrich_permission_denied_error
 
@@ -38,6 +39,14 @@ def mock_client():
     client = MagicMock(spec=PipefyClient)
     client.get_pipe_members = AsyncMock()
     return client
+
+
+@pytest.fixture(autouse=True)
+def _isolate_sa_ids(monkeypatch):
+    """Default: no service_account_ids configured (tests opt in explicitly)."""
+    mock_settings = MagicMock()
+    mock_settings.pipefy.service_account_ids = []
+    monkeypatch.setattr(settings_mod, "settings", mock_settings)
 
 
 @pytest.mark.anyio
@@ -117,3 +126,66 @@ class TestEnrichPermissionDeniedError:
         assert result is not None
         assert "Target Pipe" in result
         assert "invite_members" in result
+
+    async def test_sa_ids_configured_and_sa_not_in_members_returns_enrichment(
+        self, mock_client, monkeypatch
+    ):
+        """When service_account_ids is configured and the SA is NOT among
+        the pipe's members, enrichment must report the missing membership
+        even if the members list is non-empty (bug reproduction)."""
+        mock_settings = MagicMock()
+        mock_settings.pipefy.service_account_ids = ["sa-42"]
+        monkeypatch.setattr(settings_mod, "settings", mock_settings)
+
+        exc = _make_permission_denied_exc()
+        mock_client.get_pipe_members.return_value = {
+            "pipe": {
+                "name": "Target Pipe",
+                "members": [
+                    {"user": {"id": "other-user-1"}, "role_name": "admin"},
+                    {"user": {"id": "other-user-2"}, "role_name": "member"},
+                ],
+            }
+        }
+        result = await enrich_permission_denied_error(exc, ["200"], mock_client)
+        assert result is not None
+        assert "Target Pipe" in result
+        assert "invite_members" in result
+
+    async def test_sa_ids_configured_and_sa_is_member_returns_none(
+        self, mock_client, monkeypatch
+    ):
+        """When service_account_ids is configured and the SA IS among the
+        pipe's members, enrichment must return None (no false positive)."""
+        mock_settings = MagicMock()
+        mock_settings.pipefy.service_account_ids = ["sa-42"]
+        monkeypatch.setattr(settings_mod, "settings", mock_settings)
+
+        exc = _make_permission_denied_exc()
+        mock_client.get_pipe_members.return_value = {
+            "pipe": {
+                "name": "Target Pipe",
+                "members": [
+                    {"user": {"id": "sa-42"}, "role_name": "admin"},
+                    {"user": {"id": "other-user"}, "role_name": "member"},
+                ],
+            }
+        }
+        result = await enrich_permission_denied_error(exc, ["200"], mock_client)
+        assert result is None
+
+    async def test_sa_ids_not_configured_falls_back_to_empty_check(
+        self,
+        mock_client,
+    ):
+        """When service_account_ids is empty (autouse default), fallback to
+        the original logic: non-empty members list → None (no enrichment)."""
+        exc = _make_permission_denied_exc()
+        mock_client.get_pipe_members.return_value = {
+            "pipe": {
+                "name": "Target Pipe",
+                "members": [{"user": {"id": "u1"}, "role_name": "admin"}],
+            }
+        }
+        result = await enrich_permission_denied_error(exc, ["200"], mock_client)
+        assert result is None

--- a/tests/tools/test_graphql_error_helpers.py
+++ b/tests/tools/test_graphql_error_helpers.py
@@ -57,6 +57,8 @@ class TestEnrichPermissionDeniedError:
         assert result is not None
         assert "pipe 200" in result
         assert "invite_members" in result
+        # DD-02: message is softened — does not assert definitive "is not a member"
+        assert "Could not verify membership" in result
 
     async def test_permission_denied_is_member_returns_none(self, mock_client):
         exc = _make_permission_denied_exc()

--- a/tests/tools/test_member_tools.py
+++ b/tests/tools/test_member_tools.py
@@ -143,7 +143,7 @@ async def test_invite_members_graphql_error(
 async def test_remove_member_from_pipe_blocks_protected_service_account(
     member_session, mock_member_client, extract_payload
 ):
-    """FR-1: IDs in PIPEFY_SERVICE_ACCOUNT_IDS cannot be removed via MCP."""
+    """IDs in PIPEFY_SERVICE_ACCOUNT_IDS cannot be removed via MCP."""
     mock_member_client.remove_members_from_pipe.return_value = {
         "removeMembersFromPipe": {"success": True}
     }

--- a/tests/tools/test_member_tools.py
+++ b/tests/tools/test_member_tools.py
@@ -10,8 +10,18 @@ from mcp.shared.memory import (
     create_connected_server_and_client_session as create_client_session,
 )
 
+import pipefy_mcp.settings as _settings_mod
 from pipefy_mcp.services.pipefy import PipefyClient
 from pipefy_mcp.tools.member_tools import MemberTools
+
+
+@pytest.fixture(autouse=True)
+def _isolate_sa_ids(monkeypatch):
+    """Ensure .env service_account_ids don't leak into tests.
+
+    Tests that need specific SA IDs override via their own monkeypatch.
+    """
+    monkeypatch.setattr(_settings_mod.settings.pipefy, "service_account_ids", [])
 
 
 @pytest.fixture

--- a/tests/tools/test_pipe_tools.py
+++ b/tests/tools/test_pipe_tools.py
@@ -62,6 +62,7 @@ def mock_pipefy_client():
     )
     client.internal_api_available = True
     client.update_card = AsyncMock()
+    client.get_pipe_members = AsyncMock()
 
     return client
 
@@ -382,6 +383,39 @@ class TestCreateCardTool:
             )
             assert result.isError is False
             mock_pipefy_client.update_card.assert_not_called()
+
+    @pytest.mark.parametrize("client_session", [None], indirect=True)
+    async def test_permission_denied_enriches_error_payload(
+        self,
+        client_session,
+        mock_pipefy_client,
+        pipe_id,
+        extract_payload,
+    ):
+        from gql.transport.exceptions import TransportQueryError
+
+        mock_pipefy_client.get_start_form_fields.return_value = {
+            "start_form_fields": []
+        }
+        mock_pipefy_client.create_card.side_effect = TransportQueryError(
+            "forbidden",
+            errors=[
+                {
+                    "message": "forbidden",
+                    "extensions": {"code": "PERMISSION_DENIED"},
+                }
+            ],
+        )
+        mock_pipefy_client.get_pipe_members.side_effect = RuntimeError("no access")
+
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_card",
+                {"pipe_id": pipe_id},
+            )
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "invite_members" in payload["error"]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

Implements Phase 3 (Agent UX) from the tool-surface hardening track:

- **`validate_ai_automation_prompt`** — pre-flight validation for AI automation prompts (field refs, pipe AI flag, optional event).
- **`enrich_permission_denied_error`** — optional membership hints on cross-pipe `PERMISSION_DENIED` errors.
- **Proactive SA membership** in `validate_ai_agent_behaviors` when `PIPEFY_SERVICE_ACCOUNT_IDS` is set.

Also includes doc/test cleanup: README and automations docs, removal of internal FR/task trace tokens in comments, and the three follow-up commits from the latest polish pass.

## Test plan

- [x] `uv run pytest -m "not integration"` (1464 passed locally)
- [x] `uv run ruff check src/ tests/` and `uv run ruff format --check src/ tests/`
