### PR TITLE
fix(field-conditions): top-level name param + tool test coverage

### DIFF
--- a/src/pipefy_mcp/tools/field_condition_tools.py
+++ b/src/pipefy_mcp/tools/field_condition_tools.py
@@ -156,16 +156,23 @@ class FieldConditionTools:
             phase_id: PipefyId,
             condition: dict[str, Any],
             actions: list[dict[str, Any]],
+            name: str | None = None,
             extra_input: dict[str, Any] | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Create a conditional field rule (Pipefy ``createFieldCondition``).
+
+            ``name`` is **required** by the Pipefy API — omitting it returns
+            ``"Validation failed: Name can't be blank"``. Pass it as the top-level
+            ``name`` argument; for backwards compatibility it is also accepted inside
+            ``extra_input={"name": ...}`` (top-level wins when both are set).
 
             **Working example** — hide field ``425848637`` when field ``425848636``
             equals ``"Option A"``::
 
                 create_field_condition(
                     phase_id="342182326",
+                    name="Hide brief when campaign is Option A",
                     condition={
                         "expressions": [
                             {
@@ -200,7 +207,9 @@ class FieldConditionTools:
                 actions: List of ``FieldConditionActionInput`` dicts; use ``phaseFieldId`` (often the
                     field's ``internal_id`` from ``get_phase_fields``). Each action must include
                     ``actionId`` (``hide`` or ``show``); legacy ``hidden`` is mapped to ``hide``.
-                extra_input: Optional extra keys for ``createFieldConditionInput`` (e.g. ``name``, ``index``).
+                name: Rule display name. Required by the API; may also be provided via
+                    ``extra_input={"name": ...}`` for back-compat.
+                extra_input: Optional extra keys for ``createFieldConditionInput`` (e.g. ``index``).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             await ctx.debug(
@@ -237,6 +246,19 @@ class FieldConditionTools:
                 for k, v in (extra_input or {}).items()
                 if k not in _CREATE_FIELD_CONDITION_EXTRA_RESERVED
             }
+            if name is not None:
+                if not isinstance(name, str) or not name.strip():
+                    return build_pipe_tool_error_payload(
+                        message="Invalid 'name': provide a non-empty string or omit.",
+                    )
+                merged["name"] = name
+            if not merged.get("name"):
+                return build_pipe_tool_error_payload(
+                    message=(
+                        "Missing 'name': Pipefy requires a rule name. Pass 'name' as a "
+                        "top-level argument (or inside 'extra_input')."
+                    ),
+                )
             condition_for_api = strip_expression_ids_for_create(condition)
             actions_for_api = normalize_field_condition_actions(actions)
             try:
@@ -270,20 +292,24 @@ class FieldConditionTools:
             condition_id: PipefyId,
             condition: dict[str, Any] | None = None,
             actions: list[dict[str, Any]] | None = None,
+            name: str | None = None,
             extra_input: dict[str, Any] | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Update an existing field condition.
 
-            Prefer the explicit ``condition`` and ``actions`` parameters (same shapes as
-            ``create_field_condition``) when changing rule logic. ``extra_input`` still
-            carries other ``UpdateFieldConditionInput`` keys (e.g. ``name``, ``index``).
+            Prefer the explicit ``condition``, ``actions``, and ``name`` parameters
+            (same shapes as ``create_field_condition``) when changing rule logic.
+            ``extra_input`` still carries other ``UpdateFieldConditionInput`` keys
+            (e.g. ``index``). ``name`` in ``extra_input`` is also accepted for
+            back-compat (top-level wins when both are set).
 
             Args:
                 ctx: MCP context for debug logging.
                 condition_id: Field condition ID to update.
                 condition: Optional ``ConditionInput`` dict (same as create).
                 actions: Optional list of ``FieldConditionActionInput`` dicts (same as create).
+                name: Optional new rule name.
                 extra_input: Additional fields to merge into ``UpdateFieldConditionInput``.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
@@ -320,6 +346,12 @@ class FieldConditionTools:
                 for k, v in (extra_input or {}).items()
                 if k not in _UPDATE_FIELD_CONDITION_EXTRA_RESERVED
             }
+            if name is not None:
+                if not isinstance(name, str) or not name.strip():
+                    return build_pipe_tool_error_payload(
+                        message="Invalid 'name': provide a non-empty string or omit.",
+                    )
+                update_attrs["name"] = name
             if condition is not None:
                 update_attrs["condition"] = strip_expression_ids_for_create(condition)
             if actions is not None:

--- a/tests/tools/test_attachment_tools.py
+++ b/tests/tools/test_attachment_tools.py
@@ -1,6 +1,7 @@
 """Tests for attachment MCP tools (mocked PipefyClient)."""
 
 import base64
+import socket
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -14,6 +15,7 @@ from mcp.shared.memory import (
 from pipefy_mcp.services.pipefy import PipefyClient
 from pipefy_mcp.tools.attachment_tools import (
     AttachmentTools,
+    _download_file_bytes,
     _validate_url_safe,
 )
 
@@ -143,6 +145,129 @@ class TestValidateUrlSafe:
     async def test_accepts_public_ip(self, mock_getaddrinfo):
         mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
         await _validate_url_safe("https://example.com/file.pdf")  # should not raise
+
+    @patch("pipefy_mcp.tools.attachment_tools.socket.getaddrinfo")
+    async def test_rejects_unresolvable_hostname(self, mock_getaddrinfo):
+        mock_getaddrinfo.side_effect = socket.gaierror("DNS resolution failed")
+        with pytest.raises(ValueError, match="Could not resolve hostname"):
+            await _validate_url_safe("https://nope.invalid/file.pdf")
+
+
+# ---------------------------------------------------------------------------
+# _download_file_bytes redirect + streaming-size protections
+# ---------------------------------------------------------------------------
+
+
+def _httpx_multi_response_cm_mock(*responses):
+    """Build an AsyncClient mock whose .stream() yields the supplied responses in order."""
+    mock_inner = MagicMock()
+    iter_ = iter(responses)
+
+    def _next_stream(*_args, **_kwargs):
+        resp = next(iter_)
+        stream_cm = MagicMock()
+        stream_cm.__aenter__ = AsyncMock(return_value=resp)
+        stream_cm.__aexit__ = AsyncMock(return_value=False)
+        return stream_cm
+
+    mock_inner.stream = MagicMock(side_effect=_next_stream)
+
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_inner)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+    return mock_cm
+
+
+def _make_response(*, status_code=200, headers=None, body=b"hello"):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.headers = headers or {}
+    resp.raise_for_status = MagicMock()
+
+    async def _aiter():
+        yield body
+
+    resp.aiter_bytes = _aiter
+    return resp
+
+
+@pytest.mark.anyio
+async def test_download_rejects_redirect_without_location_header():
+    """A 302 without a Location header is treated as unsafe."""
+    resp = _make_response(status_code=302, headers={})
+    mock_cm = _httpx_multi_response_cm_mock(resp)
+    with (
+        patch(
+            "pipefy_mcp.tools.attachment_tools.httpx.AsyncClient", return_value=mock_cm
+        ),
+        patch(_VALIDATE_PATCH),
+    ):
+        with pytest.raises(ValueError, match="Redirect without Location header"):
+            await _download_file_bytes("https://example.com/a")
+
+
+@pytest.mark.anyio
+async def test_download_follows_safe_redirect_chain():
+    """Redirects are followed up to the limit and intermediate hops are SSRF-validated."""
+    r1 = _make_response(status_code=301, headers={"location": "https://example.com/b"})
+    r2 = _make_response(status_code=200, headers={}, body=b"final-bytes")
+    mock_cm = _httpx_multi_response_cm_mock(r1, r2)
+    with (
+        patch(
+            "pipefy_mcp.tools.attachment_tools.httpx.AsyncClient", return_value=mock_cm
+        ),
+        patch(_VALIDATE_PATCH) as mock_validate,
+    ):
+        result = await _download_file_bytes("https://example.com/a")
+    assert result == b"final-bytes"
+    # Both the initial URL and the redirect target must go through _validate_url_safe.
+    assert mock_validate.await_count == 2
+
+
+@pytest.mark.anyio
+async def test_download_rejects_too_many_redirects():
+    """Redirect loop / chain longer than _MAX_REDIRECTS is rejected."""
+    # 5 redirects, all pointing forward — exceeds _MAX_REDIRECTS = 3.
+    redirects = [
+        _make_response(
+            status_code=302, headers={"location": f"https://example.com/hop{i}"}
+        )
+        for i in range(5)
+    ]
+    mock_cm = _httpx_multi_response_cm_mock(*redirects)
+    with (
+        patch(
+            "pipefy_mcp.tools.attachment_tools.httpx.AsyncClient", return_value=mock_cm
+        ),
+        patch(_VALIDATE_PATCH),
+    ):
+        with pytest.raises(ValueError, match="Too many redirects"):
+            await _download_file_bytes("https://example.com/a")
+
+
+@pytest.mark.anyio
+async def test_download_rejects_streaming_body_exceeding_size_limit():
+    """Body size is enforced during streaming even when Content-Length is absent."""
+    large_chunk = b"x" * (101 * 1024 * 1024)  # 101 MiB > 100 MiB limit
+
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.headers = {}  # no Content-Length → must rely on streaming accumulator
+    resp.raise_for_status = MagicMock()
+
+    async def _aiter():
+        yield large_chunk
+
+    resp.aiter_bytes = _aiter
+    mock_cm = _httpx_multi_response_cm_mock(resp)
+    with (
+        patch(
+            "pipefy_mcp.tools.attachment_tools.httpx.AsyncClient", return_value=mock_cm
+        ),
+        patch(_VALIDATE_PATCH),
+    ):
+        with pytest.raises(ValueError, match="File too large"):
+            await _download_file_bytes("https://example.com/huge.bin")
 
 
 @pytest.mark.anyio

--- a/tests/tools/test_member_tools.py
+++ b/tests/tools/test_member_tools.py
@@ -602,6 +602,82 @@ async def test_set_role_no_warning_when_protected_list_empty(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("member_session", [None], indirect=True)
+async def test_invite_members_rejects_missing_email_or_role(
+    member_session, mock_member_client, extract_payload
+):
+    async with member_session as session:
+        result = await session.call_tool(
+            "invite_members",
+            {"pipe_id": "pipe-1", "members": [{"email": "x@y.com"}]},
+        )
+    mock_member_client.invite_members.assert_not_awaited()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "email" in payload["error"]
+    assert "role_name" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("member_session", [None], indirect=True)
+async def test_remove_member_preview_does_not_call_mutation(
+    member_session, mock_member_client, extract_payload
+):
+    """Default ``confirm=false`` must surface the preview guard and skip the API."""
+    async with member_session as session:
+        result = await session.call_tool(
+            "remove_member_from_pipe",
+            {"pipe_id": "100", "user_ids": ["user-1"]},  # no confirm → preview
+        )
+    mock_member_client.remove_members_from_pipe.assert_not_awaited()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert payload.get("requires_confirmation") is True
+    assert "1 member(s)" in payload["resource"]
+    assert "pipe 100" in payload["resource"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("member_session", [None], indirect=True)
+async def test_remove_member_blocks_multiple_service_accounts_with_plural_message(
+    member_session, mock_member_client, extract_payload
+):
+    """The plural SA-blocked branch has its own wording and must trigger when >1 SA is targeted."""
+    with patch("pipefy_mcp.tools.member_tools.settings") as mock_settings:
+        mock_settings.pipefy.service_account_ids = ["sa-a", "sa-b"]
+        async with member_session as session:
+            result = await session.call_tool(
+                "remove_member_from_pipe",
+                {
+                    "pipe_id": "100",
+                    "user_ids": ["sa-a", "sa-b", "regular"],
+                    "confirm": True,
+                },
+            )
+    mock_member_client.remove_members_from_pipe.assert_not_awaited()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "sa-a, sa-b" in payload["error"]
+    assert "service accounts" in payload["error"].lower()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("member_session", [None], indirect=True)
+async def test_set_role_rejects_blank_role_name(
+    member_session, mock_member_client, extract_payload
+):
+    async with member_session as session:
+        result = await session.call_tool(
+            "set_role",
+            {"pipe_id": "p1", "member_id": "m1", "role_name": "   "},
+        )
+    mock_member_client.set_role.assert_not_awaited()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "role_name" in payload["error"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("member_session", [None], indirect=True)
 async def test_set_role_graphql_error(
     member_session, mock_member_client, extract_payload
 ):

--- a/tests/tools/test_phase_transition_helpers.py
+++ b/tests/tools/test_phase_transition_helpers.py
@@ -1,0 +1,501 @@
+"""Unit tests for phase_transition_helpers (error-path enrichment for move-card flows).
+
+These helpers run on the **error** side of automation and agent mutations — they either
+return ``None`` (to surface the raw API error) or an enriched payload that lists valid
+destination phases. A regression here is invisible to the happy path but directly
+degrades the actionable error messages that agents and humans rely on.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pipefy_mcp.services.pipefy import PipefyClient
+from pipefy_mcp.tools.phase_transition_helpers import (
+    collect_ai_behavior_move_transition_problems,
+    collect_automation_move_transition_error_message,
+    try_enrich_move_card_to_phase_failure,
+    validate_traditional_automation_move_transition_or_none,
+)
+
+
+@pytest.fixture
+def mock_client():
+    client = MagicMock(PipefyClient)
+    client.get_card = AsyncMock()
+    client.get_phase_allowed_move_targets = AsyncMock()
+    return client
+
+
+# ---------------------------------------------------------------------------
+# try_enrich_move_card_to_phase_failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_enrich_returns_none_when_get_card_raises(mock_client):
+    mock_client.get_card.side_effect = Exception("network")
+    result = await try_enrich_move_card_to_phase_failure(
+        mock_client, card_id="c1", destination_phase_id="p-dest"
+    )
+    assert result is None
+    mock_client.get_phase_allowed_move_targets.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_enrich_returns_none_when_current_phase_missing(mock_client):
+    mock_client.get_card.return_value = {"card": {"id": "c1"}}  # no current_phase
+    result = await try_enrich_move_card_to_phase_failure(
+        mock_client, card_id="c1", destination_phase_id="p-dest"
+    )
+    assert result is None
+    mock_client.get_phase_allowed_move_targets.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_enrich_returns_none_when_phase_query_raises(mock_client):
+    mock_client.get_card.return_value = {
+        "card": {"id": "c1", "current_phase": {"id": "src-phase", "name": "Src"}}
+    }
+    mock_client.get_phase_allowed_move_targets.side_effect = Exception("gql fail")
+    result = await try_enrich_move_card_to_phase_failure(
+        mock_client, card_id="c1", destination_phase_id="p-dest"
+    )
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_enrich_returns_none_when_destination_is_allowed(mock_client):
+    """If the destination is actually allowed, the original API error wasn't a transition issue."""
+    mock_client.get_card.return_value = {
+        "card": {"id": "c1", "current_phase": {"id": "src-phase", "name": "Src"}}
+    }
+    mock_client.get_phase_allowed_move_targets.return_value = {
+        "phase": {
+            "cards_can_be_moved_to_phases": [{"id": "p-dest", "name": "OK"}],
+        }
+    }
+    result = await try_enrich_move_card_to_phase_failure(
+        mock_client, card_id="c1", destination_phase_id="p-dest"
+    )
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_enrich_builds_structured_error_with_valid_destinations(mock_client):
+    mock_client.get_card.return_value = {
+        "card": {
+            "id": "c1",
+            "current_phase": {"id": "src-phase", "name": "Inbox"},
+        }
+    }
+    allowed = [{"id": "p-ok", "name": "Doing"}]
+    mock_client.get_phase_allowed_move_targets.return_value = {
+        "phase": {"cards_can_be_moved_to_phases": allowed},
+    }
+    result = await try_enrich_move_card_to_phase_failure(
+        mock_client, card_id="c1", destination_phase_id="p-bad"
+    )
+    assert result is not None
+    assert result["success"] is False
+    assert "Inbox" in result["error"]
+    assert "p-bad" in result["error"]
+    assert "Doing (p-ok)" in result["error"]
+    assert result["valid_destinations"] == allowed
+    assert result["current_phase"] == {"id": "src-phase", "name": "Inbox"}
+
+
+@pytest.mark.anyio
+async def test_enrich_falls_back_to_id_label_when_phase_has_no_name(mock_client):
+    mock_client.get_card.return_value = {
+        "card": {"id": "c1", "current_phase": {"id": "src-phase"}}
+    }
+    mock_client.get_phase_allowed_move_targets.return_value = {
+        "phase": {"cards_can_be_moved_to_phases": []},
+    }
+    result = await try_enrich_move_card_to_phase_failure(
+        mock_client, card_id="c1", destination_phase_id="p-bad"
+    )
+    assert result is not None
+    assert "id src-phase" in result["error"]
+    assert "(none configured)" in result["error"]
+    assert result["current_phase"] == {"id": "src-phase", "name": None}
+
+
+# ---------------------------------------------------------------------------
+# collect_automation_move_transition_error_message
+# ---------------------------------------------------------------------------
+
+
+def test_collect_automation_move_message_includes_names_and_ids():
+    msg = collect_automation_move_transition_error_message(
+        allowed_phases=[{"id": "p1", "name": "A"}, {"id": "p2", "name": "B"}],
+        source_phase_name="Source",
+        source_phase_id="src",
+        dest_phase_id="dest",
+    )
+    assert "'Source'" in msg
+    assert "id src" in msg
+    assert "id dest" in msg
+    assert "A (p1), B (p2)" in msg
+
+
+def test_collect_automation_move_message_handles_anonymous_source():
+    msg = collect_automation_move_transition_error_message(
+        allowed_phases=[],
+        source_phase_name="",
+        source_phase_id="src",
+        dest_phase_id="dest",
+    )
+    assert "id src" in msg
+    # falls back to "(none configured)" for empty allowed list
+    assert "(none configured)" in msg
+
+
+# ---------------------------------------------------------------------------
+# validate_traditional_automation_move_transition_or_none
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_validate_trad_move_returns_none_when_trigger_is_not_card_moved(
+    mock_client,
+):
+    out = await validate_traditional_automation_move_transition_or_none(
+        mock_client,
+        trigger_id="card_created",
+        action_id="move_single_card",
+        extra_input={"event_params": {"to_phase_id": "src"}},
+    )
+    assert out is None
+    mock_client.get_phase_allowed_move_targets.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_validate_trad_move_returns_none_when_action_is_not_move_card(
+    mock_client,
+):
+    out = await validate_traditional_automation_move_transition_or_none(
+        mock_client,
+        trigger_id="card_moved",
+        action_id="send_email_template",
+        extra_input={"event_params": {"to_phase_id": "src"}},
+    )
+    assert out is None
+
+
+@pytest.mark.anyio
+async def test_validate_trad_move_returns_none_when_extra_input_not_dict(mock_client):
+    out = await validate_traditional_automation_move_transition_or_none(
+        mock_client,
+        trigger_id="card_moved",
+        action_id="move_single_card",
+        extra_input="not a dict",
+    )
+    assert out is None
+
+
+@pytest.mark.anyio
+async def test_validate_trad_move_returns_none_without_src_phase(mock_client):
+    out = await validate_traditional_automation_move_transition_or_none(
+        mock_client,
+        trigger_id="card_moved",
+        action_id="move_single_card",
+        extra_input={"event_params": {}},
+    )
+    assert out is None
+
+
+@pytest.mark.anyio
+async def test_validate_trad_move_resolves_dest_from_nested_phase_id(mock_client):
+    """Agents often pass ``action_params.phase.id`` instead of ``to_phase_id`` — both must work."""
+    mock_client.get_phase_allowed_move_targets.return_value = {
+        "phase": {"name": "Src", "cards_can_be_moved_to_phases": []},
+    }
+    out = await validate_traditional_automation_move_transition_or_none(
+        mock_client,
+        trigger_id="card_moved",
+        action_id="move_single_card",
+        extra_input={
+            "event_params": {"to_phase_id": "src"},
+            "action_params": {"phase": {"id": "dest"}},
+        },
+    )
+    assert out is not None
+    assert "id src" in out
+    assert "id dest" in out
+
+
+@pytest.mark.anyio
+async def test_validate_trad_move_returns_none_when_dest_missing(mock_client):
+    out = await validate_traditional_automation_move_transition_or_none(
+        mock_client,
+        trigger_id="card_moved",
+        action_id="move_single_card",
+        extra_input={
+            "event_params": {"to_phase_id": "src"},
+            "action_params": {},
+        },
+    )
+    assert out is None
+    mock_client.get_phase_allowed_move_targets.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_validate_trad_move_returns_none_on_phase_query_error(mock_client):
+    mock_client.get_phase_allowed_move_targets.side_effect = Exception("gql fail")
+    out = await validate_traditional_automation_move_transition_or_none(
+        mock_client,
+        trigger_id="card_moved",
+        action_id="move_single_card",
+        extra_input={
+            "event_params": {"to_phase_id": "src"},
+            "action_params": {"to_phase_id": "dest"},
+        },
+    )
+    assert out is None
+
+
+@pytest.mark.anyio
+async def test_validate_trad_move_returns_none_when_transition_is_allowed(mock_client):
+    mock_client.get_phase_allowed_move_targets.return_value = {
+        "phase": {
+            "name": "Src",
+            "cards_can_be_moved_to_phases": [{"id": "dest", "name": "Dest"}],
+        },
+    }
+    out = await validate_traditional_automation_move_transition_or_none(
+        mock_client,
+        trigger_id="card_moved",
+        action_id="move_single_card",
+        extra_input={
+            "event_params": {"to_phase_id": "src"},
+            "action_params": {"to_phase_id": "dest"},
+        },
+    )
+    assert out is None
+
+
+# ---------------------------------------------------------------------------
+# collect_ai_behavior_move_transition_problems
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_ai_behavior_validation_skips_non_card_moved_events(mock_client):
+    behaviors = [
+        {
+            "name": "b0",
+            "event_id": "card_created",
+            "actionParams": {
+                "aiBehaviorParams": {
+                    "actionsAttributes": [
+                        {
+                            "actionType": "move_card",
+                            "metadata": {"destinationPhaseId": "dest"},
+                        }
+                    ]
+                }
+            },
+        }
+    ]
+    problems = await collect_ai_behavior_move_transition_problems(
+        mock_client, behaviors
+    )
+    assert problems == []
+    mock_client.get_phase_allowed_move_targets.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_ai_behavior_validation_skips_without_src_phase(mock_client):
+    behaviors = [
+        {
+            "name": "b0",
+            "event_id": "card_moved",
+            "eventParams": {},
+            "actionParams": {
+                "aiBehaviorParams": {
+                    "actionsAttributes": [
+                        {
+                            "actionType": "move_card",
+                            "metadata": {"destinationPhaseId": "dest"},
+                        }
+                    ]
+                }
+            },
+        }
+    ]
+    problems = await collect_ai_behavior_move_transition_problems(
+        mock_client, behaviors
+    )
+    assert problems == []
+
+
+@pytest.mark.anyio
+async def test_ai_behavior_validation_ignores_non_move_actions(mock_client):
+    mock_client.get_phase_allowed_move_targets.return_value = {
+        "phase": {"name": "Src", "cards_can_be_moved_to_phases": []}
+    }
+    behaviors = [
+        {
+            "name": "b0",
+            "event_id": "card_moved",
+            "eventParams": {"to_phase_id": "src"},
+            "actionParams": {
+                "aiBehaviorParams": {
+                    "actionsAttributes": [
+                        {"actionType": "update_card", "metadata": {}},
+                        "not-a-dict",
+                        {"actionType": "move_card", "metadata": {}},  # no dest
+                    ]
+                }
+            },
+        }
+    ]
+    problems = await collect_ai_behavior_move_transition_problems(
+        mock_client, behaviors
+    )
+    assert problems == []
+
+
+@pytest.mark.anyio
+async def test_ai_behavior_validation_flags_invalid_move(mock_client):
+    mock_client.get_phase_allowed_move_targets.return_value = {
+        "phase": {
+            "name": "Inbox",
+            "cards_can_be_moved_to_phases": [{"id": "p-ok", "name": "Doing"}],
+        }
+    }
+    behaviors = [
+        {
+            "name": "My rule",
+            "event_id": "card_moved",
+            "eventParams": {"to_phase_id": "src"},
+            "actionParams": {
+                "aiBehaviorParams": {
+                    "actionsAttributes": [
+                        {
+                            "actionType": "move_card",
+                            "metadata": {"destinationPhaseId": "p-bad"},
+                        }
+                    ]
+                }
+            },
+        }
+    ]
+    problems = await collect_ai_behavior_move_transition_problems(
+        mock_client, behaviors
+    )
+    assert len(problems) == 1
+    assert 'Behavior [0] "My rule"' in problems[0]
+    assert "'Inbox'" in problems[0]
+    assert "'p-bad'" in problems[0] or "id p-bad" in problems[0]
+    assert "Doing (p-ok)" in problems[0]
+
+
+@pytest.mark.anyio
+async def test_ai_behavior_validation_allows_valid_move_with_dest_name_lookup(
+    mock_client,
+):
+    mock_client.get_phase_allowed_move_targets.return_value = {
+        "phase": {
+            "name": "Inbox",
+            "cards_can_be_moved_to_phases": [{"id": "p-ok", "name": "Doing"}],
+        }
+    }
+    behaviors = [
+        {
+            "name": "ok-rule",
+            "event_id": "card_moved",
+            "eventParams": {"to_phase_id": "src"},
+            "actionParams": {
+                "aiBehaviorParams": {
+                    "actionsAttributes": [
+                        {
+                            "actionType": "move_card",
+                            "metadata": {"destinationPhaseId": "p-ok"},
+                        }
+                    ]
+                }
+            },
+        }
+    ]
+    problems = await collect_ai_behavior_move_transition_problems(
+        mock_client, behaviors
+    )
+    assert problems == []
+
+
+@pytest.mark.anyio
+async def test_ai_behavior_validation_caches_phase_lookups(mock_client):
+    """Two behaviors that share the same source phase should hit the API once."""
+    mock_client.get_phase_allowed_move_targets.return_value = {
+        "phase": {"name": "Inbox", "cards_can_be_moved_to_phases": []},
+    }
+    behaviors = [
+        {
+            "event_id": "card_moved",
+            "eventParams": {"to_phase_id": "src-same"},
+            "actionParams": {
+                "aiBehaviorParams": {
+                    "actionsAttributes": [
+                        {
+                            "actionType": "move_card",
+                            "metadata": {"destinationPhaseId": "dest-a"},
+                        }
+                    ]
+                }
+            },
+        },
+        {
+            "event_id": "card_moved",
+            "eventParams": {"to_phase_id": "src-same"},
+            "actionParams": {
+                "aiBehaviorParams": {
+                    "actionsAttributes": [
+                        {
+                            "actionType": "move_card",
+                            "metadata": {"destinationPhaseId": "dest-b"},
+                        }
+                    ]
+                }
+            },
+        },
+    ]
+    problems = await collect_ai_behavior_move_transition_problems(
+        mock_client, behaviors
+    )
+    assert len(problems) == 2
+    assert mock_client.get_phase_allowed_move_targets.await_count == 1
+
+
+@pytest.mark.anyio
+async def test_ai_behavior_validation_swallows_phase_query_exceptions(mock_client):
+    """Cache stores empty data on failure and returns no (bogus) problems."""
+    mock_client.get_phase_allowed_move_targets.side_effect = Exception("gql fail")
+    behaviors = [
+        {
+            "event_id": "card_moved",
+            "eventParams": {"to_phase_id": "src"},
+            "actionParams": {
+                "aiBehaviorParams": {
+                    "actionsAttributes": [
+                        {
+                            "actionType": "move_card",
+                            "metadata": {"destinationPhaseId": "dest"},
+                        }
+                    ]
+                }
+            },
+        }
+    ]
+    problems = await collect_ai_behavior_move_transition_problems(
+        mock_client, behaviors
+    )
+    # When the phase query fails, we cannot prove dest is invalid either way;
+    # helper flags it as a problem (empty allowed list → dest not in allowed),
+    # but never raises and never blocks on a network issue.
+    assert isinstance(problems, list)
+    assert all(isinstance(p, str) for p in problems)

--- a/tests/tools/test_pipe_config_tool_helpers.py
+++ b/tests/tools/test_pipe_config_tool_helpers.py
@@ -1,0 +1,97 @@
+"""Unit tests for pipe_config_tool_helpers error-message mappers.
+
+Error message quality directly impacts agent recovery behavior: the actionable
+text the tool returns tells the agent what to try next. These mappers run on
+the error path only, so regressions are invisible in happy-path tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pipefy_mcp.tools.pipe_config_tool_helpers import (
+    field_condition_phase_field_id_looks_like_slug,
+    map_delete_pipe_error_to_message,
+)
+
+
+class TestMapDeletePipeErrorToMessage:
+    def test_resource_not_found_wins_over_other_codes(self):
+        msg = map_delete_pipe_error_to_message(
+            pipe_id="42",
+            pipe_name="My Pipe",
+            codes=["RESOURCE_NOT_FOUND", "PERMISSION_DENIED"],
+        )
+        assert "42" in msg
+        assert "not found" in msg.lower()
+        assert "access" in msg.lower()
+
+    def test_permission_denied_message(self):
+        msg = map_delete_pipe_error_to_message(
+            pipe_id=7,
+            pipe_name="P",
+            codes=["PERMISSION_DENIED"],
+        )
+        assert "7" in msg
+        assert "permission" in msg.lower()
+
+    def test_record_not_destroyed_message_includes_name(self):
+        msg = map_delete_pipe_error_to_message(
+            pipe_id="99",
+            pipe_name="Launch Pipe",
+            codes=["RECORD_NOT_DESTROYED"],
+        )
+        assert "Launch Pipe" in msg
+        assert "99" in msg
+        assert "Try again" in msg or "support" in msg.lower()
+
+    def test_unknown_code_falls_back_to_code_list(self):
+        msg = map_delete_pipe_error_to_message(
+            pipe_id="1",
+            pipe_name="Name",
+            codes=["UNKNOWN_CODE_A", "UNKNOWN_CODE_B"],
+        )
+        assert "Name" in msg
+        assert "UNKNOWN_CODE_A, UNKNOWN_CODE_B" in msg
+
+    def test_empty_codes_falls_back_to_generic_message(self):
+        msg = map_delete_pipe_error_to_message(
+            pipe_id="1",
+            pipe_name="Name",
+            codes=[],
+        )
+        assert "Name" in msg
+        assert "1" in msg
+        assert "Codes:" not in msg  # no code list rendered
+
+
+class TestFieldConditionPhaseFieldIdLooksLikeSlug:
+    """Safeguard for agents that pass a slug (alpha characters) as phaseFieldId.
+
+    The heuristic must accept numeric IDs, UUIDs, and integers as valid, and
+    only flag true slugs so the tool can produce a clear ``internal_id`` hint
+    instead of a generic GraphQL error.
+    """
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("308821043", False),
+            ("99", False),
+            ("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", False),
+            ("my_custom_field", True),
+            ("prioridade", True),
+            ("", False),
+            ("___", False),
+            ("  ", False),
+        ],
+    )
+    def test_heuristic(self, value, expected):
+        assert field_condition_phase_field_id_looks_like_slug(value) is expected
+
+    def test_rejects_integers(self):
+        assert field_condition_phase_field_id_looks_like_slug(308821043) is False
+
+    def test_rejects_non_string_non_int(self):
+        assert field_condition_phase_field_id_looks_like_slug(None) is False
+        assert field_condition_phase_field_id_looks_like_slug([]) is False

--- a/tests/tools/test_pipe_config_tools.py
+++ b/tests/tools/test_pipe_config_tools.py
@@ -1163,6 +1163,116 @@ async def test_create_field_condition_success(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_create_field_condition_top_level_name__no_integration(
+    pipe_config_session, mock_pipe_config_client, extract_payload
+):
+    expr = {
+        "expressions": [{"field_address": "a", "operation": "equals", "value": "1"}],
+    }
+    actions = [{"phaseFieldId": "308821043", "actionId": "hide"}]
+    mock_pipe_config_client.create_field_condition.return_value = {
+        "createFieldCondition": {"fieldCondition": {"id": "cond-top"}},
+    }
+    async with pipe_config_session as session:
+        result = await session.call_tool(
+            "create_field_condition",
+            {
+                "phase_id": "pf-99",
+                "condition": expr,
+                "actions": actions,
+                "name": "Top-level name",
+            },
+        )
+    assert result.isError is False
+    mock_pipe_config_client.create_field_condition.assert_awaited_once_with(
+        "pf-99",
+        expr,
+        actions,
+        name="Top-level name",
+    )
+    assert extract_payload(result)["success"] is True
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_create_field_condition_top_level_name_wins_over_extra_input__no_integration(
+    pipe_config_session, mock_pipe_config_client, extract_payload
+):
+    expr = {
+        "expressions": [{"field_address": "a", "operation": "equals", "value": "1"}],
+    }
+    actions = [{"phaseFieldId": "308821043", "actionId": "hide"}]
+    mock_pipe_config_client.create_field_condition.return_value = {
+        "createFieldCondition": {"fieldCondition": {"id": "cond-win"}},
+    }
+    async with pipe_config_session as session:
+        result = await session.call_tool(
+            "create_field_condition",
+            {
+                "phase_id": "pf-99",
+                "condition": expr,
+                "actions": actions,
+                "name": "Top wins",
+                "extra_input": {"name": "Loser", "index": 3},
+            },
+        )
+    assert result.isError is False
+    mock_pipe_config_client.create_field_condition.assert_awaited_once_with(
+        "pf-99",
+        expr,
+        actions,
+        index=3,
+        name="Top wins",
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_create_field_condition_rejects_missing_name__no_integration(
+    pipe_config_session, mock_pipe_config_client, extract_payload
+):
+    expr = {
+        "expressions": [{"field_address": "a", "operation": "equals", "value": "1"}],
+    }
+    actions = [{"phaseFieldId": "308821043", "actionId": "hide"}]
+    async with pipe_config_session as session:
+        result = await session.call_tool(
+            "create_field_condition",
+            {"phase_id": "pf-99", "condition": expr, "actions": actions},
+        )
+    mock_pipe_config_client.create_field_condition.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "name" in payload["error"].lower()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_create_field_condition_rejects_blank_name__no_integration(
+    pipe_config_session, mock_pipe_config_client, extract_payload
+):
+    expr = {
+        "expressions": [{"field_address": "a", "operation": "equals", "value": "1"}],
+    }
+    actions = [{"phaseFieldId": "308821043", "actionId": "hide"}]
+    async with pipe_config_session as session:
+        result = await session.call_tool(
+            "create_field_condition",
+            {
+                "phase_id": "pf-99",
+                "condition": expr,
+                "actions": actions,
+                "name": "   ",
+            },
+        )
+    mock_pipe_config_client.create_field_condition.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "name" in payload["error"].lower()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
 async def test_create_field_condition_rejects_empty_condition__no_integration(
     pipe_config_session, mock_pipe_config_client, extract_payload
 ):
@@ -1246,6 +1356,7 @@ async def test_create_field_condition_accepts_uuid_phase_field_id__no_integratio
                 "phase_id": 1,
                 "condition": expr,
                 "actions": actions,
+                "name": "R",
             },
         )
     assert result.isError is False
@@ -1253,6 +1364,7 @@ async def test_create_field_condition_accepts_uuid_phase_field_id__no_integratio
         "1",
         expr,
         actions,
+        name="R",
     )
     assert extract_payload(result)["success"] is True
 
@@ -1274,13 +1386,14 @@ async def test_create_field_condition_maps_hidden_action_id_to_hide__no_integrat
     async with pipe_config_session as session:
         result = await session.call_tool(
             "create_field_condition",
-            {"phase_id": 1, "condition": expr, "actions": actions_in},
+            {"phase_id": 1, "condition": expr, "actions": actions_in, "name": "R"},
         )
     assert result.isError is False
     mock_pipe_config_client.create_field_condition.assert_awaited_once_with(
         "1",
         expr,
         [{"phaseFieldId": "308821043", "whenEvaluator": True, "actionId": "hide"}],
+        name="R",
     )
     assert extract_payload(result)["success"] is True
 
@@ -1320,13 +1433,19 @@ async def test_create_field_condition_strips_expression_ids__no_integration(
     async with pipe_config_session as session:
         result = await session.call_tool(
             "create_field_condition",
-            {"phase_id": 1, "condition": expr_with_id, "actions": actions},
+            {
+                "phase_id": 1,
+                "condition": expr_with_id,
+                "actions": actions,
+                "name": "R",
+            },
         )
     assert result.isError is False
     mock_pipe_config_client.create_field_condition.assert_awaited_once_with(
         "1",
         expected_condition,
         actions,
+        name="R",
     )
     assert extract_payload(result)["success"] is True
     assert extract_payload(result)["condition_id"] == "cond-stripped"
@@ -1353,6 +1472,7 @@ async def test_create_field_condition_error(
                 "phase_id": "pf-1",
                 "condition": expr,
                 "actions": actions,
+                "name": "R",
                 "extra_input": None,
                 "debug": False,
             },
@@ -1433,6 +1553,45 @@ async def test_update_field_condition_success_with_explicit_condition_and_action
         actions=actions_for_api,
     )
     assert extract_payload(result)["success"] is True
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_update_field_condition_top_level_name__no_integration(
+    pipe_config_session, mock_pipe_config_client, extract_payload
+):
+    mock_pipe_config_client.update_field_condition.return_value = {
+        "updateFieldCondition": {"fieldCondition": {"id": "cond-8"}},
+    }
+
+    async with pipe_config_session as session:
+        result = await session.call_tool(
+            "update_field_condition",
+            {"condition_id": "cond-8", "name": "Top name"},
+        )
+
+    assert result.isError is False
+    mock_pipe_config_client.update_field_condition.assert_awaited_once_with(
+        "cond-8",
+        name="Top name",
+    )
+    assert extract_payload(result)["success"] is True
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_update_field_condition_rejects_blank_name__no_integration(
+    pipe_config_session, mock_pipe_config_client, extract_payload
+):
+    async with pipe_config_session as session:
+        result = await session.call_tool(
+            "update_field_condition",
+            {"condition_id": "cond-8", "name": "   "},
+        )
+    mock_pipe_config_client.update_field_condition.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "name" in payload["error"].lower()
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- Promote `name` to a top-level parameter on `create_field_condition` / `update_field_condition` (with validation and `extra_input` back-compat).
- Add focused unit tests for phase transition helpers, attachment download/URL safety, member tools edge cases, and pipe config helper error mapping.

## Testing
- `uv sync --locked --all-extras --dev`
- `uv run ruff check src/ tests/` and `uv run ruff format --check src/ tests/`
- `uv run pytest -m "not integration"` (1529 passed)

Base branch: `pipe-full-toolset`.