### PR TITLE
feat: GraphQL errors, label preview retry, find_cards/update_card_field envelopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
   />
 </div>
 
-**Open-source MCP for Pipefy** — **128 tools** for pipes, cards, tables, relations, automations, AI, observability and more. Alpha · built in public — [feedback & issues](https://github.com/gbrlcustodio/pipefy-mcp-server/issues) or **dev@pipefy.com**
-
 <p align="center">
   <a href="https://github.com/gbrlcustodio/pipefy-mcp-server/actions"><img src="https://github.com/gbrlcustodio/pipefy-mcp-server/workflows/CI/badge.svg" alt="CI Status" /></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="Python 3.11+" /></a>
@@ -15,6 +13,9 @@
   <a href="https://modelcontextprotocol.io/introduction"><img src="https://img.shields.io/badge/MCP-Server-orange" alt="MCP Server" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License" /></a>
 </p>
+
+**Open-source MCP for Pipefy** — **128 tools** for pipes, cards, tables, relations, automations, AI, observability and more. Alpha · built in public — [feedback & issues](https://github.com/gbrlcustodio/pipefy-mcp-server/issues) or **dev@pipefy.com**
+
 
 > **Disclaimer:** Community project for developer workflows — not Pipefy’s official or supported integration for external enterprise use.
 

--- a/src/pipefy_mcp/tools/graphql_error_helpers.py
+++ b/src/pipefy_mcp/tools/graphql_error_helpers.py
@@ -26,6 +26,7 @@ zero-regression behavior for call sites that have not been migrated yet.
 
 from __future__ import annotations
 
+import ast
 import asyncio
 import re
 from typing import TYPE_CHECKING, Any
@@ -44,6 +45,32 @@ _INTERNAL_API_CODE_BRACKET_CAPTURE_RE = re.compile(r"\[code=([^\]]*)\]")
 _INTERNAL_API_CORRELATION_BRACKET_CAPTURE_RE = re.compile(
     r"\[correlation_id=([^\]]*)\]"
 )
+
+_DICT_REPR_PREFIX_RE = re.compile(r"^\s*\{\s*['\"]message['\"]\s*:")
+
+
+def _try_extract_message_from_dict_repr(raw: str) -> str | None:
+    """Return inner ``message`` when ``str(exc)`` is a single-error dict repr.
+
+    Some gql wrappers stringify as a Python dict (single quotes), not JSON.
+    Structured codes and correlation_id are still parsed by sibling helpers from
+    the same raw string.
+
+    Args:
+        raw: ``str(exc)`` when ``exc.errors`` did not yield messages.
+    """
+    if not _DICT_REPR_PREFIX_RE.match(raw):
+        return None
+    try:
+        parsed = ast.literal_eval(raw)
+    except (ValueError, SyntaxError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    msg = parsed.get("message")
+    if isinstance(msg, str) and msg:
+        return msg
+    return None
 
 
 def strip_internal_api_diagnostic_markers(message: str) -> str:
@@ -97,7 +124,8 @@ def extract_error_strings(exc: BaseException) -> list[str]:
     returned; the raw ``str(exc)`` is skipped because it often contains
     the full error dict with ``locations`` / ``extensions`` noise.  The
     raw string is used as a fallback only when no structured messages
-    can be extracted.
+    can be extracted. When that raw string looks like a Python dict repr
+    with a top-level ``message`` key, only the inner message string is returned.
     """
     structured: list[str] = []
 
@@ -115,9 +143,14 @@ def extract_error_strings(exc: BaseException) -> list[str]:
         return structured
 
     raw = str(exc)
-    if raw:
-        return [raw]
-    return []
+    if not raw:
+        return []
+
+    extracted = _try_extract_message_from_dict_repr(raw)
+    if extracted:
+        return [extracted]
+
+    return [raw]
 
 
 def extract_graphql_error_codes(exc: BaseException) -> list[str]:

--- a/src/pipefy_mcp/tools/pipe_tool_helpers.py
+++ b/src/pipefy_mcp/tools/pipe_tool_helpers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any, Literal, cast
 
 from typing_extensions import TypedDict
@@ -107,6 +108,7 @@ async def find_label_dependents(
     pipe_id: str,
     label_id: str,
     sample_size: int = 5,
+    retry_on_empty: bool = True,
 ) -> dict[str, Any] | None:
     """Sample cards that carry ``label_id`` in ``pipe_id`` (for delete preview).
 
@@ -121,27 +123,45 @@ async def find_label_dependents(
       applied while sampling).
     * ``has_more``: ``True`` when Pipefy returned more cards than the cap
       (the real cascade is strictly larger than the sample).
+
+    Args:
+        client: Pipefy client for ``get_cards``.
+        pipe_id: Pipe that owns the label.
+        label_id: Label id to match via ``label_ids`` search.
+        sample_size: Max number of card ids to return in ``sample_card_ids``.
+        retry_on_empty: When True (default), if the first ``get_cards`` returns
+            no edges, wait briefly and query once more. Pipefy's label index can
+            lag 1-3s after attaching a label; set False for time-sensitive tests.
     """
-    try:
-        search: CardSearch = {"label_ids": [str(label_id)]}
-        payload = await client.get_cards(
-            pipe_id,
-            search,
-            include_fields=False,
-            first=sample_size + 1,
-        )
-    except Exception:  # noqa: BLE001
-        return None
-    cards_root = (payload or {}).get("cards") or {}
-    edges = cards_root.get("edges") or []
-    ids: list[str] = []
-    for edge in edges:
-        if not isinstance(edge, dict):
-            continue
-        node = edge.get("node") or {}
-        cid = node.get("id")
-        if cid is not None:
-            ids.append(str(cid))
+
+    async def _query() -> list[str]:
+        try:
+            search: CardSearch = {"label_ids": [str(label_id)]}
+            payload = await client.get_cards(
+                pipe_id,
+                search,
+                include_fields=False,
+                first=sample_size + 1,
+            )
+        except Exception:  # noqa: BLE001
+            return []
+        cards_root = (payload or {}).get("cards") or {}
+        edges = cards_root.get("edges") or []
+        out: list[str] = []
+        for edge in edges:
+            if not isinstance(edge, dict):
+                continue
+            node = edge.get("node") or {}
+            cid = node.get("id")
+            if cid is not None:
+                out.append(str(cid))
+        return out
+
+    ids = await _query()
+    if not ids and retry_on_empty:
+        await asyncio.sleep(1.5)
+        ids = await _query()
+
     if not ids:
         return None
     sampled = ids[:sample_size]

--- a/src/pipefy_mcp/tools/pipe_tools.py
+++ b/src/pipefy_mcp/tools/pipe_tools.py
@@ -569,6 +569,7 @@ class PipeTools:
             include_fields: bool = False,
             first: int | None = None,
             after: str | None = None,
+            debug: bool = False,
         ) -> dict:
             """Find cards in the pipe where a specific custom field equals a given value.
 
@@ -592,15 +593,24 @@ class PipeTools:
                 include_fields: If True, include each card's custom fields (name, value) in the response.
                 first: Max cards per page (optional).
                 after: Cursor from ``pageInfo.endCursor`` for the next page (optional).
+                debug: When True, append GraphQL codes and correlation_id on errors.
             """
-            response = await client.find_cards(
-                pipe_id,
-                field_id,
-                field_value,
-                include_fields=include_fields,
-                first=first,
-                after=after,
-            )
+            try:
+                response = await client.find_cards(
+                    pipe_id,
+                    field_id,
+                    field_value,
+                    include_fields=include_fields,
+                    first=first,
+                    after=after,
+                )
+            except Exception as exc:  # noqa: BLE001
+                return handle_tool_graphql_error(
+                    exc,
+                    "Find cards failed.",
+                    debug=debug,
+                    resource_kind="phase_field",
+                )
             edges = response.get(FIND_CARDS_RESPONSE_KEY, {}).get("edges")
             if not edges:
                 response = dict(response)
@@ -779,7 +789,10 @@ class PipeTools:
             annotations=ToolAnnotations(readOnlyHint=False),
         )
         async def update_card_field(
-            card_id: PipefyId, field_id: str, new_value: Any
+            card_id: PipefyId,
+            field_id: str,
+            new_value: Any,
+            debug: bool = False,
         ) -> dict:
             """Update a single field of a card.
 
@@ -792,12 +805,21 @@ class PipeTools:
                 field_id: The ID (slug) of the field to update.
                     Discover via: ``get_phase_fields(phase_id)[].id`` (or ``internal_id`` for numeric forms).
                 new_value: The new value for the field (string, number, list, etc.)
+                debug: When True, append GraphQL codes and correlation_id on errors.
 
             Returns:
                 dict: GraphQL response with success status and updated card information
                       including the card's id, title, fields, and updated_at timestamp
             """
-            return await client.update_card_field(card_id, field_id, new_value)
+            try:
+                return await client.update_card_field(card_id, field_id, new_value)
+            except Exception as exc:  # noqa: BLE001
+                return handle_tool_graphql_error(
+                    exc,
+                    "Update card field failed.",
+                    debug=debug,
+                    resource_kind="phase_field",
+                )
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),

--- a/tests/tools/test_pipe_tool_helpers.py
+++ b/tests/tools/test_pipe_tool_helpers.py
@@ -123,6 +123,71 @@ def test_extract_error_strings_skips_empty_message_and_blank_strings():
     assert result == ["ok"]
 
 
+@pytest.mark.unit
+def test_extract_error_strings_dict_repr_fallback_extracts_message():
+    """Single-error Python dict repr yields inner message only."""
+
+    class FakeExc(Exception):
+        def __str__(self):
+            return (
+                "{'message': 'Invalid inputs: Field X is required', "
+                "'locations': [{'line': 2, 'column': 3}], "
+                "'path': ['createCard'], "
+                "'extensions': {'code': 'MULTIPLE_INVALID_INPUT'}}"
+            )
+
+    exc = FakeExc()
+    exc.errors = None
+    assert extract_error_strings(exc) == ["Invalid inputs: Field X is required"]
+
+
+@pytest.mark.unit
+def test_extract_error_strings_dict_repr_with_double_quotes_inside_message():
+    """Message containing double-quoted field names parses correctly."""
+
+    class FakeExc(Exception):
+        def __str__(self):
+            return (
+                "{'message': 'Field \"Objetivo da demanda\" is required', "
+                "'extensions': {'code': 'MULTIPLE_INVALID_INPUT'}}"
+            )
+
+    exc = FakeExc()
+    assert extract_error_strings(exc) == ['Field "Objetivo da demanda" is required']
+
+
+@pytest.mark.unit
+def test_extract_error_strings_plain_string_exc_preserved():
+    """Non-dict-repr str(exc) flows through unchanged."""
+    exc = RuntimeError("network timeout")
+    assert extract_error_strings(exc) == ["network timeout"]
+
+
+@pytest.mark.unit
+def test_extract_error_strings_malformed_dict_repr_falls_back():
+    """Broken dict repr does not crash; returns raw string."""
+
+    class FakeExc(Exception):
+        def __str__(self):
+            return "{'message': 'unterminated..."
+
+    exc = FakeExc()
+    assert extract_error_strings(exc) == ["{'message': 'unterminated..."]
+
+
+@pytest.mark.unit
+def test_extract_error_strings_structured_errors_list_still_wins():
+    """When exc.errors is populated, the raw fallback is not consulted."""
+
+    class FakeExc(Exception):
+        errors = [{"message": "from structured list"}]
+
+        def __str__(self):
+            return "{'message': 'from dict repr'}"
+
+    assert extract_error_strings(FakeExc()) == ["from structured list"]
+
+
 # =============================================================================
 # map_add_card_comment_error_to_message
 # =============================================================================

--- a/tests/tools/test_pipe_tool_helpers.py
+++ b/tests/tools/test_pipe_tool_helpers.py
@@ -4,6 +4,9 @@ Tests validate payload builders, error message mappers, and field filters
 without invoking the MCP server or Pipefy client.
 """
 
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 
 from pipefy_mcp.tools.graphql_error_helpers import (
@@ -21,6 +24,7 @@ from pipefy_mcp.tools.pipe_tool_helpers import (
     build_add_card_comment_success_payload,
     build_delete_card_error_payload,
     build_delete_card_success_payload,
+    find_label_dependents,
     map_add_card_comment_error_to_message,
     map_delete_card_error_to_message,
 )
@@ -186,6 +190,78 @@ def test_extract_error_strings_structured_errors_list_still_wins():
             return "{'message': 'from dict repr'}"
 
     assert extract_error_strings(FakeExc()) == ["from structured list"]
+
+
+# =============================================================================
+# find_label_dependents
+# =============================================================================
+
+
+@pytest.mark.unit
+async def test_find_label_dependents_retries_when_first_query_empty(monkeypatch):
+    """Empty first get_cards then cards on second call returns dependents."""
+    sleep_mock = AsyncMock()
+    monkeypatch.setattr(asyncio, "sleep", sleep_mock)
+
+    client = MagicMock()
+    client.get_cards = AsyncMock(
+        side_effect=[
+            {"cards": {"edges": []}},
+            {
+                "cards": {
+                    "edges": [{"node": {"id": "card_1"}}, {"node": {"id": "card_2"}}]
+                }
+            },
+        ]
+    )
+
+    result = await find_label_dependents(
+        client,
+        pipe_id="pipe_1",
+        label_id="lab_1",
+        sample_size=5,
+    )
+    assert result is not None
+    assert result["sample_card_ids"] == ["card_1", "card_2"]
+    assert result["sample_size"] == 2
+    assert result["has_more"] is False
+    assert client.get_cards.call_count == 2
+    sleep_mock.assert_awaited_once_with(1.5)
+
+
+@pytest.mark.unit
+async def test_find_label_dependents_retry_on_empty_false_skips_second_query():
+    """retry_on_empty=False avoids second get_cards when first is empty."""
+    client = MagicMock()
+    client.get_cards = AsyncMock(return_value={"cards": {"edges": []}})
+
+    result = await find_label_dependents(
+        client,
+        pipe_id="pipe_1",
+        label_id="lab_1",
+        retry_on_empty=False,
+    )
+    assert result is None
+    assert client.get_cards.call_count == 1
+
+
+@pytest.mark.unit
+async def test_find_label_dependents_none_after_two_empty_queries(monkeypatch):
+    """Two empty responses yield None; sleep runs once between attempts."""
+    sleep_mock = AsyncMock()
+    monkeypatch.setattr(asyncio, "sleep", sleep_mock)
+
+    client = MagicMock()
+    client.get_cards = AsyncMock(return_value={"cards": {"edges": []}})
+
+    result = await find_label_dependents(
+        client,
+        pipe_id="pipe_1",
+        label_id="lab_1",
+    )
+    assert result is None
+    assert client.get_cards.call_count == 2
+    sleep_mock.assert_awaited_once_with(1.5)
 
 
 # =============================================================================

--- a/tests/tools/test_pipe_tools.py
+++ b/tests/tools/test_pipe_tools.py
@@ -1151,6 +1151,77 @@ class TestFindCardsTool:
         assert payload.get("message") == FIND_CARDS_EMPTY_MESSAGE
         assert payload.get(FIND_CARDS_RESPONSE_KEY, {}).get("edges") == []
 
+    @pytest.mark.parametrize("client_session", [None], indirect=True)
+    async def test_find_cards_graphql_error_returns_enriched_envelope(
+        self, client_session, mock_pipefy_client, pipe_id, extract_payload
+    ):
+        """Bad field_id (RESOURCE_NOT_FOUND) returns envelope with get_phase_fields hint."""
+        from gql.transport.exceptions import TransportQueryError
+
+        mock_pipefy_client.find_cards = AsyncMock(
+            side_effect=TransportQueryError(
+                "GraphQL Error",
+                errors=[
+                    {
+                        "message": "Field not found with id: title",
+                        "extensions": {"code": "RESOURCE_NOT_FOUND"},
+                    }
+                ],
+            )
+        )
+
+        async with client_session as session:
+            result = await session.call_tool(
+                "find_cards",
+                {
+                    "pipe_id": pipe_id,
+                    "field_id": "title",
+                    "field_value": "anything",
+                },
+            )
+
+        assert result.isError is False, "Raw exception leaked instead of envelope"
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "get_phase_fields" in tool_error_message(payload)
+
+
+@pytest.mark.anyio
+class TestUpdateCardFieldTool:
+    @pytest.mark.parametrize("client_session", [None], indirect=True)
+    async def test_update_card_field_graphql_error_returns_enriched_envelope(
+        self, client_session, mock_pipefy_client, extract_payload
+    ):
+        """Bad field_id slug returns envelope mentioning get_phase_fields, not raw exception."""
+        from gql.transport.exceptions import TransportQueryError
+
+        mock_pipefy_client.update_card_field = AsyncMock(
+            side_effect=TransportQueryError(
+                "GraphQL Error",
+                errors=[
+                    {
+                        "message": "Field not found with id: nonexistent_slug_xyz",
+                        "extensions": {"code": "RESOURCE_NOT_FOUND"},
+                    }
+                ],
+            )
+        )
+
+        async with client_session as session:
+            result = await session.call_tool(
+                "update_card_field",
+                {
+                    "card_id": 12345,
+                    "field_id": "nonexistent_slug_xyz",
+                    "new_value": "x",
+                },
+            )
+
+        assert result.isError is False, "Raw exception leaked instead of envelope"
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "get_phase_fields" in tool_error_message(payload)
+
 
 @pytest.mark.anyio
 class TestAddCardCommentTool:


### PR DESCRIPTION
## Summary
- **graphql**: Extract inner `message` from Python dict-repr in `str(exc)` fallback (`extract_error_strings`).
- **tools**: `find_label_dependents` retries after brief delay when label index returns empty (optional `retry_on_empty`).
- **tools**: `find_cards` and `update_card_field` return enriched error envelopes via `handle_tool_graphql_error` (`debug` param).
- **docs**: README tagline moved below badge row.

## Testing
- `uv run pytest tests/ -m "not integration"`
- `uv run ruff check src/ tests/` / `ruff format --check`