### PR TITLE
feat(tools): agent ergonomics — validation envelopes, GraphQL enrichment, discovery hints

### DIFF
--- a/src/pipefy_mcp/server.py
+++ b/src/pipefy_mcp/server.py
@@ -16,6 +16,7 @@ from pipefy_mcp.core.pipefy_tool_lifecycle import (
 )
 from pipefy_mcp.settings import settings
 from pipefy_mcp.tools.registry import ToolRegistry
+from pipefy_mcp.tools.validation_envelope import install_pipefy_validation_envelope
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +26,7 @@ async def lifespan(app: FastMCP) -> AsyncIterator[FastMCP]:
     """Lifespan function to manage the lifecycle of the server."""
     try:
         logger.info("Initializing services")
+        install_pipefy_validation_envelope()
         services_container = ServicesContainer.get_instance()
         services_container.initialize_services(settings)
         prepare_app_for_repeat_pipefy_tool_registration(app)

--- a/src/pipefy_mcp/tools/ai_agent_tools.py
+++ b/src/pipefy_mcp/tools/ai_agent_tools.py
@@ -270,12 +270,15 @@ class AiAgentTools:
             Args:
                 name: Agent display name.
                 repo_uuid: UUID of the pipe (from ``get_pipe``), not the numeric pipe ID.
+                    Discover via: ``search_pipes`` then ``get_pipe(pipe_id).uuid``.
                 instruction: Agent-level purpose (Pipefy UI "Description"; API ``instruction``).
                 behaviors: 1–5 behavior dicts. Each requires ``name``, ``event_id``, and
                     ``actionParams.aiBehaviorParams`` with a non-empty ``actionsAttributes`` list.
                     Optional: ``eventParams`` to filter event triggers (e.g. ``triggerFieldIds``, ``to_phase_id``).
                     Optional: ``template_params`` / ``placeholders``, ``instruction_template``.
                     See example above for the full shape.
+                    Discover via: ``get_automation_events(pipe_id)`` for ``event_id`` and
+                    ``get_phase_fields(phase_id)`` for ``triggerFieldIds`` / ``destinationPhaseId``.
                 data_source_ids: Optional knowledge-source IDs (same as ``update_ai_agent``).
             """
             await ctx.debug(
@@ -389,14 +392,17 @@ class AiAgentTools:
 
             Args:
                 uuid: UUID of the agent to update.
+                    Discover via: ``get_ai_agents(repo_uuid)[].uuid``.
                 name: Agent display name.
                 repo_uuid: UUID of the pipe (from ``get_pipe``).
+                    Discover via: ``search_pipes`` then ``get_pipe(pipe_id).uuid``.
                 instruction: Agent-level purpose (Pipefy UI "Description"; API ``instruction``).
                 behaviors: 1–5 behavior dicts. Same shape as ``create_ai_agent``: each needs ``name``,
                     ``event_id``, and ``actionParams.aiBehaviorParams.actionsAttributes``.
                     Accepts both ``snake_case`` and ``camelCase`` keys.
                     Optional: ``template_params`` / ``placeholders`` and ``instruction_template``
                     (same interpolation as ``create_ai_agent``).
+                    Discover via: ``get_automation_events(pipe_id)`` and ``get_phase_fields(phase_id)``.
                 data_source_ids: Optional list of data source IDs.
             """
             await ctx.debug(
@@ -611,9 +617,12 @@ class AiAgentTools:
 
             Args:
                 pipe_id: Numeric pipe ID (used to fetch fields, phases, and relations).
+                    Discover via: ``search_pipes`` or ``get_organization``.
                 behaviors: 1–5 behavior dicts (same shape as ``create_ai_agent``). Each must
                     include ``name``, ``event_id`` (or ``eventId``), and ``actionParams`` with
                     ``aiBehaviorParams`` (``instruction`` + ``actionsAttributes``).
+                    Discover via: ``get_automation_events(pipe_id)`` for ``event_id`` and
+                    ``get_phase_fields(phase_id)`` for field references inside ``actionsAttributes``.
                 strict_unknown_action_types: When ``True`` (default), unknown ``actionType`` values
                     are reported in ``problems``. When ``False``, they appear in ``warnings`` only.
             """

--- a/src/pipefy_mcp/tools/ai_automation_tools.py
+++ b/src/pipefy_mcp/tools/ai_automation_tools.py
@@ -139,9 +139,13 @@ class AiAutomationTools:
 
             Args:
                 pipe_id: Pipe where the AI automation will run.
+                    Discover via: ``search_pipes`` or ``get_organization``.
                 prompt: AI prompt text with ``%{internal_id}`` field references.
+                    Discover via: ``get_phase_fields(phase_id)[].internal_id``.
                 field_ids: Output field internal IDs where the AI writes results.
+                    Discover via: ``get_phase_fields(phase_id)[].internal_id``.
                 event_id: Optional trigger event ID to validate (e.g. ``card_created``).
+                    Discover via: ``get_automation_events(pipe_id)``.
 
             Returns:
                 ``valid`` is True when no problems found. ``problems`` lists blocking
@@ -323,7 +327,13 @@ class AiAutomationTools:
             try:
                 raw = await client.get_automation(aid)
             except Exception as exc:  # noqa: BLE001
-                return await handle_automation_tool_graphql_error(exc, ctx, debug)
+                return await handle_automation_tool_graphql_error(
+                    exc,
+                    ctx,
+                    debug,
+                    resource_kind="ai_automation",
+                    resource_id=aid,
+                )
             message = (
                 "No automation found for the given ID."
                 if not raw
@@ -380,7 +390,13 @@ class AiAutomationTools:
                     pipe_id=pid,
                 )
             except Exception as exc:  # noqa: BLE001
-                return await handle_automation_tool_graphql_error(exc, ctx, debug)
+                return await handle_automation_tool_graphql_error(
+                    exc,
+                    ctx,
+                    debug,
+                    resource_kind="pipe",
+                    resource_id=pid,
+                )
             filtered = _filter_ai_automation_summaries(rows)
             return build_automation_read_success_payload(
                 filtered,
@@ -433,7 +449,13 @@ class AiAutomationTools:
             try:
                 raw = await client.delete_automation(rid)
             except Exception as exc:  # noqa: BLE001
-                return await handle_automation_tool_graphql_error(exc, ctx, debug)
+                return await handle_automation_tool_graphql_error(
+                    exc,
+                    ctx,
+                    debug,
+                    resource_kind="ai_automation",
+                    resource_id=rid,
+                )
             if not raw.get("success"):
                 return build_automation_error_payload(
                     message="Delete AI automation did not succeed.",
@@ -469,9 +491,13 @@ class AiAutomationTools:
             Args:
                 name: Automation name.
                 event_id: Event trigger (e.g. card_created, card_moved).
+                    Discover via: ``get_automation_events(pipe_id)``.
                 pipe_id: Pipe ID where the automation runs.
+                    Discover via: ``search_pipes`` or ``get_organization``.
                 prompt: AI prompt text. MUST reference at least one pipe field using %{internal_id} syntax (e.g. "Summarize the brief: %{425829426}"). Use the pipe's field internal_id values. Without a field reference the API rejects the request.
+                    Discover via: ``get_phase_fields(phase_id)[].internal_id`` for ``%{internal_id}`` tokens.
                 field_ids: List of field internal IDs where the AI writes its output.
+                    Discover via: ``get_phase_fields(phase_id)[].internal_id``.
                 skills_ids: AI skill IDs to attach. Defaults to empty (no skills).
                 event_params: Trigger-specific filters (e.g. {"to_phase_id": "..."} for card_moved, {"triggerFieldIds": [...]} for field_updated).
                 condition: Optional trigger condition dict. Omit to use the built-in placeholder (empty expression list) so Pipefy always receives a condition on create. Pass a dict to set a custom condition.
@@ -533,6 +559,7 @@ class AiAutomationTools:
 
             Args:
                 automation_id: ID of the automation to update.
+                    Discover via: ``get_ai_automations(repo_uuid)[].id``.
                 name: New automation name (optional).
                 active: Whether the automation is active (optional).
                 prompt: New AI prompt text (optional). Must use %{internal_id} syntax to reference pipe fields (e.g. "Classify %{425829426}").
@@ -563,8 +590,12 @@ class AiAutomationTools:
             try:
                 result = await client.update_ai_automation(validated)
             except Exception as exc:  # noqa: BLE001
-                return _ai_automation_api_failure_payload(
-                    exc, fallback=AI_AUTOMATION_UPDATE_FAILED, debug=debug
+                return await handle_automation_tool_graphql_error(
+                    exc,
+                    ctx,
+                    debug,
+                    resource_kind="ai_automation",
+                    resource_id=str(validated.automation_id),
                 )
 
             return build_update_automation_success(

--- a/src/pipefy_mcp/tools/automation_tool_helpers.py
+++ b/src/pipefy_mcp/tools/automation_tool_helpers.py
@@ -17,6 +17,8 @@ from pipefy_mcp.tools.graphql_error_helpers import (
     extract_error_strings,
     extract_graphql_correlation_id,
     extract_graphql_error_codes,
+    strip_internal_api_diagnostic_markers,
+    try_enrich_graphql_error,
     with_debug_suffix,
 )
 from pipefy_mcp.tools.tool_error_envelope import ToolErrorDetail, tool_error
@@ -128,22 +130,48 @@ async def handle_automation_tool_graphql_error(
     exc: BaseException,
     ctx: Context,
     debug: bool,
+    *,
+    resource_kind: str | None = None,
+    resource_id: str | None = None,
+    invalid_args_hint: str | None = None,
 ) -> AutomationToolErrorPayload:
     """Format ``exc`` as ``build_automation_error_payload``; optional MCP debug log.
+
+    Mirrors :func:`handle_tool_graphql_error` enrichment precedence so automation
+    tools surface the same discovery hints as other domains.
 
     Args:
         exc: Root exception from gql/httpx.
         ctx: MCP context for ``ctx.debug`` when ``debug`` is True.
         debug: Log raw exception and append codes / ``correlation_id`` to the message.
+        resource_kind: Optional canonical kind; opts into NOT_FOUND enrichment.
+        resource_id: Optional resource id; surfaced in the enriched message.
+        invalid_args_hint: Optional tool-specific hint for BAD_USER_INPUT errors.
     """
-    msgs = extract_error_strings(exc)
-    base = "; ".join(msgs) if msgs else "Automation request failed."
-    codes = extract_graphql_error_codes(exc)
-    first_code = codes[0] if codes else None
     if debug:
         await ctx.debug(f"automation GraphQL error: {exc!r}")
-        cid = extract_graphql_correlation_id(exc)
-        base = with_debug_suffix(base, debug=True, codes=codes, correlation_id=cid)
+
+    codes = extract_graphql_error_codes(exc)
+    first_code = codes[0] if codes else None
+    cid = extract_graphql_correlation_id(exc) if debug else None
+
+    enriched_result = try_enrich_graphql_error(
+        exc,
+        codes=codes,
+        debug=debug,
+        correlation_id=cid,
+        resource_kind=resource_kind,
+        resource_id=resource_id,
+        invalid_args_hint=invalid_args_hint,
+    )
+    if enriched_result is not None:
+        message, code = enriched_result
+        return build_automation_error_payload(message=message, code=code)
+
+    msgs = extract_error_strings(exc)
+    base = "; ".join(msgs) if msgs else "Automation request failed."
+    base = strip_internal_api_diagnostic_markers(base)
+    base = with_debug_suffix(base, debug=debug, codes=codes, correlation_id=cid)
     return build_automation_error_payload(message=base, code=first_code)
 
 

--- a/src/pipefy_mcp/tools/automation_tools.py
+++ b/src/pipefy_mcp/tools/automation_tools.py
@@ -76,7 +76,13 @@ class AutomationTools:
             try:
                 raw = await client.get_automation(aid)
             except Exception as exc:  # noqa: BLE001
-                return await handle_automation_tool_graphql_error(exc, ctx, False)
+                return await handle_automation_tool_graphql_error(
+                    exc,
+                    ctx,
+                    False,
+                    resource_kind="automation",
+                    resource_id=aid,
+                )
             message = (
                 "No automation found for the given ID."
                 if not raw
@@ -126,7 +132,13 @@ class AutomationTools:
                     pipe_id=pipe,
                 )
             except Exception as exc:  # noqa: BLE001
-                return await handle_automation_tool_graphql_error(exc, ctx, False)
+                return await handle_automation_tool_graphql_error(
+                    exc,
+                    ctx,
+                    False,
+                    resource_kind="pipe" if pipe else "organization",
+                    resource_id=pipe or org,
+                )
             return build_automation_read_success_payload(
                 rows,
                 "Automations listed.",
@@ -153,7 +165,13 @@ class AutomationTools:
             try:
                 rows = await client.get_automation_actions(pid)
             except Exception as exc:  # noqa: BLE001
-                return await handle_automation_tool_graphql_error(exc, ctx, False)
+                return await handle_automation_tool_graphql_error(
+                    exc,
+                    ctx,
+                    False,
+                    resource_kind="pipe",
+                    resource_id=pid,
+                )
             return build_automation_read_success_payload(
                 rows,
                 "Automation actions catalog retrieved.",
@@ -180,7 +198,13 @@ class AutomationTools:
             try:
                 rows = await client.get_automation_events(pid)
             except Exception as exc:  # noqa: BLE001
-                return await handle_automation_tool_graphql_error(exc, ctx, False)
+                return await handle_automation_tool_graphql_error(
+                    exc,
+                    ctx,
+                    False,
+                    resource_kind="pipe",
+                    resource_id=pid,
+                )
             return build_automation_read_success_payload(
                 rows,
                 "Automation events catalog retrieved.",
@@ -274,7 +298,13 @@ class AutomationTools:
                     extra_input=extra_input,
                 )
             except Exception as exc:  # noqa: BLE001
-                return await handle_automation_tool_graphql_error(exc, ctx, debug)
+                return await handle_automation_tool_graphql_error(
+                    exc,
+                    ctx,
+                    debug,
+                    resource_kind="pipe",
+                    resource_id=pid,
+                )
             sim_row = result["automation_simulation"]
             if not isinstance(sim_row, dict):
                 sim_row = {}
@@ -372,7 +402,11 @@ class AutomationTools:
                     )
                     if perm_msg:
                         base = await handle_automation_tool_graphql_error(
-                            exc, ctx, debug
+                            exc,
+                            ctx,
+                            debug,
+                            resource_kind="pipe",
+                            resource_id=pid,
                         )
                         prev = tool_error_message(base)
                         err_body = base.get("error")
@@ -381,7 +415,13 @@ class AutomationTools:
                             message=f"{perm_msg}\n{prev}",
                             code=c if isinstance(c, str) else None,
                         )
-                return await handle_automation_tool_graphql_error(exc, ctx, debug)
+                return await handle_automation_tool_graphql_error(
+                    exc,
+                    ctx,
+                    debug,
+                    resource_kind="pipe",
+                    resource_id=pid,
+                )
             block = raw.get("createAutomation") or {}
             automation = block.get("automation") or {}
             if not isinstance(automation, dict):
@@ -466,7 +506,13 @@ class AutomationTools:
                     extra_input=extra_input,
                 )
             except Exception as exc:  # noqa: BLE001
-                return await handle_automation_tool_graphql_error(exc, ctx, False)
+                return await handle_automation_tool_graphql_error(
+                    exc,
+                    ctx,
+                    False,
+                    resource_kind="pipe",
+                    resource_id=str(validated.pipe_id),
+                )
             block = raw.get("createAutomation") or {}
             automation = block.get("automation") or {}
             if not isinstance(automation, dict):
@@ -506,7 +552,13 @@ class AutomationTools:
                     extra_input=extra_input,
                 )
             except Exception as exc:  # noqa: BLE001
-                return await handle_automation_tool_graphql_error(exc, ctx, debug)
+                return await handle_automation_tool_graphql_error(
+                    exc,
+                    ctx,
+                    debug,
+                    resource_kind="automation",
+                    resource_id=rid,
+                )
             block = raw.get("updateAutomation") or {}
             automation = block.get("automation") or {}
             if not isinstance(automation, dict):
@@ -548,7 +600,13 @@ class AutomationTools:
             try:
                 raw = await client.delete_automation(rid)
             except Exception as exc:  # noqa: BLE001
-                return await handle_automation_tool_graphql_error(exc, ctx, debug)
+                return await handle_automation_tool_graphql_error(
+                    exc,
+                    ctx,
+                    debug,
+                    resource_kind="automation",
+                    resource_id=rid,
+                )
             if not raw.get("success"):
                 return build_automation_error_payload(
                     message="Delete automation did not succeed.",

--- a/src/pipefy_mcp/tools/field_condition_tools.py
+++ b/src/pipefy_mcp/tools/field_condition_tools.py
@@ -81,7 +81,11 @@ class FieldConditionTools:
                 raw = await client.get_field_conditions(phase_id_str)
             except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
-                    exc, "List field conditions failed.", debug=debug
+                    exc,
+                    "List field conditions failed.",
+                    debug=debug,
+                    resource_kind="phase",
+                    resource_id=phase_id_str,
                 )
 
             phase = raw.get("phase")
@@ -129,7 +133,11 @@ class FieldConditionTools:
                 raw = await client.get_field_condition(cid)
             except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
-                    exc, "Get field condition failed.", debug=debug
+                    exc,
+                    "Get field condition failed.",
+                    debug=debug,
+                    resource_kind="field_condition",
+                    resource_id=cid,
                 )
 
             fc = raw.get("fieldCondition")
@@ -196,12 +204,15 @@ class FieldConditionTools:
             Args:
                 ctx: MCP context for debug logging.
                 phase_id: Phase ID that owns the condition (``phaseId`` on the API input).
+                    Discover via: ``get_pipe(pipe_id)`` then inspect ``phases[].id``.
                 condition: ``ConditionInput`` dict. Must include ``expressions`` (list of expression
                     objects with ``structure_id``, ``field_address``, ``operation``, ``value``) and
                     ``expressions_structure`` (array of arrays of string indices).
+                    Discover via: ``get_phase_fields(phase_id)[].internal_id`` for ``field_address``.
                 actions: List of ``FieldConditionActionInput`` dicts; use ``phaseFieldId`` (often the
                     field's ``internal_id`` from ``get_phase_fields``). Each action must include
                     ``actionId`` (``hide`` or ``show``); legacy ``hidden`` is mapped to ``hide``.
+                    Discover via: ``get_phase_fields(phase_id)[].internal_id`` for ``phaseFieldId``.
                 name: Rule display name. Required by the API; may also be provided via
                     ``extra_input={"name": ...}`` for back-compat.
                 extra_input: Optional extra keys for ``createFieldConditionInput`` (e.g. ``index``).
@@ -216,10 +227,12 @@ class FieldConditionTools:
             if not isinstance(condition, dict):
                 return build_pipe_tool_error_payload(
                     message="Invalid 'condition': provide an object/dict.",
+                    code="INVALID_ARGUMENTS",
                 )
             if not condition:
                 return build_pipe_tool_error_payload(
                     message="Invalid 'condition': provide a non-empty object (e.g. expressions).",
+                    code="INVALID_ARGUMENTS",
                 )
             expressions = condition.get("expressions")
             if isinstance(expressions, list) and len(expressions) == 0:
@@ -228,14 +241,18 @@ class FieldConditionTools:
                         "Invalid 'condition': 'expressions' must not be empty; "
                         "provide at least one expression."
                     ),
+                    code="INVALID_ARGUMENTS",
                 )
             if extra_input is not None and not isinstance(extra_input, dict):
                 return build_pipe_tool_error_payload(
                     message="Invalid 'extra_input': provide an object/dict or omit.",
+                    code="INVALID_ARGUMENTS",
                 )
             act_err = field_condition_actions_error_message(actions)
             if act_err:
-                return build_pipe_tool_error_payload(message=act_err)
+                return build_pipe_tool_error_payload(
+                    message=act_err, code="INVALID_ARGUMENTS"
+                )
             merged: dict[str, Any] = {
                 k: v
                 for k, v in (extra_input or {}).items()
@@ -245,6 +262,7 @@ class FieldConditionTools:
                 if not isinstance(name, str) or not name.strip():
                     return build_pipe_tool_error_payload(
                         message="Invalid 'name': provide a non-empty string or omit.",
+                        code="INVALID_ARGUMENTS",
                     )
                 merged["name"] = name
             if not merged.get("name"):
@@ -253,6 +271,7 @@ class FieldConditionTools:
                         "Missing 'name': Pipefy requires a rule name. Pass 'name' as a "
                         "top-level argument (or inside 'extra_input')."
                     ),
+                    code="INVALID_ARGUMENTS",
                 )
             condition_for_api = strip_expression_ids_for_create(condition)
             actions_for_api = normalize_field_condition_actions(actions)
@@ -265,7 +284,15 @@ class FieldConditionTools:
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
-                    exc, "Create field condition failed.", debug=debug
+                    exc,
+                    "Create field condition failed.",
+                    debug=debug,
+                    resource_kind="phase",
+                    resource_id=pid,
+                    invalid_args_hint=(
+                        "Use 'get_phase_fields' to list valid 'internal_id' values for "
+                        "'field_address' / 'phaseFieldId'."
+                    ),
                 )
             fc = raw.get("createFieldCondition", {}).get("fieldCondition") or {}
             cid = fc.get("id")
@@ -274,6 +301,7 @@ class FieldConditionTools:
                     message=(
                         "Create field condition succeeded but no condition id was returned."
                     ),
+                    code="INVALID_ARGUMENTS",
                 )
             return build_field_condition_success_payload(str(cid), "created")
 
@@ -302,8 +330,11 @@ class FieldConditionTools:
             Args:
                 ctx: MCP context for debug logging.
                 condition_id: Field condition ID to update.
+                    Discover via: ``get_field_conditions(phase_id)[].id``.
                 condition: Optional ``ConditionInput`` dict (same as create).
+                    Discover via: ``get_phase_fields(phase_id)[].internal_id`` for ``field_address``.
                 actions: Optional list of ``FieldConditionActionInput`` dicts (same as create).
+                    Discover via: ``get_phase_fields(phase_id)[].internal_id`` for ``phaseFieldId``.
                 name: Optional new rule name.
                 extra_input: Additional fields to merge into ``UpdateFieldConditionInput``.
                 debug: When True, append GraphQL codes and correlation_id to errors.
@@ -317,10 +348,12 @@ class FieldConditionTools:
             if extra_input is not None and not isinstance(extra_input, dict):
                 return build_pipe_tool_error_payload(
                     message="Invalid 'extra_input': provide an object/dict or omit.",
+                    code="INVALID_ARGUMENTS",
                 )
             if condition is not None and not isinstance(condition, dict):
                 return build_pipe_tool_error_payload(
                     message="Invalid 'condition': provide an object/dict or omit.",
+                    code="INVALID_ARGUMENTS",
                 )
             if condition is not None:
                 expressions = condition.get("expressions")
@@ -330,11 +363,14 @@ class FieldConditionTools:
                             "Invalid 'condition': 'expressions' must not be empty; "
                             "provide at least one expression."
                         ),
+                        code="INVALID_ARGUMENTS",
                     )
             if actions is not None:
                 act_err = field_condition_actions_error_message(actions)
                 if act_err:
-                    return build_pipe_tool_error_payload(message=act_err)
+                    return build_pipe_tool_error_payload(
+                        message=act_err, code="INVALID_ARGUMENTS"
+                    )
 
             update_attrs: dict[str, Any] = {
                 k: v
@@ -345,6 +381,7 @@ class FieldConditionTools:
                 if not isinstance(name, str) or not name.strip():
                     return build_pipe_tool_error_payload(
                         message="Invalid 'name': provide a non-empty string or omit.",
+                        code="INVALID_ARGUMENTS",
                     )
                 update_attrs["name"] = name
             if condition is not None:
@@ -357,12 +394,21 @@ class FieldConditionTools:
                         "Provide at least one of: 'condition', 'actions', or a non-empty "
                         "'extra_input' to update."
                     ),
+                    code="INVALID_ARGUMENTS",
                 )
             try:
                 raw = await client.update_field_condition(cid_str, **update_attrs)
             except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
-                    exc, "Update field condition failed.", debug=debug
+                    exc,
+                    "Update field condition failed.",
+                    debug=debug,
+                    resource_kind="field_condition",
+                    resource_id=cid_str,
+                    invalid_args_hint=(
+                        "Use 'get_phase_fields' to list valid 'internal_id' values for "
+                        "'field_address' / 'phaseFieldId'."
+                    ),
                 )
             fc = raw.get("updateFieldCondition", {}).get("fieldCondition") or {}
             out_id = fc.get("id")
@@ -371,6 +417,7 @@ class FieldConditionTools:
                     message=(
                         "Update field condition succeeded but no condition id was returned."
                     ),
+                    code="INVALID_ARGUMENTS",
                 )
             return build_field_condition_success_payload(str(out_id), "updated")
 
@@ -417,7 +464,11 @@ class FieldConditionTools:
                 raw = await client.delete_field_condition(cid_str)
             except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
-                    exc, "Delete field condition failed.", debug=debug
+                    exc,
+                    "Delete field condition failed.",
+                    debug=debug,
+                    resource_kind="field_condition",
+                    resource_id=cid_str,
                 )
             ok = bool(raw.get("success"))
             return build_field_condition_delete_payload(ok)

--- a/src/pipefy_mcp/tools/graphql_error_helpers.py
+++ b/src/pipefy_mcp/tools/graphql_error_helpers.py
@@ -1,4 +1,28 @@
-"""Shared GraphQL / transport error extraction for MCP tool payloads."""
+"""Shared GraphQL / transport error extraction for MCP tool payloads.
+
+**Enrichment precedence** (4 tiers, most specific first):
+
+1. :func:`enrich_permission_denied_error` — opt-in *at the call site*, runs
+   **before** :func:`handle_tool_graphql_error`. Requires a ``PipefyClient``
+   because it performs follow-up membership lookups.
+2. :func:`enrich_not_found_error` — invoked *inside*
+   :func:`handle_tool_graphql_error` when the caller passes ``resource_kind``.
+   Rewrites the message to name the missing resource and point at the
+   appropriate discovery tool (see :data:`_DISCOVERY_HINTS`).
+3. :func:`enrich_invalid_arguments_error` — also invoked *inside* the handler
+   when the caller passes ``resource_kind`` or ``invalid_args_hint``. Appends a
+   hint clarifying how to discover valid argument values.
+4. :func:`enrich_ambiguous_access_error` — invoked *inside* the handler when
+   ``resource_kind`` is set and the error code is ``PERMISSION_DENIED``. Covers
+   the Pipefy API quirk where a nonexistent ID returns ``PERMISSION_DENIED``
+   (indistinguishable from a real access denial without a membership lookup).
+
+Tiers 2–4 run inside :func:`handle_tool_graphql_error` via the shared
+:func:`try_enrich_graphql_error` helper. When no enricher matches (or when the
+caller does not opt in), the handler falls through to the **legacy path**:
+concatenate extracted error strings and return the bare message, preserving
+zero-regression behavior for call sites that have not been migrated yet.
+"""
 
 from __future__ import annotations
 
@@ -116,6 +140,7 @@ def extract_graphql_error_codes(exc: BaseException) -> list[str]:
     if raw:
         for match in re.findall(r"""['"]code['"]\s*[:=]\s*['"]([A-Z_]+)['"]""", raw):
             codes.append(match)
+        codes.extend(extract_internal_api_bracket_codes(raw))
 
     seen: set[str] = set()
     unique: list[str] = []
@@ -135,7 +160,7 @@ def extract_graphql_correlation_id(exc: BaseException) -> str | None:
     match = re.search(r"""['"]correlation_id['"]\s*[:=]\s*['"]([^'"]+)['"]""", raw)
     if match:
         return match.group(1)
-    return None
+    return extract_internal_api_bracket_correlation_id(raw)
 
 
 def with_debug_suffix(
@@ -156,30 +181,301 @@ def with_debug_suffix(
     return f"{message} (debug: {'; '.join(parts)})"
 
 
+_PERMISSION_DENIED_CODE = "PERMISSION_DENIED"
+_NOT_FOUND_CODES = frozenset({"NOT_FOUND", "RESOURCE_NOT_FOUND"})
+_INVALID_ARGUMENT_CODES = frozenset({"INVALID_ARGUMENTS", "BAD_USER_INPUT"})
+_NOT_FOUND_STRING_MARKERS = ("not found", "does not exist", "doesn't exist")
+_GENERIC_NOT_FOUND_HINT = "Verify the ID and try again."
+_GENERIC_INVALID_ARGS_HINT = "Check the tool's docstring for required field shapes."
+
+# Per-resource discovery hints for NOT_FOUND / ambiguous access messages.
+_DISCOVERY_HINTS: dict[str, str] = {
+    "pipe": "Use 'search_pipes' or 'get_organization' to list accessible pipes.",
+    "card": "Use 'find_cards' or 'get_cards' to list cards in a pipe.",
+    "phase": "Use 'get_pipe' to list phases in a pipe.",
+    "phase_field": "Use 'get_phase_fields' to list fields of a phase.",
+    "table": "Use 'search_tables' to find tables.",
+    "table_record": "Use 'find_records' to find table records.",
+    "table_field": "Use 'get_table' to list fields of a table.",
+    "field_condition": "Use 'get_field_conditions' to list conditions of a phase.",
+    "ai_agent": "Use 'get_ai_agents' to list AI agents of a repo.",
+    "ai_agent_log": "Use 'get_ai_agent_logs' to list agent execution logs for a repo.",
+    "ai_automation": "Use 'get_ai_automations' to list AI automations.",
+    "automation": "Use 'get_automations' to list automations.",
+    "label": "Use 'get_labels' to list labels in a pipe.",
+    "webhook": "Use 'get_webhooks' to list webhooks of a pipe.",
+    "organization": "Use 'get_organization' to verify the organization ID.",
+    "organization_report": "Use 'get_organization_reports' to list organization reports.",
+    "pipe_report": "Use 'get_pipe_reports' to list reports of a pipe.",
+    "member": "Use 'get_pipe_members' to list current members of a pipe.",
+    "comment": "Use 'get_card' to list comments on a card.",
+    "email_template": "Use 'get_email_templates' to list available templates.",
+}
+
+# Pipe-scoped kinds: ambiguous PERMISSION_DENIED messages add get_pipe_members.
+_PIPE_CENTRIC_KINDS: frozenset[str] = frozenset(
+    {
+        "pipe",
+        "phase",
+        "phase_field",
+        "card",
+        "label",
+        "pipe_report",
+        "pipe_relation",
+        "field_condition",
+        "start_form_field",
+    }
+)
+
+
+def _humanize_resource_kind(kind: str) -> str:
+    """Render a snake_case resource kind for user-visible messages.
+
+    ``"pipe"`` -> ``"Pipe"``; ``"table_record"`` -> ``"Table record"``.
+    """
+    if not kind:
+        return kind
+    humanized = kind.replace("_", " ")
+    return humanized[:1].upper() + humanized[1:]
+
+
+def _looks_like_not_found(exc: BaseException, codes: list[str]) -> bool:
+    """Detect NOT_FOUND either via structured code or low-signal text marker."""
+    if any(code in _NOT_FOUND_CODES for code in codes):
+        return True
+    haystack = " ".join(extract_error_strings(exc)).lower()
+    return any(marker in haystack for marker in _NOT_FOUND_STRING_MARKERS)
+
+
+def enrich_not_found_error(
+    exc: BaseException,
+    *,
+    resource_kind: str,
+    resource_id: str | None = None,
+) -> str | None:
+    """Return an enriched message for NOT_FOUND errors, or ``None`` when inapplicable.
+
+    Recognizes both structured GraphQL codes (``NOT_FOUND`` /
+    ``RESOURCE_NOT_FOUND``) and raw-text markers (``"not found"``,
+    ``"does not exist"``). For unknown resource kinds the hint falls back to a
+    generic "Verify the ID and try again." line so the response is still
+    actionable.
+
+    Args:
+        exc: Root exception from gql/httpx.
+        resource_kind: Canonical kind (e.g. ``"pipe"``, ``"card"``,
+            ``"phase_field"``). Used both as discovery-hint key and as the
+            user-facing label in the rendered message.
+        resource_id: Target resource identifier; omitted from the message
+            when ``None``.
+    """
+    codes = extract_graphql_error_codes(exc)
+    if not _looks_like_not_found(exc, codes):
+        return None
+
+    discovery_hint = _DISCOVERY_HINTS.get(resource_kind, _GENERIC_NOT_FOUND_HINT)
+    label = _humanize_resource_kind(resource_kind)
+    if resource_id:
+        return f"{label} not found (ID: {resource_id}). {discovery_hint}"
+    return f"{label} not found. {discovery_hint}"
+
+
+def enrich_invalid_arguments_error(
+    exc: BaseException,
+    *,
+    hint: str | None = None,
+) -> str | None:
+    """Append a hint to BAD_USER_INPUT / INVALID_ARGUMENTS messages, or ``None``.
+
+    Args:
+        exc: Root exception from gql/httpx.
+        hint: Tool-specific guidance (e.g. "Use 'get_phase_fields' to list
+            valid field IDs."). When ``None`` a generic docstring-reference
+            hint is used.
+    """
+    codes = extract_graphql_error_codes(exc)
+    if not any(code in _INVALID_ARGUMENT_CODES for code in codes):
+        return None
+
+    msgs = extract_error_strings(exc)
+    base = "; ".join(msgs) if msgs else "Invalid arguments."
+    appended = hint or _GENERIC_INVALID_ARGS_HINT
+    return f"{base} Hint: {appended}"
+
+
+def enrich_ambiguous_access_error(
+    exc: BaseException,
+    *,
+    resource_kind: str,
+    resource_id: str | None = None,
+) -> str | None:
+    """Rewrite PERMISSION_DENIED to an ambiguity-hint message when appropriate.
+
+    Pipefy's GraphQL API returns ``PERMISSION_DENIED`` both for resources the
+    service account cannot access AND for resources that do not exist — a
+    common security-conscious pattern to prevent resource enumeration. From
+    the caller's perspective the two are indistinguishable, and the raw
+    "Permission denied" string gives an agent no actionable next step.
+
+    When a call site opts in by passing ``resource_kind``, this enricher
+    produces a dual-meaning message that points at BOTH the discovery tool
+    (in case the ID is wrong) AND the membership-verification path (in case
+    access is the actual issue). Returns ``None`` when the code is not
+    ``PERMISSION_DENIED`` so other enrichers get a turn.
+
+    Distinct from :func:`enrich_permission_denied_error` — that async helper
+    runs *before* :func:`handle_tool_graphql_error` at specific cross-pipe
+    write call sites (``create_card``, ``create_automation``, etc.) with a
+    ``PipefyClient`` and performs real membership lookups. This helper is the
+    synchronous fallback for **read** tools where we have no client context
+    to verify membership; it honors the existing pre-handler enrichment by
+    returning ``None`` unless its own predicate matches.
+
+    Args:
+        exc: Root exception from gql/httpx.
+        resource_kind: Canonical kind (e.g. ``"pipe"``, ``"webhook"``).
+        resource_id: Target resource identifier; omitted from the message
+            when ``None``.
+    """
+    codes = extract_graphql_error_codes(exc)
+    if _PERMISSION_DENIED_CODE not in codes:
+        return None
+
+    discovery_hint = _DISCOVERY_HINTS.get(resource_kind, _GENERIC_NOT_FOUND_HINT)
+    label = _humanize_resource_kind(resource_kind)
+    id_clause = f" (ID: {resource_id})" if resource_id else ""
+    base = (
+        f"Cannot access {label.lower()}{id_clause}. The ID may not exist OR "
+        f"the service account may lack access. {discovery_hint}"
+    )
+    if resource_kind in _PIPE_CENTRIC_KINDS:
+        base += " If the resource is listed, verify membership with 'get_pipe_members'."
+    return base
+
+
+def try_enrich_graphql_error(
+    exc: BaseException,
+    *,
+    codes: list[str],
+    debug: bool,
+    correlation_id: str | None,
+    resource_kind: str | None,
+    resource_id: str | None,
+    invalid_args_hint: str | None,
+) -> tuple[str, str] | None:
+    """Run enrichment tiers. Returns ``(message, code)`` or ``None``.
+
+    Shared by :func:`handle_tool_graphql_error` and
+    ``handle_automation_tool_graphql_error`` so the 3-tier precedence lives in
+    one place. Callers pass pre-extracted ``codes`` and ``correlation_id`` so
+    the expensive extraction is not repeated.
+
+    Args:
+        exc: Root exception from gql/httpx.
+        codes: GraphQL error codes extracted from ``exc``.
+        debug: When True, append codes and ``correlation_id`` to messages.
+        correlation_id: Pre-extracted correlation id; appended when ``debug`` is True.
+        resource_kind: Optional canonical kind; opts into NOT_FOUND enrichment.
+        resource_id: Optional resource id; surfaced in the enriched message.
+        invalid_args_hint: Optional tool-specific hint for BAD_USER_INPUT errors.
+    """
+    first_code = codes[0] if codes else None
+    enrichment_opted_in = resource_kind is not None or invalid_args_hint is not None
+    if not enrichment_opted_in:
+        return None
+
+    if resource_kind is not None:
+        enriched = enrich_not_found_error(
+            exc, resource_kind=resource_kind, resource_id=resource_id
+        )
+        if enriched is not None:
+            message = with_debug_suffix(
+                enriched, debug=debug, codes=codes, correlation_id=correlation_id
+            )
+            return message, first_code or "NOT_FOUND"
+
+    enriched = enrich_invalid_arguments_error(exc, hint=invalid_args_hint)
+    if enriched is not None:
+        message = with_debug_suffix(
+            enriched, debug=debug, codes=codes, correlation_id=correlation_id
+        )
+        return message, first_code or "INVALID_ARGUMENTS"
+
+    if resource_kind is not None:
+        enriched = enrich_ambiguous_access_error(
+            exc, resource_kind=resource_kind, resource_id=resource_id
+        )
+        if enriched is not None:
+            message = with_debug_suffix(
+                enriched, debug=debug, codes=codes, correlation_id=correlation_id
+            )
+            return message, first_code or _PERMISSION_DENIED_CODE
+
+    return None
+
+
 def handle_tool_graphql_error(
     exc: BaseException,
     fallback_msg: str,
     *,
     debug: bool = False,
+    resource_kind: str | None = None,
+    resource_id: str | None = None,
+    invalid_args_hint: str | None = None,
 ) -> dict[str, Any]:
     """Turn transport/GraphQL failures into a structured :func:`tool_error` payload.
+
+    **Enrichment is opt-in.** When neither ``resource_kind`` nor
+    ``invalid_args_hint`` is passed, behavior is identical to the pre-Wave-2
+    path: concatenate ``extract_error_strings`` (or ``fallback_msg`` if empty),
+    optionally append a debug suffix, and emit the envelope.
+
+    When opted-in, the handler tries (in order):
+
+    * :func:`enrich_not_found_error` with ``resource_kind``/``resource_id``;
+    * :func:`enrich_invalid_arguments_error` with ``invalid_args_hint``;
+    * :func:`enrich_ambiguous_access_error` with ``resource_kind``/
+      ``resource_id`` — covers the Pipefy API case where a nonexistent ID
+      returns ``PERMISSION_DENIED`` (indistinguishable from a real
+      access-denied). Only fires when ``resource_kind`` was passed.
+    * the legacy path, so unrelated codes (e.g. timeouts) still reach clients
+      with the original message.
+
+    Call sites that own PERMISSION_DENIED handling should keep invoking
+    :func:`enrich_permission_denied_error` *before* this function — it runs at
+    a different layer (needs the Pipefy client for membership lookups).
 
     Args:
         exc: Root exception from gql/httpx.
         fallback_msg: Used when ``extract_error_strings`` is empty.
         debug: When True, append codes and ``correlation_id`` to the message.
+        resource_kind: Optional canonical kind; opts this call site into
+            NOT_FOUND enrichment.
+        resource_id: Optional resource id; surfaced in the enriched message.
+        invalid_args_hint: Optional tool-specific hint for BAD_USER_INPUT
+            errors; opts this call site into invalid-arguments enrichment.
     """
-    msgs = extract_error_strings(exc)
-    base = "; ".join(msgs) if msgs else fallback_msg
     codes = extract_graphql_error_codes(exc)
     first_code = codes[0] if codes else None
-    if debug:
-        cid = extract_graphql_correlation_id(exc)
-        base = with_debug_suffix(base, debug=True, codes=codes, correlation_id=cid)
+    cid = extract_graphql_correlation_id(exc) if debug else None
+
+    enriched_result = try_enrich_graphql_error(
+        exc,
+        codes=codes,
+        debug=debug,
+        correlation_id=cid,
+        resource_kind=resource_kind,
+        resource_id=resource_id,
+        invalid_args_hint=invalid_args_hint,
+    )
+    if enriched_result is not None:
+        message, code = enriched_result
+        return tool_error(message, code=code)
+
+    msgs = extract_error_strings(exc)
+    base = "; ".join(msgs) if msgs else fallback_msg
+    base = with_debug_suffix(base, debug=debug, codes=codes, correlation_id=cid)
     return tool_error(base, code=first_code)
-
-
-_PERMISSION_DENIED_CODE = "PERMISSION_DENIED"
 
 
 async def enrich_permission_denied_error(
@@ -258,6 +554,9 @@ async def enrich_permission_denied_error(
 
 
 __all__ = [
+    "enrich_ambiguous_access_error",
+    "enrich_invalid_arguments_error",
+    "enrich_not_found_error",
     "enrich_permission_denied_error",
     "extract_error_strings",
     "extract_graphql_correlation_id",
@@ -266,5 +565,6 @@ __all__ = [
     "extract_internal_api_bracket_correlation_id",
     "handle_tool_graphql_error",
     "strip_internal_api_diagnostic_markers",
+    "try_enrich_graphql_error",
     "with_debug_suffix",
 ]

--- a/src/pipefy_mcp/tools/member_tool_helpers.py
+++ b/src/pipefy_mcp/tools/member_tool_helpers.py
@@ -59,9 +59,19 @@ def handle_member_tool_graphql_error(
     fallback_msg: str,
     *,
     debug: bool = False,
+    resource_kind: str | None = None,
+    resource_id: str | None = None,
+    invalid_args_hint: str | None = None,
 ) -> dict[str, Any]:
-    """Delegate to :func:`handle_tool_graphql_error`."""
-    return handle_tool_graphql_error(exc, fallback_msg, debug=debug)
+    """Delegate to :func:`handle_tool_graphql_error` with enrichment opt-ins."""
+    return handle_tool_graphql_error(
+        exc,
+        fallback_msg,
+        debug=debug,
+        resource_kind=resource_kind,
+        resource_id=resource_id,
+        invalid_args_hint=invalid_args_hint,
+    )
 
 
 __all__ = [

--- a/src/pipefy_mcp/tools/member_tools.py
+++ b/src/pipefy_mcp/tools/member_tools.py
@@ -62,7 +62,11 @@ class MemberTools:
                 raw = await client.invite_members(pipe_id, members)
             except Exception as exc:  # noqa: BLE001
                 return handle_member_tool_graphql_error(
-                    exc, "Invite members failed.", debug=debug
+                    exc,
+                    "Invite members failed.",
+                    debug=debug,
+                    resource_kind="pipe",
+                    resource_id=str(pipe_id),
                 )
             return build_member_success_payload(
                 message="Members invited.",
@@ -151,7 +155,12 @@ class MemberTools:
                     f"remove_member_from_pipe: mutation failed: {type(exc).__name__}: {exc}"
                 )
                 return handle_member_tool_graphql_error(
-                    exc, "Remove members from pipe failed.", debug=debug
+                    exc,
+                    "Remove members from pipe failed.",
+                    debug=debug,
+                    resource_kind="pipe",
+                    resource_id=str(pipe_id),
+                    invalid_args_hint="Use 'get_pipe_members(pipe_id)' to list current members.",
                 )
 
             await ctx.debug(
@@ -199,7 +208,11 @@ class MemberTools:
                 raw = await client.set_role(pipe_id, member_id, role_name.strip())
             except Exception as exc:  # noqa: BLE001
                 return handle_member_tool_graphql_error(
-                    exc, "Set role failed.", debug=debug
+                    exc,
+                    "Set role failed.",
+                    debug=debug,
+                    resource_kind="pipe",
+                    resource_id=str(pipe_id),
                 )
             warning: str | None = None
             protected_ids = settings.pipefy.service_account_ids

--- a/src/pipefy_mcp/tools/observability_tool_helpers.py
+++ b/src/pipefy_mcp/tools/observability_tool_helpers.py
@@ -76,9 +76,19 @@ def handle_observability_tool_graphql_error(
     fallback_msg: str,
     *,
     debug: bool = False,
+    resource_kind: str | None = None,
+    resource_id: str | None = None,
+    invalid_args_hint: str | None = None,
 ) -> dict[str, Any]:
-    """Delegate to :func:`handle_tool_graphql_error`."""
-    return handle_tool_graphql_error(exc, fallback_msg, debug=debug)
+    """Delegate to :func:`handle_tool_graphql_error` with enrichment opt-ins."""
+    return handle_tool_graphql_error(
+        exc,
+        fallback_msg,
+        debug=debug,
+        resource_kind=resource_kind,
+        resource_id=resource_id,
+        invalid_args_hint=invalid_args_hint,
+    )
 
 
 __all__ = [

--- a/src/pipefy_mcp/tools/observability_tools.py
+++ b/src/pipefy_mcp/tools/observability_tools.py
@@ -98,7 +98,11 @@ class ObservabilityTools:
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_observability_tool_graphql_error(
-                    exc, "Get AI agent logs failed.", debug=debug
+                    exc,
+                    "Get AI agent logs failed.",
+                    debug=debug,
+                    resource_kind="pipe",
+                    resource_id=repo_uuid,
                 )
             return build_observability_read_success_payload(
                 raw, message="AI agent logs retrieved."
@@ -128,7 +132,11 @@ class ObservabilityTools:
                 if rewritten is not None:
                     return build_observability_error_payload(message=rewritten)
                 return handle_observability_tool_graphql_error(
-                    exc, "Get AI agent log details failed.", debug=debug
+                    exc,
+                    "Get AI agent log details failed.",
+                    debug=debug,
+                    resource_kind="ai_agent_log",
+                    resource_id=log_uuid,
                 )
             return build_observability_read_success_payload(
                 raw, message="AI agent log details retrieved."
@@ -173,7 +181,11 @@ class ObservabilityTools:
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_observability_tool_graphql_error(
-                    exc, "Get automation logs failed.", debug=debug
+                    exc,
+                    "Get automation logs failed.",
+                    debug=debug,
+                    resource_kind="automation",
+                    resource_id=str(automation_id),
                 )
             return build_observability_read_success_payload(
                 raw, message="Automation logs retrieved."
@@ -218,7 +230,11 @@ class ObservabilityTools:
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_observability_tool_graphql_error(
-                    exc, "Get automation logs by repo failed.", debug=debug
+                    exc,
+                    "Get automation logs by repo failed.",
+                    debug=debug,
+                    resource_kind="pipe",
+                    resource_id=str(repo_id),
                 )
             return build_observability_read_success_payload(
                 raw, message="Automation logs by repo retrieved."
@@ -266,7 +282,11 @@ class ObservabilityTools:
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_observability_tool_graphql_error(
-                    exc, "Get agents usage failed.", debug=debug
+                    exc,
+                    "Get agents usage failed.",
+                    debug=debug,
+                    resource_kind="organization",
+                    resource_id=str(organization_uuid),
                 )
             return build_observability_read_success_payload(
                 raw, message="Agents usage retrieved."
@@ -314,7 +334,11 @@ class ObservabilityTools:
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_observability_tool_graphql_error(
-                    exc, "Get automations usage failed.", debug=debug
+                    exc,
+                    "Get automations usage failed.",
+                    debug=debug,
+                    resource_kind="organization",
+                    resource_id=str(organization_uuid),
                 )
             return build_observability_read_success_payload(
                 raw, message="Automations usage retrieved."
@@ -351,7 +375,11 @@ class ObservabilityTools:
                 return build_observability_error_payload(message=str(exc))
             except Exception as exc:  # noqa: BLE001
                 return handle_observability_tool_graphql_error(
-                    exc, "Get AI credit usage failed.", debug=debug
+                    exc,
+                    "Get AI credit usage failed.",
+                    debug=debug,
+                    resource_kind="organization",
+                    resource_id=str(organization_uuid),
                 )
             return build_observability_read_success_payload(
                 raw, message="AI credit usage retrieved."
@@ -383,7 +411,11 @@ class ObservabilityTools:
                 raw = await client.export_automation_jobs(organization_id, period)
             except Exception as exc:  # noqa: BLE001
                 return handle_observability_tool_graphql_error(
-                    exc, "Export automation jobs failed.", debug=debug
+                    exc,
+                    "Export automation jobs failed.",
+                    debug=debug,
+                    resource_kind="organization",
+                    resource_id=str(organization_id),
                 )
             return build_observability_mutation_success_payload(
                 message="Automation jobs export triggered.",
@@ -411,7 +443,11 @@ class ObservabilityTools:
                 raw = await client.get_automation_jobs_export(export_id)
             except Exception as exc:  # noqa: BLE001
                 return handle_observability_tool_graphql_error(
-                    exc, "Get automation jobs export failed.", debug=debug
+                    exc,
+                    "Get automation jobs export failed.",
+                    debug=debug,
+                    resource_kind="automation",
+                    resource_id=str(export_id),
                 )
             return build_observability_read_success_payload(
                 raw, message="Automation jobs export retrieved."
@@ -471,6 +507,8 @@ class ObservabilityTools:
                     exc,
                     "Get automation jobs export as CSV failed.",
                     debug=debug,
+                    resource_kind="automation",
+                    resource_id=str(export_id),
                 )
             return build_observability_read_success_payload(
                 raw, message="Automation jobs export converted to CSV (first sheet)."

--- a/src/pipefy_mcp/tools/pipe_config_tool_helpers.py
+++ b/src/pipefy_mcp/tools/pipe_config_tool_helpers.py
@@ -72,9 +72,19 @@ def handle_pipe_config_tool_graphql_error(
     fallback_msg: str,
     *,
     debug: bool = False,
+    resource_kind: str | None = None,
+    resource_id: str | None = None,
+    invalid_args_hint: str | None = None,
 ) -> dict[str, Any]:
-    """Delegate to :func:`handle_tool_graphql_error`."""
-    return handle_tool_graphql_error(exc, fallback_msg, debug=debug)
+    """Delegate to :func:`handle_tool_graphql_error` with enrichment opt-ins."""
+    return handle_tool_graphql_error(
+        exc,
+        fallback_msg,
+        debug=debug,
+        resource_kind=resource_kind,
+        resource_id=resource_id,
+        invalid_args_hint=invalid_args_hint,
+    )
 
 
 def build_pipe_mutation_success_payload(
@@ -92,13 +102,19 @@ def build_pipe_mutation_success_payload(
     )
 
 
-def build_pipe_tool_error_payload(*, message: str) -> dict[str, Any]:
+def build_pipe_tool_error_payload(
+    *, message: str, code: str | None = None
+) -> dict[str, Any]:
     """``success: False`` with ``error`` text.
 
     Args:
         message: User-visible failure reason.
+        code: Optional machine-readable error code. Pass
+            ``"INVALID_ARGUMENTS"`` for pre-API argument-shape failures so
+            the envelope matches the shape of arg-coercion errors
+            emitted by :class:`pipefy_mcp.tools.validation_envelope.PipefyValidationTool`.
     """
-    return tool_error(message)
+    return tool_error(message, code=code)
 
 
 def build_field_condition_success_payload(

--- a/src/pipefy_mcp/tools/pipe_config_tools.py
+++ b/src/pipefy_mcp/tools/pipe_config_tools.py
@@ -97,6 +97,7 @@ async def _diagnose_phase_field_cascade(
             "If you expected the field to still exist, verify with "
             "get_phase_fields on each phase of this pipe."
         ),
+        code="NOT_FOUND",
     )
 
 
@@ -127,6 +128,7 @@ class PipeConfigTools:
             if not isinstance(name, str) or not name.strip():
                 return build_pipe_tool_error_payload(
                     message="Invalid 'name': provide a non-empty string.",
+                    code="INVALID_ARGUMENTS",
                 )
             org_id, err = validate_tool_id(organization_id, "organization_id")
             if err is not None:
@@ -135,7 +137,11 @@ class PipeConfigTools:
                 raw = await client.create_pipe(name.strip(), org_id)
             except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
-                    exc, "Create pipe failed.", debug=debug
+                    exc,
+                    "Create pipe failed.",
+                    debug=debug,
+                    resource_kind="organization",
+                    resource_id=org_id,
                 )
             return build_pipe_mutation_success_payload(
                 label="Pipe created.",
@@ -176,6 +182,7 @@ class PipeConfigTools:
                     message=(
                         "Provide at least one of: name, icon, color, preferences."
                     ),
+                    code="INVALID_ARGUMENTS",
                 )
             try:
                 raw = await client.update_pipe(
@@ -187,7 +194,11 @@ class PipeConfigTools:
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
-                    exc, "Update pipe failed.", debug=debug
+                    exc,
+                    "Update pipe failed.",
+                    debug=debug,
+                    resource_kind="pipe",
+                    resource_id=pipe_id_str,
                 )
             return build_pipe_mutation_success_payload(
                 label="Pipe updated.",
@@ -315,7 +326,11 @@ class PipeConfigTools:
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
-                    exc, "Clone pipe failed.", debug=debug
+                    exc,
+                    "Clone pipe failed.",
+                    debug=debug,
+                    resource_kind="pipe",
+                    resource_id=str(pipe_template_id),
                 )
             return build_pipe_mutation_success_payload(
                 label="Pipe(s) cloned.",
@@ -351,6 +366,7 @@ class PipeConfigTools:
             if not isinstance(name, str) or not name.strip():
                 return build_pipe_tool_error_payload(
                     message="Invalid 'name': provide a non-empty string.",
+                    code="INVALID_ARGUMENTS",
                 )
             try:
                 raw = await client.create_phase(
@@ -362,7 +378,11 @@ class PipeConfigTools:
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
-                    exc, "Create phase failed.", debug=debug
+                    exc,
+                    "Create phase failed.",
+                    debug=debug,
+                    resource_kind="pipe",
+                    resource_id=str(pipe_id),
                 )
             return build_pipe_mutation_success_payload(
                 label="Phase created.",
@@ -393,6 +413,7 @@ class PipeConfigTools:
 
             Args:
                 phase_id: Phase ID to update.
+                    Discover via: ``get_pipe(pipe_id).phases[].id``.
                 name: New name, if changing.
                 description: New description, if changing.
                 done: Whether the phase is a final phase, if changing.
@@ -429,6 +450,7 @@ class PipeConfigTools:
             if not update_attrs:
                 return build_pipe_tool_error_payload(
                     message="Provide at least one attribute to update.",
+                    code="INVALID_ARGUMENTS",
                 )
 
             if "name" not in update_attrs:
@@ -436,12 +458,17 @@ class PipeConfigTools:
                     phase_info = await client.get_phase_fields(phase_id)
                 except Exception as exc:  # noqa: BLE001
                     return handle_pipe_config_tool_graphql_error(
-                        exc, "Could not load phase.", debug=debug
+                        exc,
+                        "Could not load phase.",
+                        debug=debug,
+                        resource_kind="phase",
+                        resource_id=str(phase_id),
                     )
                 current = phase_info.get("phase_name")
                 if not current:
                     return build_pipe_tool_error_payload(
                         message=f"Phase {phase_id} not found or has no name.",
+                        code="INVALID_ARGUMENTS",
                     )
                 update_attrs["name"] = current
 
@@ -449,7 +476,11 @@ class PipeConfigTools:
                 raw = await client.update_phase(phase_id, **update_attrs)
             except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
-                    exc, "Update phase failed.", debug=debug
+                    exc,
+                    "Update phase failed.",
+                    debug=debug,
+                    resource_kind="phase",
+                    resource_id=str(phase_id),
                 )
             return build_pipe_mutation_success_payload(
                 label="Phase updated.",
@@ -495,7 +526,11 @@ class PipeConfigTools:
                 raw = await client.delete_phase(phase_id)
             except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
-                    exc, "Delete phase failed.", debug=debug
+                    exc,
+                    "Delete phase failed.",
+                    debug=debug,
+                    resource_kind="phase",
+                    resource_id=str(phase_id),
                 )
             return build_pipe_mutation_success_payload(
                 label="Phase deleted.",
@@ -527,6 +562,7 @@ class PipeConfigTools:
 
             Args:
                 phase_id: Phase that will receive the field.
+                    Discover via: ``get_pipe(pipe_id).phases[].id``.
                 label: Field label shown in the UI.
                 field_type: Pipefy field type string (API input field ``type``).
                 options: Option values for select/radio/checklist fields (e.g. ["Alta", "Média", "Baixa"]).
@@ -541,10 +577,12 @@ class PipeConfigTools:
             if not isinstance(label, str) or not label.strip():
                 return build_pipe_tool_error_payload(
                     message="Invalid 'label': provide a non-empty string.",
+                    code="INVALID_ARGUMENTS",
                 )
             if not isinstance(field_type, str) or not field_type.strip():
                 return build_pipe_tool_error_payload(
                     message="Invalid 'field_type': provide a non-empty string.",
+                    code="INVALID_ARGUMENTS",
                 )
             merged: dict[str, Any] = {
                 k: v
@@ -566,7 +604,11 @@ class PipeConfigTools:
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
-                    exc, "Create phase field failed.", debug=debug
+                    exc,
+                    "Create phase field failed.",
+                    debug=debug,
+                    resource_kind="phase",
+                    resource_id=str(phase_id),
                 )
             return build_pipe_mutation_success_payload(
                 label="Phase field created.",
@@ -599,11 +641,13 @@ class PipeConfigTools:
 
             Args:
                 field_id: Field slug (from create_phase_field or get_phase_fields).
+                    Discover via: ``get_phase_fields(phase_id)[].id`` (or ``uuid`` for disambiguation).
                 label: Field label (required by the Pipefy API even if unchanged — pass the current value).
                 description: New description, if changing.
                 required: Whether the field is required, if changing.
                 options: Field options list (e.g. ["Alta", "Média", "Baixa"] for select fields).
                 uuid: Field UUID for disambiguation when the slug exists on multiple phases.
+                    Discover via: ``get_phase_fields(phase_id)[].uuid``.
                 extra_input: Additional UpdatePhaseFieldInput fields, if any.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
@@ -616,6 +660,7 @@ class PipeConfigTools:
                         "Invalid 'label': the Pipefy API requires label on every update "
                         "(pass the current label if unchanged)."
                     ),
+                    code="INVALID_ARGUMENTS",
                 )
             update_attrs: dict[str, Any] = {
                 k: v
@@ -636,7 +681,14 @@ class PipeConfigTools:
                 raw = await client.update_phase_field(fid, **update_attrs)
             except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
-                    exc, "Update phase field failed.", debug=debug
+                    exc,
+                    "Update phase field failed.",
+                    debug=debug,
+                    resource_kind="phase_field",
+                    resource_id=str(fid),
+                    invalid_args_hint=(
+                        "Use 'get_phase_fields' to list valid field slugs and UUIDs."
+                    ),
                 )
             return build_pipe_mutation_success_payload(
                 label="Phase field updated.",
@@ -678,9 +730,11 @@ class PipeConfigTools:
 
             Args:
                 field_id: Field slug or uuid (from create_phase_field or get_phase_fields).
+                    Discover via: ``get_phase_fields(phase_id)[].id`` or ``.uuid``.
                 confirm: Set to True to execute the deletion (step 2).
                 pipe_uuid: Pipe UUID for disambiguation when the slug is not unique across phases.
                 pipe_id: Numeric pipe ID; enables cascade-aware error diagnosis when set.
+                    Discover via: ``search_pipes`` or ``get_organization``.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             field_id, err = validate_tool_id(field_id, "field_id")
@@ -689,7 +743,8 @@ class PipeConfigTools:
             ok_p, pipe_id_norm, pid_err = validate_optional_tool_id(pipe_id, "pipe_id")
             if not ok_p:
                 return build_pipe_tool_error_payload(
-                    message=tool_error_message(pid_err)
+                    message=tool_error_message(pid_err),
+                    code="INVALID_ARGUMENTS",
                 )
 
             guard = await check_destructive_confirmation(
@@ -709,7 +764,11 @@ class PipeConfigTools:
                 if enriched is not None:
                     return enriched
                 return handle_pipe_config_tool_graphql_error(
-                    exc, "Delete phase field failed.", debug=debug
+                    exc,
+                    "Delete phase field failed.",
+                    debug=debug,
+                    resource_kind="phase_field",
+                    resource_id=str(field_id),
                 )
             return build_pipe_mutation_success_payload(
                 label="Phase field deleted.",
@@ -741,10 +800,12 @@ class PipeConfigTools:
             if not isinstance(name, str) or not name.strip():
                 return build_pipe_tool_error_payload(
                     message="Invalid 'name': provide a non-empty string.",
+                    code="INVALID_ARGUMENTS",
                 )
             if not isinstance(color, str) or not color.strip():
                 return build_pipe_tool_error_payload(
                     message="Invalid 'color': provide a non-empty string.",
+                    code="INVALID_ARGUMENTS",
                 )
             try:
                 raw = await client.create_label(
@@ -754,7 +815,11 @@ class PipeConfigTools:
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
-                    exc, "Create label failed.", debug=debug
+                    exc,
+                    "Create label failed.",
+                    debug=debug,
+                    resource_kind="pipe",
+                    resource_id=str(pipe_id),
                 )
             return build_pipe_mutation_success_payload(
                 label="Label created.",
@@ -793,10 +858,12 @@ class PipeConfigTools:
             if not isinstance(name, str) or not name.strip():
                 return build_pipe_tool_error_payload(
                     message="Invalid 'name': provide a non-empty string.",
+                    code="INVALID_ARGUMENTS",
                 )
             if not isinstance(color, str) or not color.strip():
                 return build_pipe_tool_error_payload(
                     message="Invalid 'color': provide a non-empty string.",
+                    code="INVALID_ARGUMENTS",
                 )
             update_attrs: dict[str, Any] = {
                 k: v
@@ -809,7 +876,11 @@ class PipeConfigTools:
                 raw = await client.update_label(label_id, **update_attrs)
             except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
-                    exc, "Update label failed.", debug=debug
+                    exc,
+                    "Update label failed.",
+                    debug=debug,
+                    resource_kind="label",
+                    resource_id=str(label_id),
                 )
             return build_pipe_mutation_success_payload(
                 label="Label updated.",
@@ -855,7 +926,11 @@ class PipeConfigTools:
                 raw = await client.delete_label(label_id)
             except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
-                    exc, "Delete label failed.", debug=debug
+                    exc,
+                    "Delete label failed.",
+                    debug=debug,
+                    resource_kind="label",
+                    resource_id=str(label_id),
                 )
             return build_pipe_mutation_success_payload(
                 label="Label deleted.",

--- a/src/pipefy_mcp/tools/pipe_tools.py
+++ b/src/pipefy_mcp/tools/pipe_tools.py
@@ -173,8 +173,10 @@ class PipeTools:
             ),
         )
         async def get_card(
+            ctx: Context[ServerSession, None],
             card_id: PipefyId,
             include_fields: bool = False,
+            debug: bool = False,
         ) -> dict:
             """Load one card by ID for title, phase, assignees, labels, and optional field values.
 
@@ -184,13 +186,28 @@ class PipeTools:
 
             Args:
                 card_id: Pipefy card ID (string or positive integer).
+                    Discover via: ``find_cards`` or ``get_cards(pipe_id)``.
                 include_fields: If True, include each custom field's name and value on the card node.
+                debug: When True, append GraphQL codes and correlation_id on errors.
 
             Returns:
                 dict: GraphQL ``card`` query payload (typically ``card`` with ``id``, ``title``,
                 ``phase``, ``assignees``, ``labels``, and—when requested—``fields``).
             """
-            return await client.get_card(card_id, include_fields=include_fields)
+            await ctx.debug(f"get_card: card_id={card_id}")
+            card_id_str, err = validate_tool_id(card_id, "card_id")
+            if err is not None:
+                return err
+            try:
+                return await client.get_card(card_id_str, include_fields=include_fields)
+            except Exception as exc:  # noqa: BLE001
+                return handle_tool_graphql_error(
+                    exc,
+                    "Failed to load card.",
+                    debug=debug,
+                    resource_kind="card",
+                    resource_id=card_id_str,
+                )
 
         @mcp.tool(
             annotations=ToolAnnotations(
@@ -226,7 +243,11 @@ class PipeTools:
                 raw = await client.get_card_relations(card_id_str)
             except Exception as exc:  # noqa: BLE001
                 return handle_relation_tool_graphql_error(
-                    exc, "Get card relations failed.", debug=debug
+                    exc,
+                    "Get card relations failed.",
+                    debug=debug,
+                    resource_kind="card",
+                    resource_id=card_id_str,
                 )
 
             card_node = raw.get("card")
@@ -438,7 +459,11 @@ class PipeTools:
                 raw = await client.delete_card_relation(cid, pid, sid)
             except Exception as exc:  # noqa: BLE001
                 return handle_relation_tool_graphql_error(
-                    exc, "Delete card relation failed.", debug=debug
+                    exc,
+                    "Delete card relation failed.",
+                    debug=debug,
+                    resource_kind="card",
+                    resource_id=str(cid),
                 )
 
             node = raw.get("deleteCardRelation") or {}
@@ -558,7 +583,11 @@ class PipeTools:
                 readOnlyHint=True,
             ),
         )
-        async def get_pipe(pipe_id: PipefyId) -> dict:
+        async def get_pipe(
+            ctx: Context[ServerSession, None],
+            pipe_id: PipefyId,
+            debug: bool = False,
+        ) -> dict:
             """Load a pipe by ID: name, phases, labels, and start-form field definitions.
 
             Use this after resolving ``pipe_id`` (e.g. from ``search_pipes``) to inspect workflow
@@ -567,12 +596,27 @@ class PipeTools:
 
             Args:
                 pipe_id: Pipe identifier (string or positive integer).
+                    Discover via: ``search_pipes`` or ``get_organization``.
+                debug: When True, append GraphQL codes and correlation_id on errors.
 
             Returns:
                 dict: GraphQL response containing a ``pipe`` object with ``id``, ``name``,
                 ``phases``, ``labels``, ``start_form_fields``, and related metadata from the API.
             """
-            return await client.get_pipe(pipe_id)
+            await ctx.debug(f"get_pipe: pipe_id={pipe_id}")
+            pipe_id_str, err = validate_tool_id(pipe_id, "pipe_id")
+            if err is not None:
+                return err
+            try:
+                return await client.get_pipe(pipe_id_str)
+            except Exception as exc:  # noqa: BLE001
+                return handle_tool_graphql_error(
+                    exc,
+                    "Failed to load pipe.",
+                    debug=debug,
+                    resource_kind="pipe",
+                    resource_id=pipe_id_str,
+                )
 
         @mcp.tool(
             annotations=ToolAnnotations(
@@ -605,7 +649,13 @@ class PipeTools:
             try:
                 raw = await client.get_pipe(pipe_id_str)
             except Exception as exc:  # noqa: BLE001
-                return handle_tool_graphql_error(exc, "Get labels failed.", debug=debug)
+                return handle_tool_graphql_error(
+                    exc,
+                    "Get labels failed.",
+                    debug=debug,
+                    resource_kind="pipe",
+                    resource_id=pipe_id_str,
+                )
 
             pipe_node = raw.get("pipe")
             if pipe_node is None:
@@ -625,7 +675,11 @@ class PipeTools:
                 readOnlyHint=True,
             ),
         )
-        async def get_pipe_members(pipe_id: PipefyId) -> dict:
+        async def get_pipe_members(
+            ctx: Context[ServerSession, None],
+            pipe_id: PipefyId,
+            debug: bool = False,
+        ) -> dict:
             """List members of a pipe with roles and basic user profile fields.
 
             Use this to audit who has access, resolve user IDs for assignments, or before
@@ -633,12 +687,27 @@ class PipeTools:
 
             Args:
                 pipe_id: Pipe identifier (string or positive integer).
+                    Discover via: ``search_pipes`` or ``get_organization``.
+                debug: When True, append GraphQL codes and correlation_id on errors.
 
             Returns:
                 dict: GraphQL payload whose ``pipe.members`` entries include ``user``
                 (``id``, ``uuid``, ``name``, ``email``) and ``role_name`` per member.
             """
-            return await client.get_pipe_members(pipe_id)
+            await ctx.debug(f"get_pipe_members: pipe_id={pipe_id}")
+            pipe_id_str, err = validate_tool_id(pipe_id, "pipe_id")
+            if err is not None:
+                return err
+            try:
+                return await client.get_pipe_members(pipe_id_str)
+            except Exception as exc:  # noqa: BLE001
+                return handle_tool_graphql_error(
+                    exc,
+                    "Failed to load pipe members.",
+                    debug=debug,
+                    resource_kind="pipe",
+                    resource_id=pipe_id_str,
+                )
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False, idempotentHint=True),
@@ -655,7 +724,9 @@ class PipeTools:
 
             Args:
                 card_id: The card to move.
+                    Discover via: ``find_cards`` or ``get_cards(pipe_id)``.
                 destination_phase_id: Target phase ID (must be allowed for the current phase).
+                    Discover via: ``get_pipe(pipe_id).phases[].id``.
 
             Returns:
                 dict: Pipefy move mutation response on success. On some validation failures,
@@ -687,8 +758,10 @@ class PipeTools:
             will be replaced with the new value provided.
 
             Args:
-                card_id: The ID of the card containing the field to update
-                field_id: The ID (slug) of the field to update
+                card_id: The ID of the card containing the field to update.
+                    Discover via: ``find_cards`` or ``get_cards(pipe_id)``.
+                field_id: The ID (slug) of the field to update.
+                    Discover via: ``get_phase_fields(phase_id)[].id`` (or ``internal_id`` for numeric forms).
                 new_value: The new value for the field (string, number, list, etc.)
 
             Returns:
@@ -844,10 +917,13 @@ class PipeTools:
 
             Args:
                 card_id: The ID of the card to update.
+                    Discover via: ``find_cards`` or ``get_cards(pipe_id)``.
                 phase_id: The ID of the phase whose fields should be filled.
+                    Discover via: ``get_pipe(pipe_id).phases[].id``.
                 fields: A dictionary of fields that can be pre-filled.
                         When ``skip_elicitation`` is False, these pre-fill the
                         interactive form. When True, they are sent directly.
+                        Discover via: ``get_phase_fields(phase_id)[].id`` for valid keys.
                 required_fields_only: If True, only elicit required fields. Default: False.
                 skip_elicitation: When True, bypass interactive elicitation and send
                     ``fields`` directly to the API. Recommended for AI agent workflows.

--- a/src/pipefy_mcp/tools/relation_tool_helpers.py
+++ b/src/pipefy_mcp/tools/relation_tool_helpers.py
@@ -76,9 +76,19 @@ def handle_relation_tool_graphql_error(
     fallback_msg: str,
     *,
     debug: bool = False,
+    resource_kind: str | None = None,
+    resource_id: str | None = None,
+    invalid_args_hint: str | None = None,
 ) -> dict[str, Any]:
-    """Delegate to :func:`handle_tool_graphql_error`."""
-    return handle_tool_graphql_error(exc, fallback_msg, debug=debug)
+    """Delegate to :func:`handle_tool_graphql_error` with enrichment opt-ins."""
+    return handle_tool_graphql_error(
+        exc,
+        fallback_msg,
+        debug=debug,
+        resource_kind=resource_kind,
+        resource_id=resource_id,
+        invalid_args_hint=invalid_args_hint,
+    )
 
 
 __all__ = [

--- a/src/pipefy_mcp/tools/relation_tools.py
+++ b/src/pipefy_mcp/tools/relation_tools.py
@@ -48,7 +48,10 @@ class RelationTools:
                 raw = await client.get_pipe_relations(pipe_id)
             except Exception as exc:  # noqa: BLE001
                 return handle_relation_tool_graphql_error(
-                    exc, "Get pipe relations failed."
+                    exc,
+                    "Get pipe relations failed.",
+                    resource_kind="pipe",
+                    resource_id=str(pipe_id),
                 )
             return build_relation_read_success_payload(
                 raw,
@@ -84,7 +87,9 @@ class RelationTools:
                 raw = await client.get_table_relations(validated_ids)
             except Exception as exc:  # noqa: BLE001
                 return handle_relation_tool_graphql_error(
-                    exc, "Get table relations failed."
+                    exc,
+                    "Get table relations failed.",
+                    resource_kind="table",
                 )
             return build_relation_read_success_payload(
                 raw,
@@ -108,7 +113,9 @@ class RelationTools:
 
             Args:
                 parent_id: Parent pipe ID.
+                    Discover via: ``search_pipes`` or ``get_organization``.
                 child_id: Child pipe ID.
+                    Discover via: ``search_pipes`` or ``get_organization``.
                 name: Relation name/label.
                 extra_input: Optional extra fields for the mutation input.
                 debug: When True, append GraphQL codes and correlation_id to errors.
@@ -137,7 +144,11 @@ class RelationTools:
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_relation_tool_graphql_error(
-                    exc, "Create pipe relation failed.", debug=debug
+                    exc,
+                    "Create pipe relation failed.",
+                    debug=debug,
+                    resource_kind="pipe",
+                    resource_id=str(parent_id),
                 )
             return build_relation_mutation_success_payload(
                 message="Pipe relation created.",
@@ -184,7 +195,11 @@ class RelationTools:
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_relation_tool_graphql_error(
-                    exc, "Update pipe relation failed.", debug=debug
+                    exc,
+                    "Update pipe relation failed.",
+                    debug=debug,
+                    resource_kind="pipe",
+                    resource_id=str(relation_id),
                 )
             return build_relation_mutation_success_payload(
                 message="Pipe relation updated.",
@@ -231,7 +246,11 @@ class RelationTools:
                 raw = await client.delete_pipe_relation(relation_id)
             except Exception as exc:  # noqa: BLE001
                 return handle_relation_tool_graphql_error(
-                    exc, "Delete pipe relation failed.", debug=debug
+                    exc,
+                    "Delete pipe relation failed.",
+                    debug=debug,
+                    resource_kind="pipe",
+                    resource_id=str(relation_id),
                 )
             return build_relation_mutation_success_payload(
                 message="Pipe relation deleted.",
@@ -255,8 +274,11 @@ class RelationTools:
 
             Args:
                 parent_id: Parent card ID.
+                    Discover via: ``find_cards`` or ``get_cards(pipe_id)``.
                 child_id: Child card ID.
+                    Discover via: ``find_cards`` or ``get_cards(pipe_id)``.
                 source_id: Pipe relation ID that defines the parent/child pipe link.
+                    Discover via: ``get_pipe_relations(pipe_id)[].id``.
                 extra_input: Optional ``CreateCardRelationInput`` fields (camelCase), e.g. ``sourceType`` (default ``PipeRelation``).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
@@ -283,7 +305,11 @@ class RelationTools:
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_relation_tool_graphql_error(
-                    exc, "Create card relation failed.", debug=debug
+                    exc,
+                    "Create card relation failed.",
+                    debug=debug,
+                    resource_kind="card",
+                    resource_id=str(parent_id),
                 )
             return build_relation_mutation_success_payload(
                 message="Card relation created.",

--- a/src/pipefy_mcp/tools/report_tool_helpers.py
+++ b/src/pipefy_mcp/tools/report_tool_helpers.py
@@ -76,9 +76,19 @@ def handle_report_tool_graphql_error(
     fallback_msg: str,
     *,
     debug: bool = False,
+    resource_kind: str | None = None,
+    resource_id: str | None = None,
+    invalid_args_hint: str | None = None,
 ) -> dict[str, Any]:
-    """Delegate to :func:`handle_tool_graphql_error`."""
-    return handle_tool_graphql_error(exc, fallback_msg, debug=debug)
+    """Delegate to :func:`handle_tool_graphql_error` with enrichment opt-ins."""
+    return handle_tool_graphql_error(
+        exc,
+        fallback_msg,
+        debug=debug,
+        resource_kind=resource_kind,
+        resource_id=resource_id,
+        invalid_args_hint=invalid_args_hint,
+    )
 
 
 __all__ = [

--- a/src/pipefy_mcp/tools/report_tools.py
+++ b/src/pipefy_mcp/tools/report_tools.py
@@ -73,7 +73,11 @@ class ReportTools:
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_report_tool_graphql_error(
-                    exc, "Get pipe reports failed.", debug=debug
+                    exc,
+                    "Get pipe reports failed.",
+                    debug=debug,
+                    resource_kind="pipe",
+                    resource_id=pipe_uuid,
                 )
             return build_report_read_success_payload(
                 raw,
@@ -116,7 +120,11 @@ class ReportTools:
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_report_tool_graphql_error(
-                    exc, "Get pipe report failed.", debug=debug
+                    exc,
+                    "Get pipe report failed.",
+                    debug=debug,
+                    resource_kind="pipe",
+                    resource_id=pipe_uuid,
                 )
             edges = (raw.get("pipeReports") or {}).get("edges") or []
             node: dict[str, Any] | None = None
@@ -156,7 +164,11 @@ class ReportTools:
                 raw = await client.get_pipe_report_columns(pipe_uuid)
             except Exception as exc:  # noqa: BLE001
                 return handle_report_tool_graphql_error(
-                    exc, "Get pipe report columns failed.", debug=debug
+                    exc,
+                    "Get pipe report columns failed.",
+                    debug=debug,
+                    resource_kind="pipe",
+                    resource_id=pipe_uuid,
                 )
             return build_report_read_success_payload(
                 raw,
@@ -185,7 +197,11 @@ class ReportTools:
                 raw = await client.get_pipe_report_filterable_fields(pipe_uuid)
             except Exception as exc:  # noqa: BLE001
                 return handle_report_tool_graphql_error(
-                    exc, "Get pipe report filterable fields failed.", debug=debug
+                    exc,
+                    "Get pipe report filterable fields failed.",
+                    debug=debug,
+                    resource_kind="pipe",
+                    resource_id=pipe_uuid,
                 )
             return build_report_read_success_payload(
                 raw,
@@ -212,7 +228,11 @@ class ReportTools:
                 raw = await client.get_organization_report(report_id)
             except Exception as exc:  # noqa: BLE001
                 return handle_report_tool_graphql_error(
-                    exc, "Get organization report failed.", debug=debug
+                    exc,
+                    "Get organization report failed.",
+                    debug=debug,
+                    resource_kind="organization_report",
+                    resource_id=str(report_id),
                 )
             return build_report_read_success_payload(
                 raw,
@@ -249,7 +269,11 @@ class ReportTools:
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_report_tool_graphql_error(
-                    exc, "Get organization reports failed.", debug=debug
+                    exc,
+                    "Get organization reports failed.",
+                    debug=debug,
+                    resource_kind="organization",
+                    resource_id=str(organization_id),
                 )
             return build_report_read_success_payload(
                 raw,
@@ -276,7 +300,11 @@ class ReportTools:
                 raw = await client.get_pipe_report_export(export_id)
             except Exception as exc:  # noqa: BLE001
                 return handle_report_tool_graphql_error(
-                    exc, "Get pipe report export failed.", debug=debug
+                    exc,
+                    "Get pipe report export failed.",
+                    debug=debug,
+                    resource_kind="pipe_report",
+                    resource_id=str(export_id),
                 )
             return build_report_read_success_payload(
                 raw,
@@ -303,7 +331,11 @@ class ReportTools:
                 raw = await client.get_organization_report_export(export_id)
             except Exception as exc:  # noqa: BLE001
                 return handle_report_tool_graphql_error(
-                    exc, "Get organization report export failed.", debug=debug
+                    exc,
+                    "Get organization report export failed.",
+                    debug=debug,
+                    resource_kind="organization_report",
+                    resource_id=str(export_id),
                 )
             return build_report_read_success_payload(
                 raw,
@@ -343,7 +375,11 @@ class ReportTools:
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_report_tool_graphql_error(
-                    exc, "Create pipe report failed.", debug=debug
+                    exc,
+                    "Create pipe report failed.",
+                    debug=debug,
+                    resource_kind="pipe",
+                    resource_id=str(pipe_id),
                 )
             return build_report_mutation_success_payload(
                 message="Pipe report created.",
@@ -390,7 +426,11 @@ class ReportTools:
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_report_tool_graphql_error(
-                    exc, "Update pipe report failed.", debug=debug
+                    exc,
+                    "Update pipe report failed.",
+                    debug=debug,
+                    resource_kind="pipe_report",
+                    resource_id=str(report_id),
                 )
             return build_report_mutation_success_payload(
                 message="Pipe report updated.",
@@ -436,7 +476,11 @@ class ReportTools:
                 raw = await client.delete_pipe_report(report_id)
             except Exception as exc:  # noqa: BLE001
                 return handle_report_tool_graphql_error(
-                    exc, "Delete pipe report failed.", debug=debug
+                    exc,
+                    "Delete pipe report failed.",
+                    debug=debug,
+                    resource_kind="pipe_report",
+                    resource_id=str(report_id),
                 )
             return build_report_mutation_success_payload(
                 message="Pipe report deleted.",
@@ -480,7 +524,11 @@ class ReportTools:
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_report_tool_graphql_error(
-                    exc, "Create organization report failed.", debug=debug
+                    exc,
+                    "Create organization report failed.",
+                    debug=debug,
+                    resource_kind="organization",
+                    resource_id=str(organization_id),
                 )
             return build_report_mutation_success_payload(
                 message="Organization report created.",
@@ -524,7 +572,11 @@ class ReportTools:
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_report_tool_graphql_error(
-                    exc, "Update organization report failed.", debug=debug
+                    exc,
+                    "Update organization report failed.",
+                    debug=debug,
+                    resource_kind="organization_report",
+                    resource_id=str(report_id),
                 )
             return build_report_mutation_success_payload(
                 message="Organization report updated.",
@@ -570,7 +622,11 @@ class ReportTools:
                 raw = await client.delete_organization_report(report_id)
             except Exception as exc:  # noqa: BLE001
                 return handle_report_tool_graphql_error(
-                    exc, "Delete organization report failed.", debug=debug
+                    exc,
+                    "Delete organization report failed.",
+                    debug=debug,
+                    resource_kind="organization_report",
+                    resource_id=str(report_id),
                 )
             return build_report_mutation_success_payload(
                 message="Organization report deleted.",
@@ -614,7 +670,11 @@ class ReportTools:
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_report_tool_graphql_error(
-                    exc, "Export pipe report failed.", debug=debug
+                    exc,
+                    "Export pipe report failed.",
+                    debug=debug,
+                    resource_kind="pipe",
+                    resource_id=str(pipe_id),
                 )
             return build_report_mutation_success_payload(
                 message="Pipe report export started.",
@@ -659,7 +719,11 @@ class ReportTools:
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_report_tool_graphql_error(
-                    exc, "Export organization report failed.", debug=debug
+                    exc,
+                    "Export organization report failed.",
+                    debug=debug,
+                    resource_kind="organization",
+                    resource_id=str(organization_id),
                 )
             return build_report_mutation_success_payload(
                 message="Organization report export started.",
@@ -691,7 +755,11 @@ class ReportTools:
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_report_tool_graphql_error(
-                    exc, "Export pipe audit logs failed.", debug=debug
+                    exc,
+                    "Export pipe audit logs failed.",
+                    debug=debug,
+                    resource_kind="pipe",
+                    resource_id=pipe_uuid,
                 )
             return build_report_mutation_success_payload(
                 message="Pipe audit logs export queued.",

--- a/src/pipefy_mcp/tools/table_tool_helpers.py
+++ b/src/pipefy_mcp/tools/table_tool_helpers.py
@@ -209,9 +209,19 @@ def handle_table_tool_graphql_error(
     fallback_msg: str,
     *,
     debug: bool = False,
+    resource_kind: str | None = None,
+    resource_id: str | None = None,
+    invalid_args_hint: str | None = None,
 ) -> dict[str, Any]:
-    """Delegate to :func:`handle_tool_graphql_error`."""
-    return handle_tool_graphql_error(exc, fallback_msg, debug=debug)
+    """Delegate to :func:`handle_tool_graphql_error` with enrichment opt-ins."""
+    return handle_tool_graphql_error(
+        exc,
+        fallback_msg,
+        debug=debug,
+        resource_kind=resource_kind,
+        resource_id=resource_id,
+        invalid_args_hint=invalid_args_hint,
+    )
 
 
 __all__ = [

--- a/src/pipefy_mcp/tools/table_tools.py
+++ b/src/pipefy_mcp/tools/table_tools.py
@@ -120,7 +120,12 @@ class TableTools:
             try:
                 raw = await client.get_table(table_id)
             except Exception as exc:  # noqa: BLE001
-                return handle_table_tool_graphql_error(exc, "Get table failed.")
+                return handle_table_tool_graphql_error(
+                    exc,
+                    "Get table failed.",
+                    resource_kind="table",
+                    resource_id=str(table_id),
+                )
             return build_table_read_success_payload(
                 raw,
                 message="Table metadata retrieved.",
@@ -152,7 +157,11 @@ class TableTools:
             try:
                 raw = await client.get_tables(cleaned_ids)
             except Exception as exc:  # noqa: BLE001
-                return handle_table_tool_graphql_error(exc, "Get tables failed.")
+                return handle_table_tool_graphql_error(
+                    exc,
+                    "Get tables failed.",
+                    resource_kind="table",
+                )
             return build_table_read_success_payload(
                 raw,
                 message="Tables metadata retrieved.",
@@ -208,7 +217,10 @@ class TableTools:
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_table_tool_graphql_error(
-                    exc, "List table records failed."
+                    exc,
+                    "List table records failed.",
+                    resource_kind="table",
+                    resource_id=str(table_id),
                 )
             return build_table_read_success_payload(
                 raw,
@@ -242,7 +254,12 @@ class TableTools:
             try:
                 raw = await client.get_table_record(record_id)
             except Exception as exc:  # noqa: BLE001
-                return handle_table_tool_graphql_error(exc, "Get table record failed.")
+                return handle_table_tool_graphql_error(
+                    exc,
+                    "Get table record failed.",
+                    resource_kind="table_record",
+                    resource_id=str(record_id),
+                )
             return build_table_read_success_payload(
                 raw,
                 message="Table record retrieved.",
@@ -305,7 +322,12 @@ class TableTools:
                     after=after.strip() if isinstance(after, str) else after,
                 )
             except Exception as exc:  # noqa: BLE001
-                return handle_table_tool_graphql_error(exc, "Find records failed.")
+                return handle_table_tool_graphql_error(
+                    exc,
+                    "Find records failed.",
+                    resource_kind="table",
+                    resource_id=str(table_id),
+                )
             return build_table_read_success_payload(
                 raw,
                 message="Record search completed.",
@@ -350,7 +372,11 @@ class TableTools:
                 raw = await client.create_table(name.strip(), organization_id, **merged)
             except Exception as exc:  # noqa: BLE001
                 return handle_table_tool_graphql_error(
-                    exc, "Create table failed.", debug=debug
+                    exc,
+                    "Create table failed.",
+                    debug=debug,
+                    resource_kind="organization",
+                    resource_id=str(organization_id),
                 )
             return build_table_mutation_success_payload(
                 message="Table created.",
@@ -406,7 +432,11 @@ class TableTools:
                 raw = await client.update_table(table_id, **kwargs)
             except Exception as exc:  # noqa: BLE001
                 return handle_table_tool_graphql_error(
-                    exc, "Update table failed.", debug=debug
+                    exc,
+                    "Update table failed.",
+                    debug=debug,
+                    resource_kind="table",
+                    resource_id=str(table_id),
                 )
             return build_table_mutation_success_payload(
                 message="Table updated.",
@@ -512,7 +542,9 @@ class TableTools:
 
             Args:
                 table_id: Target table ID.
+                    Discover via: ``search_tables`` or ``get_tables(table_ids)``.
                 fields: Map of field_id -> value, or list of objects with field_id / field_value.
+                    Discover via: ``get_table(table_id).table_fields[].id``.
                 title: Optional record title.
                 extra_input: Other `CreateTableRecordInput` keys (e.g. label_ids).
                 debug: When True, append GraphQL codes and correlation_id to errors.
@@ -565,7 +597,11 @@ class TableTools:
                 raw = await client.create_table_record(table_id, fields, **merged_attrs)
             except Exception as exc:  # noqa: BLE001
                 return handle_table_tool_graphql_error(
-                    exc, "Create table record failed.", debug=debug
+                    exc,
+                    "Create table record failed.",
+                    debug=debug,
+                    resource_kind="table",
+                    resource_id=str(table_id),
                 )
             return build_table_mutation_success_payload(
                 message="Table record created.",
@@ -586,6 +622,8 @@ class TableTools:
 
             Args:
                 record_id: Record ID.
+                    Discover via: ``find_records(table_id, field_id, field_value)`` or
+                    ``get_table_records(table_id)[].id``.
                 fields: Keys may include title, due_date, status_id (or statusId).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
@@ -609,7 +647,11 @@ class TableTools:
                 raw = await client.update_table_record(record_id, fields)
             except Exception as exc:  # noqa: BLE001
                 return handle_table_tool_graphql_error(
-                    exc, "Update table record failed.", debug=debug
+                    exc,
+                    "Update table record failed.",
+                    debug=debug,
+                    resource_kind="table_record",
+                    resource_id=str(record_id),
                 )
             return build_table_mutation_success_payload(
                 message="Table record updated.",
@@ -657,7 +699,11 @@ class TableTools:
                 raw = await client.delete_table_record(record_id)
             except Exception as exc:  # noqa: BLE001
                 return handle_table_tool_graphql_error(
-                    exc, "Delete table record failed.", debug=debug
+                    exc,
+                    "Delete table record failed.",
+                    debug=debug,
+                    resource_kind="table_record",
+                    resource_id=str(record_id),
                 )
             return build_table_mutation_success_payload(
                 message="Table record deleted.",
@@ -677,7 +723,10 @@ class TableTools:
 
             Args:
                 record_id: Record ID.
+                    Discover via: ``find_records(table_id, field_id, field_value)`` or
+                    ``get_table_records(table_id)[].id``.
                 field_id: Table field ID.
+                    Discover via: ``get_table(table_id).table_fields[].id``.
                 value: New value (string/number/list as required by the field type).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
@@ -701,7 +750,12 @@ class TableTools:
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_table_tool_graphql_error(
-                    exc, "Set table record field value failed.", debug=debug
+                    exc,
+                    "Set table record field value failed.",
+                    debug=debug,
+                    resource_kind="table_record",
+                    resource_id=str(record_id),
+                    invalid_args_hint="Use 'get_table' to list valid field IDs for this table.",
                 )
             return build_table_mutation_success_payload(
                 message="Field value updated.",
@@ -729,6 +783,7 @@ class TableTools:
 
             Args:
                 table_id: Database table ID.
+                    Discover via: ``search_tables`` or ``get_tables(table_ids)``.
                 label: Field label in the UI.
                 field_type: Pipefy field type string (API input key `type`). See common types above.
                 extra_input: Additional CreateTableFieldInput keys to merge (e.g. required, options).
@@ -765,7 +820,11 @@ class TableTools:
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_table_tool_graphql_error(
-                    exc, "Create table field failed.", debug=debug
+                    exc,
+                    "Create table field failed.",
+                    debug=debug,
+                    resource_kind="table",
+                    resource_id=str(table_id),
                 )
             return build_table_mutation_success_payload(
                 message="Table field created.",
@@ -849,7 +908,11 @@ class TableTools:
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_table_tool_graphql_error(
-                    exc, "Update table field failed.", debug=debug
+                    exc,
+                    "Update table field failed.",
+                    debug=debug,
+                    resource_kind="table_field",
+                    resource_id=str(field_id),
                 )
             return build_table_mutation_success_payload(
                 message="Table field updated.",
@@ -904,7 +967,11 @@ class TableTools:
                 raw = await client.delete_table_field(field_id, table_id)
             except Exception as exc:  # noqa: BLE001
                 return handle_table_tool_graphql_error(
-                    exc, "Delete table field failed.", debug=debug
+                    exc,
+                    "Delete table field failed.",
+                    debug=debug,
+                    resource_kind="table_field",
+                    resource_id=str(field_id),
                 )
             return build_table_mutation_success_payload(
                 message="Table field deleted.",

--- a/src/pipefy_mcp/tools/validation_envelope.py
+++ b/src/pipefy_mcp/tools/validation_envelope.py
@@ -1,0 +1,179 @@
+"""Rewrap FastMCP argument-validation errors as canonical tool-error envelopes.
+
+FastMCP's ``Tool.run`` catches any exception raised by
+``fn_metadata.call_fn_with_arg_validation`` and wraps it as
+``ToolError(f"Error executing tool {name}: {e}")``. For argument coercion
+failures the underlying cause is a ``pydantic.ValidationError`` whose default
+string rendering leaks implementation details (``pydantic.dev`` URLs, internal
+``Arguments`` class names). :class:`PipefyValidationTool` intercepts that
+``ToolError`` *before* it reaches the MCP transport layer and returns a
+``{"success": False, "error": {...}}`` payload with an agent-friendly message.
+
+Install once at server startup via :func:`install_pipefy_validation_envelope`.
+The patch is idempotent so repeated startup (e.g. in tests) does not stack.
+
+Tested against ``mcp == 1.25.0`` (``Tool.run`` signature in
+``mcp.server.fastmcp.tools.base``). If the upstream package is upgraded,
+re-verify the ``call_fn_with_arg_validation`` / ``Tool.run`` contract.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.fastmcp.tools.base import Tool
+from mcp.server.fastmcp.tools.tool_manager import ToolManager
+from pydantic import ValidationError
+
+from pipefy_mcp.tools.tool_error_envelope import tool_error
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from mcp.server.fastmcp.server import Context
+    from mcp.server.session import ServerSessionT
+    from mcp.shared.context import LifespanContextT, RequestT
+    from mcp.types import Icon, ToolAnnotations
+
+__all__ = [
+    "INVALID_ARGUMENTS_CODE",
+    "PipefyValidationTool",
+    "install_pipefy_validation_envelope",
+]
+
+logger = logging.getLogger(__name__)
+
+INVALID_ARGUMENTS_CODE = "INVALID_ARGUMENTS"
+_PATCH_SENTINEL = "_pipefy_validation_envelope_patched"
+
+
+def _format_validation_errors(exc: ValidationError, tool_name: str) -> str:
+    """Render a ``ValidationError`` as a single agent-friendly line.
+
+    The output never contains ``pydantic.dev`` URLs nor FastMCP-internal
+    ``Arguments`` model names. Each error becomes a short clause; clauses are
+    joined with ``"; "`` and prefixed with the offending tool name.
+    """
+    clauses: list[str] = []
+    for err in exc.errors():
+        loc = ".".join(str(part) for part in err.get("loc", ()))
+        err_type = err.get("type", "")
+        msg = err.get("msg", "")
+        if err_type == "missing":
+            clauses.append(f"missing required argument '{loc}'")
+        elif err_type == "extra_forbidden":
+            clauses.append(f"unknown argument '{loc}'")
+        elif loc:
+            clauses.append(f"{loc}: {msg}")
+        else:
+            clauses.append(msg)
+    joined = "; ".join(clause for clause in clauses if clause)
+    return f"Tool '{tool_name}' received invalid arguments: {joined}"
+
+
+def _serialize_errors(exc: ValidationError) -> list[dict[str, Any]]:
+    """Return a minimal JSON-serializable list for ``details.errors``.
+
+    Only keeps ``path``, ``type``, and ``message`` so the response stays free
+    of Pydantic URLs and input echoes (which may contain secrets).
+    """
+    serialized: list[dict[str, Any]] = []
+    for err in exc.errors():
+        serialized.append(
+            {
+                "path": list(err.get("loc", ())),
+                "type": err.get("type", ""),
+                "message": err.get("msg", ""),
+            }
+        )
+    return serialized
+
+
+class PipefyValidationTool(Tool):
+    """FastMCP ``Tool`` subclass that intercepts argument-validation errors.
+
+    ``Tool.run`` wraps any exception as a ``ToolError`` whose ``__cause__`` is
+    the underlying exception. We re-inspect that chain: when the cause is a
+    ``ValidationError`` from the tool's own arg-model (not an inner body
+    validation), we swap the ``ToolError`` for a canonical
+    ``{"success": False, "error": {...}}`` payload.
+    """
+
+    async def run(
+        self,
+        arguments: dict[str, Any],
+        context: Context[ServerSessionT, LifespanContextT, RequestT] | None = None,
+        convert_result: bool = False,
+    ) -> Any:
+        """Run the tool, rewrapping arg-coercion ``ValidationError`` as an envelope."""
+        try:
+            return await super().run(
+                arguments, context=context, convert_result=convert_result
+            )
+        except ToolError as exc:
+            cause = exc.__cause__
+            if isinstance(cause, ValidationError) and self._is_arg_model_error(cause):
+                payload = tool_error(
+                    _format_validation_errors(cause, self.name),
+                    code=INVALID_ARGUMENTS_CODE,
+                    details={"errors": _serialize_errors(cause)},
+                )
+                if convert_result:
+                    payload = self.fn_metadata.convert_result(payload)
+                return payload
+            raise
+
+    def _is_arg_model_error(self, exc: ValidationError) -> bool:
+        """True when the ``ValidationError`` was raised by our arg-coercion step.
+
+        Pydantic v2 sets ``ValidationError.title`` to the model class name.
+        ``FuncMetadata`` constructs a per-tool arg model named ``<fn>Arguments``;
+        matching on that name keeps inner-body ``ValidationError`` cases (e.g. a
+        tool manually calling ``SomeModel.model_validate(...)``) untouched.
+        """
+        return exc.title == self.fn_metadata.arg_model.__name__
+
+
+def install_pipefy_validation_envelope() -> None:
+    """Monkey-patch ``ToolManager.add_tool`` so every registered tool uses the envelope.
+
+    Idempotent: re-invocation is a no-op, which keeps repeated server startup
+    (in tests) from stacking patches.
+    """
+    if getattr(ToolManager, _PATCH_SENTINEL, False):
+        return
+
+    def _add_tool(
+        self: ToolManager,
+        fn: Callable[..., Any],
+        name: str | None = None,
+        title: str | None = None,
+        description: str | None = None,
+        annotations: ToolAnnotations | None = None,
+        icons: list[Icon] | None = None,
+        meta: dict[str, Any] | None = None,
+        structured_output: bool | None = None,
+    ) -> Tool:
+        tool = PipefyValidationTool.from_function(
+            fn,
+            name=name,
+            title=title,
+            description=description,
+            annotations=annotations,
+            icons=icons,
+            meta=meta,
+            structured_output=structured_output,
+        )
+        existing = self._tools.get(tool.name)
+        if existing:
+            if self.warn_on_duplicate_tools:
+                logger.warning("Tool already exists: %s", tool.name)
+            return existing
+        self._tools[tool.name] = tool
+        return tool
+
+    ToolManager.add_tool = _add_tool  # type: ignore[assignment]
+    setattr(ToolManager, _PATCH_SENTINEL, True)
+    logger.debug("PipefyValidationTool wiring active (ToolManager.add_tool patched)")

--- a/src/pipefy_mcp/tools/webhook_tool_helpers.py
+++ b/src/pipefy_mcp/tools/webhook_tool_helpers.py
@@ -49,9 +49,19 @@ def handle_webhook_tool_graphql_error(
     fallback_msg: str,
     *,
     debug: bool = False,
+    resource_kind: str | None = None,
+    resource_id: str | None = None,
+    invalid_args_hint: str | None = None,
 ) -> dict[str, Any]:
-    """Delegate to :func:`handle_tool_graphql_error`."""
-    return handle_tool_graphql_error(exc, fallback_msg, debug=debug)
+    """Delegate to :func:`handle_tool_graphql_error` with enrichment opt-ins."""
+    return handle_tool_graphql_error(
+        exc,
+        fallback_msg,
+        debug=debug,
+        resource_kind=resource_kind,
+        resource_id=resource_id,
+        invalid_args_hint=invalid_args_hint,
+    )
 
 
 __all__ = [

--- a/src/pipefy_mcp/tools/webhook_tools.py
+++ b/src/pipefy_mcp/tools/webhook_tools.py
@@ -58,7 +58,11 @@ class WebhookTools:
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_webhook_tool_graphql_error(
-                    exc, "List email templates failed.", debug=debug
+                    exc,
+                    "List email templates failed.",
+                    debug=debug,
+                    resource_kind="pipe",
+                    resource_id=str(rid),
                 )
             return build_webhook_success_payload(
                 message="Email templates listed.",
@@ -101,7 +105,11 @@ class WebhookTools:
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_webhook_tool_graphql_error(
-                    exc, "Get card inbox emails failed.", debug=debug
+                    exc,
+                    "Get card inbox emails failed.",
+                    debug=debug,
+                    resource_kind="card",
+                    resource_id=str(cid),
                 )
             return build_webhook_success_payload(
                 message="Card inbox emails listed.",
@@ -172,7 +180,11 @@ class WebhookTools:
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_webhook_tool_graphql_error(
-                    exc, "Send inbox email failed.", debug=debug
+                    exc,
+                    "Send inbox email failed.",
+                    debug=debug,
+                    resource_kind="card",
+                    resource_id=str(cid),
                 )
             return build_webhook_success_payload(
                 message="Email sent.",
@@ -235,7 +247,11 @@ class WebhookTools:
                 return build_webhook_error_payload(message=str(exc))
             except Exception as exc:  # noqa: BLE001
                 return handle_webhook_tool_graphql_error(
-                    exc, "Send email with template failed.", debug=debug
+                    exc,
+                    "Send email with template failed.",
+                    debug=debug,
+                    resource_kind="email_template",
+                    resource_id=str(email_template_id),
                 )
             return build_webhook_success_payload(
                 message="Email sent with template.",
@@ -267,7 +283,11 @@ class WebhookTools:
                 raw = await client.get_webhooks(pid)
             except Exception as exc:  # noqa: BLE001
                 return handle_webhook_tool_graphql_error(
-                    exc, "List webhooks failed.", debug=debug
+                    exc,
+                    "List webhooks failed.",
+                    debug=debug,
+                    resource_kind="pipe",
+                    resource_id=str(pid),
                 )
             return build_webhook_success_payload(
                 message="Webhooks listed.",
@@ -291,6 +311,7 @@ class WebhookTools:
 
             Args:
                 pipe_id: ID of the pipe.
+                    Discover via: ``search_pipes`` or ``get_organization``.
                 url: HTTPS URL to receive events.
                 actions: List of event action strings.
                 extra_input: Optional extra CreateWebhookInput fields (name, filters, headers).
@@ -327,7 +348,11 @@ class WebhookTools:
                 return build_webhook_error_payload(message=str(exc))
             except Exception as exc:  # noqa: BLE001
                 return handle_webhook_tool_graphql_error(
-                    exc, "Create webhook failed.", debug=debug
+                    exc,
+                    "Create webhook failed.",
+                    debug=debug,
+                    resource_kind="pipe",
+                    resource_id=str(pid),
                 )
             return build_webhook_success_payload(
                 message="Webhook created.",
@@ -352,6 +377,7 @@ class WebhookTools:
 
             Args:
                 webhook_id: ID of the webhook to update.
+                    Discover via: ``get_webhooks(pipe_id)[].id``.
                 name: Optional new display name.
                 url: Optional new HTTPS callback URL.
                 actions: Optional new list of event action strings (non-empty when provided).
@@ -407,7 +433,11 @@ class WebhookTools:
                 return build_webhook_error_payload(message=str(exc))
             except Exception as exc:  # noqa: BLE001
                 return handle_webhook_tool_graphql_error(
-                    exc, "Update webhook failed.", debug=debug
+                    exc,
+                    "Update webhook failed.",
+                    debug=debug,
+                    resource_kind="webhook",
+                    resource_id=str(wid),
                 )
             return build_webhook_success_payload(
                 message="Webhook updated.",
@@ -454,7 +484,11 @@ class WebhookTools:
                 raw = await client.delete_webhook(wid)
             except Exception as exc:  # noqa: BLE001
                 return handle_webhook_tool_graphql_error(
-                    exc, "Delete webhook failed.", debug=debug
+                    exc,
+                    "Delete webhook failed.",
+                    debug=debug,
+                    resource_kind="webhook",
+                    resource_id=str(wid),
                 )
             return build_webhook_success_payload(
                 message="Webhook deleted.",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,13 @@
 
 import pytest
 
+from pipefy_mcp.tools.validation_envelope import install_pipefy_validation_envelope
+
+# Mirror the production wiring in ``server.py``'s lifespan so every in-memory
+# FastMCP instance constructed in tests also goes through ``PipefyValidationTool``.
+# The patch is idempotent — calling it here is safe regardless of other imports.
+install_pipefy_validation_envelope()
+
 
 @pytest.fixture
 def anyio_backend():

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -5,33 +5,59 @@ import json
 import pytest
 
 
+def _extract_payload_impl(result):
+    """Extract tool payload from CallToolResult across MCP SDK versions."""
+    structured = getattr(result, "structuredContent", None)
+    if structured is not None:
+        if isinstance(structured, dict) and "result" in structured:
+            payload = structured.get("result")
+            if isinstance(payload, dict):
+                if "success" in payload or "error" in payload:
+                    return payload
+                if "success" in structured or "error" in structured:
+                    return structured
+                return payload
+        if isinstance(structured, dict):
+            return structured
+    content = getattr(result, "content", None) or []
+    for item in content:
+        if getattr(item, "type", None) == "text":
+            text = getattr(item, "text", "")
+            try:
+                payload = json.loads(text)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(payload, dict):
+                return payload
+    raise AssertionError("Could not extract tool payload from CallToolResult")
+
+
 @pytest.fixture
 def extract_payload():
-    """Extract tool payload from CallToolResult across MCP SDK versions."""
+    """Return the shared extractor as a callable fixture (back-compat)."""
+    return _extract_payload_impl
 
-    def _extract(result):
-        structured = getattr(result, "structuredContent", None)
-        if structured is not None:
-            if isinstance(structured, dict) and "result" in structured:
-                payload = structured.get("result")
-                if isinstance(payload, dict):
-                    if "success" in payload or "error" in payload:
-                        return payload
-                    if "success" in structured or "error" in structured:
-                        return structured
-                    return payload
-            if isinstance(structured, dict):
-                return structured
-        content = getattr(result, "content", None) or []
-        for item in content:
-            if getattr(item, "type", None) == "text":
-                text = getattr(item, "text", "")
-                try:
-                    payload = json.loads(text)
-                except json.JSONDecodeError:
-                    continue
-                if isinstance(payload, dict):
-                    return payload
-        raise AssertionError("Could not extract tool payload from CallToolResult")
 
-    return _extract
+def assert_invalid_arguments_envelope(result):
+    """Assert a ``CallToolResult`` carries a Pipefy ``INVALID_ARGUMENTS`` envelope.
+
+    Use this for cases where FastMCP's argument coercion rejects the input
+    (missing required arg, wrong type, ``@field_validator`` rejecting blank /
+    empty strings). The envelope is produced by
+    :class:`pipefy_mcp.tools.validation_envelope.PipefyValidationTool` and is
+    delivered as a structured success payload (``isError == False``), not as a
+    transport-level error.
+    """
+    assert result.isError is False, (
+        "Expected a tool-error envelope (isError=False), got a transport error: "
+        f"{result}"
+    )
+    payload = _extract_payload_impl(result)
+    assert payload.get("success") is False, (
+        f"Expected envelope success=False, got payload: {payload!r}"
+    )
+    error = payload.get("error") or {}
+    assert error.get("code") == "INVALID_ARGUMENTS", (
+        f"Expected error.code=INVALID_ARGUMENTS, got payload: {payload!r}"
+    )
+    return payload

--- a/tests/tools/test_ai_agent_tools.py
+++ b/tests/tools/test_ai_agent_tools.py
@@ -16,6 +16,7 @@ from pipefy_mcp.models.ai_agent import UpdateAiAgentInput
 from pipefy_mcp.tools.ai_agent_tools import AiAgentTools
 from pipefy_mcp.tools.tool_error_envelope import tool_error_message
 from tests.ai_agent_test_payloads import behavior_with_action, minimal_behavior_dict
+from tests.tools.conftest import assert_invalid_arguments_envelope
 
 
 @pytest.fixture(autouse=True)
@@ -1311,7 +1312,7 @@ class TestValidateAiAgentBehaviorsErrorPaths:
                 "validate_ai_agent_behaviors",
                 {"pipe_id": "  ", "behaviors": [minimal_behavior_dict()]},
             )
-        assert result.isError is True
+        assert_invalid_arguments_envelope(result)
 
     async def test_pydantic_validation_failure(
         self,

--- a/tests/tools/test_ai_automation_tools.py
+++ b/tests/tools/test_ai_automation_tools.py
@@ -13,6 +13,7 @@ from mcp.shared.memory import (
 from pipefy_mcp.services.pipefy import PipefyClient
 from pipefy_mcp.tools.ai_automation_tools import AiAutomationTools
 from pipefy_mcp.tools.tool_error_envelope import tool_error_message
+from tests.tools.conftest import assert_invalid_arguments_envelope
 
 
 @pytest.fixture
@@ -146,7 +147,7 @@ class TestGetAiAutomation:
                 {"automation_id": ""},
             )
         mock_pipefy_client.get_automation.assert_not_called()
-        assert result.isError is True
+        assert_invalid_arguments_envelope(result)
 
     async def test_rejects_non_positive_int_id(
         self,
@@ -331,7 +332,7 @@ class TestGetAiAutomations:
                 {"pipe_id": ""},
             )
         mock_pipefy_client.get_automations.assert_not_called()
-        assert result.isError is True
+        assert_invalid_arguments_envelope(result)
 
     async def test_rejects_invalid_organization_id(
         self,
@@ -344,7 +345,7 @@ class TestGetAiAutomations:
                 {"pipe_id": "1", "organization_id": ""},
             )
         mock_pipefy_client.get_automations.assert_not_called()
-        assert result.isError is True
+        assert_invalid_arguments_envelope(result)
 
     async def test_works_without_oauth_config(
         self,
@@ -484,7 +485,7 @@ class TestDeleteAiAutomation:
                 {"automation_id": "", "confirm": True},
             )
         mock_pipefy_client.delete_automation.assert_not_called()
-        assert result.isError is True
+        assert_invalid_arguments_envelope(result)
 
     async def test_has_destructive_hint(self, client_session):
         async with client_session as session:
@@ -799,7 +800,8 @@ class TestUpdateAiAutomation:
         err = tool_error_message(payload)
         assert "[code=" not in err
         assert "[correlation_id=" not in err
-        assert "Not found" in err
+        assert "Ai automation not found (ID: 789)" in err
+        assert "get_ai_automations" in err
         assert "corr-9" not in err
 
     async def test_update_debug_true_includes_correlation_and_codes(
@@ -826,10 +828,54 @@ class TestUpdateAiAutomation:
         assert payload["success"] is False
         err = tool_error_message(payload)
         assert "[code=" not in err
-        assert "Not found" in err
+        assert "Ai automation not found (ID: 789)" in err
         assert "(debug:" in err
         assert "NOT_FOUND" in err
         assert "corr-9" in err
+
+    async def test_update_plain_api_automation_not_found_gets_discovery_hint(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.update_ai_automation.side_effect = ValueError(
+            "API error: Automation not found with id: 99999999999"
+        )
+        async with client_session as session:
+            result = await session.call_tool(
+                "update_ai_automation",
+                {"automation_id": "99999999999", "name": "x"},
+            )
+        assert result.isError is False
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        err = tool_error_message(payload)
+        assert "Ai automation not found (ID: 99999999999)" in err
+        assert "get_ai_automations" in err
+        assert payload["error"]["code"] == "NOT_FOUND"
+
+    async def test_update_permission_denied_gets_gap_a_ambiguity_hint(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        mock_pipefy_client.update_ai_automation.side_effect = ValueError(
+            "Permission denied [code=PERMISSION_DENIED] [correlation_id=c1]"
+        )
+        async with client_session as session:
+            result = await session.call_tool(
+                "update_ai_automation",
+                {"automation_id": "42", "name": "x"},
+            )
+        assert result.isError is False
+        payload = extract_payload(result)
+        err = tool_error_message(payload)
+        assert "may not exist OR" in err
+        assert "get_ai_automations" in err
+        assert "get_pipe_members" not in err
+        assert payload["error"]["code"] == "PERMISSION_DENIED"
 
 
 ## ---------------------------------------------------------------------------
@@ -1266,7 +1312,7 @@ class TestValidateAiAutomationPrompt:
                 },
             )
         mock_pipefy_client.get_pipe_with_preferences.assert_not_called()
-        assert result.isError is True
+        assert_invalid_arguments_envelope(result)
 
     async def test_event_fetch_failure_adds_warning(
         self,

--- a/tests/tools/test_automation_tools.py
+++ b/tests/tools/test_automation_tools.py
@@ -13,6 +13,7 @@ from mcp.shared.memory import (
 from pipefy_mcp.services.pipefy import PipefyClient
 from pipefy_mcp.tools.automation_tools import AutomationTools
 from pipefy_mcp.tools.tool_error_envelope import tool_error_message
+from tests.tools.conftest import assert_invalid_arguments_envelope
 
 
 @pytest.fixture
@@ -120,7 +121,7 @@ async def test_get_automation_rejects_empty_automation_id(
         result = await session.call_tool("get_automation", {"automation_id": ""})
 
     mock_automation_client.get_automation.assert_not_called()
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)
 
 
 @pytest.mark.anyio
@@ -147,7 +148,7 @@ async def test_get_automations_rejects_empty_string_filters(
         )
 
     mock_automation_client.get_automations.assert_not_called()
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)
 
 
 @pytest.mark.anyio
@@ -702,7 +703,7 @@ async def test_simulate_automation_rejects_invalid_pipe_id(
         )
 
     mock_automation_client.simulate_automation.assert_not_called()
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)
 
 
 @pytest.mark.anyio
@@ -915,8 +916,13 @@ async def test_create_automation_cross_pipe_permission_denied_enriches_error(
         )
     payload = extract_payload(result)
     assert payload["success"] is False
+    # Cross-pipe permission-denied enrichment ran (prepends membership hint via
+    # the async enrich_permission_denied_error at the call site).
     assert "invite_members" in tool_error_message(payload)
-    assert "forbidden" in tool_error_message(payload)
+    # handle_automation_tool_graphql_error's ambiguity enricher also ran
+    # (rewrites the raw "forbidden" into a dual-meaning NOT_FOUND/denied hint).
+    assert "may lack access" in tool_error_message(payload)
+    assert payload["error"]["code"] == "PERMISSION_DENIED"
 
 
 @pytest.mark.anyio

--- a/tests/tools/test_docstring_discovery_hints.py
+++ b/tests/tools/test_docstring_discovery_hints.py
@@ -1,0 +1,133 @@
+"""Enforce `Discover via:` annotations on tools whose args depend on other tools.
+
+Parses each tool module with ``ast`` to avoid importing the full server (the
+monkey-patch in ``validation_envelope`` is side-effectful). For every audited
+tool, asserts (a) the phrase ``"Discover via"`` appears in the docstring and
+(b) each ``must_mention_tool`` substring is present, anchoring the hint to the
+correct discovery path.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+AUDIT: list[tuple[str, str, list[str]]] = [
+    # (tool name, module file under src/pipefy_mcp/tools/, must-mention tools)
+    (
+        "create_field_condition",
+        "field_condition_tools.py",
+        ["get_pipe", "get_phase_fields"],
+    ),
+    (
+        "update_field_condition",
+        "field_condition_tools.py",
+        ["get_field_conditions", "get_phase_fields"],
+    ),
+    ("create_card_relation", "relation_tools.py", ["get_pipe_relations"]),
+    ("create_pipe_relation", "relation_tools.py", ["search_pipes", "get_organization"]),
+    ("get_pipe", "pipe_tools.py", ["search_pipes"]),
+    ("get_card", "pipe_tools.py", ["find_cards"]),
+    ("get_pipe_members", "pipe_tools.py", ["search_pipes"]),
+    ("fill_card_phase_fields", "pipe_tools.py", ["get_phase_fields"]),
+    ("update_card_field", "pipe_tools.py", ["get_phase_fields"]),
+    ("move_card_to_phase", "pipe_tools.py", ["get_pipe"]),
+    ("create_phase_field", "pipe_config_tools.py", ["get_pipe"]),
+    ("update_phase_field", "pipe_config_tools.py", ["get_phase_fields"]),
+    ("delete_phase_field", "pipe_config_tools.py", ["get_phase_fields"]),
+    ("update_phase", "pipe_config_tools.py", ["get_pipe"]),
+    ("create_table_field", "table_tools.py", ["search_tables"]),
+    ("create_table_record", "table_tools.py", ["search_tables", "get_table"]),
+    ("update_table_record", "table_tools.py", ["find_records"]),
+    ("set_table_record_field_value", "table_tools.py", ["find_records", "get_table"]),
+    ("create_ai_agent", "ai_agent_tools.py", ["search_pipes", "get_automation_events"]),
+    ("update_ai_agent", "ai_agent_tools.py", ["get_ai_agents"]),
+    (
+        "validate_ai_agent_behaviors",
+        "ai_agent_tools.py",
+        ["search_pipes", "get_automation_events"],
+    ),
+    (
+        "create_ai_automation",
+        "ai_automation_tools.py",
+        ["get_automation_events", "get_phase_fields"],
+    ),
+    (
+        "update_ai_automation",
+        "ai_automation_tools.py",
+        ["get_ai_automations"],
+    ),
+    (
+        "validate_ai_automation_prompt",
+        "ai_automation_tools.py",
+        ["get_phase_fields", "get_automation_events"],
+    ),
+    ("create_webhook", "webhook_tools.py", ["search_pipes"]),
+    ("update_webhook", "webhook_tools.py", ["get_webhooks"]),
+]
+
+_TOOLS_DIR = pathlib.Path(__file__).parents[2] / "src" / "pipefy_mcp" / "tools"
+
+
+def _collect_tool_docstrings(module_path: pathlib.Path) -> dict[str, str]:
+    """Return ``{tool_name: docstring}`` for every @mcp.tool-decorated inner fn.
+
+    Walks the whole AST — the decorator detection is intentionally tolerant
+    so it finds both plain ``@mcp.tool(...)`` and bare ``@mcp.tool`` forms.
+    """
+    tree = ast.parse(module_path.read_text())
+    found: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+            continue
+        if not _has_mcp_tool_decorator(node):
+            continue
+        docstring = ast.get_docstring(node) or ""
+        found[node.name] = docstring
+    return found
+
+
+def _has_mcp_tool_decorator(node: ast.AsyncFunctionDef | ast.FunctionDef) -> bool:
+    for dec in node.decorator_list:
+        target = dec.func if isinstance(dec, ast.Call) else dec
+        if (
+            isinstance(target, ast.Attribute)
+            and isinstance(target.value, ast.Name)
+            and target.value.id == "mcp"
+            and target.attr == "tool"
+        ):
+            return True
+    return False
+
+
+@pytest.fixture(scope="module")
+def docstrings_by_module() -> dict[str, dict[str, str]]:
+    cache: dict[str, dict[str, str]] = {}
+    for _, module_filename, _ in AUDIT:
+        if module_filename not in cache:
+            cache[module_filename] = _collect_tool_docstrings(
+                _TOOLS_DIR / module_filename
+            )
+    return cache
+
+
+@pytest.mark.parametrize("tool_name,module_filename,must_mention", AUDIT)
+def test_tool_docstring_has_discovery_hints(
+    tool_name, module_filename, must_mention, docstrings_by_module
+):
+    module_docstrings = docstrings_by_module[module_filename]
+    assert tool_name in module_docstrings, (
+        f"Tool '{tool_name}' not found in {module_filename}. Update AUDIT if renamed."
+    )
+    docstring = module_docstrings[tool_name]
+    assert "Discover via" in docstring, (
+        f"Tool '{tool_name}' is missing a 'Discover via:' annotation. "
+        f"Add one in the Args section for fields that depend on other tools."
+    )
+    for tool in must_mention:
+        assert tool in docstring, (
+            f"Tool '{tool_name}' docstring does not mention '{tool}'. "
+            f"Add a 'Discover via: ... {tool} ...' line in the relevant Args entry."
+        )

--- a/tests/tools/test_graphql_error_enrichment.py
+++ b/tests/tools/test_graphql_error_enrichment.py
@@ -1,0 +1,306 @@
+"""Tests for NOT_FOUND / INVALID_ARGUMENTS enrichment in graphql_error_helpers."""
+
+import pytest
+
+from pipefy_mcp.tools.graphql_error_helpers import (
+    enrich_ambiguous_access_error,
+    enrich_invalid_arguments_error,
+    enrich_not_found_error,
+    handle_tool_graphql_error,
+)
+from pipefy_mcp.tools.tool_error_envelope import tool_error_message
+
+
+class _FakeGraphQLError(Exception):
+    """Mimics ``gql.transport.exceptions.TransportQueryError`` shape."""
+
+    def __init__(self, code: str | None, message: str):
+        super().__init__(message)
+        self._raw_message = message
+        error_item: dict = {"message": message}
+        if code is not None:
+            error_item["extensions"] = {"code": code}
+        self.errors = [error_item]
+
+    def __str__(self) -> str:
+        return self._raw_message
+
+
+def _build_graphql_exc(code: str | None, message: str) -> _FakeGraphQLError:
+    return _FakeGraphQLError(code, message)
+
+
+class TestEnrichNotFoundError:
+    def test_not_found_enriches_pipe_error(self):
+        exc = _build_graphql_exc("NOT_FOUND", "Pipe not found")
+        result = enrich_not_found_error(exc, resource_kind="pipe", resource_id="42")
+        assert result is not None
+        assert "Pipe not found" in result
+        assert "42" in result
+        assert "search_pipes" in result
+
+    def test_not_found_string_based_fallback(self):
+        exc = _build_graphql_exc(None, "Record not found for id 99")
+        result = enrich_not_found_error(exc, resource_kind="card")
+        assert result is not None
+        assert "find_cards" in result
+
+    def test_not_found_returns_none_for_unrelated(self):
+        exc = _build_graphql_exc(
+            "PERMISSION_DENIED", "You do not have permission to access this pipe"
+        )
+        result = enrich_not_found_error(exc, resource_kind="pipe", resource_id="42")
+        assert result is None
+
+    def test_not_found_unknown_resource_kind(self):
+        exc = _build_graphql_exc("NOT_FOUND", "Banana not found")
+        result = enrich_not_found_error(exc, resource_kind="banana")
+        assert result is not None
+        assert result.endswith("Verify the ID and try again.")
+
+    def test_not_found_omits_id_clause_when_missing(self):
+        exc = _build_graphql_exc("NOT_FOUND", "Pipe not found")
+        result = enrich_not_found_error(exc, resource_kind="pipe")
+        assert result is not None
+        assert "(ID:" not in result
+        assert "search_pipes" in result
+
+    def test_not_found_humanizes_snake_case(self):
+        exc = _build_graphql_exc("NOT_FOUND", "Record not found")
+        result = enrich_not_found_error(
+            exc, resource_kind="table_record", resource_id="rec_1"
+        )
+        assert result is not None
+        assert "Table record not found" in result
+        assert "find_records" in result
+
+
+class TestEnrichAmbiguousAccessError:
+    def test_permission_denied_rewritten_with_ambiguity_hint(self):
+        exc = _build_graphql_exc("PERMISSION_DENIED", "Permission denied")
+        result = enrich_ambiguous_access_error(
+            exc, resource_kind="pipe", resource_id="99999999"
+        )
+        assert result is not None
+        assert "99999999" in result
+        assert "may not exist" in result
+        assert "may lack access" in result
+        assert "search_pipes" in result
+        assert "get_pipe_members" in result
+
+    def test_returns_none_when_not_permission_denied(self):
+        exc = _build_graphql_exc("NOT_FOUND", "Pipe not found")
+        result = enrich_ambiguous_access_error(exc, resource_kind="pipe")
+        assert result is None
+
+    def test_returns_none_when_code_absent(self):
+        exc = _build_graphql_exc(None, "Some other error")
+        result = enrich_ambiguous_access_error(exc, resource_kind="pipe")
+        assert result is None
+
+    def test_omits_id_clause_when_missing(self):
+        exc = _build_graphql_exc("PERMISSION_DENIED", "Permission denied")
+        result = enrich_ambiguous_access_error(exc, resource_kind="webhook")
+        assert result is not None
+        assert "(ID:" not in result
+        assert "get_webhooks" in result
+
+    def test_unknown_resource_kind_falls_back_to_generic_hint(self):
+        exc = _build_graphql_exc("PERMISSION_DENIED", "Permission denied")
+        result = enrich_ambiguous_access_error(
+            exc, resource_kind="banana", resource_id="x"
+        )
+        assert result is not None
+        assert "Verify the ID and try again." in result
+
+    @pytest.mark.parametrize(
+        "kind",
+        [
+            "pipe",
+            "phase",
+            "phase_field",
+            "card",
+            "label",
+            "pipe_report",
+            "pipe_relation",
+            "field_condition",
+            "start_form_field",
+        ],
+    )
+    def test_pipe_centric_kinds_include_membership_hint(self, kind):
+        exc = _build_graphql_exc("PERMISSION_DENIED", "Permission denied")
+        result = enrich_ambiguous_access_error(exc, resource_kind=kind)
+        assert result is not None
+        assert "get_pipe_members" in result
+
+    @pytest.mark.parametrize(
+        "kind",
+        [
+            "automation",
+            "ai_automation",
+            "table",
+            "table_record",
+            "webhook",
+            "ai_agent",
+            "ai_agent_log",
+            "organization",
+            "organization_report",
+            "email_template",
+        ],
+    )
+    def test_non_pipe_centric_kinds_omit_membership_hint(self, kind):
+        exc = _build_graphql_exc("PERMISSION_DENIED", "Permission denied")
+        result = enrich_ambiguous_access_error(exc, resource_kind=kind)
+        assert result is not None
+        assert "get_pipe_members" not in result
+        assert "may not exist" in result
+
+
+class TestEnrichInvalidArgumentsError:
+    def test_invalid_arguments_adds_hint(self):
+        exc = _build_graphql_exc("BAD_USER_INPUT", "Argument 'phaseFieldId' is invalid")
+        hint = "Use 'get_phase_fields' to list valid field IDs."
+        result = enrich_invalid_arguments_error(exc, hint=hint)
+        assert result is not None
+        assert hint in result
+
+    def test_invalid_arguments_default_hint(self):
+        exc = _build_graphql_exc("BAD_USER_INPUT", "Field 'x' invalid")
+        result = enrich_invalid_arguments_error(exc)
+        assert result is not None
+        assert "docstring" in result
+
+    def test_invalid_arguments_returns_none_for_unrelated(self):
+        exc = _build_graphql_exc("NOT_FOUND", "Pipe not found")
+        result = enrich_invalid_arguments_error(exc, hint="any hint")
+        assert result is None
+
+
+class TestHandleToolGraphqlErrorIntegration:
+    def test_preserves_legacy_when_no_kind_passed(self):
+        exc = _build_graphql_exc("NOT_FOUND", "Pipe not found")
+        payload = handle_tool_graphql_error(exc, "Failed")
+        message = tool_error_message(payload)
+        assert message == "Pipe not found"
+        assert "search_pipes" not in message
+        assert payload["error"]["code"] == "NOT_FOUND"
+
+    def test_enriches_when_kind_passed(self):
+        exc = _build_graphql_exc("NOT_FOUND", "Pipe not found")
+        payload = handle_tool_graphql_error(
+            exc, "Failed", resource_kind="pipe", resource_id="42"
+        )
+        message = tool_error_message(payload)
+        assert "Pipe not found (ID: 42)" in message
+        assert "search_pipes" in message
+        assert payload["error"]["code"] == "NOT_FOUND"
+
+    def test_enriches_invalid_arguments_when_hint_passed(self):
+        exc = _build_graphql_exc("BAD_USER_INPUT", "Invalid argument 'field_id'")
+        payload = handle_tool_graphql_error(
+            exc,
+            "Failed",
+            invalid_args_hint="Use 'get_phase_fields' to list valid field IDs.",
+        )
+        message = tool_error_message(payload)
+        assert "get_phase_fields" in message
+        assert payload["error"]["code"] == "BAD_USER_INPUT"
+
+    def test_not_found_takes_precedence_over_invalid_args(self):
+        exc = _build_graphql_exc("NOT_FOUND", "Pipe not found")
+        payload = handle_tool_graphql_error(
+            exc,
+            "Failed",
+            resource_kind="pipe",
+            resource_id="42",
+            invalid_args_hint="Should not appear.",
+        )
+        message = tool_error_message(payload)
+        assert "Pipe not found (ID: 42)" in message
+        assert "Should not appear." not in message
+
+    def test_fallthrough_legacy_for_unrelated_codes_when_opted_in(self):
+        exc = _build_graphql_exc("INTERNAL_ERROR", "Something broke")
+        payload = handle_tool_graphql_error(
+            exc, "Failed", resource_kind="pipe", resource_id="42"
+        )
+        message = tool_error_message(payload)
+        assert message == "Something broke"
+        assert "search_pipes" not in message
+
+    def test_permission_denied_enriched_when_resource_kind_passed(self):
+        exc = _build_graphql_exc("PERMISSION_DENIED", "Permission denied")
+        payload = handle_tool_graphql_error(
+            exc, "Failed", resource_kind="pipe", resource_id="99999999"
+        )
+        message = tool_error_message(payload)
+        assert "99999999" in message
+        assert "may not exist" in message
+        assert "may lack access" in message
+        assert "search_pipes" in message
+        assert payload["error"]["code"] == "PERMISSION_DENIED"
+
+    def test_permission_denied_legacy_when_no_kind_passed(self):
+        exc = _build_graphql_exc("PERMISSION_DENIED", "Permission denied")
+        payload = handle_tool_graphql_error(exc, "Failed")
+        message = tool_error_message(payload)
+        assert message == "Permission denied"
+        assert "may not exist" not in message
+
+    def test_not_found_still_takes_precedence_over_ambiguous_access(self):
+        # If both codes appeared (unlikely but possible), NOT_FOUND wins because
+        # it is unambiguous.
+        class _DualCodeExc(Exception):
+            def __init__(self):
+                super().__init__("Resource not found")
+                self.errors = [
+                    {"message": "Not found", "extensions": {"code": "NOT_FOUND"}},
+                    {
+                        "message": "Permission denied",
+                        "extensions": {"code": "PERMISSION_DENIED"},
+                    },
+                ]
+
+            def __str__(self):
+                return "Resource not found"
+
+        payload = handle_tool_graphql_error(
+            _DualCodeExc(), "Failed", resource_kind="pipe", resource_id="42"
+        )
+        message = tool_error_message(payload)
+        assert "Pipe not found (ID: 42)" in message
+        assert "may not exist OR" not in message
+
+    def test_debug_suffix_applies_to_enriched_message(self):
+        exc = _build_graphql_exc("NOT_FOUND", "Pipe not found")
+        payload = handle_tool_graphql_error(
+            exc, "Failed", debug=True, resource_kind="pipe", resource_id="42"
+        )
+        message = tool_error_message(payload)
+        assert "Pipe not found (ID: 42)" in message
+        assert "codes=NOT_FOUND" in message
+
+    @pytest.mark.parametrize(
+        "kind,expected_label,expected_hint_substring",
+        [
+            ("pipe", "Pipe not found", "search_pipes"),
+            ("card", "Card not found", "find_cards"),
+            ("phase", "Phase not found", "get_pipe"),
+            ("phase_field", "Phase field not found", "get_phase_fields"),
+            ("table", "Table not found", "search_tables"),
+            ("table_record", "Table record not found", "find_records"),
+            ("field_condition", "Field condition not found", "get_field_conditions"),
+            ("ai_agent", "Ai agent not found", "get_ai_agents"),
+            ("ai_automation", "Ai automation not found", "get_ai_automations"),
+            ("automation", "Automation not found", "get_automations"),
+            ("label", "Label not found", "get_labels"),
+            ("webhook", "Webhook not found", "get_webhooks"),
+            ("organization", "Organization not found", "get_organization"),
+        ],
+    )
+    def test_discovery_hint_matrix(self, kind, expected_label, expected_hint_substring):
+        exc = _build_graphql_exc("NOT_FOUND", "Not found")
+        result = enrich_not_found_error(exc, resource_kind=kind, resource_id="id_1")
+        assert result is not None
+        assert expected_label in result
+        assert expected_hint_substring in result

--- a/tests/tools/test_observability_tools.py
+++ b/tests/tools/test_observability_tools.py
@@ -13,6 +13,7 @@ from mcp.shared.memory import (
 from pipefy_mcp.services.pipefy import PipefyClient
 from pipefy_mcp.tools.observability_tools import _MAX_PAGE_SIZE, ObservabilityTools
 from pipefy_mcp.tools.tool_error_envelope import tool_error_message
+from tests.tools.conftest import assert_invalid_arguments_envelope
 
 
 @pytest.fixture
@@ -477,7 +478,7 @@ async def test_get_automation_jobs_export_rejects_empty_export_id(
         )
 
     mock_observability_client.get_automation_jobs_export.assert_not_called()
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)
 
 
 @pytest.mark.anyio
@@ -739,7 +740,7 @@ async def test_get_agents_usage_rejects_empty_org_uuid(
         )
 
     mock_observability_client.get_agents_usage.assert_not_called()
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)
 
 
 @pytest.mark.anyio
@@ -804,11 +805,12 @@ async def test_get_ai_agent_logs_debug_true_appends_codes(
     assert result.isError is False
     p = extract_payload(result)
     assert p["success"] is False
-    assert "not authorized" in tool_error_message(p)
-    assert "codes=" in tool_error_message(p) or "correlation_id=" in tool_error_message(
-        p
-    )
-    assert "PERMISSION_DENIED" in tool_error_message(p)
+    # The ambiguity enricher rewrote the raw "not authorized" into a
+    # dual-meaning message; the debug suffix still carries the code + correlation.
+    msg = tool_error_message(p)
+    assert "may lack access" in msg
+    assert "codes=" in msg or "correlation_id=" in msg
+    assert "PERMISSION_DENIED" in msg
 
 
 @pytest.mark.anyio
@@ -962,7 +964,7 @@ async def test_get_automation_logs_rejects_blank_automation_id(
         result = await session.call_tool("get_automation_logs", {"automation_id": ""})
 
     mock_observability_client.get_automation_logs.assert_not_called()
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)
 
 
 @pytest.mark.anyio
@@ -996,7 +998,7 @@ async def test_get_automation_logs_by_repo_rejects_blank_repo_id(
         result = await session.call_tool("get_automation_logs_by_repo", {"repo_id": ""})
 
     mock_observability_client.get_automation_logs_by_repo.assert_not_called()
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)
 
 
 @pytest.mark.anyio
@@ -1066,7 +1068,7 @@ async def test_get_automations_usage_rejects_empty_org_uuid(
         )
 
     mock_observability_client.get_automations_usage.assert_not_called()
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)
 
 
 @pytest.mark.anyio
@@ -1110,7 +1112,7 @@ async def test_get_ai_credit_usage_rejects_empty_org_uuid(
         )
 
     mock_observability_client.get_ai_credit_usage.assert_not_called()
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)
 
 
 # ---------------------------------------------------------------------------
@@ -1130,7 +1132,7 @@ async def test_export_automation_jobs_rejects_empty_org_id(
         )
 
     mock_observability_client.export_automation_jobs.assert_not_called()
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)
 
 
 @pytest.mark.anyio
@@ -1191,7 +1193,7 @@ async def test_get_ai_agent_log_details_graphql_error(
 
     p = extract_payload(result)
     assert p["success"] is False
-    assert "log not found" in tool_error_message(p)
+    assert "Ai agent log not found" in tool_error_message(p)
 
 
 @pytest.mark.anyio
@@ -1331,4 +1333,4 @@ async def test_get_automation_jobs_export_csv_rejects_empty_export_id(
         )
 
     mock_observability_client.get_automation_jobs_export_csv.assert_not_called()
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)

--- a/tests/tools/test_pipe_config_tools.py
+++ b/tests/tools/test_pipe_config_tools.py
@@ -21,6 +21,7 @@ from pipefy_mcp.tools.pipe_config_tool_helpers import (
 )
 from pipefy_mcp.tools.pipe_config_tools import PipeConfigTools
 from pipefy_mcp.tools.tool_error_envelope import tool_error, tool_error_message
+from tests.tools.conftest import assert_invalid_arguments_envelope
 
 
 @pytest.mark.unit
@@ -742,7 +743,7 @@ async def test_update_label_missing_color_rejected_at_tool_boundary(
             {"label_id": 3, "name": "Story"},
         )
     mock_pipe_config_client.update_label.assert_not_called()
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)
 
 
 @pytest.mark.anyio
@@ -1310,6 +1311,42 @@ async def test_create_field_condition_success(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_create_field_condition_slug_like_phase_field_id_carries_invalid_arguments_code(
+    pipe_config_session, mock_pipe_config_client, extract_payload
+):
+    """Pre-API arg validation must surface ``error.code = INVALID_ARGUMENTS``.
+
+    Hit by smoke Phase 6 Probe 5: a slug-looking ``phaseFieldId`` (e.g.
+    ``"nome_do_campo"``) triggers ``field_condition_actions_error_message``
+    before any Pipefy call. The envelope must match the shape of coercion
+    errors so agents can branch on ``error.code`` consistently.
+    """
+    expr = {
+        "expressions": [{"field_address": "a", "operation": "equals", "value": "1"}],
+    }
+    # Slug-like phaseFieldId (non-digit) triggers the looks_like_slug check.
+    actions = [{"phaseFieldId": "nome_do_campo", "actionId": "hide"}]
+    async with pipe_config_session as session:
+        result = await session.call_tool(
+            "create_field_condition",
+            {
+                "phase_id": "pf-99",
+                "condition": expr,
+                "actions": actions,
+                "name": "probe-5",
+            },
+        )
+
+    assert result.isError is False
+    mock_pipe_config_client.create_field_condition.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert payload["error"]["code"] == "INVALID_ARGUMENTS"
+    assert "get_phase_fields" in payload["error"]["message"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
 async def test_create_field_condition_top_level_name__no_integration(
     pipe_config_session, mock_pipe_config_client, extract_payload
 ):
@@ -1764,7 +1801,7 @@ async def test_update_field_condition_error(
     assert result.isError is False
     payload = extract_payload(result)
     assert payload["success"] is False
-    assert "Not found" in tool_error_message(payload)
+    assert "Field condition not found" in tool_error_message(payload)
 
 
 @pytest.mark.anyio

--- a/tests/tools/test_relation_tools.py
+++ b/tests/tools/test_relation_tools.py
@@ -13,6 +13,7 @@ from mcp.shared.memory import (
 from pipefy_mcp.services.pipefy import PipefyClient
 from pipefy_mcp.tools.relation_tools import RelationTools
 from pipefy_mcp.tools.tool_error_envelope import tool_error_message
+from tests.tools.conftest import assert_invalid_arguments_envelope
 
 
 @pytest.fixture
@@ -94,7 +95,7 @@ async def test_get_pipe_relations_invalid_pipe_id(
     async with relation_session as session:
         result = await session.call_tool("get_pipe_relations", {"pipe_id": ""})
 
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)
     mock_relation_client.get_pipe_relations.assert_not_called()
 
 
@@ -367,7 +368,7 @@ async def test_create_card_relation_invalid_source_id(
         )
 
     mock_relation_client.create_card_relation.assert_not_called()
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)
 
 
 @pytest.mark.anyio

--- a/tests/tools/test_report_tools.py
+++ b/tests/tools/test_report_tools.py
@@ -13,6 +13,7 @@ from mcp.shared.memory import (
 from pipefy_mcp.services.pipefy import PipefyClient
 from pipefy_mcp.tools.report_tools import ReportTools
 from pipefy_mcp.tools.tool_error_envelope import tool_error_message
+from tests.tools.conftest import assert_invalid_arguments_envelope
 
 
 @pytest.fixture
@@ -460,11 +461,12 @@ async def test_create_pipe_report_graphql_error_with_debug(
     assert result.isError is False
     payload = extract_payload(result)
     assert payload["success"] is False
-    assert "invalid pipe" in tool_error_message(payload)
-    assert "codes=" in tool_error_message(
-        payload
-    ) or "correlation_id=" in tool_error_message(payload)
-    assert "PERMISSION_DENIED" in tool_error_message(payload)
+    # The ambiguity enricher rewrote the raw "invalid pipe" into a dual-meaning
+    # message; the debug suffix still carries the code + correlation id.
+    msg = tool_error_message(payload)
+    assert "may lack access" in msg
+    assert "codes=" in msg or "correlation_id=" in msg
+    assert "PERMISSION_DENIED" in msg
 
 
 @pytest.mark.anyio
@@ -969,7 +971,7 @@ async def test_get_organization_report_blank_report_id(report_session):
     async with report_session as session:
         result = await session.call_tool("get_organization_report", {"report_id": ""})
 
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)
 
 
 @pytest.mark.anyio
@@ -980,7 +982,7 @@ async def test_get_organization_reports_blank_organization_id(report_session):
             "get_organization_reports", {"organization_id": ""}
         )
 
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)
 
 
 @pytest.mark.anyio
@@ -989,7 +991,7 @@ async def test_get_pipe_report_export_blank_export_id(report_session):
     async with report_session as session:
         result = await session.call_tool("get_pipe_report_export", {"export_id": ""})
 
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)
 
 
 @pytest.mark.anyio
@@ -1000,7 +1002,7 @@ async def test_get_organization_report_export_blank_export_id(report_session):
             "get_organization_report_export", {"export_id": ""}
         )
 
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)
 
 
 @pytest.mark.anyio
@@ -1011,7 +1013,7 @@ async def test_create_pipe_report_blank_pipe_id(report_session):
             "create_pipe_report", {"pipe_id": "", "name": "x"}
         )
 
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)
 
 
 @pytest.mark.anyio
@@ -1033,7 +1035,7 @@ async def test_update_pipe_report_blank_report_id(report_session):
     async with report_session as session:
         result = await session.call_tool("update_pipe_report", {"report_id": ""})
 
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)
 
 
 @pytest.mark.anyio
@@ -1045,7 +1047,7 @@ async def test_create_organization_report_blank_organization_id(report_session):
             {"organization_id": "", "name": "x", "pipe_ids": ["1"]},
         )
 
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)
 
 
 @pytest.mark.anyio
@@ -1070,7 +1072,7 @@ async def test_update_organization_report_blank_report_id(report_session):
             "update_organization_report", {"report_id": ""}
         )
 
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)
 
 
 @pytest.mark.anyio
@@ -1081,7 +1083,7 @@ async def test_export_pipe_report_blank_pipe_id(report_session):
             "export_pipe_report", {"pipe_id": "", "pipe_report_id": "x"}
         )
 
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)
 
 
 @pytest.mark.anyio
@@ -1092,7 +1094,7 @@ async def test_export_pipe_report_blank_pipe_report_id(report_session):
             "export_pipe_report", {"pipe_id": "x", "pipe_report_id": ""}
         )
 
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)
 
 
 ## ---------------------------------------------------------------------------
@@ -1191,7 +1193,7 @@ async def test_get_organization_report_graphql_error(
 
     payload = extract_payload(result)
     assert payload["success"] is False
-    assert "org not found" in tool_error_message(payload)
+    assert "Organization report not found" in tool_error_message(payload)
 
 
 @pytest.mark.anyio
@@ -1229,7 +1231,7 @@ async def test_get_pipe_report_export_graphql_error(
 
     payload = extract_payload(result)
     assert payload["success"] is False
-    assert "export not found" in tool_error_message(payload)
+    assert "Pipe report not found" in tool_error_message(payload)
 
 
 @pytest.mark.anyio

--- a/tests/tools/test_table_tools.py
+++ b/tests/tools/test_table_tools.py
@@ -14,6 +14,7 @@ from pipefy_mcp.services.pipefy import PipefyClient
 from pipefy_mcp.tools.table_tools import TableTools
 from pipefy_mcp.tools.tool_error_envelope import tool_error_message
 from tests.pagination_test_defaults import DEFAULT_FIRST
+from tests.tools.conftest import assert_invalid_arguments_envelope
 
 
 @pytest.fixture
@@ -896,7 +897,7 @@ async def test_get_table_empty_table_id(table_session, mock_table_client):
         result = await session.call_tool("get_table", {"table_id": ""})
 
     mock_table_client.get_table.assert_not_called()
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)
 
 
 # ---------------------------------------------------------------------------
@@ -1180,7 +1181,7 @@ async def test_set_table_record_field_value_blank_field_id(
         )
 
     mock_table_client.set_table_record_field_value.assert_not_called()
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_validation_envelope.py
+++ b/tests/tools/test_validation_envelope.py
@@ -1,0 +1,158 @@
+"""Tests for the PipefyValidationTool argument-error envelope."""
+
+from datetime import timedelta
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
+from mcp.shared.exceptions import UrlElicitationRequiredError
+from mcp.shared.memory import (
+    create_connected_server_and_client_session as create_client_session,
+)
+from mcp.types import ElicitRequestURLParams
+from pydantic import BaseModel, ValidationError
+
+from pipefy_mcp.tools.validation_envelope import (
+    PipefyValidationTool,
+    _format_validation_errors,
+    _serialize_errors,
+)
+from tests.tools.conftest import assert_invalid_arguments_envelope
+
+
+@pytest.fixture
+def mcp_server():
+    mcp = FastMCP("envelope-test-server")
+
+    @mcp.tool(description="Probe tool for envelope tests.")
+    async def probe(pipe_id: int, actions: list[str], confirm: bool = False) -> dict:
+        return {
+            "success": True,
+            "pipe_id": pipe_id,
+            "actions": actions,
+            "confirm": confirm,
+        }
+
+    @mcp.tool(description="Tool whose required arg is named 'uuid' on purpose.")
+    async def delete_probe(uuid: str, confirm: bool = True) -> dict:
+        return {"success": True, "uuid": uuid, "confirm": confirm}
+
+    return mcp
+
+
+@pytest.fixture
+def client_session(mcp_server):
+    return create_client_session(
+        mcp_server,
+        read_timeout_seconds=timedelta(seconds=10),
+        raise_exceptions=True,
+    )
+
+
+@pytest.mark.anyio
+class TestEnvelopeAgainstLiveServer:
+    async def test_missing_required_arg_returns_envelope(self, client_session):
+        async with client_session as session:
+            result = await session.call_tool("probe", {"actions": ["a"]})
+
+        payload = assert_invalid_arguments_envelope(result)
+        message = payload["error"]["message"]
+        assert "missing required argument 'pipe_id'" in message
+        assert "pydantic.dev" not in message
+        assert "Arguments" not in message
+        details = payload["error"]["details"]
+        assert isinstance(details["errors"], list) and details["errors"]
+        first = details["errors"][0]
+        assert set(first.keys()) == {"path", "type", "message"}
+
+    async def test_wrong_arg_name_returns_envelope(self, client_session):
+        async with client_session as session:
+            result = await session.call_tool(
+                "delete_probe", {"ai_agent_uuid": "x", "confirm": True}
+            )
+
+        payload = assert_invalid_arguments_envelope(result)
+        message = payload["error"]["message"]
+        assert ("missing required argument 'uuid'" in message) or (
+            "unknown argument 'ai_agent_uuid'" in message
+        )
+        assert "pydantic.dev" not in message
+
+    async def test_wrong_type_returns_envelope(self, client_session):
+        async with client_session as session:
+            result = await session.call_tool(
+                "probe", {"pipe_id": 42, "actions": "card.create"}
+            )
+
+        payload = assert_invalid_arguments_envelope(result)
+        message = payload["error"]["message"]
+        assert "actions" in message
+        assert "pydantic.dev" not in message
+
+
+class TestFormatters:
+    def test_format_has_no_pydantic_noise(self):
+        class _Probe(BaseModel):
+            x: int
+            y: list[str]
+
+        try:
+            _Probe.model_validate({})
+        except ValidationError as exc:
+            message = _format_validation_errors(exc, "probe")
+
+        assert "pydantic.dev" not in message
+        assert "Arguments" not in message
+        assert message.startswith("Tool 'probe' received invalid arguments:")
+        assert "missing required argument 'x'" in message
+        assert "missing required argument 'y'" in message
+
+    def test_serialize_errors_keeps_minimal_keys(self):
+        class _Probe(BaseModel):
+            x: int
+
+        try:
+            _Probe.model_validate({})
+        except ValidationError as exc:
+            serialized = _serialize_errors(exc)
+
+        assert isinstance(serialized, list)
+        assert serialized
+        first = serialized[0]
+        assert set(first.keys()) == {"path", "type", "message"}
+        assert first["path"] == ["x"]
+        assert first["type"] == "missing"
+
+
+@pytest.mark.anyio
+class TestEnvelopeBoundaryCases:
+    async def test_url_elicitation_required_not_rewrapped(self):
+        elicitation = ElicitRequestURLParams(
+            mode="url",
+            message="auth required",
+            url="https://example.com/oauth/authorize",
+            elicitationId="auth-test-001",
+        )
+
+        async def _fn() -> dict:
+            raise UrlElicitationRequiredError([elicitation])
+
+        tool = PipefyValidationTool.from_function(_fn, name="url_elicit_probe")
+
+        with pytest.raises(UrlElicitationRequiredError):
+            await tool.run({})
+
+    async def test_tool_body_validation_error_unaffected(self):
+        class _Inner(BaseModel):
+            required_field: int
+
+        async def _fn(payload: dict) -> dict:
+            _Inner.model_validate(payload)
+            return {"success": True}
+
+        tool = PipefyValidationTool.from_function(_fn, name="inner_validator_probe")
+
+        with pytest.raises(ToolError) as excinfo:
+            await tool.run({"payload": {}})
+
+        assert isinstance(excinfo.value.__cause__, ValidationError)

--- a/tests/tools/test_webhook_tools.py
+++ b/tests/tools/test_webhook_tools.py
@@ -14,6 +14,7 @@ from pipefy_mcp.services.pipefy import PipefyClient
 from pipefy_mcp.tools.tool_error_envelope import tool_error_message
 from pipefy_mcp.tools.webhook_tools import WebhookTools
 from tests.pagination_test_defaults import DEFAULT_FIRST
+from tests.tools.conftest import assert_invalid_arguments_envelope
 
 
 @pytest.fixture
@@ -404,7 +405,7 @@ class TestGetWebhooks:
         assert result.isError is False
         payload = extract_payload(result)
         assert payload["success"] is False
-        assert "pipe not found" in tool_error_message(payload)
+        assert "pipe not found" in tool_error_message(payload).lower()
 
     @pytest.mark.anyio
     @pytest.mark.parametrize("webhook_session", [None], indirect=True)
@@ -554,7 +555,7 @@ async def test_delete_webhook_graphql_error(
     assert result.isError is False
     payload = extract_payload(result)
     assert payload["success"] is False
-    assert "webhook not found" in tool_error_message(payload)
+    assert "webhook not found" in tool_error_message(payload).lower()
 
 
 @pytest.mark.anyio
@@ -652,7 +653,7 @@ async def test_get_card_inbox_emails_graphql_error(
     assert result.isError is False
     payload = extract_payload(result)
     assert payload["success"] is False
-    assert "card not found" in tool_error_message(payload)
+    assert "card not found" in tool_error_message(payload).lower()
 
 
 @pytest.mark.anyio
@@ -893,7 +894,7 @@ async def test_send_inbox_email_rejects_invalid_card_id(
         )
 
     mock_webhook_client.send_inbox_email.assert_not_called()
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)
 
 
 # ---------------------------------------------------------------------------
@@ -913,7 +914,7 @@ async def test_send_email_with_template_rejects_blank_template_id(
         )
 
     mock_webhook_client.send_email_with_template.assert_not_called()
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)
 
 
 @pytest.mark.anyio
@@ -991,7 +992,7 @@ async def test_create_webhook_rejects_invalid_pipe_id(
         )
 
     mock_webhook_client.create_webhook.assert_not_called()
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)
 
 
 # ---------------------------------------------------------------------------
@@ -1017,7 +1018,7 @@ async def test_get_email_templates_graphql_error(
     assert result.isError is False
     p = extract_payload(result)
     assert p["success"] is False
-    assert "pipe not found" in tool_error_message(p)
+    assert "pipe not found" in tool_error_message(p).lower()
 
 
 @pytest.mark.anyio
@@ -1032,7 +1033,7 @@ async def test_get_email_templates_rejects_invalid_repo_id(
         )
 
     mock_webhook_client.get_email_templates.assert_not_called()
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)
 
 
 # ---------------------------------------------------------------------------
@@ -1052,7 +1053,7 @@ async def test_get_card_inbox_emails_rejects_invalid_card_id(
         )
 
     mock_webhook_client.get_card_inbox_emails.assert_not_called()
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)
 
 
 # ---------------------------------------------------------------------------
@@ -1072,7 +1073,7 @@ async def test_send_email_with_template_rejects_invalid_card_id(
         )
 
     mock_webhook_client.send_email_with_template.assert_not_called()
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)
 
 
 # ---------------------------------------------------------------------------
@@ -1093,4 +1094,4 @@ async def test_delete_webhook_rejects_blank_webhook_id(
         )
 
     mock_webhook_client.delete_webhook.assert_not_called()
-    assert result.isError is True
+    assert_invalid_arguments_envelope(result)


### PR DESCRIPTION
## Summary

Stack of 5 commits on top of `pipe-full-toolset`:

1. **feat(tools):** centralize GraphQL error enrichment and discovery hints (`graphql_error_helpers`, tests).
2. **feat(tools):** align automation GraphQL errors with shared enrichment (`automation_tool_helpers`).
3. **feat(server):** FastMCP arg validation → `INVALID_ARGUMENTS` envelopes (`validation_envelope`, `server`, conftest).
4. **feat(tools):** wire `resource_kind` / discovery across domain tools and `update_ai_automation`.
5. **test(tools):** integration-style tool tests + docstring discovery hints.

## Local CI (mirrors `.github/workflows/ci.yml`)

- `uv sync --locked --all-extras --dev`
- `uv run ruff check .` / `uv run ruff format --check .`
- `uv run pytest -m "not integration"` with dummy `PIPEFY_*_URL` / OAuth env (see workflow)

## Merge target

**Base:** `pipe-full-toolset` (as requested).