### PR TITLE
feat(tools): unified envelope, pagination, and review follow-ups

### DIFF
--- a/src/pipefy_mcp/server.py
+++ b/src/pipefy_mcp/server.py
@@ -26,6 +26,10 @@ async def lifespan(app: FastMCP) -> AsyncIterator[FastMCP]:
     """Lifespan function to manage the lifecycle of the server."""
     try:
         logger.info("Initializing services")
+        logger.info(
+            "PIPEFY_MCP_UNIFIED_ENVELOPE=%s",
+            "enabled" if settings.pipefy.mcp_unified_envelope else "disabled",
+        )
         install_pipefy_validation_envelope()
         services_container = ServicesContainer.get_instance()
         services_container.initialize_services(settings)

--- a/src/pipefy_mcp/settings.py
+++ b/src/pipefy_mcp/settings.py
@@ -84,11 +84,9 @@ class PipefySettings(BaseModel):
     mcp_unified_envelope: bool = Field(
         default=True,
         description=(
-            "When true (env: PIPEFY_MCP_UNIFIED_ENVELOPE), migrated MCP tools emit the "
-            "unified success shape `{success, data, message?, pagination?}`. Set to "
-            "false to restore the legacy per-tool shapes for migrated helpers without a "
-            "redeploy. Read per tool call (never cached at import). See "
-            "envelope-pagination-unification ADR-0002."
+            "When true (env: PIPEFY_MCP_UNIFIED_ENVELOPE), migrated MCP tools return "
+            "{success, data, message?, pagination?}. When false, legacy shapes. "
+            "Read at call time, not cached at import."
         ),
     )
 

--- a/src/pipefy_mcp/settings.py
+++ b/src/pipefy_mcp/settings.py
@@ -81,6 +81,17 @@ class PipefySettings(BaseModel):
         ),
     )
 
+    mcp_unified_envelope: bool = Field(
+        default=True,
+        description=(
+            "When true (env: PIPEFY_MCP_UNIFIED_ENVELOPE), migrated MCP tools emit the "
+            "unified success shape `{success, data, message?, pagination?}`. Set to "
+            "false to restore the legacy per-tool shapes for migrated helpers without a "
+            "redeploy. Read per tool call (never cached at import). See "
+            "envelope-pagination-unification ADR-0002."
+        ),
+    )
+
     @field_validator("service_account_ids", mode="before")
     @classmethod
     def _coerce_service_account_ids(cls, value: object) -> list[str]:

--- a/src/pipefy_mcp/tools/ai_tool_helpers.py
+++ b/src/pipefy_mcp/tools/ai_tool_helpers.py
@@ -35,46 +35,51 @@ class ValidateAiAutomationPromptPayload(TypedDict):
     field_map: dict[str, str]
 
 
-class CreateAiAutomationSuccessPayload(TypedDict):
+# The ``Legacy*SuccessPayload`` TypedDicts below describe the flag=false shape
+# only. Under the default ``PIPEFY_MCP_UNIFIED_ENVELOPE=true``, helpers return
+# ``ToolSuccessPayload`` instead (see ADR-0001).
+
+
+class LegacyCreateAiAutomationSuccessPayload(TypedDict):
     success: Literal[True]
     automation_id: str
     message: str
 
 
-class UpdateAiAutomationSuccessPayload(TypedDict):
+class LegacyUpdateAiAutomationSuccessPayload(TypedDict):
     success: Literal[True]
     automation_id: str
     message: str
 
 
-class CreateAiAgentSuccessPayload(TypedDict):
+class LegacyCreateAiAgentSuccessPayload(TypedDict):
     success: Literal[True]
     agent_uuid: str
     message: str
 
 
-class UpdateAiAgentSuccessPayload(TypedDict):
+class LegacyUpdateAiAgentSuccessPayload(TypedDict):
     success: Literal[True]
     agent_uuid: str
     message: str
 
 
-class ToggleAiAgentStatusSuccessPayload(TypedDict):
+class LegacyToggleAiAgentStatusSuccessPayload(TypedDict):
     success: Literal[True]
     message: str
 
 
-class GetAiAgentSuccessPayload(TypedDict):
+class LegacyGetAiAgentSuccessPayload(TypedDict):
     success: Literal[True]
     agent: AiAgentGraphPayload
 
 
-class GetAiAgentsSuccessPayload(TypedDict):
+class LegacyGetAiAgentsSuccessPayload(TypedDict):
     success: Literal[True]
     agents: list[AiAgentGraphPayload]
 
 
-class DeleteAiAgentSuccessPayload(TypedDict):
+class LegacyDeleteAiAgentSuccessPayload(TypedDict):
     success: Literal[True]
     message: str
 
@@ -772,15 +777,15 @@ def enrich_behavior_error(
 __all__ = [
     "AiToolErrorPayload",
     "CreateAgentPartialFailurePayload",
-    "CreateAiAgentSuccessPayload",
-    "CreateAiAutomationSuccessPayload",
-    "DeleteAiAgentSuccessPayload",
-    "GetAiAgentSuccessPayload",
-    "GetAiAgentsSuccessPayload",
     "KNOWN_AI_ACTION_TYPES",
-    "ToggleAiAgentStatusSuccessPayload",
-    "UpdateAiAgentSuccessPayload",
-    "UpdateAiAutomationSuccessPayload",
+    "LegacyCreateAiAgentSuccessPayload",
+    "LegacyCreateAiAutomationSuccessPayload",
+    "LegacyDeleteAiAgentSuccessPayload",
+    "LegacyGetAiAgentSuccessPayload",
+    "LegacyGetAiAgentsSuccessPayload",
+    "LegacyToggleAiAgentStatusSuccessPayload",
+    "LegacyUpdateAiAgentSuccessPayload",
+    "LegacyUpdateAiAutomationSuccessPayload",
     "ValidateAiAutomationPromptPayload",
     "build_ai_tool_error",
     "build_create_agent_partial_failure",

--- a/src/pipefy_mcp/tools/ai_tool_helpers.py
+++ b/src/pipefy_mcp/tools/ai_tool_helpers.py
@@ -10,13 +10,13 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 from typing_extensions import TypedDict
 
 from pipefy_mcp.services.pipefy.types import AiAgentGraphPayload
-from pipefy_mcp.settings import settings
 from pipefy_mcp.tools.graphql_error_helpers import (
     extract_error_strings,
     strip_internal_api_diagnostic_markers,
 )
 from pipefy_mcp.tools.tool_error_envelope import (
     ToolErrorDetail,
+    is_unified_envelope_enabled,
     tool_error,
     tool_success,
 )
@@ -104,7 +104,7 @@ def build_create_automation_success(
         automation_id: New automation id from the API.
         message: Short summary for the client.
     """
-    if settings.pipefy.mcp_unified_envelope:
+    if is_unified_envelope_enabled():
         return tool_success(data={"automation_id": automation_id}, message=message)
     return {"success": True, "automation_id": automation_id, "message": message}
 
@@ -118,7 +118,7 @@ def build_update_automation_success(
         automation_id: Target automation id.
         message: Short summary for the client.
     """
-    if settings.pipefy.mcp_unified_envelope:
+    if is_unified_envelope_enabled():
         return tool_success(data={"automation_id": automation_id}, message=message)
     return {"success": True, "automation_id": automation_id, "message": message}
 
@@ -130,7 +130,7 @@ def build_create_agent_success(*, agent_uuid: str, message: str) -> dict[str, An
         agent_uuid: New agent UUID from the API.
         message: Short summary for the client.
     """
-    if settings.pipefy.mcp_unified_envelope:
+    if is_unified_envelope_enabled():
         return tool_success(data={"agent_uuid": agent_uuid}, message=message)
     return {"success": True, "agent_uuid": agent_uuid, "message": message}
 
@@ -142,7 +142,7 @@ def build_update_agent_success(*, agent_uuid: str, message: str) -> dict[str, An
         agent_uuid: Target agent UUID.
         message: Short summary for the client.
     """
-    if settings.pipefy.mcp_unified_envelope:
+    if is_unified_envelope_enabled():
         return tool_success(data={"agent_uuid": agent_uuid}, message=message)
     return {"success": True, "agent_uuid": agent_uuid, "message": message}
 
@@ -153,7 +153,7 @@ def build_toggle_agent_status_success(*, message: str) -> dict[str, Any]:
     Args:
         message: Short summary for the client.
     """
-    if settings.pipefy.mcp_unified_envelope:
+    if is_unified_envelope_enabled():
         return tool_success(message=message)
     return {"success": True, "message": message}
 
@@ -164,7 +164,7 @@ def build_get_agent_success(agent: AiAgentGraphPayload) -> dict[str, Any]:
     Args:
         agent: ``aiAgent`` subtree (may be empty dict when missing).
     """
-    if settings.pipefy.mcp_unified_envelope:
+    if is_unified_envelope_enabled():
         return tool_success(data={"agent": agent})
     return {"success": True, "agent": agent}
 
@@ -177,7 +177,7 @@ def build_get_agents_success(
     Args:
         agents: Unwrapped connection nodes for the repo.
     """
-    if settings.pipefy.mcp_unified_envelope:
+    if is_unified_envelope_enabled():
         return tool_success(data={"agents": agents})
     return {"success": True, "agents": agents}
 
@@ -188,7 +188,7 @@ def build_delete_agent_success(*, message: str) -> dict[str, Any]:
     Args:
         message: Short summary for the client.
     """
-    if settings.pipefy.mcp_unified_envelope:
+    if is_unified_envelope_enabled():
         return tool_success(message=message)
     return {"success": True, "message": message}
 

--- a/src/pipefy_mcp/tools/ai_tool_helpers.py
+++ b/src/pipefy_mcp/tools/ai_tool_helpers.py
@@ -241,9 +241,6 @@ def build_create_agent_partial_failure(
     return cast(CreateAgentPartialFailurePayload, body)
 
 
-# --- Error enrichment for behavior-level failures ---
-
-# Patterns the Pipefy API returns that map to actionable advice.
 _BEHAVIOR_ERROR_EMPTY_AFTER_SANITIZE = (
     "The AI behavior request failed. Check behaviors and pipe context, then retry."
 )
@@ -297,9 +294,6 @@ def _summarize_behaviors(behaviors: list[dict[str, Any]]) -> str:
     return "\n".join(lines)
 
 
-# --- Behavior validation against pipe context ---
-
-# actionTypes that the Pipefy AI behavior system recognizes.
 KNOWN_AI_ACTION_TYPES = frozenset(
     {
         "create_card",
@@ -359,7 +353,6 @@ def validate_behaviors_against_pipe(
         abp = ap.get("aiBehaviorParams") or ap.get("ai_behavior_params") or {}
         attrs = abp.get("actionsAttributes") or abp.get("actions_attributes") or []
 
-        # Check eventParams phase references
         ep = b.get("eventParams") or b.get("event_params") or {}
         to_phase = ep.get("to_phase_id") or ep.get("toPhaseId")
         if to_phase and str(to_phase) not in pipe_phase_ids:
@@ -384,7 +377,6 @@ def validate_behaviors_against_pipe(
                 elif unknown_action_types == "warning":
                     warnings.append(msg)
 
-            # Check destinationPhaseId for move_card
             if action_type == "move_card":
                 dest = metadata.get("destinationPhaseId", "")
                 if dest and str(dest) not in pipe_phase_ids:
@@ -393,11 +385,6 @@ def validate_behaviors_against_pipe(
                         f'destinationPhaseId "{dest}" not found in pipe phases.'
                     )
 
-            # Check fieldsAttributes fieldId references.
-            # Same-pipe actions check against pipe_field_ids; cross-pipe actions
-            # check against cross_pipe_field_ids when available.
-            # Skip fieldId validation for create_table_record (table fields) and
-            # send_email_template (no pipe field list; pipeId omission would mis-route checks).
             if action_type not in ("create_table_record", "send_email_template"):
                 action_pipe = str(metadata.get("pipeId", ""))
                 targets_source = not action_pipe or action_pipe == pipe_id
@@ -436,7 +423,6 @@ def validate_behaviors_against_pipe(
                     "against this pipe. Verify IDs with get_table or get_table_record."
                 )
 
-            # Check create_connected_card relation (skipped when related_pipe_ids is None)
             if action_type == "create_connected_card" and related_pipe_ids is not None:
                 target_pipe = metadata.get("pipeId", "")
                 if target_pipe and str(target_pipe) not in related_pipe_ids:
@@ -448,9 +434,6 @@ def validate_behaviors_against_pipe(
                     )
 
     return problems, warnings
-
-
-# --- Slug → numeric fieldId resolution ---
 
 
 def _extract_slug_field_ids_by_pipe(

--- a/src/pipefy_mcp/tools/ai_tool_helpers.py
+++ b/src/pipefy_mcp/tools/ai_tool_helpers.py
@@ -10,11 +10,16 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 from typing_extensions import TypedDict
 
 from pipefy_mcp.services.pipefy.types import AiAgentGraphPayload
+from pipefy_mcp.settings import settings
 from pipefy_mcp.tools.graphql_error_helpers import (
     extract_error_strings,
     strip_internal_api_diagnostic_markers,
 )
-from pipefy_mcp.tools.tool_error_envelope import ToolErrorDetail, tool_error
+from pipefy_mcp.tools.tool_error_envelope import (
+    ToolErrorDetail,
+    tool_error,
+    tool_success,
+)
 
 if TYPE_CHECKING:
     from pipefy_mcp.services.pipefy import PipefyClient
@@ -87,89 +92,99 @@ class CreateAgentPartialFailurePayload(TypedDict):
 
 def build_create_automation_success(
     *, automation_id: str, message: str
-) -> CreateAiAutomationSuccessPayload:
+) -> dict[str, Any]:
     """Successful AI automation create.
 
     Args:
         automation_id: New automation id from the API.
         message: Short summary for the client.
     """
+    if settings.pipefy.mcp_unified_envelope:
+        return tool_success(data={"automation_id": automation_id}, message=message)
     return {"success": True, "automation_id": automation_id, "message": message}
 
 
 def build_update_automation_success(
     *, automation_id: str, message: str
-) -> UpdateAiAutomationSuccessPayload:
+) -> dict[str, Any]:
     """Successful AI automation update.
 
     Args:
         automation_id: Target automation id.
         message: Short summary for the client.
     """
+    if settings.pipefy.mcp_unified_envelope:
+        return tool_success(data={"automation_id": automation_id}, message=message)
     return {"success": True, "automation_id": automation_id, "message": message}
 
 
-def build_create_agent_success(
-    *, agent_uuid: str, message: str
-) -> CreateAiAgentSuccessPayload:
+def build_create_agent_success(*, agent_uuid: str, message: str) -> dict[str, Any]:
     """Successful AI agent create.
 
     Args:
         agent_uuid: New agent UUID from the API.
         message: Short summary for the client.
     """
+    if settings.pipefy.mcp_unified_envelope:
+        return tool_success(data={"agent_uuid": agent_uuid}, message=message)
     return {"success": True, "agent_uuid": agent_uuid, "message": message}
 
 
-def build_update_agent_success(
-    *, agent_uuid: str, message: str
-) -> UpdateAiAgentSuccessPayload:
+def build_update_agent_success(*, agent_uuid: str, message: str) -> dict[str, Any]:
     """Successful AI agent update.
 
     Args:
         agent_uuid: Target agent UUID.
         message: Short summary for the client.
     """
+    if settings.pipefy.mcp_unified_envelope:
+        return tool_success(data={"agent_uuid": agent_uuid}, message=message)
     return {"success": True, "agent_uuid": agent_uuid, "message": message}
 
 
-def build_toggle_agent_status_success(
-    *, message: str
-) -> ToggleAiAgentStatusSuccessPayload:
+def build_toggle_agent_status_success(*, message: str) -> dict[str, Any]:
     """Successful agent enable/disable.
 
     Args:
         message: Short summary for the client.
     """
+    if settings.pipefy.mcp_unified_envelope:
+        return tool_success(message=message)
     return {"success": True, "message": message}
 
 
-def build_get_agent_success(agent: AiAgentGraphPayload) -> GetAiAgentSuccessPayload:
+def build_get_agent_success(agent: AiAgentGraphPayload) -> dict[str, Any]:
     """Single-agent read envelope.
 
     Args:
         agent: ``aiAgent`` subtree (may be empty dict when missing).
     """
+    if settings.pipefy.mcp_unified_envelope:
+        return tool_success(data={"agent": agent})
     return {"success": True, "agent": agent}
 
 
 def build_get_agents_success(
     agents: list[AiAgentGraphPayload],
-) -> GetAiAgentsSuccessPayload:
+) -> dict[str, Any]:
     """List-agents read envelope.
 
     Args:
         agents: Unwrapped connection nodes for the repo.
     """
+    if settings.pipefy.mcp_unified_envelope:
+        return tool_success(data={"agents": agents})
     return {"success": True, "agents": agents}
 
 
-def build_delete_agent_success(*, message: str) -> DeleteAiAgentSuccessPayload:
+def build_delete_agent_success(*, message: str) -> dict[str, Any]:
     """Successful AI agent delete.
 
     Args:
         message: Short summary for the client.
     """
+    if settings.pipefy.mcp_unified_envelope:
+        return tool_success(message=message)
     return {"success": True, "message": message}
 
 

--- a/src/pipefy_mcp/tools/pagination_helpers.py
+++ b/src/pipefy_mcp/tools/pagination_helpers.py
@@ -41,8 +41,13 @@ def validate_page_size(
     integer input returns ``(n, None)``. On invalid input returns
     ``(0, error_dict)``; return that dict from the tool unchanged.
 
+    String digits (e.g. ``"100"``) are accepted and coerced to ``int`` on
+    purpose — some MCP clients pass scalar arguments as strings. Anything that
+    ``int(...)`` cannot parse yields an ``INVALID_ARGUMENTS`` error.
+
     Args:
-        first: The requested page size, or None to use the default.
+        first: The requested page size, or None to use the default. Accepts
+            ``int`` or a digit-string parseable by ``int(...)``.
         arg_name: Name of the tool argument (appears in the error message to
             help agents fix their call). Default "first".
         max_size: Upper bound. Defaults to ``MAX_PAGE_SIZE``; tools with an

--- a/src/pipefy_mcp/tools/pagination_helpers.py
+++ b/src/pipefy_mcp/tools/pagination_helpers.py
@@ -1,11 +1,4 @@
-"""Pagination helpers — unified bounds validation and cursor info for MCP tools.
-
-Introduced by the envelope-pagination-unification capability (Proposal 7). Every
-paginated tool migrated to the unified envelope uses :func:`validate_page_size`
-to reject out-of-bounds ``first`` with a structured ``INVALID_ARGUMENTS`` error,
-and :func:`build_pagination_info` to emit a consistent top-level
-``pagination: {has_more, end_cursor, page_size}`` block.
-"""
+"""Bounds validation and top-level ``pagination`` for unified MCP tool responses."""
 
 from __future__ import annotations
 
@@ -45,9 +38,8 @@ def validate_page_size(
     """Normalize and validate a pagination ``first`` argument.
 
     Returns ``(DEFAULT_PAGE_SIZE, None)`` when ``first`` is None. On valid
-    integer input returns ``(int(first), None)``. On invalid input returns
-    ``(0, <tool_error dict>)`` — the caller SHOULD propagate the error dict
-    verbatim.
+    integer input returns ``(n, None)``. On invalid input returns
+    ``(0, error_dict)``; return that dict from the tool unchanged.
 
     Args:
         first: The requested page size, or None to use the default.

--- a/src/pipefy_mcp/tools/pagination_helpers.py
+++ b/src/pipefy_mcp/tools/pagination_helpers.py
@@ -1,0 +1,97 @@
+"""Pagination helpers — unified bounds validation and cursor info for MCP tools.
+
+Introduced by the envelope-pagination-unification capability (Proposal 7). Every
+paginated tool migrated to the unified envelope uses :func:`validate_page_size`
+to reject out-of-bounds ``first`` with a structured ``INVALID_ARGUMENTS`` error,
+and :func:`build_pagination_info` to emit a consistent top-level
+``pagination: {has_more, end_cursor, page_size}`` block.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from typing_extensions import TypedDict
+
+from pipefy_mcp.tools.tool_error_envelope import tool_error
+
+__all__ = [
+    "DEFAULT_PAGE_SIZE",
+    "MAX_PAGE_SIZE",
+    "PaginationInfo",
+    "build_pagination_info",
+    "validate_page_size",
+]
+
+
+DEFAULT_PAGE_SIZE = 50
+MAX_PAGE_SIZE = 500
+
+
+class PaginationInfo(TypedDict, total=False):
+    """Top-level pagination block for unified-envelope responses."""
+
+    has_more: bool
+    end_cursor: str | None
+    page_size: int
+
+
+def validate_page_size(
+    first: int | None,
+    *,
+    arg_name: str = "first",
+    max_size: int = MAX_PAGE_SIZE,
+) -> tuple[int, dict[str, Any] | None]:
+    """Normalize and validate a pagination ``first`` argument.
+
+    Returns ``(DEFAULT_PAGE_SIZE, None)`` when ``first`` is None. On valid
+    integer input returns ``(int(first), None)``. On invalid input returns
+    ``(0, <tool_error dict>)`` — the caller SHOULD propagate the error dict
+    verbatim.
+
+    Args:
+        first: The requested page size, or None to use the default.
+        arg_name: Name of the tool argument (appears in the error message to
+            help agents fix their call). Default "first".
+        max_size: Upper bound. Defaults to ``MAX_PAGE_SIZE``; tools with an
+            API-imposed narrower range may pass a smaller value.
+    """
+    if first is None:
+        return DEFAULT_PAGE_SIZE, None
+    try:
+        n = int(first)
+    except (TypeError, ValueError):
+        return 0, tool_error(
+            f"Invalid '{arg_name}': must be an integer between 1 and {max_size}.",
+            code="INVALID_ARGUMENTS",
+        )
+    if n < 1 or n > max_size:
+        return 0, tool_error(
+            f"Invalid '{arg_name}': must be between 1 and {max_size} (got {n}).",
+            code="INVALID_ARGUMENTS",
+            details={"min": 1, "max": max_size, "provided": n},
+        )
+    return n, None
+
+
+def build_pagination_info(
+    *,
+    page_info: dict[str, Any] | None,
+    page_size: int,
+) -> PaginationInfo:
+    """Build a ``PaginationInfo`` from a GraphQL ``pageInfo`` subtree.
+
+    Args:
+        page_info: The ``pageInfo`` dict as returned by Pipefy's GraphQL
+            connections (keys ``hasNextPage``, ``endCursor``). ``None`` or an
+            empty dict yields ``has_more=False, end_cursor=None``.
+        page_size: Page size used for the request (already validated).
+    """
+    info: PaginationInfo = {"page_size": page_size}
+    if page_info:
+        info["has_more"] = bool(page_info.get("hasNextPage"))
+        info["end_cursor"] = page_info.get("endCursor")
+    else:
+        info["has_more"] = False
+        info["end_cursor"] = None
+    return info

--- a/src/pipefy_mcp/tools/pipe_tool_helpers.py
+++ b/src/pipefy_mcp/tools/pipe_tool_helpers.py
@@ -14,6 +14,7 @@ from pipefy_mcp.tools.destructive_tool_guard import (
 from pipefy_mcp.tools.graphql_error_helpers import extract_error_strings
 from pipefy_mcp.tools.tool_error_envelope import (
     ToolErrorDetail,
+    ToolSuccessPayload,
     tool_error,
     tool_success,
 )
@@ -33,7 +34,9 @@ class AddCardCommentErrorPayload(TypedDict):
     error: ToolErrorDetail
 
 
-AddCardCommentPayload = AddCardCommentSuccessPayload | AddCardCommentErrorPayload
+AddCardCommentPayload = (
+    AddCardCommentSuccessPayload | ToolSuccessPayload | AddCardCommentErrorPayload
+)
 
 
 class UpdateCommentSuccessPayload(TypedDict):
@@ -46,7 +49,9 @@ class UpdateCommentErrorPayload(TypedDict):
     error: ToolErrorDetail
 
 
-UpdateCommentPayload = UpdateCommentSuccessPayload | UpdateCommentErrorPayload
+UpdateCommentPayload = (
+    UpdateCommentSuccessPayload | ToolSuccessPayload | UpdateCommentErrorPayload
+)
 
 
 class DeleteCommentSuccessPayload(TypedDict):
@@ -59,7 +64,10 @@ class DeleteCommentErrorPayload(TypedDict):
 
 
 DeleteCommentPayload = (
-    DestructivePreviewPayload | DeleteCommentSuccessPayload | DeleteCommentErrorPayload
+    DestructivePreviewPayload
+    | DeleteCommentSuccessPayload
+    | ToolSuccessPayload
+    | DeleteCommentErrorPayload
 )
 
 
@@ -80,6 +88,7 @@ DeleteCardPayload = (
     DestructivePreviewPayload
     | DestructiveCancelledPayload
     | DeleteCardSuccessPayload
+    | ToolSuccessPayload
     | DeleteCardErrorPayload
 )
 

--- a/src/pipefy_mcp/tools/pipe_tool_helpers.py
+++ b/src/pipefy_mcp/tools/pipe_tool_helpers.py
@@ -6,7 +6,6 @@ from typing_extensions import TypedDict
 
 from pipefy_mcp.services.pipefy import PipefyClient
 from pipefy_mcp.services.pipefy.types import CardSearch
-from pipefy_mcp.settings import settings
 from pipefy_mcp.tools.destructive_tool_guard import (
     DestructiveCancelledPayload,
     DestructivePreviewPayload,
@@ -15,6 +14,7 @@ from pipefy_mcp.tools.graphql_error_helpers import extract_error_strings
 from pipefy_mcp.tools.tool_error_envelope import (
     ToolErrorDetail,
     ToolSuccessPayload,
+    is_unified_envelope_enabled,
     tool_error,
     tool_success,
 )
@@ -161,7 +161,7 @@ def build_add_card_comment_success_payload(*, comment_id: object) -> dict[str, A
         comment_id: New comment id from the API (coerced to str).
     """
     cid = str(comment_id)
-    if settings.pipefy.mcp_unified_envelope:
+    if is_unified_envelope_enabled():
         return tool_success(data={"comment_id": cid})
     return {"success": True, "comment_id": cid}
 
@@ -277,7 +277,7 @@ def build_update_comment_success_payload(*, comment_id: object) -> dict[str, Any
         comment_id: Updated comment id (coerced to str).
     """
     cid = str(comment_id)
-    if settings.pipefy.mcp_unified_envelope:
+    if is_unified_envelope_enabled():
         return tool_success(data={"comment_id": cid})
     return {"success": True, "comment_id": cid}
 
@@ -293,7 +293,7 @@ def build_update_comment_error_payload(*, message: str) -> UpdateCommentErrorPay
 
 def build_delete_comment_success_payload() -> dict[str, Any]:
     """Minimal success body after delete_comment."""
-    if settings.pipefy.mcp_unified_envelope:
+    if is_unified_envelope_enabled():
         return tool_success()
     return {"success": True}
 
@@ -321,7 +321,7 @@ def build_delete_card_success_payload(
         f"Card '{card_title}' (ID: {card_id}) from pipe '{pipe_name}' "
         "has been permanently deleted."
     )
-    if settings.pipefy.mcp_unified_envelope:
+    if is_unified_envelope_enabled():
         return tool_success(
             data={
                 "card_id": card_id,

--- a/src/pipefy_mcp/tools/pipe_tool_helpers.py
+++ b/src/pipefy_mcp/tools/pipe_tool_helpers.py
@@ -6,12 +6,17 @@ from typing_extensions import TypedDict
 
 from pipefy_mcp.services.pipefy import PipefyClient
 from pipefy_mcp.services.pipefy.types import CardSearch
+from pipefy_mcp.settings import settings
 from pipefy_mcp.tools.destructive_tool_guard import (
     DestructiveCancelledPayload,
     DestructivePreviewPayload,
 )
 from pipefy_mcp.tools.graphql_error_helpers import extract_error_strings
-from pipefy_mcp.tools.tool_error_envelope import ToolErrorDetail, tool_error
+from pipefy_mcp.tools.tool_error_envelope import (
+    ToolErrorDetail,
+    tool_error,
+    tool_success,
+)
 
 
 class UserCancelledError(Exception):
@@ -135,15 +140,16 @@ async def find_label_dependents(
     }
 
 
-def build_add_card_comment_success_payload(
-    *, comment_id: object
-) -> AddCardCommentSuccessPayload:
+def build_add_card_comment_success_payload(*, comment_id: object) -> dict[str, Any]:
     """Recorded comment id.
 
     Args:
         comment_id: New comment id from the API (coerced to str).
     """
-    return {"success": True, "comment_id": str(comment_id)}
+    cid = str(comment_id)
+    if settings.pipefy.mcp_unified_envelope:
+        return tool_success(data={"comment_id": cid})
+    return {"success": True, "comment_id": cid}
 
 
 # Markers for mapping GraphQL errors to user-friendly messages.
@@ -250,15 +256,16 @@ def build_add_card_comment_error_payload(*, message: str) -> AddCardCommentError
     return cast(AddCardCommentErrorPayload, _build_comment_error_payload(message))
 
 
-def build_update_comment_success_payload(
-    *, comment_id: object
-) -> UpdateCommentSuccessPayload:
+def build_update_comment_success_payload(*, comment_id: object) -> dict[str, Any]:
     """Updated comment id.
 
     Args:
         comment_id: Updated comment id (coerced to str).
     """
-    return {"success": True, "comment_id": str(comment_id)}
+    cid = str(comment_id)
+    if settings.pipefy.mcp_unified_envelope:
+        return tool_success(data={"comment_id": cid})
+    return {"success": True, "comment_id": cid}
 
 
 def build_update_comment_error_payload(*, message: str) -> UpdateCommentErrorPayload:
@@ -270,8 +277,10 @@ def build_update_comment_error_payload(*, message: str) -> UpdateCommentErrorPay
     return cast(UpdateCommentErrorPayload, _build_comment_error_payload(message))
 
 
-def build_delete_comment_success_payload() -> DeleteCommentSuccessPayload:
+def build_delete_comment_success_payload() -> dict[str, Any]:
     """Minimal success body after delete_comment."""
+    if settings.pipefy.mcp_unified_envelope:
+        return tool_success()
     return {"success": True}
 
 
@@ -286,7 +295,7 @@ def build_delete_comment_error_payload(*, message: str) -> DeleteCommentErrorPay
 
 def build_delete_card_success_payload(
     *, card_id: str | int, card_title: str, pipe_name: str
-) -> DeleteCardSuccessPayload:
+) -> dict[str, Any]:
     """Confirmed card deletion.
 
     Args:
@@ -294,15 +303,25 @@ def build_delete_card_success_payload(
         card_title: Card title for messaging.
         pipe_name: Pipe name for messaging.
     """
+    message = (
+        f"Card '{card_title}' (ID: {card_id}) from pipe '{pipe_name}' "
+        "has been permanently deleted."
+    )
+    if settings.pipefy.mcp_unified_envelope:
+        return tool_success(
+            data={
+                "card_id": card_id,
+                "card_title": card_title,
+                "pipe_name": pipe_name,
+            },
+            message=message,
+        )
     return {
         "success": True,
         "card_id": card_id,
         "card_title": card_title,
         "pipe_name": pipe_name,
-        "message": (
-            f"Card '{card_title}' (ID: {card_id}) from pipe '{pipe_name}' "
-            "has been permanently deleted."
-        ),
+        "message": message,
     }
 
 

--- a/src/pipefy_mcp/tools/pipe_tool_helpers.py
+++ b/src/pipefy_mcp/tools/pipe_tool_helpers.py
@@ -24,7 +24,12 @@ class UserCancelledError(Exception):
     """Raised when a user cancels an interactive flow."""
 
 
-class AddCardCommentSuccessPayload(TypedDict):
+# The ``Legacy*SuccessPayload`` TypedDicts below describe the flag=false shape
+# only. Under the default ``PIPEFY_MCP_UNIFIED_ENVELOPE=true``, helpers return
+# ``ToolSuccessPayload`` instead (see ADR-0001).
+
+
+class LegacyAddCardCommentSuccessPayload(TypedDict):
     success: Literal[True]
     comment_id: str
 
@@ -35,11 +40,11 @@ class AddCardCommentErrorPayload(TypedDict):
 
 
 AddCardCommentPayload = (
-    AddCardCommentSuccessPayload | ToolSuccessPayload | AddCardCommentErrorPayload
+    LegacyAddCardCommentSuccessPayload | ToolSuccessPayload | AddCardCommentErrorPayload
 )
 
 
-class UpdateCommentSuccessPayload(TypedDict):
+class LegacyUpdateCommentSuccessPayload(TypedDict):
     success: Literal[True]
     comment_id: str
 
@@ -50,11 +55,11 @@ class UpdateCommentErrorPayload(TypedDict):
 
 
 UpdateCommentPayload = (
-    UpdateCommentSuccessPayload | ToolSuccessPayload | UpdateCommentErrorPayload
+    LegacyUpdateCommentSuccessPayload | ToolSuccessPayload | UpdateCommentErrorPayload
 )
 
 
-class DeleteCommentSuccessPayload(TypedDict):
+class LegacyDeleteCommentSuccessPayload(TypedDict):
     success: Literal[True]
 
 
@@ -65,13 +70,13 @@ class DeleteCommentErrorPayload(TypedDict):
 
 DeleteCommentPayload = (
     DestructivePreviewPayload
-    | DeleteCommentSuccessPayload
+    | LegacyDeleteCommentSuccessPayload
     | ToolSuccessPayload
     | DeleteCommentErrorPayload
 )
 
 
-class DeleteCardSuccessPayload(TypedDict):
+class LegacyDeleteCardSuccessPayload(TypedDict):
     success: Literal[True]
     card_id: str | int
     card_title: str
@@ -87,7 +92,7 @@ class DeleteCardErrorPayload(TypedDict):
 DeleteCardPayload = (
     DestructivePreviewPayload
     | DestructiveCancelledPayload
-    | DeleteCardSuccessPayload
+    | LegacyDeleteCardSuccessPayload
     | ToolSuccessPayload
     | DeleteCardErrorPayload
 )
@@ -408,18 +413,18 @@ def map_delete_card_error_to_message(
 __all__ = [
     "AddCardCommentErrorPayload",
     "AddCardCommentPayload",
-    "AddCardCommentSuccessPayload",
     "DeleteCardErrorPayload",
     "DeleteCardPayload",
-    "DeleteCardSuccessPayload",
     "DeleteCommentErrorPayload",
     "DeleteCommentPayload",
-    "DeleteCommentSuccessPayload",
     "FIND_CARDS_EMPTY_MESSAGE",
+    "LegacyAddCardCommentSuccessPayload",
+    "LegacyDeleteCardSuccessPayload",
+    "LegacyDeleteCommentSuccessPayload",
+    "LegacyUpdateCommentSuccessPayload",
     "find_label_dependents",
     "UpdateCommentErrorPayload",
     "UpdateCommentPayload",
-    "UpdateCommentSuccessPayload",
     "UserCancelledError",
     "build_add_card_comment_error_payload",
     "build_add_card_comment_success_payload",

--- a/src/pipefy_mcp/tools/pipe_tools.py
+++ b/src/pipefy_mcp/tools/pipe_tools.py
@@ -40,8 +40,7 @@ from pipefy_mcp.tools.pipe_tool_helpers import (
     AddCardCommentPayload,
     DeleteCardPayload,
     DeleteCommentPayload,
-    UpdateCommentErrorPayload,
-    UpdateCommentSuccessPayload,
+    UpdateCommentPayload,
     UserCancelledError,
     _filter_editable_field_definitions,
     _filter_fields_by_definitions,
@@ -320,7 +319,7 @@ class PipeTools:
         )
         async def update_comment(
             comment_id: PipefyId, text: str
-        ) -> UpdateCommentSuccessPayload | UpdateCommentErrorPayload:
+        ) -> UpdateCommentPayload:
             """Update an existing comment by its ID.
 
             Args:

--- a/src/pipefy_mcp/tools/pipe_tools.py
+++ b/src/pipefy_mcp/tools/pipe_tools.py
@@ -18,7 +18,6 @@ from pipefy_mcp.models.form import create_form_model
 from pipefy_mcp.models.validators import PipefyId
 from pipefy_mcp.services.pipefy import PipefyClient
 from pipefy_mcp.services.pipefy.types import CardSearch, copy_card_search
-from pipefy_mcp.settings import settings
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.graphql_error_helpers import (
     enrich_permission_denied_error,
@@ -63,6 +62,7 @@ from pipefy_mcp.tools.relation_tool_helpers import (
     handle_relation_tool_graphql_error,
 )
 from pipefy_mcp.tools.tool_error_envelope import (
+    is_unified_envelope_enabled,
     tool_error,
     tool_error_message,
     tool_success,
@@ -543,7 +543,7 @@ class PipeTools:
                 first=first,
                 after=after,
             )
-            if settings.pipefy.mcp_unified_envelope:
+            if is_unified_envelope_enabled():
                 # When the caller omits ``first`` the tool falls through to the
                 # Pipefy API default page; there is no requested page size to
                 # report back, so omit the pagination block rather than publish

--- a/src/pipefy_mcp/tools/pipe_tools.py
+++ b/src/pipefy_mcp/tools/pipe_tools.py
@@ -517,8 +517,6 @@ class PipeTools:
                 first: Max cards to return per page (1-500).
                 after: Cursor for fetching the next page (from ``pageInfo.endCursor`` of a previous call).
             """
-            # Only validate when the caller supplied a value; ``None`` means
-            # "use the API default page" and is left unchanged.
             if first is not None:
                 validated_first, err = validate_page_size(first)
                 if err is not None:
@@ -544,10 +542,6 @@ class PipeTools:
                 after=after,
             )
             if is_unified_envelope_enabled():
-                # When the caller omits ``first`` the tool falls through to the
-                # Pipefy API default page; there is no requested page size to
-                # report back, so omit the pagination block rather than publish
-                # ``page_size=0`` (which our own validator would reject).
                 pagination = None
                 if first is not None:
                     page_info = (

--- a/src/pipefy_mcp/tools/pipe_tools.py
+++ b/src/pipefy_mcp/tools/pipe_tools.py
@@ -545,18 +545,22 @@ class PipeTools:
                 after=after,
             )
             if settings.pipefy.mcp_unified_envelope:
-                page_info = (
-                    (raw.get("cards") or {}).get("pageInfo")
-                    if isinstance(raw, dict)
-                    else None
-                )
+                # When the caller omits ``first`` the tool falls through to the
+                # Pipefy API default page; there is no requested page size to
+                # report back, so omit the pagination block rather than publish
+                # ``page_size=0`` (which our own validator would reject).
+                pagination = None
+                if first is not None:
+                    page_info = (
+                        (raw.get("cards") or {}).get("pageInfo")
+                        if isinstance(raw, dict)
+                        else None
+                    )
+                    pagination = build_pagination_info(
+                        page_info=page_info, page_size=first
+                    )
                 return tool_success(
-                    data=raw,
-                    message="Cards retrieved.",
-                    pagination=build_pagination_info(
-                        page_info=page_info,
-                        page_size=first if first is not None else 0,
-                    ),
+                    data=raw, message="Cards retrieved.", pagination=pagination
                 )
             return raw
 

--- a/src/pipefy_mcp/tools/pipe_tools.py
+++ b/src/pipefy_mcp/tools/pipe_tools.py
@@ -18,6 +18,7 @@ from pipefy_mcp.models.form import create_form_model
 from pipefy_mcp.models.validators import PipefyId
 from pipefy_mcp.services.pipefy import PipefyClient
 from pipefy_mcp.services.pipefy.types import CardSearch, copy_card_search
+from pipefy_mcp.settings import settings
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.graphql_error_helpers import (
     enrich_permission_denied_error,
@@ -27,6 +28,10 @@ from pipefy_mcp.tools.graphql_error_helpers import (
     with_debug_suffix,
 )
 from pipefy_mcp.tools.mcp_capabilities import supports_elicitation
+from pipefy_mcp.tools.pagination_helpers import (
+    build_pagination_info,
+    validate_page_size,
+)
 from pipefy_mcp.tools.phase_transition_helpers import (
     try_enrich_move_card_to_phase_failure,
 )
@@ -58,7 +63,11 @@ from pipefy_mcp.tools.relation_tool_helpers import (
     build_relation_mutation_success_payload,
     handle_relation_tool_graphql_error,
 )
-from pipefy_mcp.tools.tool_error_envelope import tool_error, tool_error_message
+from pipefy_mcp.tools.tool_error_envelope import (
+    tool_error,
+    tool_error_message,
+    tool_success,
+)
 from pipefy_mcp.tools.validation_helpers import validate_tool_id
 
 # Key for findCards response; used when reading edges and adding empty message.
@@ -506,9 +515,17 @@ class PipeTools:
                 search: Optional search filters (title, assignee_ids, label_ids,
                     include_done, etc.). See ``CardSearch`` for all supported keys.
                 include_fields: If True, include each card's custom fields (name, value) in the response.
-                first: Max cards to return per page.
+                first: Max cards to return per page (1-500).
                 after: Cursor for fetching the next page (from ``pageInfo.endCursor`` of a previous call).
             """
+            # Only validate when the caller supplied a value; ``None`` means
+            # "use the API default page" and is left unchanged.
+            if first is not None:
+                validated_first, err = validate_page_size(first)
+                if err is not None:
+                    return err
+                first = validated_first
+
             merged_search: CardSearch = copy_card_search(search) if search else {}
             if title:
                 merged_search["title"] = title
@@ -520,13 +537,28 @@ class PipeTools:
             await ctx.debug(
                 f"Getting cards for pipe {pipe_id} (include_fields={include_fields}, search={effective_search})"
             )
-            return await client.get_cards(
+            raw = await client.get_cards(
                 pipe_id,
                 effective_search,
                 include_fields=include_fields,
                 first=first,
                 after=after,
             )
+            if settings.pipefy.mcp_unified_envelope:
+                page_info = (
+                    (raw.get("cards") or {}).get("pageInfo")
+                    if isinstance(raw, dict)
+                    else None
+                )
+                return tool_success(
+                    data=raw,
+                    message="Cards retrieved.",
+                    pagination=build_pagination_info(
+                        page_info=page_info,
+                        page_size=first if first is not None else 0,
+                    ),
+                )
+            return raw
 
         @mcp.tool(
             annotations=ToolAnnotations(

--- a/src/pipefy_mcp/tools/report_tool_helpers.py
+++ b/src/pipefy_mcp/tools/report_tool_helpers.py
@@ -6,11 +6,14 @@ from typing import Any, Literal
 
 from typing_extensions import TypedDict
 
-from pipefy_mcp.settings import settings
 from pipefy_mcp.tools.graphql_error_helpers import (
     handle_tool_graphql_error,
 )
-from pipefy_mcp.tools.tool_error_envelope import tool_error, tool_success
+from pipefy_mcp.tools.tool_error_envelope import (
+    is_unified_envelope_enabled,
+    tool_error,
+    tool_success,
+)
 
 # The ``Legacy*SuccessPayload`` TypedDicts below describe the flag=false shape
 # only. Under the default ``PIPEFY_MCP_UNIFIED_ENVELOPE=true``, helpers return
@@ -40,7 +43,7 @@ def build_report_read_success_payload(
         data: Subtree returned by the report query.
         message: Short summary for the client.
     """
-    if settings.pipefy.mcp_unified_envelope:
+    if is_unified_envelope_enabled():
         return tool_success(data=data, message=message)
     return {"success": True, "message": message, "data": data}
 
@@ -56,7 +59,7 @@ def build_report_mutation_success_payload(
         message: Short summary for the client.
         data: Mutation payload (legacy path exposes it as ``result``).
     """
-    if settings.pipefy.mcp_unified_envelope:
+    if is_unified_envelope_enabled():
         return tool_success(data=data, message=message)
     return {"success": True, "message": message, "result": data}
 

--- a/src/pipefy_mcp/tools/report_tool_helpers.py
+++ b/src/pipefy_mcp/tools/report_tool_helpers.py
@@ -6,10 +6,11 @@ from typing import Any, Literal, cast
 
 from typing_extensions import TypedDict
 
+from pipefy_mcp.settings import settings
 from pipefy_mcp.tools.graphql_error_helpers import (
     handle_tool_graphql_error,
 )
-from pipefy_mcp.tools.tool_error_envelope import tool_error
+from pipefy_mcp.tools.tool_error_envelope import tool_error, tool_success
 
 
 class ReportReadSuccessPayload(TypedDict):
@@ -28,13 +29,15 @@ def build_report_read_success_payload(
     data: dict[str, Any],
     *,
     message: str,
-) -> ReportReadSuccessPayload:
+) -> dict[str, Any]:
     """``success``, ``message``, and GraphQL ``data`` for read tools.
 
     Args:
         data: Subtree returned by the report query.
         message: Short summary for the client.
     """
+    if settings.pipefy.mcp_unified_envelope:
+        return tool_success(data=data, message=message)
     return cast(
         ReportReadSuccessPayload,
         {
@@ -49,13 +52,17 @@ def build_report_mutation_success_payload(
     *,
     message: str,
     data: dict[str, Any],
-) -> ReportMutationSuccessPayload:
+) -> dict[str, Any]:
     """``success``, ``message``, and mutation ``result``.
 
     Args:
         message: Short summary for the client.
-        data: Raw mutation payload (stored as ``result``).
+        data: Raw mutation payload (stored as ``result`` under flag=false;
+            under the unified envelope the same dict moves to ``data`` to
+            match every other migrated helper).
     """
+    if settings.pipefy.mcp_unified_envelope:
+        return tool_success(data=data, message=message)
     return cast(
         ReportMutationSuccessPayload,
         {"success": True, "message": message, "result": data},

--- a/src/pipefy_mcp/tools/report_tool_helpers.py
+++ b/src/pipefy_mcp/tools/report_tool_helpers.py
@@ -57,9 +57,7 @@ def build_report_mutation_success_payload(
 
     Args:
         message: Short summary for the client.
-        data: Raw mutation payload (stored as ``result`` under flag=false;
-            under the unified envelope the same dict moves to ``data`` to
-            match every other migrated helper).
+        data: Mutation payload (legacy path exposes it as ``result``).
     """
     if settings.pipefy.mcp_unified_envelope:
         return tool_success(data=data, message=message)

--- a/src/pipefy_mcp/tools/report_tool_helpers.py
+++ b/src/pipefy_mcp/tools/report_tool_helpers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 from typing_extensions import TypedDict
 
@@ -12,14 +12,18 @@ from pipefy_mcp.tools.graphql_error_helpers import (
 )
 from pipefy_mcp.tools.tool_error_envelope import tool_error, tool_success
 
+# The ``Legacy*SuccessPayload`` TypedDicts below describe the flag=false shape
+# only. Under the default ``PIPEFY_MCP_UNIFIED_ENVELOPE=true``, helpers return
+# ``ToolSuccessPayload`` instead (see ADR-0001).
 
-class ReportReadSuccessPayload(TypedDict):
+
+class LegacyReportReadSuccessPayload(TypedDict):
     success: Literal[True]
     message: str
     data: dict[str, Any]
 
 
-class ReportMutationSuccessPayload(TypedDict):
+class LegacyReportMutationSuccessPayload(TypedDict):
     success: Literal[True]
     message: str
     result: dict[str, Any]
@@ -38,14 +42,7 @@ def build_report_read_success_payload(
     """
     if settings.pipefy.mcp_unified_envelope:
         return tool_success(data=data, message=message)
-    return cast(
-        ReportReadSuccessPayload,
-        {
-            "success": True,
-            "message": message,
-            "data": data,
-        },
-    )
+    return {"success": True, "message": message, "data": data}
 
 
 def build_report_mutation_success_payload(
@@ -61,10 +58,7 @@ def build_report_mutation_success_payload(
     """
     if settings.pipefy.mcp_unified_envelope:
         return tool_success(data=data, message=message)
-    return cast(
-        ReportMutationSuccessPayload,
-        {"success": True, "message": message, "result": data},
-    )
+    return {"success": True, "message": message, "result": data}
 
 
 def build_report_error_payload(*, message: str) -> dict[str, Any]:
@@ -97,8 +91,8 @@ def handle_report_tool_graphql_error(
 
 
 __all__ = [
-    "ReportMutationSuccessPayload",
-    "ReportReadSuccessPayload",
+    "LegacyReportMutationSuccessPayload",
+    "LegacyReportReadSuccessPayload",
     "build_report_error_payload",
     "build_report_mutation_success_payload",
     "build_report_read_success_payload",

--- a/src/pipefy_mcp/tools/report_tools.py
+++ b/src/pipefy_mcp/tools/report_tools.py
@@ -423,7 +423,7 @@ class ReportTools:
             featured_field: str | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
-            """Update a pipe report. All params except `report_id` are optional -- only provided values are changed.
+            """Update a pipe report; omitted parameters are unchanged.
 
             Args:
                 report_id: Pipe report ID.
@@ -571,7 +571,7 @@ class ReportTools:
             pipe_ids: list[str] | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
-            """Update an organization report. All params except `report_id` are optional -- only provided values are changed.
+            """Update an organization report; omitted parameters are unchanged.
 
             Args:
                 report_id: Organization report ID.

--- a/src/pipefy_mcp/tools/report_tools.py
+++ b/src/pipefy_mcp/tools/report_tools.py
@@ -10,13 +10,19 @@ from mcp.types import ToolAnnotations
 
 from pipefy_mcp.models.validators import PipefyId
 from pipefy_mcp.services.pipefy import PipefyClient
+from pipefy_mcp.settings import settings
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
+from pipefy_mcp.tools.pagination_helpers import (
+    build_pagination_info,
+    validate_page_size,
+)
 from pipefy_mcp.tools.report_tool_helpers import (
     build_report_error_payload,
     build_report_mutation_success_payload,
     build_report_read_success_payload,
     handle_report_tool_graphql_error,
 )
+from pipefy_mcp.tools.tool_error_envelope import tool_success
 from pipefy_mcp.tools.validation_helpers import validate_tool_id
 
 
@@ -58,14 +64,13 @@ class ReportTools:
             err = _blank_field_error(pipe_uuid, "pipe_uuid")
             if err is not None:
                 return err
-            if first < 1:
-                return build_report_error_payload(
-                    message="'first' must be a positive integer.",
-                )
+            nfirst, page_err = validate_page_size(first)
+            if page_err is not None:
+                return page_err
             try:
                 raw = await client.get_pipe_reports(
                     pipe_uuid,
-                    first=first,
+                    first=nfirst,
                     after=after,
                     search=search,
                     report_id=report_id,
@@ -78,6 +83,15 @@ class ReportTools:
                     debug=debug,
                     resource_kind="pipe",
                     resource_id=pipe_uuid,
+                )
+            if settings.pipefy.mcp_unified_envelope:
+                page_info = (raw.get("pipeReports") or {}).get("pageInfo")
+                return tool_success(
+                    data=raw,
+                    message="Pipe reports retrieved.",
+                    pagination=build_pagination_info(
+                        page_info=page_info, page_size=nfirst
+                    ),
                 )
             return build_report_read_success_payload(
                 raw,
@@ -259,13 +273,12 @@ class ReportTools:
             err = _blank_field_error(organization_id, "organization_id")
             if err is not None:
                 return err
-            if first < 1:
-                return build_report_error_payload(
-                    message="'first' must be a positive integer.",
-                )
+            nfirst, page_err = validate_page_size(first)
+            if page_err is not None:
+                return page_err
             try:
                 raw = await client.get_organization_reports(
-                    organization_id, first=first, after=after
+                    organization_id, first=nfirst, after=after
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_report_tool_graphql_error(
@@ -274,6 +287,15 @@ class ReportTools:
                     debug=debug,
                     resource_kind="organization",
                     resource_id=str(organization_id),
+                )
+            if settings.pipefy.mcp_unified_envelope:
+                page_info = (raw.get("organizationReports") or {}).get("pageInfo")
+                return tool_success(
+                    data=raw,
+                    message="Organization reports retrieved.",
+                    pagination=build_pagination_info(
+                        page_info=page_info, page_size=nfirst
+                    ),
                 )
             return build_report_read_success_payload(
                 raw,

--- a/src/pipefy_mcp/tools/report_tools.py
+++ b/src/pipefy_mcp/tools/report_tools.py
@@ -10,7 +10,6 @@ from mcp.types import ToolAnnotations
 
 from pipefy_mcp.models.validators import PipefyId
 from pipefy_mcp.services.pipefy import PipefyClient
-from pipefy_mcp.settings import settings
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.pagination_helpers import (
     build_pagination_info,
@@ -22,7 +21,10 @@ from pipefy_mcp.tools.report_tool_helpers import (
     build_report_read_success_payload,
     handle_report_tool_graphql_error,
 )
-from pipefy_mcp.tools.tool_error_envelope import tool_success
+from pipefy_mcp.tools.tool_error_envelope import (
+    is_unified_envelope_enabled,
+    tool_success,
+)
 from pipefy_mcp.tools.validation_helpers import validate_tool_id
 
 
@@ -84,7 +86,7 @@ class ReportTools:
                     resource_kind="pipe",
                     resource_id=pipe_uuid,
                 )
-            if settings.pipefy.mcp_unified_envelope:
+            if is_unified_envelope_enabled():
                 page_info = (raw.get("pipeReports") or {}).get("pageInfo")
                 return tool_success(
                     data=raw,
@@ -288,7 +290,7 @@ class ReportTools:
                     resource_kind="organization",
                     resource_id=str(organization_id),
                 )
-            if settings.pipefy.mcp_unified_envelope:
+            if is_unified_envelope_enabled():
                 page_info = (raw.get("organizationReports") or {}).get("pageInfo")
                 return tool_success(
                     data=raw,

--- a/src/pipefy_mcp/tools/table_tools.py
+++ b/src/pipefy_mcp/tools/table_tools.py
@@ -46,9 +46,7 @@ from pipefy_mcp.tools.validation_helpers import (
 )
 
 _TABLE_RECORDS_FIRST_MIN = 1
-# Pipefy's ``table_records(first: ...)`` is capped at 200 server-side; the
-# unified validator receives ``max_size=200`` so the error matches what the API
-# would reject, rather than using the global ``MAX_PAGE_SIZE`` default (500).
+# ``table_records(first:)`` is capped at 200; align validator max with the API (not 500).
 _TABLE_RECORDS_FIRST_MAX = 200
 _SEARCH_TABLES_FIRST_MAX = 500
 
@@ -110,11 +108,6 @@ class TableTools:
                 return err
             raw = await client.search_tables(table_name, first=nfirst)
             if is_unified_envelope_enabled():
-                # The outer call is not paginable (no ``after`` argument), so
-                # ``has_more=False`` is the honest signal. Agents that need to
-                # detect "more rows exist somewhere" check
-                # ``data.search_limits.tables_has_next_page`` or the per-org
-                # ``tables_page_end_cursor`` fields.
                 return tool_success(
                     data=raw,
                     message="Tables search retrieved.",

--- a/src/pipefy_mcp/tools/table_tools.py
+++ b/src/pipefy_mcp/tools/table_tools.py
@@ -14,11 +14,16 @@ from pipefy_mcp.services.pipefy.table_service import (
     UPDATE_TABLE_RECORD_ALLOWED_FIELD_KEYS,
     UPDATE_TABLE_RECORD_FIELDS_ERROR_MESSAGE,
 )
+from pipefy_mcp.settings import settings
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.graphql_error_helpers import (
     extract_graphql_correlation_id,
     extract_graphql_error_codes,
     with_debug_suffix,
+)
+from pipefy_mcp.tools.pagination_helpers import (
+    build_pagination_info,
+    validate_page_size,
 )
 from pipefy_mcp.tools.table_tool_helpers import (
     build_delete_table_error_payload,
@@ -30,7 +35,7 @@ from pipefy_mcp.tools.table_tool_helpers import (
     handle_table_tool_graphql_error,
     map_delete_table_error_to_message,
 )
-from pipefy_mcp.tools.tool_error_envelope import tool_error_message
+from pipefy_mcp.tools.tool_error_envelope import tool_error_message, tool_success
 from pipefy_mcp.tools.validation_helpers import (
     mutation_error_if_not_optional_dict,
     validate_optional_tool_id,
@@ -38,7 +43,11 @@ from pipefy_mcp.tools.validation_helpers import (
 )
 
 _TABLE_RECORDS_FIRST_MIN = 1
+# Pipefy's ``table_records(first: ...)`` is capped at 200 server-side; the
+# unified validator receives ``max_size=200`` so the error matches what the API
+# would reject, rather than using the global ``MAX_PAGE_SIZE`` default (500).
 _TABLE_RECORDS_FIRST_MAX = 200
+_SEARCH_TABLES_FIRST_MAX = 500
 
 
 _CREATE_TABLE_EXTRA_RESERVED = frozenset({"name", "organization_id"})
@@ -63,7 +72,7 @@ class TableTools:
 
             Use this tool to find a table's ID when you only know its name.
             Returns up to ``first`` tables per organization from the GraphQL connection
-            (clamped 1--500, default 100). Optionally filtered by name client-side on that page.
+            (1-500, default 100). Optionally filtered by name client-side on that page.
 
             When filtering by name, uses substring matching first (score 100) and
             falls back to fuzzy matching with a 70% similarity threshold.
@@ -75,7 +84,7 @@ class TableTools:
 
             Args:
                 table_name: Optional table name to search for (case-insensitive partial match).
-                first: GraphQL ``tables(first: ...)`` per organization (1--500).
+                first: GraphQL ``tables(first: ...)`` per organization (1-500).
 
             Returns:
                 dict: Contains 'organizations' array, each with:
@@ -89,8 +98,24 @@ class TableTools:
                                          100 for substring matches, fuzzy score otherwise.
                       And ``search_limits`` (``tables_first``, ``tables_has_next_page``).
             """
-            nfirst = max(1, min(500, int(first)))
-            return await client.search_tables(table_name, first=nfirst)
+            nfirst, err = validate_page_size(first, max_size=_SEARCH_TABLES_FIRST_MAX)
+            if err is not None:
+                return err
+            raw = await client.search_tables(table_name, first=nfirst)
+            if settings.pipefy.mcp_unified_envelope:
+                aggregate_has_more = bool(
+                    (raw.get("search_limits") or {}).get("tables_has_next_page")
+                )
+                return tool_success(
+                    data=raw,
+                    message="Tables search retrieved.",
+                    pagination={
+                        "has_more": aggregate_has_more,
+                        "end_cursor": None,
+                        "page_size": nfirst,
+                    },
+                )
+            return raw
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
@@ -194,17 +219,11 @@ class TableTools:
             table_id, err = validate_tool_id(table_id, "table_id")
             if err is not None:
                 return build_table_read_error_payload(message=tool_error_message(err))
-            if (
-                not isinstance(first, int)
-                or first < _TABLE_RECORDS_FIRST_MIN
-                or first > _TABLE_RECORDS_FIRST_MAX
-            ):
-                return build_table_read_error_payload(
-                    message=(
-                        "Invalid 'first': use an integer between "
-                        f"{_TABLE_RECORDS_FIRST_MIN} and {_TABLE_RECORDS_FIRST_MAX}."
-                    ),
-                )
+            nfirst, page_err = validate_page_size(
+                first, max_size=_TABLE_RECORDS_FIRST_MAX
+            )
+            if page_err is not None:
+                return page_err
             if after is not None and (not isinstance(after, str) or not after.strip()):
                 return build_table_read_error_payload(
                     message="Invalid 'after': omit or pass a non-empty cursor string.",
@@ -212,7 +231,7 @@ class TableTools:
             try:
                 raw = await client.get_table_records(
                     table_id,
-                    first=first,
+                    first=nfirst,
                     after=after.strip() if isinstance(after, str) else after,
                 )
             except Exception as exc:  # noqa: BLE001
@@ -221,6 +240,15 @@ class TableTools:
                     "List table records failed.",
                     resource_kind="table",
                     resource_id=str(table_id),
+                )
+            if settings.pipefy.mcp_unified_envelope:
+                page_info = (raw.get("table_records") or {}).get("pageInfo")
+                return tool_success(
+                    data=raw,
+                    message="Table records page retrieved.",
+                    pagination=build_pagination_info(
+                        page_info=page_info, page_size=nfirst
+                    ),
                 )
             return build_table_read_success_payload(
                 raw,

--- a/src/pipefy_mcp/tools/table_tools.py
+++ b/src/pipefy_mcp/tools/table_tools.py
@@ -14,7 +14,6 @@ from pipefy_mcp.services.pipefy.table_service import (
     UPDATE_TABLE_RECORD_ALLOWED_FIELD_KEYS,
     UPDATE_TABLE_RECORD_FIELDS_ERROR_MESSAGE,
 )
-from pipefy_mcp.settings import settings
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.graphql_error_helpers import (
     extract_graphql_correlation_id,
@@ -35,7 +34,11 @@ from pipefy_mcp.tools.table_tool_helpers import (
     handle_table_tool_graphql_error,
     map_delete_table_error_to_message,
 )
-from pipefy_mcp.tools.tool_error_envelope import tool_error_message, tool_success
+from pipefy_mcp.tools.tool_error_envelope import (
+    is_unified_envelope_enabled,
+    tool_error_message,
+    tool_success,
+)
 from pipefy_mcp.tools.validation_helpers import (
     mutation_error_if_not_optional_dict,
     validate_optional_tool_id,
@@ -106,7 +109,7 @@ class TableTools:
             if err is not None:
                 return err
             raw = await client.search_tables(table_name, first=nfirst)
-            if settings.pipefy.mcp_unified_envelope:
+            if is_unified_envelope_enabled():
                 # The outer call is not paginable (no ``after`` argument), so
                 # ``has_more=False`` is the honest signal. Agents that need to
                 # detect "more rows exist somewhere" check
@@ -247,7 +250,7 @@ class TableTools:
                     resource_kind="table",
                     resource_id=str(table_id),
                 )
-            if settings.pipefy.mcp_unified_envelope:
+            if is_unified_envelope_enabled():
                 page_info = (raw.get("table_records") or {}).get("pageInfo")
                 return tool_success(
                     data=raw,

--- a/src/pipefy_mcp/tools/table_tools.py
+++ b/src/pipefy_mcp/tools/table_tools.py
@@ -79,8 +79,12 @@ class TableTools:
             Only tables with a match score of 70 or higher are included in results.
             Results are sorted by match score (best matches first).
 
-            If an org has more rows than ``first``, ``tables_has_next_page`` is set on that
-            org and in ``search_limits`` (cursor pagination is not yet exposed on this tool).
+            **Pagination.** The top-level ``pagination.has_more`` is always ``False``
+            because this tool does not accept ``after``; the outer call is not
+            paginable. Per-organization cursors live inside
+            ``data.organizations[i].tables_page_end_cursor`` (set when that org has
+            more rows than ``first``). The legacy ``search_limits.tables_has_next_page``
+            key remains as an aggregate hint.
 
             Args:
                 table_name: Optional table name to search for (case-insensitive partial match).
@@ -103,14 +107,16 @@ class TableTools:
                 return err
             raw = await client.search_tables(table_name, first=nfirst)
             if settings.pipefy.mcp_unified_envelope:
-                aggregate_has_more = bool(
-                    (raw.get("search_limits") or {}).get("tables_has_next_page")
-                )
+                # The outer call is not paginable (no ``after`` argument), so
+                # ``has_more=False`` is the honest signal. Agents that need to
+                # detect "more rows exist somewhere" check
+                # ``data.search_limits.tables_has_next_page`` or the per-org
+                # ``tables_page_end_cursor`` fields.
                 return tool_success(
                     data=raw,
                     message="Tables search retrieved.",
                     pagination={
-                        "has_more": aggregate_has_more,
+                        "has_more": False,
                         "end_cursor": None,
                         "page_size": nfirst,
                     },

--- a/src/pipefy_mcp/tools/tool_error_envelope.py
+++ b/src/pipefy_mcp/tools/tool_error_envelope.py
@@ -40,13 +40,9 @@ __all__ = [
 
 
 def is_unified_envelope_enabled() -> bool:
-    """Return the current ``PIPEFY_MCP_UNIFIED_ENVELOPE`` flag value.
+    """Whether unified tool envelopes are enabled (``PIPEFY_MCP_UNIFIED_ENVELOPE``).
 
-    Reads ``settings.pipefy.mcp_unified_envelope`` at call time (REQ-2) so
-    tests and runtime toggles take effect immediately. Migrated helpers use
-    this single accessor instead of dotting into ``settings`` directly, which
-    keeps the ``read-per-call`` guarantee centralised and makes the eventual
-    flag-removal cleanup a single-file change.
+    Read from settings at call time so tests and toggles apply without restart.
     """
     return settings.pipefy.mcp_unified_envelope
 

--- a/src/pipefy_mcp/tools/tool_error_envelope.py
+++ b/src/pipefy_mcp/tools/tool_error_envelope.py
@@ -29,8 +29,10 @@ from typing_extensions import NotRequired, TypedDict
 __all__ = [
     "ToolErrorDetail",
     "ToolFailurePayload",
+    "ToolSuccessPayload",
     "tool_error",
     "tool_error_message",
+    "tool_success",
 ]
 
 
@@ -47,6 +49,19 @@ class ToolFailurePayload(TypedDict):
 
     success: Literal[False]
     error: ToolErrorDetail
+
+
+class ToolSuccessPayload(TypedDict, total=False):
+    """``success: true`` with optional ``data``, ``message``, ``pagination`` keys.
+
+    Canonical unified success envelope. See ADR-0001 (verbatim GraphQL wrap under
+    ``data``) and ADR-0002 (feature-flag default TRUE).
+    """
+
+    success: Literal[True]
+    data: dict[str, Any]
+    message: str
+    pagination: dict[str, Any]
 
 
 def tool_error(
@@ -68,6 +83,31 @@ def tool_error(
     if details:
         err["details"] = details
     return {"success": False, "error": err}
+
+
+def tool_success(
+    data: dict[str, Any] | None = None,
+    *,
+    message: str | None = None,
+    pagination: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Canonical success payload. Optional keys omitted when args are ``None``.
+
+    Args:
+        data: Verbatim payload (e.g. raw Pipefy GraphQL subtree). Preserves
+            query-name wrappers per ADR-0001 — callers SHOULD NOT unwrap.
+        message: Optional short human-readable summary.
+        pagination: Optional top-level pagination block (typically built by
+            :func:`pipefy_mcp.tools.pagination_helpers.build_pagination_info`).
+    """
+    payload: dict[str, Any] = {"success": True}
+    if data is not None:
+        payload["data"] = data
+    if message is not None:
+        payload["message"] = message
+    if pagination is not None:
+        payload["pagination"] = pagination
+    return payload
 
 
 def tool_error_message(payload: Mapping[str, Any]) -> str:

--- a/src/pipefy_mcp/tools/tool_error_envelope.py
+++ b/src/pipefy_mcp/tools/tool_error_envelope.py
@@ -8,8 +8,8 @@ All tools that return ``{"success": false, ...}`` should use
 * **Failure** - ``{"success": false, "error": {"message": str, "code"?: str, "details"?: dict}}``.
   Optional top-level fields (e.g. ``valid_destinations``) are allowed for tools
   that already expose extra context.
-* **Success** - remains tool-specific (flat fields or ``data``) until a follow-up
-  unification pass.
+* **Success** - use :func:`tool_success` for the unified shape; other tools may
+  still return legacy flat payloads.
 
 **User-visible text (N1):** Strings passed to :func:`tool_error` and other returned
 ``error.message`` (and equivalent warnings) use ASCII only: straight ``'`` / ``"``,
@@ -52,11 +52,7 @@ class ToolFailurePayload(TypedDict):
 
 
 class ToolSuccessPayload(TypedDict, total=False):
-    """``success: true`` with optional ``data``, ``message``, ``pagination`` keys.
-
-    Canonical unified success envelope. See ADR-0001 (verbatim GraphQL wrap under
-    ``data``) and ADR-0002 (feature-flag default TRUE).
-    """
+    """``success: true`` with optional ``data``, ``message``, ``pagination``."""
 
     success: Literal[True]
     data: dict[str, Any]
@@ -94,8 +90,7 @@ def tool_success(
     """Canonical success payload. Optional keys omitted when args are ``None``.
 
     Args:
-        data: Verbatim payload (e.g. raw Pipefy GraphQL subtree). Preserves
-            query-name wrappers per ADR-0001 — callers SHOULD NOT unwrap.
+        data: Verbatim GraphQL subtree; keep query-root keys inside this dict.
         message: Optional short human-readable summary.
         pagination: Optional top-level pagination block (typically built by
             :func:`pipefy_mcp.tools.pagination_helpers.build_pagination_info`).

--- a/src/pipefy_mcp/tools/tool_error_envelope.py
+++ b/src/pipefy_mcp/tools/tool_error_envelope.py
@@ -26,14 +26,29 @@ from typing import Any, Literal, Mapping
 
 from typing_extensions import NotRequired, TypedDict
 
+from pipefy_mcp.settings import settings
+
 __all__ = [
     "ToolErrorDetail",
     "ToolFailurePayload",
     "ToolSuccessPayload",
+    "is_unified_envelope_enabled",
     "tool_error",
     "tool_error_message",
     "tool_success",
 ]
+
+
+def is_unified_envelope_enabled() -> bool:
+    """Return the current ``PIPEFY_MCP_UNIFIED_ENVELOPE`` flag value.
+
+    Reads ``settings.pipefy.mcp_unified_envelope`` at call time (REQ-2) so
+    tests and runtime toggles take effect immediately. Migrated helpers use
+    this single accessor instead of dotting into ``settings`` directly, which
+    keeps the ``read-per-call`` guarantee centralised and makes the eventual
+    flag-removal cleanup a single-file change.
+    """
+    return settings.pipefy.mcp_unified_envelope
 
 
 class ToolErrorDetail(TypedDict):

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -9,30 +9,21 @@ from pipefy_mcp.settings import settings
 
 @pytest.fixture
 def legacy_envelope(monkeypatch):
-    """Force the legacy (pre-unified) success shape by disabling the flag.
-
-    Use this in tests that assert byte-identical pre-PR output from a migrated
-    helper or tool. Without it, the default-TRUE ``PIPEFY_MCP_UNIFIED_ENVELOPE``
-    causes migrated helpers to emit the unified ``{success, data, message?}`` shape.
-    """
+    """Disable unified envelope (``PIPEFY_MCP_UNIFIED_ENVELOPE`` off)."""
     monkeypatch.setattr(settings.pipefy, "mcp_unified_envelope", False)
     return False
 
 
 @pytest.fixture
 def unified_envelope(monkeypatch):
-    """Force the unified envelope shape (explicit, not relying on default)."""
+    """Enable unified envelope (explicit)."""
     monkeypatch.setattr(settings.pipefy, "mcp_unified_envelope", True)
     return True
 
 
 @pytest.fixture(params=[True, False], ids=["flag-on", "flag-off"])
 def envelope_flag(request, monkeypatch):
-    """Parametrize a test across both flag states via monkeypatch.
-
-    Tests that use this fixture receive the current flag value as ``envelope_flag``
-    and run twice — once with ``True`` (unified) and once with ``False`` (legacy).
-    """
+    """Runs the test twice: unified envelope on, then off."""
     monkeypatch.setattr(settings.pipefy, "mcp_unified_envelope", request.param)
     return request.param
 

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -4,6 +4,38 @@ import json
 
 import pytest
 
+from pipefy_mcp.settings import settings
+
+
+@pytest.fixture
+def legacy_envelope(monkeypatch):
+    """Force the legacy (pre-unified) success shape by disabling the flag.
+
+    Use this in tests that assert byte-identical pre-PR output from a migrated
+    helper or tool. Without it, the default-TRUE ``PIPEFY_MCP_UNIFIED_ENVELOPE``
+    causes migrated helpers to emit the unified ``{success, data, message?}`` shape.
+    """
+    monkeypatch.setattr(settings.pipefy, "mcp_unified_envelope", False)
+    return False
+
+
+@pytest.fixture
+def unified_envelope(monkeypatch):
+    """Force the unified envelope shape (explicit, not relying on default)."""
+    monkeypatch.setattr(settings.pipefy, "mcp_unified_envelope", True)
+    return True
+
+
+@pytest.fixture(params=[True, False], ids=["flag-on", "flag-off"])
+def envelope_flag(request, monkeypatch):
+    """Parametrize a test across both flag states via monkeypatch.
+
+    Tests that use this fixture receive the current flag value as ``envelope_flag``
+    and run twice — once with ``True`` (unified) and once with ``False`` (legacy).
+    """
+    monkeypatch.setattr(settings.pipefy, "mcp_unified_envelope", request.param)
+    return request.param
+
 
 def _extract_payload_impl(result):
     """Extract tool payload from CallToolResult across MCP SDK versions."""

--- a/tests/tools/test_ai_agent_tools.py
+++ b/tests/tools/test_ai_agent_tools.py
@@ -143,6 +143,7 @@ class TestCreateAiAgent:
         client_session,
         mock_pipefy_client,
         extract_payload,
+        envelope_flag,
     ):
         mock_pipefy_client.create_ai_agent.return_value = {
             "agent_uuid": "new-uuid",
@@ -179,7 +180,10 @@ class TestCreateAiAgent:
         assert update_arg.data_source_ids == ["ds-1", "ds-2"]
         payload = extract_payload(result)
         assert payload["success"] is True
-        assert payload["agent_uuid"] == "new-uuid"
+        if envelope_flag:
+            assert payload["data"]["agent_uuid"] == "new-uuid"
+        else:
+            assert payload["agent_uuid"] == "new-uuid"
 
     async def test_partial_failure_returns_uuid_and_error(
         self,
@@ -333,6 +337,7 @@ class TestUpdateAiAgent:
         client_session,
         mock_pipefy_client,
         extract_payload,
+        legacy_envelope,
     ):
         mock_pipefy_client.update_ai_agent.return_value = {
             "agent_uuid": "agent-uuid",
@@ -874,6 +879,7 @@ class TestGetAiAgent:
         client_session,
         mock_pipefy_client,
         extract_payload,
+        legacy_envelope,
     ):
         agent = {
             "uuid": "agent-1",
@@ -893,11 +899,30 @@ class TestGetAiAgent:
         payload = extract_payload(result)
         assert payload == {"success": True, "agent": agent}
 
+    async def test_success_unified_envelope(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+        unified_envelope,
+    ):
+        """Flag=True — agent payload sits under ``data.agent`` (ADR-0001)."""
+        agent = {"uuid": "agent-1", "name": "Assistant"}
+        mock_pipefy_client.get_ai_agent.return_value = agent
+        async with client_session as session:
+            result = await session.call_tool(
+                "get_ai_agent",
+                {"uuid": "agent-1"},
+            )
+        payload = extract_payload(result)
+        assert payload == {"success": True, "data": {"agent": agent}}
+
     async def test_success_with_behaviors(
         self,
         client_session,
         mock_pipefy_client,
         extract_payload,
+        legacy_envelope,
     ):
         """Behaviors from the API are included verbatim in the MCP tool response."""
         from tests.ai_agent_test_payloads import mock_agent_with_behaviors
@@ -924,6 +949,7 @@ class TestGetAiAgent:
         client_session,
         mock_pipefy_client,
         extract_payload,
+        legacy_envelope,
     ):
         """When API returns behaviors: null, the tool response exposes it.
 
@@ -997,6 +1023,7 @@ class TestGetAiAgents:
         client_session,
         mock_pipefy_client,
         extract_payload,
+        legacy_envelope,
     ):
         agents = [{"uuid": "a1", "name": "One"}]
         mock_pipefy_client.get_ai_agents.return_value = agents
@@ -1009,6 +1036,24 @@ class TestGetAiAgents:
         mock_pipefy_client.get_ai_agents.assert_awaited_once_with("pipe-uuid-9")
         payload = extract_payload(result)
         assert payload == {"success": True, "agents": agents}
+
+    async def test_success_unified_envelope(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+        unified_envelope,
+    ):
+        """Flag=True — agents list sits under ``data.agents`` (ADR-0001)."""
+        agents = [{"uuid": "a1"}, {"uuid": "a2"}]
+        mock_pipefy_client.get_ai_agents.return_value = agents
+        async with client_session as session:
+            result = await session.call_tool(
+                "get_ai_agents",
+                {"repo_uuid": "pipe-uuid-9"},
+            )
+        payload = extract_payload(result)
+        assert payload == {"success": True, "data": {"agents": agents}}
 
     async def test_blank_repo_uuid_returns_error_payload(
         self, client_session, mock_pipefy_client, extract_payload
@@ -1141,6 +1186,7 @@ class TestGetAiAgentsErrorPaths:
         client_session,
         mock_pipefy_client,
         extract_payload,
+        legacy_envelope,
     ):
         mock_pipefy_client.get_ai_agents.return_value = []
         async with client_session as session:

--- a/tests/tools/test_ai_automation_tools.py
+++ b/tests/tools/test_ai_automation_tools.py
@@ -503,6 +503,7 @@ class TestCreateAiAutomation:
         client_session,
         mock_pipefy_client,
         extract_payload,
+        legacy_envelope,
     ):
         mock_pipefy_client.create_ai_automation.return_value = {
             "automation_id": "123",
@@ -528,6 +529,36 @@ class TestCreateAiAutomation:
         }
         assert isinstance(payload["message"], str)
         assert isinstance(payload["automation_id"], str)
+
+    async def test_success_unified_envelope(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+        unified_envelope,
+    ):
+        """Default flag=True — automation_id sits under ``data``."""
+        mock_pipefy_client.create_ai_automation.return_value = {
+            "automation_id": "123",
+            "message": "AI Automation created successfully. ID: 123",
+        }
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_ai_automation",
+                {
+                    "name": "My Auto",
+                    "event_id": "card_created",
+                    "pipe_id": "303",
+                    "prompt": "Summarize %{133}",
+                    "field_ids": ["133"],
+                },
+            )
+        payload = extract_payload(result)
+        assert payload == {
+            "success": True,
+            "data": {"automation_id": "123"},
+            "message": "AI Automation created successfully. ID: 123",
+        }
 
     async def test_service_error_returns_error_payload(
         self,
@@ -741,6 +772,7 @@ class TestUpdateAiAutomation:
         client_session,
         mock_pipefy_client,
         extract_payload,
+        legacy_envelope,
     ):
         mock_pipefy_client.update_ai_automation.return_value = {
             "automation_id": "789",

--- a/tests/tools/test_ai_tool_helpers.py
+++ b/tests/tools/test_ai_tool_helpers.py
@@ -4,6 +4,14 @@ import pytest
 from gql.transport.exceptions import TransportQueryError
 
 from pipefy_mcp.tools.ai_tool_helpers import (
+    build_create_agent_success,
+    build_create_automation_success,
+    build_delete_agent_success,
+    build_get_agent_success,
+    build_get_agents_success,
+    build_toggle_agent_status_success,
+    build_update_agent_success,
+    build_update_automation_success,
     enrich_behavior_error,
     validate_behaviors_against_pipe,
 )
@@ -32,6 +40,104 @@ def _make_behaviors(*specs):
             }
         )
     return result
+
+
+# --- Unified-envelope / legacy-shape parity for AI success builders ---
+
+
+@pytest.mark.unit
+def test_build_create_agent_success_parametrized_flag(envelope_flag):
+    out = build_create_agent_success(agent_uuid="abc", message="ok")
+    if envelope_flag:
+        assert out == {
+            "success": True,
+            "data": {"agent_uuid": "abc"},
+            "message": "ok",
+        }
+    else:
+        assert out == {"success": True, "agent_uuid": "abc", "message": "ok"}
+
+
+@pytest.mark.unit
+def test_build_update_agent_success_parametrized_flag(envelope_flag):
+    out = build_update_agent_success(agent_uuid="u1", message="updated")
+    if envelope_flag:
+        assert out == {
+            "success": True,
+            "data": {"agent_uuid": "u1"},
+            "message": "updated",
+        }
+    else:
+        assert out == {"success": True, "agent_uuid": "u1", "message": "updated"}
+
+
+@pytest.mark.unit
+def test_build_create_automation_success_parametrized_flag(envelope_flag):
+    out = build_create_automation_success(automation_id="42", message="created")
+    if envelope_flag:
+        assert out == {
+            "success": True,
+            "data": {"automation_id": "42"},
+            "message": "created",
+        }
+    else:
+        assert out == {
+            "success": True,
+            "automation_id": "42",
+            "message": "created",
+        }
+
+
+@pytest.mark.unit
+def test_build_update_automation_success_parametrized_flag(envelope_flag):
+    out = build_update_automation_success(automation_id="42", message="updated")
+    if envelope_flag:
+        assert out == {
+            "success": True,
+            "data": {"automation_id": "42"},
+            "message": "updated",
+        }
+    else:
+        assert out == {
+            "success": True,
+            "automation_id": "42",
+            "message": "updated",
+        }
+
+
+@pytest.mark.unit
+def test_build_toggle_agent_status_success_parametrized_flag(envelope_flag):
+    out = build_toggle_agent_status_success(message="toggled")
+    # Same shape under both flag states — no domain key to wrap.
+    assert out == {"success": True, "message": "toggled"}
+
+
+@pytest.mark.unit
+def test_build_get_agent_success_parametrized_flag(envelope_flag):
+    agent_payload = {"aiAgent": {"uuid": "u", "name": "n"}}
+    out = build_get_agent_success(agent_payload)
+    if envelope_flag:
+        # ADR-0001: verbatim wrap preserves outer 'agent' key inside data.
+        assert out == {"success": True, "data": {"agent": agent_payload}}
+    else:
+        assert out == {"success": True, "agent": agent_payload}
+
+
+@pytest.mark.unit
+def test_build_get_agents_success_parametrized_flag(envelope_flag):
+    agents = [{"uuid": "a"}, {"uuid": "b"}]
+    out = build_get_agents_success(agents)
+    if envelope_flag:
+        assert out == {"success": True, "data": {"agents": agents}}
+    else:
+        assert out == {"success": True, "agents": agents}
+
+
+@pytest.mark.unit
+def test_build_delete_agent_success_parametrized_flag(envelope_flag):
+    out = build_delete_agent_success(message="gone")
+    # No domain key — same shape under both flag states.
+    assert out == {"success": True, "message": "gone"}
 
 
 @pytest.mark.unit

--- a/tests/tools/test_pagination_helpers.py
+++ b/tests/tools/test_pagination_helpers.py
@@ -1,0 +1,111 @@
+"""Unit tests for pagination_helpers (REQ-4)."""
+
+from pipefy_mcp.tools.pagination_helpers import (
+    DEFAULT_PAGE_SIZE,
+    MAX_PAGE_SIZE,
+    build_pagination_info,
+    validate_page_size,
+)
+
+
+def test_validate_page_size_none_returns_default() -> None:
+    value, err = validate_page_size(None)
+    assert value == DEFAULT_PAGE_SIZE == 50
+    assert err is None
+
+
+def test_validate_page_size_valid_int_passes_through() -> None:
+    value, err = validate_page_size(100)
+    assert value == 100
+    assert err is None
+
+
+def test_validate_page_size_above_max_returns_structured_error() -> None:
+    value, err = validate_page_size(1000)
+    assert value == 0
+    assert err is not None
+    assert err["success"] is False
+    assert err["error"]["code"] == "INVALID_ARGUMENTS"
+    assert err["error"]["details"] == {"min": 1, "max": 500, "provided": 1000}
+
+
+def test_validate_page_size_below_1_returns_structured_error() -> None:
+    value, err = validate_page_size(0)
+    assert value == 0
+    assert err is not None
+    assert err["error"]["code"] == "INVALID_ARGUMENTS"
+    assert err["error"]["details"] == {"min": 1, "max": 500, "provided": 0}
+
+
+def test_validate_page_size_negative_returns_structured_error() -> None:
+    value, err = validate_page_size(-5)
+    assert value == 0
+    assert err is not None
+    assert err["error"]["code"] == "INVALID_ARGUMENTS"
+    assert err["error"]["details"]["provided"] == -5
+
+
+def test_validate_page_size_non_integer_returns_structured_error() -> None:
+    value, err = validate_page_size("abc")  # type: ignore[arg-type]
+    assert value == 0
+    assert err is not None
+    assert err["error"]["code"] == "INVALID_ARGUMENTS"
+    # Non-int does not populate provided (no int to report).
+    assert "message" in err["error"]
+
+
+def test_validate_page_size_accepts_integer_string() -> None:
+    # int("100") coerces successfully, so "100" is treated as 100.
+    value, err = validate_page_size("100")  # type: ignore[arg-type]
+    assert value == 100
+    assert err is None
+
+
+def test_validate_page_size_custom_max() -> None:
+    value, err = validate_page_size(750, max_size=1000)
+    assert value == 750
+    assert err is None
+
+
+def test_validate_page_size_custom_max_still_enforces_lower_bound() -> None:
+    value, err = validate_page_size(0, max_size=1000)
+    assert value == 0
+    assert err is not None
+    assert err["error"]["details"]["max"] == 1000
+
+
+def test_validate_page_size_uses_arg_name_in_error() -> None:
+    _, err = validate_page_size(9999, arg_name="first")
+    assert err is not None
+    assert "'first'" in err["error"]["message"]
+
+
+def test_max_page_size_is_500() -> None:
+    assert MAX_PAGE_SIZE == 500
+
+
+def test_build_pagination_info_with_page_info() -> None:
+    info = build_pagination_info(
+        page_info={"hasNextPage": True, "endCursor": "xyz"},
+        page_size=50,
+    )
+    assert info == {"has_more": True, "end_cursor": "xyz", "page_size": 50}
+
+
+def test_build_pagination_info_without_page_info() -> None:
+    info = build_pagination_info(page_info=None, page_size=50)
+    assert info == {"has_more": False, "end_cursor": None, "page_size": 50}
+
+
+def test_build_pagination_info_empty_page_info() -> None:
+    info = build_pagination_info(page_info={}, page_size=25)
+    # Empty dict is falsy — treated like absent pageInfo.
+    assert info == {"has_more": False, "end_cursor": None, "page_size": 25}
+
+
+def test_build_pagination_info_missing_next_page_key() -> None:
+    info = build_pagination_info(
+        page_info={"endCursor": "abc"},
+        page_size=10,
+    )
+    assert info == {"has_more": False, "end_cursor": "abc", "page_size": 10}

--- a/tests/tools/test_pagination_helpers.py
+++ b/tests/tools/test_pagination_helpers.py
@@ -8,19 +8,19 @@ from pipefy_mcp.tools.pagination_helpers import (
 )
 
 
-def test_validate_page_size_none_returns_default() -> None:
+def test_validate_page_size_none_returns_default():
     value, err = validate_page_size(None)
     assert value == DEFAULT_PAGE_SIZE == 50
     assert err is None
 
 
-def test_validate_page_size_valid_int_passes_through() -> None:
+def test_validate_page_size_valid_int_passes_through():
     value, err = validate_page_size(100)
     assert value == 100
     assert err is None
 
 
-def test_validate_page_size_above_max_returns_structured_error() -> None:
+def test_validate_page_size_above_max_returns_structured_error():
     value, err = validate_page_size(1000)
     assert value == 0
     assert err is not None
@@ -29,7 +29,7 @@ def test_validate_page_size_above_max_returns_structured_error() -> None:
     assert err["error"]["details"] == {"min": 1, "max": 500, "provided": 1000}
 
 
-def test_validate_page_size_below_1_returns_structured_error() -> None:
+def test_validate_page_size_below_1_returns_structured_error():
     value, err = validate_page_size(0)
     assert value == 0
     assert err is not None
@@ -37,7 +37,7 @@ def test_validate_page_size_below_1_returns_structured_error() -> None:
     assert err["error"]["details"] == {"min": 1, "max": 500, "provided": 0}
 
 
-def test_validate_page_size_negative_returns_structured_error() -> None:
+def test_validate_page_size_negative_returns_structured_error():
     value, err = validate_page_size(-5)
     assert value == 0
     assert err is not None
@@ -45,7 +45,7 @@ def test_validate_page_size_negative_returns_structured_error() -> None:
     assert err["error"]["details"]["provided"] == -5
 
 
-def test_validate_page_size_non_integer_returns_structured_error() -> None:
+def test_validate_page_size_non_integer_returns_structured_error():
     value, err = validate_page_size("abc")  # type: ignore[arg-type]
     assert value == 0
     assert err is not None
@@ -54,37 +54,37 @@ def test_validate_page_size_non_integer_returns_structured_error() -> None:
     assert "message" in err["error"]
 
 
-def test_validate_page_size_accepts_integer_string() -> None:
+def test_validate_page_size_accepts_integer_string():
     # int("100") coerces successfully, so "100" is treated as 100.
     value, err = validate_page_size("100")  # type: ignore[arg-type]
     assert value == 100
     assert err is None
 
 
-def test_validate_page_size_custom_max() -> None:
+def test_validate_page_size_custom_max():
     value, err = validate_page_size(750, max_size=1000)
     assert value == 750
     assert err is None
 
 
-def test_validate_page_size_custom_max_still_enforces_lower_bound() -> None:
+def test_validate_page_size_custom_max_still_enforces_lower_bound():
     value, err = validate_page_size(0, max_size=1000)
     assert value == 0
     assert err is not None
     assert err["error"]["details"]["max"] == 1000
 
 
-def test_validate_page_size_uses_arg_name_in_error() -> None:
+def test_validate_page_size_uses_arg_name_in_error():
     _, err = validate_page_size(9999, arg_name="first")
     assert err is not None
     assert "'first'" in err["error"]["message"]
 
 
-def test_max_page_size_is_500() -> None:
+def test_max_page_size_is_500():
     assert MAX_PAGE_SIZE == 500
 
 
-def test_build_pagination_info_with_page_info() -> None:
+def test_build_pagination_info_with_page_info():
     info = build_pagination_info(
         page_info={"hasNextPage": True, "endCursor": "xyz"},
         page_size=50,
@@ -92,18 +92,18 @@ def test_build_pagination_info_with_page_info() -> None:
     assert info == {"has_more": True, "end_cursor": "xyz", "page_size": 50}
 
 
-def test_build_pagination_info_without_page_info() -> None:
+def test_build_pagination_info_without_page_info():
     info = build_pagination_info(page_info=None, page_size=50)
     assert info == {"has_more": False, "end_cursor": None, "page_size": 50}
 
 
-def test_build_pagination_info_empty_page_info() -> None:
+def test_build_pagination_info_empty_page_info():
     info = build_pagination_info(page_info={}, page_size=25)
     # Empty dict is falsy — treated like absent pageInfo.
     assert info == {"has_more": False, "end_cursor": None, "page_size": 25}
 
 
-def test_build_pagination_info_missing_next_page_key() -> None:
+def test_build_pagination_info_missing_next_page_key():
     info = build_pagination_info(
         page_info={"endCursor": "abc"},
         page_size=10,

--- a/tests/tools/test_pipe_tool_helpers.py
+++ b/tests/tools/test_pipe_tool_helpers.py
@@ -50,17 +50,31 @@ def test_user_cancelled_error_can_be_raised_and_caught():
 
 
 @pytest.mark.unit
-def test_build_add_card_comment_success_payload_converts_comment_id_to_str():
-    """Success payload uses string comment_id."""
+def test_build_add_card_comment_success_payload_converts_comment_id_to_str(
+    legacy_envelope,
+):
+    """Legacy shape — success payload uses flat string comment_id."""
     out = build_add_card_comment_success_payload(comment_id=12345)
     assert out == {"success": True, "comment_id": "12345"}
 
 
 @pytest.mark.unit
-def test_build_add_card_comment_success_payload_accepts_str_comment_id():
-    """Success payload accepts string comment_id as-is."""
+def test_build_add_card_comment_success_payload_accepts_str_comment_id(
+    legacy_envelope,
+):
+    """Legacy shape — success payload accepts string comment_id as-is."""
     out = build_add_card_comment_success_payload(comment_id="c_abc")
     assert out == {"success": True, "comment_id": "c_abc"}
+
+
+@pytest.mark.unit
+def test_build_add_card_comment_success_payload_parametrized_flag(envelope_flag):
+    """Both flag states — flag-on wraps comment_id under ``data``; flag-off is flat."""
+    out = build_add_card_comment_success_payload(comment_id=42)
+    if envelope_flag:
+        assert out == {"success": True, "data": {"comment_id": "42"}}
+    else:
+        assert out == {"success": True, "comment_id": "42"}
 
 
 # =============================================================================
@@ -172,8 +186,8 @@ def test_build_add_card_comment_error_payload():
 
 
 @pytest.mark.unit
-def test_build_delete_card_success_payload():
-    """Success payload includes card and pipe info and confirmation message."""
+def test_build_delete_card_success_payload(legacy_envelope):
+    """Legacy shape — success payload includes flat card and pipe info."""
     out = build_delete_card_success_payload(
         card_id=99, card_title="My Card", pipe_name="My Pipe"
     )
@@ -181,6 +195,22 @@ def test_build_delete_card_success_payload():
     assert out["card_id"] == 99
     assert out["card_title"] == "My Card"
     assert out["pipe_name"] == "My Pipe"
+    assert "permanently deleted" in out["message"]
+
+
+@pytest.mark.unit
+def test_build_delete_card_success_payload_flag_on(unified_envelope):
+    """Unified shape — card fields move inside ``data``; message stays top-level."""
+    out = build_delete_card_success_payload(
+        card_id=99, card_title="My Card", pipe_name="My Pipe"
+    )
+    assert set(out.keys()) == {"success", "data", "message"}
+    assert out["success"] is True
+    assert out["data"] == {
+        "card_id": 99,
+        "card_title": "My Card",
+        "pipe_name": "My Pipe",
+    }
     assert "permanently deleted" in out["message"]
 
 

--- a/tests/tools/test_pipe_tools.py
+++ b/tests/tools/test_pipe_tools.py
@@ -940,6 +940,85 @@ class TestGetCardsTool:
         )
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
+    async def test_get_cards_flag_on_emits_pagination(
+        self,
+        client_session,
+        mock_pipefy_client,
+        pipe_id,
+        extract_payload,
+        unified_envelope,
+    ):
+        """Flag=true — response is the unified envelope with a top-level pagination block."""
+        mock_pipefy_client.get_cards = AsyncMock(
+            return_value={
+                "cards": {
+                    "edges": [{"node": {"id": "1"}}],
+                    "pageInfo": {"hasNextPage": True, "endCursor": "x"},
+                }
+            }
+        )
+        async with client_session as session:
+            result = await session.call_tool(
+                "get_cards", {"pipe_id": pipe_id, "first": 10}
+            )
+        payload = extract_payload(result)
+        assert payload["success"] is True
+        assert payload["pagination"] == {
+            "has_more": True,
+            "end_cursor": "x",
+            "page_size": 10,
+        }
+        assert payload["data"]["cards"]["edges"][0]["node"]["id"] == "1"
+
+    @pytest.mark.parametrize("client_session", [None], indirect=True)
+    async def test_get_cards_flag_off_returns_raw_graphql(
+        self,
+        client_session,
+        mock_pipefy_client,
+        pipe_id,
+        extract_payload,
+        legacy_envelope,
+    ):
+        """Flag=false — tool returns the client response verbatim (legacy shape)."""
+        expected = {"cards": {"edges": [], "pageInfo": {"hasNextPage": False}}}
+        mock_pipefy_client.get_cards = AsyncMock(return_value=expected)
+        async with client_session as session:
+            result = await session.call_tool(
+                "get_cards", {"pipe_id": pipe_id, "first": 10}
+            )
+        payload = extract_payload(result)
+        assert payload == expected
+
+    @pytest.mark.parametrize("flag_value", [True, False])
+    @pytest.mark.parametrize("client_session", [None], indirect=True)
+    async def test_get_cards_out_of_bounds_returns_invalid_arguments(
+        self,
+        client_session,
+        mock_pipefy_client,
+        pipe_id,
+        extract_payload,
+        flag_value,
+        monkeypatch,
+    ):
+        from pipefy_mcp.settings import settings
+
+        monkeypatch.setattr(settings.pipefy, "mcp_unified_envelope", flag_value)
+        mock_pipefy_client.get_cards = AsyncMock(return_value={"cards": {}})
+        async with client_session as session:
+            result = await session.call_tool(
+                "get_cards", {"pipe_id": pipe_id, "first": 99999}
+            )
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert payload["error"]["code"] == "INVALID_ARGUMENTS"
+        assert payload["error"]["details"] == {
+            "min": 1,
+            "max": 500,
+            "provided": 99999,
+        }
+        mock_pipefy_client.get_cards.assert_not_called()
+
+    @pytest.mark.parametrize("client_session", [None], indirect=True)
     async def test_get_cards_title_param_merges_into_search(
         self, client_session, mock_pipefy_client, pipe_id
     ):

--- a/tests/tools/test_pipe_tools.py
+++ b/tests/tools/test_pipe_tools.py
@@ -682,6 +682,7 @@ class TestDirectToolCalls:
         client_session,
         mock_pipefy_client,
         extract_payload,
+        legacy_envelope,
     ):
         """update_comment with valid input returns success payload with comment_id."""
         async with client_session as session:
@@ -700,6 +701,7 @@ class TestDirectToolCalls:
         client_session,
         mock_pipefy_client,
         extract_payload,
+        legacy_envelope,
     ):
         """update_comment with comment_id=0 coerces to '0' via PipefyId and calls the API."""
         async with client_session as session:
@@ -1060,6 +1062,7 @@ class TestAddCardCommentTool:
         client_session,
         mock_pipefy_client,
         extract_payload,
+        legacy_envelope,
     ):
         async with client_session as session:
             result = await session.call_tool(
@@ -1080,6 +1083,7 @@ class TestAddCardCommentTool:
         client_session,
         mock_pipefy_client,
         extract_payload,
+        legacy_envelope,
     ):
         async with client_session as session:
             result = await session.call_tool(

--- a/tests/tools/test_pipe_tools.py
+++ b/tests/tools/test_pipe_tools.py
@@ -971,6 +971,30 @@ class TestGetCardsTool:
         assert payload["data"]["cards"]["edges"][0]["node"]["id"] == "1"
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
+    async def test_get_cards_flag_on_no_first_omits_pagination(
+        self,
+        client_session,
+        mock_pipefy_client,
+        pipe_id,
+        extract_payload,
+        unified_envelope,
+    ):
+        """Flag=true with first=None — pagination block is omitted.
+
+        Regression: the earlier implementation emitted ``page_size=0`` in this
+        case, which the shared ``validate_page_size`` itself would reject as
+        ``INVALID_ARGUMENTS``.
+        """
+        mock_pipefy_client.get_cards = AsyncMock(
+            return_value={"cards": {"edges": [], "pageInfo": {"hasNextPage": False}}}
+        )
+        async with client_session as session:
+            result = await session.call_tool("get_cards", {"pipe_id": pipe_id})
+        payload = extract_payload(result)
+        assert payload["success"] is True
+        assert "pagination" not in payload
+
+    @pytest.mark.parametrize("client_session", [None], indirect=True)
     async def test_get_cards_flag_off_returns_raw_graphql(
         self,
         client_session,

--- a/tests/tools/test_pipe_tools.py
+++ b/tests/tools/test_pipe_tools.py
@@ -1013,7 +1013,6 @@ class TestGetCardsTool:
         payload = extract_payload(result)
         assert payload == expected
 
-    @pytest.mark.parametrize("flag_value", [True, False])
     @pytest.mark.parametrize("client_session", [None], indirect=True)
     async def test_get_cards_out_of_bounds_returns_invalid_arguments(
         self,
@@ -1021,12 +1020,8 @@ class TestGetCardsTool:
         mock_pipefy_client,
         pipe_id,
         extract_payload,
-        flag_value,
-        monkeypatch,
+        envelope_flag,
     ):
-        from pipefy_mcp.settings import settings
-
-        monkeypatch.setattr(settings.pipefy, "mcp_unified_envelope", flag_value)
         mock_pipefy_client.get_cards = AsyncMock(return_value={"cards": {}})
         async with client_session as session:
             result = await session.call_tool(

--- a/tests/tools/test_report_tool_helpers.py
+++ b/tests/tools/test_report_tool_helpers.py
@@ -1,0 +1,60 @@
+"""Unit tests for report_tool_helpers — both flag states (REQ-3, ADR-0001)."""
+
+import pytest
+
+from pipefy_mcp.tools.report_tool_helpers import (
+    build_report_mutation_success_payload,
+    build_report_read_success_payload,
+)
+
+
+@pytest.mark.unit
+def test_build_report_read_success_payload_flag_on(unified_envelope):
+    raw = {"pipeReports": {"edges": [{"node": {"id": "r1"}}], "pageInfo": {}}}
+    out = build_report_read_success_payload(raw, message="Pipe reports retrieved.")
+    # ADR-0001: verbatim wrap — 'pipeReports' key is preserved inside data.
+    assert out == {
+        "success": True,
+        "data": raw,
+        "message": "Pipe reports retrieved.",
+    }
+    assert "pipeReports" in out["data"]
+
+
+@pytest.mark.unit
+def test_build_report_read_success_payload_flag_off(legacy_envelope):
+    raw = {"pipeReports": {"edges": [], "pageInfo": {}}}
+    out = build_report_read_success_payload(raw, message="Pipe reports retrieved.")
+    # Legacy shape — byte-identical to pre-PR output.
+    assert out == {
+        "success": True,
+        "message": "Pipe reports retrieved.",
+        "data": raw,
+    }
+
+
+@pytest.mark.unit
+def test_build_report_read_success_payload_parametrized(envelope_flag):
+    raw = {"pipeReport": {"id": "42", "name": "Alpha"}}
+    out = build_report_read_success_payload(raw, message="ok")
+    # Both states — 'data' always holds the verbatim GraphQL subtree.
+    assert out["success"] is True
+    assert out["data"] == raw
+    assert out["message"] == "ok"
+
+
+@pytest.mark.unit
+def test_build_report_mutation_success_payload_flag_on(unified_envelope):
+    raw = {"createPipeReport": {"pipeReport": {"id": "9"}}}
+    out = build_report_mutation_success_payload(message="Created.", data=raw)
+    assert out == {"success": True, "data": raw, "message": "Created."}
+    assert "result" not in out
+
+
+@pytest.mark.unit
+def test_build_report_mutation_success_payload_flag_off(legacy_envelope):
+    raw = {"createPipeReport": {"pipeReport": {"id": "9"}}}
+    out = build_report_mutation_success_payload(message="Created.", data=raw)
+    # Legacy shape — raw payload sits under 'result'.
+    assert out == {"success": True, "message": "Created.", "result": raw}
+    assert "data" not in out

--- a/tests/tools/test_report_tools.py
+++ b/tests/tools/test_report_tools.py
@@ -1152,14 +1152,10 @@ async def test_get_pipe_reports_flag_off_no_top_level_pagination(
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("flag_value", [True, False])
 @pytest.mark.parametrize("report_session", [None], indirect=True)
 async def test_get_pipe_reports_out_of_bounds_returns_invalid_arguments_regardless_of_flag(
-    report_session, mock_report_client, extract_payload, flag_value, monkeypatch
+    report_session, mock_report_client, extract_payload, envelope_flag
 ):
-    from pipefy_mcp.settings import settings
-
-    monkeypatch.setattr(settings.pipefy, "mcp_unified_envelope", flag_value)
     async with report_session as session:
         result = await session.call_tool(
             "get_pipe_reports", {"pipe_uuid": "uuid-1", "first": 99999}
@@ -1197,14 +1193,10 @@ async def test_get_organization_reports_flag_on_emits_pagination(
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("flag_value", [True, False])
 @pytest.mark.parametrize("report_session", [None], indirect=True)
 async def test_get_organization_reports_out_of_bounds_returns_invalid_arguments(
-    report_session, mock_report_client, extract_payload, flag_value, monkeypatch
+    report_session, mock_report_client, extract_payload, envelope_flag
 ):
-    from pipefy_mcp.settings import settings
-
-    monkeypatch.setattr(settings.pipefy, "mcp_unified_envelope", flag_value)
     async with report_session as session:
         result = await session.call_tool(
             "get_organization_reports",
@@ -1214,6 +1206,134 @@ async def test_get_organization_reports_out_of_bounds_returns_invalid_arguments(
     assert payload["success"] is False
     assert payload["error"]["code"] == "INVALID_ARGUMENTS"
     assert payload["error"]["details"] == {"min": 1, "max": 500, "provided": 99999}
+
+
+# ---------------------------------------------------------------------------
+# Implicit-migration coverage: non-Wave-1 report tools that share
+# ``build_report_read_success_payload`` / ``build_report_mutation_success_payload``
+# (IM-01). Under the default flag they emit the unified envelope; under
+# flag=false they fall back to the legacy shape.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_get_pipe_report_flag_on_wraps_raw(
+    report_session, mock_report_client, extract_payload, unified_envelope
+):
+    mock_report_client.get_pipe_reports.return_value = {
+        "pipeReports": {
+            "edges": [{"node": {"id": "r42", "name": "Solo"}}],
+            "pageInfo": {"hasNextPage": False, "endCursor": None},
+        }
+    }
+    async with report_session as session:
+        result = await session.call_tool(
+            "get_pipe_report", {"pipe_uuid": "uuid-1", "report_id": "r42"}
+        )
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    assert payload["data"] == {"pipeReport": {"id": "r42", "name": "Solo"}}
+    assert "pagination" not in payload  # non-paginated read
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_get_pipe_report_columns_flag_on_wraps_raw(
+    report_session, mock_report_client, extract_payload, unified_envelope
+):
+    raw = {"pipe": {"reportColumns": [{"name": "title", "label": "Title"}]}}
+    mock_report_client.get_pipe_report_columns.return_value = raw
+    async with report_session as session:
+        result = await session.call_tool(
+            "get_pipe_report_columns", {"pipe_uuid": "uuid-1"}
+        )
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    assert payload["data"] == raw
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_get_pipe_report_filterable_fields_flag_on_wraps_raw(
+    report_session, mock_report_client, extract_payload, unified_envelope
+):
+    raw = {"pipe": {"reportFilterableFields": [{"name": "status"}]}}
+    mock_report_client.get_pipe_report_filterable_fields.return_value = raw
+    async with report_session as session:
+        result = await session.call_tool(
+            "get_pipe_report_filterable_fields", {"pipe_uuid": "uuid-1"}
+        )
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    assert payload["data"] == raw
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_get_organization_report_flag_on_wraps_raw(
+    report_session, mock_report_client, extract_payload, unified_envelope
+):
+    raw = {"organizationReport": {"id": "or5", "name": "Cross-Pipe"}}
+    mock_report_client.get_organization_report.return_value = raw
+    async with report_session as session:
+        result = await session.call_tool(
+            "get_organization_report", {"report_id": "or5"}
+        )
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    assert payload["data"] == raw
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_get_pipe_report_export_flag_on_wraps_raw(
+    report_session, mock_report_client, extract_payload, unified_envelope
+):
+    raw = {"pipeReportExport": {"id": "exp1", "state": "done"}}
+    mock_report_client.get_pipe_report_export.return_value = raw
+    async with report_session as session:
+        result = await session.call_tool(
+            "get_pipe_report_export", {"export_id": "exp1"}
+        )
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    assert payload["data"] == raw
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_get_organization_report_export_flag_on_wraps_raw(
+    report_session, mock_report_client, extract_payload, unified_envelope
+):
+    raw = {"organizationReportExport": {"id": "exp-or-1", "state": "processing"}}
+    mock_report_client.get_organization_report_export.return_value = raw
+    async with report_session as session:
+        result = await session.call_tool(
+            "get_organization_report_export", {"export_id": "exp-or-1"}
+        )
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    assert payload["data"] == raw
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_create_pipe_report_flag_on_wraps_raw_mutation(
+    report_session, mock_report_client, extract_payload, unified_envelope
+):
+    """Mutation tools also migrate via ``build_report_mutation_success_payload``."""
+    raw = {"createPipeReport": {"pipeReport": {"id": "r10"}}}
+    mock_report_client.create_pipe_report.return_value = raw
+    async with report_session as session:
+        result = await session.call_tool(
+            "create_pipe_report", {"pipe_id": "123", "name": "New"}
+        )
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    assert payload["data"] == raw
+    # Under the unified envelope the legacy ``result`` key is gone.
+    assert "result" not in payload
 
 
 @pytest.mark.anyio

--- a/tests/tools/test_report_tools.py
+++ b/tests/tools/test_report_tools.py
@@ -1143,9 +1143,7 @@ async def test_get_pipe_reports_flag_off_no_top_level_pagination(
         }
     }
     async with report_session as session:
-        result = await session.call_tool(
-            "get_pipe_reports", {"pipe_uuid": "uuid-1"}
-        )
+        result = await session.call_tool("get_pipe_reports", {"pipe_uuid": "uuid-1"})
     payload = extract_payload(result)
     assert payload["success"] is True
     assert "pagination" not in payload  # legacy shape has no top-level pagination

--- a/tests/tools/test_report_tools.py
+++ b/tests/tools/test_report_tools.py
@@ -1102,6 +1102,122 @@ async def test_export_pipe_report_blank_pipe_report_id(report_session):
 ## ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Unified-envelope pagination & bounds (REQ-5)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_get_pipe_reports_flag_on_emits_pagination(
+    report_session, mock_report_client, extract_payload, unified_envelope
+):
+    mock_report_client.get_pipe_reports.return_value = {
+        "pipeReports": {
+            "edges": [{"node": {"id": "r1"}}],
+            "pageInfo": {"hasNextPage": True, "endCursor": "c1"},
+        }
+    }
+    async with report_session as session:
+        result = await session.call_tool(
+            "get_pipe_reports", {"pipe_uuid": "uuid-1", "first": 25}
+        )
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    assert payload["pagination"] == {
+        "has_more": True,
+        "end_cursor": "c1",
+        "page_size": 25,
+    }
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_get_pipe_reports_flag_off_no_top_level_pagination(
+    report_session, mock_report_client, extract_payload, legacy_envelope
+):
+    mock_report_client.get_pipe_reports.return_value = {
+        "pipeReports": {
+            "edges": [],
+            "pageInfo": {"hasNextPage": False, "endCursor": None},
+        }
+    }
+    async with report_session as session:
+        result = await session.call_tool(
+            "get_pipe_reports", {"pipe_uuid": "uuid-1"}
+        )
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    assert "pagination" not in payload  # legacy shape has no top-level pagination
+    # Legacy cursor paths inside the raw GraphQL are preserved.
+    assert payload["data"]["pipeReports"]["pageInfo"]["hasNextPage"] is False
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("flag_value", [True, False])
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_get_pipe_reports_out_of_bounds_returns_invalid_arguments_regardless_of_flag(
+    report_session, mock_report_client, extract_payload, flag_value, monkeypatch
+):
+    from pipefy_mcp.settings import settings
+
+    monkeypatch.setattr(settings.pipefy, "mcp_unified_envelope", flag_value)
+    async with report_session as session:
+        result = await session.call_tool(
+            "get_pipe_reports", {"pipe_uuid": "uuid-1", "first": 99999}
+        )
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert payload["error"]["code"] == "INVALID_ARGUMENTS"
+    assert payload["error"]["details"] == {"min": 1, "max": 500, "provided": 99999}
+    mock_report_client.get_pipe_reports.assert_not_called()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_get_organization_reports_flag_on_emits_pagination(
+    report_session, mock_report_client, extract_payload, unified_envelope
+):
+    mock_report_client.get_organization_reports.return_value = {
+        "organizationReports": {
+            "edges": [],
+            "pageInfo": {"hasNextPage": False, "endCursor": None},
+        }
+    }
+    async with report_session as session:
+        result = await session.call_tool(
+            "get_organization_reports",
+            {"organization_id": "org-1", "first": 10},
+        )
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    assert payload["pagination"] == {
+        "has_more": False,
+        "end_cursor": None,
+        "page_size": 10,
+    }
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("flag_value", [True, False])
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_get_organization_reports_out_of_bounds_returns_invalid_arguments(
+    report_session, mock_report_client, extract_payload, flag_value, monkeypatch
+):
+    from pipefy_mcp.settings import settings
+
+    monkeypatch.setattr(settings.pipefy, "mcp_unified_envelope", flag_value)
+    async with report_session as session:
+        result = await session.call_tool(
+            "get_organization_reports",
+            {"organization_id": "org-1", "first": 99999},
+        )
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert payload["error"]["code"] == "INVALID_ARGUMENTS"
+    assert payload["error"]["details"] == {"min": 1, "max": 500, "provided": 99999}
+
+
 @pytest.mark.anyio
 @pytest.mark.parametrize("report_session", [None], indirect=True)
 async def test_get_pipe_reports_first_less_than_one(report_session, extract_payload):
@@ -1112,7 +1228,9 @@ async def test_get_pipe_reports_first_less_than_one(report_session, extract_payl
 
     payload = extract_payload(result)
     assert payload["success"] is False
-    assert "positive integer" in tool_error_message(payload)
+    # Bounds enforcement now uses the shared INVALID_ARGUMENTS envelope.
+    assert payload["error"]["code"] == "INVALID_ARGUMENTS"
+    assert payload["error"]["details"] == {"min": 1, "max": 500, "provided": 0}
 
 
 @pytest.mark.anyio
@@ -1127,7 +1245,8 @@ async def test_get_organization_reports_first_less_than_one(
 
     payload = extract_payload(result)
     assert payload["success"] is False
-    assert "positive integer" in tool_error_message(payload)
+    assert payload["error"]["code"] == "INVALID_ARGUMENTS"
+    assert payload["error"]["details"] == {"min": 1, "max": 500, "provided": 0}
 
 
 ## ---------------------------------------------------------------------------

--- a/tests/tools/test_report_tools.py
+++ b/tests/tools/test_report_tools.py
@@ -397,7 +397,7 @@ async def test_all_read_tools_have_readonly_hint(report_session):
 @pytest.mark.anyio
 @pytest.mark.parametrize("report_session", [None], indirect=True)
 async def test_create_pipe_report_success(
-    report_session, mock_report_client, extract_payload
+    report_session, mock_report_client, extract_payload, legacy_envelope
 ):
     mock_report_client.create_pipe_report.return_value = {
         "createPipeReport": {"pipeReport": {"id": "r10", "name": "New Report"}}
@@ -472,7 +472,7 @@ async def test_create_pipe_report_graphql_error_with_debug(
 @pytest.mark.anyio
 @pytest.mark.parametrize("report_session", [None], indirect=True)
 async def test_update_pipe_report_success(
-    report_session, mock_report_client, extract_payload
+    report_session, mock_report_client, extract_payload, legacy_envelope
 ):
     mock_report_client.update_pipe_report.return_value = {
         "updatePipeReport": {"pipeReport": {"id": "r10", "name": "Updated"}}
@@ -522,7 +522,7 @@ async def test_delete_pipe_report_success(
 @pytest.mark.anyio
 @pytest.mark.parametrize("report_session", [None], indirect=True)
 async def test_create_organization_report_success(
-    report_session, mock_report_client, extract_payload
+    report_session, mock_report_client, extract_payload, legacy_envelope
 ):
     mock_report_client.create_organization_report.return_value = {
         "createOrganizationReport": {
@@ -600,7 +600,7 @@ async def test_delete_organization_report_success(
 @pytest.mark.anyio
 @pytest.mark.parametrize("report_session", [None], indirect=True)
 async def test_export_pipe_report_success(
-    report_session, mock_report_client, extract_payload
+    report_session, mock_report_client, extract_payload, legacy_envelope
 ):
     mock_report_client.export_pipe_report.return_value = {
         "exportPipeReport": {
@@ -654,7 +654,7 @@ async def test_export_pipe_report_graphql_error(
 @pytest.mark.anyio
 @pytest.mark.parametrize("report_session", [None], indirect=True)
 async def test_export_organization_report_success(
-    report_session, mock_report_client, extract_payload
+    report_session, mock_report_client, extract_payload, legacy_envelope
 ):
     mock_report_client.export_organization_report.return_value = {
         "exportOrganizationReport": {
@@ -694,7 +694,7 @@ async def test_export_organization_report_success(
 @pytest.mark.anyio
 @pytest.mark.parametrize("report_session", [None], indirect=True)
 async def test_export_pipe_audit_logs_success(
-    report_session, mock_report_client, extract_payload
+    report_session, mock_report_client, extract_payload, legacy_envelope
 ):
     mock_report_client.export_pipe_audit_logs.return_value = {
         "exportPipeAuditLogsReport": {"success": True},

--- a/tests/tools/test_table_tools.py
+++ b/tests/tools/test_table_tools.py
@@ -927,6 +927,44 @@ async def test_search_tables_unified_envelope(
     }
 
 
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_search_tables_unified_has_more_stays_false_even_with_aggregate_has_next_page(
+    table_session, mock_table_client, extract_payload, unified_envelope
+):
+    """Flag=true, aggregate ``tables_has_next_page=True`` — top-level ``has_more`` stays False.
+
+    The outer tool does not accept ``after`` and is therefore not paginable;
+    publishing ``has_more=True`` with ``end_cursor=None`` would mislead agents
+    into looping on a null cursor. Per-org cursors inside ``data`` carry the
+    real signal (see DD-02).
+    """
+    response = {
+        "organizations": [
+            {
+                "id": "org1",
+                "name": "Acme",
+                "tables": [],
+                "tables_has_next_page": True,
+                "tables_page_end_cursor": "org1-cursor-abc",
+            }
+        ],
+        "search_limits": {"tables_first": 100, "tables_has_next_page": True},
+    }
+    mock_table_client.search_tables.return_value = response
+    async with table_session as session:
+        result = await session.call_tool("search_tables", {"table_name": "Clients"})
+    payload = extract_payload(result)
+    assert payload["pagination"]["has_more"] is False
+    assert payload["pagination"]["end_cursor"] is None
+    # Per-org cursors are preserved inside ``data`` for agents that need them.
+    assert payload["data"]["search_limits"]["tables_has_next_page"] is True
+    assert (
+        payload["data"]["organizations"][0]["tables_page_end_cursor"]
+        == "org1-cursor-abc"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Input validation: get_table
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_table_tools.py
+++ b/tests/tools/test_table_tools.py
@@ -1033,14 +1033,10 @@ async def test_get_table_records_invalid_table_id(
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("flag_value", [True, False])
 @pytest.mark.parametrize("table_session", [None], indirect=True)
 async def test_get_table_records_first_too_small(
-    table_session, mock_table_client, extract_payload, flag_value, monkeypatch
+    table_session, mock_table_client, extract_payload, envelope_flag
 ):
-    from pipefy_mcp.settings import settings
-
-    monkeypatch.setattr(settings.pipefy, "mcp_unified_envelope", flag_value)
     async with table_session as session:
         result = await session.call_tool(
             "get_table_records", {"table_id": "t1", "first": 0}
@@ -1054,14 +1050,10 @@ async def test_get_table_records_first_too_small(
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("flag_value", [True, False])
 @pytest.mark.parametrize("table_session", [None], indirect=True)
 async def test_get_table_records_first_too_large(
-    table_session, mock_table_client, extract_payload, flag_value, monkeypatch
+    table_session, mock_table_client, extract_payload, envelope_flag
 ):
-    from pipefy_mcp.settings import settings
-
-    monkeypatch.setattr(settings.pipefy, "mcp_unified_envelope", flag_value)
     async with table_session as session:
         result = await session.call_tool(
             "get_table_records", {"table_id": "t1", "first": 201}
@@ -1076,14 +1068,10 @@ async def test_get_table_records_first_too_large(
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("flag_value", [True, False])
 @pytest.mark.parametrize("table_session", [None], indirect=True)
 async def test_search_tables_out_of_bounds_returns_invalid_arguments(
-    table_session, mock_table_client, extract_payload, flag_value, monkeypatch
+    table_session, mock_table_client, extract_payload, envelope_flag
 ):
-    from pipefy_mcp.settings import settings
-
-    monkeypatch.setattr(settings.pipefy, "mcp_unified_envelope", flag_value)
     async with table_session as session:
         result = await session.call_tool("search_tables", {"first": 99999})
     mock_table_client.search_tables.assert_not_called()

--- a/tests/tools/test_table_tools.py
+++ b/tests/tools/test_table_tools.py
@@ -124,8 +124,9 @@ async def test_get_tables_graphql_error(
 @pytest.mark.anyio
 @pytest.mark.parametrize("table_session", [None], indirect=True)
 async def test_get_table_records_success_and_pagination(
-    table_session, mock_table_client, extract_payload
+    table_session, mock_table_client, extract_payload, legacy_envelope
 ):
+    """Flag=false — legacy pagination shape (pageInfo camelCase)."""
     mock_table_client.get_table_records.return_value = {
         "table_records": {
             "edges": [],
@@ -146,6 +147,34 @@ async def test_get_table_records_success_and_pagination(
     assert payload["success"] is True
     assert payload["pagination"]["hasNextPage"] is True
     assert payload["pagination"]["endCursor"] == "n1"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_get_table_records_unified_envelope_pagination(
+    table_session, mock_table_client, extract_payload, unified_envelope
+):
+    """Flag=true — pagination block uses snake_case keys and includes page_size."""
+    mock_table_client.get_table_records.return_value = {
+        "table_records": {
+            "edges": [],
+            "pageInfo": {"hasNextPage": True, "endCursor": "n1"},
+        }
+    }
+    async with table_session as session:
+        result = await session.call_tool(
+            "get_table_records",
+            {"table_id": "t1", "first": DEFAULT_FIRST},
+        )
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    assert payload["pagination"] == {
+        "has_more": True,
+        "end_cursor": "n1",
+        "page_size": DEFAULT_FIRST,
+    }
+    assert "data" in payload
+    assert "table_records" in payload["data"]
 
 
 @pytest.mark.anyio
@@ -851,7 +880,7 @@ async def test_search_tables_with_name_passes_it_to_client(
 @pytest.mark.anyio
 @pytest.mark.parametrize("table_session", [None], indirect=True)
 async def test_search_tables_returns_client_response(
-    table_session, mock_table_client, extract_payload
+    table_session, mock_table_client, extract_payload, legacy_envelope
 ):
     expected = {
         "organizations": [
@@ -869,6 +898,33 @@ async def test_search_tables_returns_client_response(
 
     payload = extract_payload(result)
     assert payload == expected
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_search_tables_unified_envelope(
+    table_session, mock_table_client, extract_payload, unified_envelope
+):
+    """Flag=true — raw GraphQL wraps under ``data`` and top-level pagination is added."""
+    expected = {
+        "organizations": [
+            {"id": "org1", "name": "Acme", "tables": []},
+        ],
+        "search_limits": {"tables_first": 100, "tables_has_next_page": False},
+    }
+    mock_table_client.search_tables.return_value = expected
+
+    async with table_session as session:
+        result = await session.call_tool("search_tables", {"table_name": "Clients"})
+
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    assert payload["data"] == expected
+    assert payload["pagination"] == {
+        "has_more": False,
+        "end_cursor": None,
+        "page_size": 100,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -939,10 +995,14 @@ async def test_get_table_records_invalid_table_id(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("flag_value", [True, False])
 @pytest.mark.parametrize("table_session", [None], indirect=True)
 async def test_get_table_records_first_too_small(
-    table_session, mock_table_client, extract_payload
+    table_session, mock_table_client, extract_payload, flag_value, monkeypatch
 ):
+    from pipefy_mcp.settings import settings
+
+    monkeypatch.setattr(settings.pipefy, "mcp_unified_envelope", flag_value)
     async with table_session as session:
         result = await session.call_tool(
             "get_table_records", {"table_id": "t1", "first": 0}
@@ -951,14 +1011,19 @@ async def test_get_table_records_first_too_small(
     mock_table_client.get_table_records.assert_not_called()
     payload = extract_payload(result)
     assert payload["success"] is False
-    assert "first" in tool_error_message(payload)
+    assert payload["error"]["code"] == "INVALID_ARGUMENTS"
+    assert payload["error"]["details"] == {"min": 1, "max": 200, "provided": 0}
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("flag_value", [True, False])
 @pytest.mark.parametrize("table_session", [None], indirect=True)
 async def test_get_table_records_first_too_large(
-    table_session, mock_table_client, extract_payload
+    table_session, mock_table_client, extract_payload, flag_value, monkeypatch
 ):
+    from pipefy_mcp.settings import settings
+
+    monkeypatch.setattr(settings.pipefy, "mcp_unified_envelope", flag_value)
     async with table_session as session:
         result = await session.call_tool(
             "get_table_records", {"table_id": "t1", "first": 201}
@@ -967,7 +1032,27 @@ async def test_get_table_records_first_too_large(
     mock_table_client.get_table_records.assert_not_called()
     payload = extract_payload(result)
     assert payload["success"] is False
-    assert "first" in tool_error_message(payload)
+    assert payload["error"]["code"] == "INVALID_ARGUMENTS"
+    # table_records uses the API-imposed max of 200 (not the default 500).
+    assert payload["error"]["details"] == {"min": 1, "max": 200, "provided": 201}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("flag_value", [True, False])
+@pytest.mark.parametrize("table_session", [None], indirect=True)
+async def test_search_tables_out_of_bounds_returns_invalid_arguments(
+    table_session, mock_table_client, extract_payload, flag_value, monkeypatch
+):
+    from pipefy_mcp.settings import settings
+
+    monkeypatch.setattr(settings.pipefy, "mcp_unified_envelope", flag_value)
+    async with table_session as session:
+        result = await session.call_tool("search_tables", {"first": 99999})
+    mock_table_client.search_tables.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert payload["error"]["code"] == "INVALID_ARGUMENTS"
+    assert payload["error"]["details"] == {"min": 1, "max": 500, "provided": 99999}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_tool_success_envelope.py
+++ b/tests/tools/test_tool_success_envelope.py
@@ -1,4 +1,4 @@
-"""Unit tests for the canonical tool_success helper (REQ-1)."""
+"""Unit tests for ``tool_success``."""
 
 from pipefy_mcp.tools.tool_error_envelope import tool_success
 

--- a/tests/tools/test_tool_success_envelope.py
+++ b/tests/tools/test_tool_success_envelope.py
@@ -3,15 +3,15 @@
 from pipefy_mcp.tools.tool_error_envelope import tool_success
 
 
-def test_minimal_call_returns_only_success_true() -> None:
+def test_minimal_call_returns_only_success_true():
     assert tool_success() == {"success": True}
 
 
-def test_data_only() -> None:
+def test_data_only():
     assert tool_success({"id": "42"}) == {"success": True, "data": {"id": "42"}}
 
 
-def test_all_keys_present() -> None:
+def test_all_keys_present():
     out = tool_success({"items": []}, message="ok", pagination={"has_more": False})
     assert set(out.keys()) == {"success", "data", "message", "pagination"}
     assert out["success"] is True
@@ -20,14 +20,14 @@ def test_all_keys_present() -> None:
     assert out["pagination"] == {"has_more": False}
 
 
-def test_optional_keys_omitted_when_none() -> None:
+def test_optional_keys_omitted_when_none():
     out = tool_success({"x": 1}, message=None, pagination=None)
     assert set(out.keys()) == {"success", "data"}
     assert "message" not in out
     assert "pagination" not in out
 
 
-def test_data_none_is_omitted() -> None:
+def test_data_none_is_omitted():
     out = tool_success(data=None, message="hello")
     assert set(out.keys()) == {"success", "message"}
     assert out == {"success": True, "message": "hello"}

--- a/tests/tools/test_tool_success_envelope.py
+++ b/tests/tools/test_tool_success_envelope.py
@@ -1,0 +1,33 @@
+"""Unit tests for the canonical tool_success helper (REQ-1)."""
+
+from pipefy_mcp.tools.tool_error_envelope import tool_success
+
+
+def test_minimal_call_returns_only_success_true() -> None:
+    assert tool_success() == {"success": True}
+
+
+def test_data_only() -> None:
+    assert tool_success({"id": "42"}) == {"success": True, "data": {"id": "42"}}
+
+
+def test_all_keys_present() -> None:
+    out = tool_success({"items": []}, message="ok", pagination={"has_more": False})
+    assert set(out.keys()) == {"success", "data", "message", "pagination"}
+    assert out["success"] is True
+    assert out["data"] == {"items": []}
+    assert out["message"] == "ok"
+    assert out["pagination"] == {"has_more": False}
+
+
+def test_optional_keys_omitted_when_none() -> None:
+    out = tool_success({"x": 1}, message=None, pagination=None)
+    assert set(out.keys()) == {"success", "data"}
+    assert "message" not in out
+    assert "pagination" not in out
+
+
+def test_data_none_is_omitted() -> None:
+    out = tool_success(data=None, message="hello")
+    assert set(out.keys()) == {"success", "message"}
+    assert out == {"success": True, "message": "hello"}


### PR DESCRIPTION
## Summary
Merges **envelope + pagination unification** work into `pipe-full-toolset`: unified success/error shapes, top-level `pagination` where applicable, shared bounds validation, RF-01 regression (no pagination when `get_cards` omits `first`), legacy payload naming, `search_tables` outer `has_more` semantics, `is_unified_envelope_enabled()` accessor, implicit report-tool coverage, and small doc/comment tidy-ups.

## Testing
- `uv run ruff check .` / `uv run ruff format --check .`
- `uv run pytest -m "not integration"` (1784 passed)

## Notes
- **Breaking / consumer-facing:** clients should expect unified envelope on migrated tools when `PIPEFY_MCP_UNIFIED_ENVELOPE` is true (default); see project docs/spec for rollback via env.

Co-authored-by: automation (pre-PR atomic commits + push).