### PR TITLE
fix(tools): AI agent referencedFieldIds after mixed slug and numeric field refs

### DIFF
--- a/src/pipefy_mcp/tools/ai_agent_tools.py
+++ b/src/pipefy_mcp/tools/ai_agent_tools.py
@@ -24,7 +24,7 @@ from pipefy_mcp.tools.ai_tool_helpers import (
     collect_pipe_ids_from_behaviors,
     enrich_behavior_error,
     fetch_pipe_validation_context,
-    resolve_field_slugs_to_numeric,
+    resolve_and_populate_field_refs,
     validate_behaviors_against_pipe,
 )
 from pipefy_mcp.tools.behavior_placeholder_interpolation import (
@@ -320,7 +320,7 @@ class AiAgentTools:
 
             agent_uuid = create_result["agent_uuid"]
 
-            resolved_behaviors = await resolve_field_slugs_to_numeric(
+            resolved_behaviors = await resolve_and_populate_field_refs(
                 client,
                 [b.model_dump(by_alias=True) for b in validated.behaviors],
             )
@@ -420,7 +420,7 @@ class AiAgentTools:
                 behaviors_expanded = expand_behaviors_placeholders(behaviors)
             except ValueError as exc:
                 return build_ai_tool_error(str(exc))
-            resolved_behaviors = await resolve_field_slugs_to_numeric(
+            resolved_behaviors = await resolve_and_populate_field_refs(
                 client, behaviors_expanded
             )
             try:
@@ -599,6 +599,12 @@ class AiAgentTools:
 
             Runs Pydantic model validation (same as the mutation tools) plus cross-references
             against live pipe data. Does not persist anything.
+
+            Note: this validation runs against the user-supplied behaviors verbatim. Slug
+            resolution (``%{field:<slug>}`` → ``%{field:<internal_id>}``) and
+            ``referencedFieldIds`` population happen only in ``create_ai_agent`` /
+            ``update_ai_agent``, so the persisted state may differ slightly from what is
+            checked here when behaviors include slug-form field references.
 
             Response fields:
               - ``success``: the tool finished without an unexpected failure (same idea as other

--- a/src/pipefy_mcp/tools/ai_tool_helpers.py
+++ b/src/pipefy_mcp/tools/ai_tool_helpers.py
@@ -659,6 +659,42 @@ async def resolve_field_slugs_to_numeric(
     return resolved
 
 
+async def resolve_and_populate_field_refs(
+    client: PipefyClient,
+    behaviors: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Resolve slug fieldIds to numeric and populate ``referencedFieldIds``.
+
+    Wraps :func:`resolve_field_slugs_to_numeric` and then runs
+    :func:`populate_referenced_field_ids` on each behavior so the per-behavior
+    ``referencedFieldIds`` list reflects the **post-resolution** instruction.
+
+    Running populate after slug resolution is required for the mixed case where
+    a single instruction contains both numeric (``%{field:159}``) and slug
+    (``%{field:my_slug}``) refs: populating earlier would capture only the
+    numeric subset and the conservative non-empty guard inside
+    :func:`populate_referenced_field_ids` would then prevent a second pass from
+    picking up the slug-resolved ids.
+
+    Args:
+        client: PipefyClient for fetching field-slug maps.
+        behaviors: Behavior dicts (same shape as ``create_ai_agent``).
+
+    Returns:
+        Resolved-and-populated behavior dicts.
+    """
+    # Local import keeps the module-level dependency graph flat (the helpers
+    # module doesn't otherwise need to know about the interpolation module).
+    from pipefy_mcp.tools.behavior_placeholder_interpolation import (
+        populate_referenced_field_ids,
+    )
+
+    resolved = await resolve_field_slugs_to_numeric(client, behaviors)
+    for b in resolved:
+        populate_referenced_field_ids(b)
+    return resolved
+
+
 async def fetch_pipe_validation_context(
     client: PipefyClient,
     pipe_id: str,
@@ -786,6 +822,7 @@ __all__ = [
     "enrich_behavior_error",
     "fetch_pipe_validation_context",
     "pipe_ids_from_behavior",
+    "resolve_and_populate_field_refs",
     "resolve_field_slugs_to_numeric",
     "validate_behaviors_against_pipe",
 ]

--- a/src/pipefy_mcp/tools/behavior_placeholder_interpolation.py
+++ b/src/pipefy_mcp/tools/behavior_placeholder_interpolation.py
@@ -17,6 +17,10 @@ _PIPEFY_ACTION_UUID = re.compile(
 # wrapped (``%{123}``) and bare (``{123}``) variants to ``%{field:123}``.
 _PIPEFY_PREFIXED_NUMERIC_FIELD = re.compile(r"%\{(\d+)\}")
 _PIPEFY_UNPREFIXED_NUMERIC_FIELD = re.compile(r"(?<!\%)\{(\d+)\}")
+# Numeric `%{field:<digits>}` references in a (post-normalization) behavior
+# instruction. Used to populate `aiBehaviorParams.referencedFieldIds` so
+# pipefy-core forwards the referenced fields' values in the BehaviorRequest.
+_PIPEFY_NUMERIC_FIELD_REF = re.compile(r"%\{field:(\d+)\}")
 
 _TEMPLATE_PARAM_SOURCE_KEYS = (
     "template_params",
@@ -96,6 +100,71 @@ def normalize_pipefy_ai_instruction_tokens(text: str) -> str:
     out = _PIPEFY_ACTION_UUID.sub(r"%{action:\1}", out)
     out = _PIPEFY_PREFIXED_NUMERIC_FIELD.sub(r"%{field:\1}", out)
     return _PIPEFY_UNPREFIXED_NUMERIC_FIELD.sub(r"%{field:\1}", out)
+
+
+def extract_referenced_field_ids(instruction: str) -> list[str]:
+    """Extract numeric field ids referenced in an instruction's ``%{field:<digits>}`` tokens.
+
+    Only matches the canonical numeric form (post :func:`normalize_pipefy_ai_instruction_tokens`
+    and post-slug-resolution). Slug-form references like ``%{field:my_slug}`` are
+    intentionally skipped — they should be resolved to numeric ids before this runs.
+
+    The regex deliberately matches bare digits only, mirroring pipefy-core's
+    runtime parser in ``start_behavior_execution.rb`` which forwards card fields
+    based on this same shape. Dotted connected-pipe references like
+    ``%{field:136.135}`` (handled by pipefy-core's importer for clone-time static
+    analysis) are not picked up at runtime, so populating them here would not
+    change what arrives in ``BehaviorRequest.card.fields[]``.
+
+    Args:
+        instruction: Behavior instruction text.
+
+    Returns:
+        Field ids in first-occurrence order, deduplicated, as strings.
+    """
+    if not instruction:
+        return []
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for match in _PIPEFY_NUMERIC_FIELD_REF.finditer(instruction):
+        fid = match.group(1)
+        if fid not in seen:
+            seen.add(fid)
+            ordered.append(fid)
+    return ordered
+
+
+def populate_referenced_field_ids(behavior: dict[str, Any]) -> None:
+    """Set ``aiBehaviorParams.referencedFieldIds`` from the behavior's instruction.
+
+    Idempotent and conservative: if ``referencedFieldIds`` is already a non-empty
+    list (caller-supplied), leaves it alone. Otherwise overwrites with the
+    extracted ids — including the empty list when no tokens are present.
+
+    pipefy-core uses this stored list to decide which card fields to forward in
+    the ``BehaviorRequest.card.fields[]`` array at trigger time. When it is null,
+    the array arrives empty and pipefy-ai's placeholder resolver has nothing to
+    substitute.
+
+    Should run **after** slug resolution so that slug-form refs already became
+    numeric. Running it before slug resolution would capture only the numeric
+    subset and the non-empty guard would then prevent a second pass from filling
+    in the resolved slugs.
+
+    Mutates ``behavior`` in place.
+    """
+    ap = behavior.get("actionParams") or behavior.get("action_params")
+    if not isinstance(ap, dict):
+        return
+    abp = ap.get("aiBehaviorParams") or ap.get("ai_behavior_params")
+    if not isinstance(abp, dict):
+        return
+    existing = abp.get("referencedFieldIds") or abp.get("referenced_field_ids")
+    if isinstance(existing, list) and existing:
+        return
+    instruction = abp.get("instruction")
+    if isinstance(instruction, str):
+        abp["referencedFieldIds"] = extract_referenced_field_ids(instruction)
 
 
 def _normalize_instruction_in_behavior(behavior: dict[str, Any]) -> None:
@@ -189,5 +258,7 @@ def expand_behaviors_placeholders(
 __all__ = [
     "expand_behavior_placeholders",
     "expand_behaviors_placeholders",
+    "extract_referenced_field_ids",
     "normalize_pipefy_ai_instruction_tokens",
+    "populate_referenced_field_ids",
 ]

--- a/tests/tools/test_ai_tool_helpers_slug_resolution.py
+++ b/tests/tools/test_ai_tool_helpers_slug_resolution.py
@@ -7,6 +7,7 @@ import pytest
 
 from pipefy_mcp.tools.ai_tool_helpers import (
     build_field_slug_map,
+    resolve_and_populate_field_refs,
     resolve_field_slugs_to_numeric,
 )
 
@@ -387,3 +388,96 @@ async def test_resolve_skips_behaviors_without_pipe_id():
     # No API calls, behaviors returned as-is
     client.get_pipe.assert_not_called()
     assert resolved == behaviors
+
+
+# --- resolve_and_populate_field_refs tests ---
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resolve_and_populate_pure_numeric_instruction():
+    client = AsyncMock()
+
+    b = _behavior_with_fields("306996636", ["427911728"])
+    b["actionParams"]["aiBehaviorParams"]["instruction"] = (
+        "Use %{field:111} and %{field:222}"
+    )
+    resolved = await resolve_and_populate_field_refs(client, [b])
+
+    # No slug → no API call
+    client.get_pipe.assert_not_called()
+    assert resolved[0]["actionParams"]["aiBehaviorParams"]["referencedFieldIds"] == [
+        "111",
+        "222",
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resolve_and_populate_pure_slug_instruction():
+    client = AsyncMock()
+    client.get_pipe = AsyncMock(
+        return_value={
+            "pipe": {
+                "phases": [],
+                "start_form_fields": [
+                    {"id": "briefing", "internal_id": "111"},
+                ],
+            }
+        }
+    )
+
+    b = _behavior_with_fields("306996636", ["111"])
+    b["actionParams"]["aiBehaviorParams"]["instruction"] = "Read %{field:briefing}"
+    resolved = await resolve_and_populate_field_refs(client, [b])
+
+    abp = resolved[0]["actionParams"]["aiBehaviorParams"]
+    assert abp["instruction"] == "Read %{field:111}"
+    assert abp["referencedFieldIds"] == ["111"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resolve_and_populate_mixed_numeric_and_slug_instruction():
+    """Regression test: when an instruction mixes already-numeric refs with slug
+    refs, both must end up in ``referencedFieldIds``. Earlier versions called
+    ``populate_referenced_field_ids`` before slug resolution; the conservative
+    non-empty guard then prevented the slug-resolved id from being added on a
+    second pass, silently dropping it from the list pipefy-core uses to forward
+    card field values at trigger time."""
+    client = AsyncMock()
+    client.get_pipe = AsyncMock(
+        return_value={
+            "pipe": {
+                "phases": [],
+                "start_form_fields": [
+                    {"id": "briefing", "internal_id": "222"},
+                ],
+            }
+        }
+    )
+
+    b = _behavior_with_fields("306996636", ["222"])
+    b["actionParams"]["aiBehaviorParams"]["instruction"] = (
+        "Use %{field:111} and %{field:briefing}"
+    )
+    resolved = await resolve_and_populate_field_refs(client, [b])
+
+    abp = resolved[0]["actionParams"]["aiBehaviorParams"]
+    assert abp["instruction"] == "Use %{field:111} and %{field:222}"
+    assert abp["referencedFieldIds"] == ["111", "222"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resolve_and_populate_preserves_caller_supplied_refs():
+    client = AsyncMock()
+
+    b = _behavior_with_fields("306996636", ["111"])
+    b["actionParams"]["aiBehaviorParams"]["instruction"] = "Use %{field:111}"
+    b["actionParams"]["aiBehaviorParams"]["referencedFieldIds"] = ["999"]
+    resolved = await resolve_and_populate_field_refs(client, [b])
+
+    assert resolved[0]["actionParams"]["aiBehaviorParams"]["referencedFieldIds"] == [
+        "999"
+    ]

--- a/tests/tools/test_behavior_placeholder_interpolation.py
+++ b/tests/tools/test_behavior_placeholder_interpolation.py
@@ -7,7 +7,9 @@ import pytest
 from pipefy_mcp.tools.behavior_placeholder_interpolation import (
     expand_behavior_placeholders,
     expand_behaviors_placeholders,
+    extract_referenced_field_ids,
     normalize_pipefy_ai_instruction_tokens,
+    populate_referenced_field_ids,
 )
 
 
@@ -197,3 +199,125 @@ def test_placeholders_overrides_template_params_same_key():
 
     out = expand_behavior_placeholders(b)
     assert out["actionParams"]["aiBehaviorParams"]["instruction"] == "second"
+
+
+@pytest.mark.unit
+def test_extract_referenced_field_ids_empty_instruction():
+    assert extract_referenced_field_ids("") == []
+    assert extract_referenced_field_ids(None) == []  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_extract_referenced_field_ids_single():
+    assert extract_referenced_field_ids("Validate %{field:159}") == ["159"]
+
+
+@pytest.mark.unit
+def test_extract_referenced_field_ids_multiple_preserves_order():
+    text = "Use %{field:200} then %{field:100} then %{field:300}"
+    assert extract_referenced_field_ids(text) == ["200", "100", "300"]
+
+
+@pytest.mark.unit
+def test_extract_referenced_field_ids_deduplicates():
+    text = "%{field:159} %{field:160} %{field:159}"
+    assert extract_referenced_field_ids(text) == ["159", "160"]
+
+
+@pytest.mark.unit
+def test_extract_referenced_field_ids_skips_slug_refs():
+    """Pipefy-core's ``referencedFieldIds`` is a list of numeric ids; slug-form
+    references should be resolved upstream before this runs."""
+    text = "Numeric %{field:159} and slug %{field:my_slug_field}"
+    assert extract_referenced_field_ids(text) == ["159"]
+
+
+@pytest.mark.unit
+def test_extract_referenced_field_ids_no_tokens():
+    assert extract_referenced_field_ids("Just text, no tokens.") == []
+
+
+@pytest.mark.unit
+def test_extract_referenced_field_ids_skips_dotted_connected_refs():
+    """Dotted connected-pipe refs like ``%{field:136.135}`` are handled by
+    pipefy-core's importer for clone-time static analysis but are not picked up
+    by pipefy-core's runtime ``start_behavior_execution.rb`` parser. Mirroring
+    runtime here keeps populated ids aligned with what actually arrives in
+    ``BehaviorRequest.card.fields[]``."""
+    text = "Bare %{field:159} and dotted %{field:136.135}"
+    assert extract_referenced_field_ids(text) == ["159"]
+
+
+@pytest.mark.unit
+def test_extract_referenced_field_ids_ignores_action_tokens():
+    text = "%{action:78164d3e-8b69-47dd-9dcc-56014f8a55c6} and %{field:159}"
+    assert extract_referenced_field_ids(text) == ["159"]
+
+
+@pytest.mark.unit
+def test_populate_sets_referenced_field_ids_when_missing():
+    b = _minimal_behavior()
+    b["actionParams"]["aiBehaviorParams"]["instruction"] = (
+        "Hi %{field:159} %{field:160}"
+    )
+    populate_referenced_field_ids(b)
+    assert b["actionParams"]["aiBehaviorParams"]["referencedFieldIds"] == ["159", "160"]
+
+
+@pytest.mark.unit
+def test_populate_leaves_caller_supplied_non_empty_list_alone():
+    b = _minimal_behavior()
+    b["actionParams"]["aiBehaviorParams"]["instruction"] = "Hi %{field:159}"
+    b["actionParams"]["aiBehaviorParams"]["referencedFieldIds"] = ["999"]
+    populate_referenced_field_ids(b)
+    assert b["actionParams"]["aiBehaviorParams"]["referencedFieldIds"] == ["999"]
+
+
+@pytest.mark.unit
+def test_populate_overwrites_empty_list():
+    """Empty list is treated as missing — common after a first populate-then-
+    slug-resolve pass where the initial pass found no numeric tokens."""
+    b = _minimal_behavior()
+    b["actionParams"]["aiBehaviorParams"]["instruction"] = "Hi %{field:159}"
+    b["actionParams"]["aiBehaviorParams"]["referencedFieldIds"] = []
+    populate_referenced_field_ids(b)
+    assert b["actionParams"]["aiBehaviorParams"]["referencedFieldIds"] == ["159"]
+
+
+@pytest.mark.unit
+def test_populate_with_snake_case_keys():
+    b = {
+        "name": "B",
+        "event_id": "card_created",
+        "action_params": {
+            "ai_behavior_params": {
+                "instruction": "Hi %{field:159}",
+                "actionsAttributes": [],
+            }
+        },
+    }
+    populate_referenced_field_ids(b)
+    assert b["action_params"]["ai_behavior_params"]["referencedFieldIds"] == ["159"]
+
+
+@pytest.mark.unit
+def test_populate_noop_when_action_params_missing():
+    b = {"name": "B", "event_id": "card_created"}
+    populate_referenced_field_ids(b)
+    assert "referencedFieldIds" not in b
+    assert b == {"name": "B", "event_id": "card_created"}
+
+
+@pytest.mark.unit
+def test_populate_noop_when_ai_behavior_params_missing():
+    b = {"name": "B", "actionParams": {"otherKey": "other"}}
+    populate_referenced_field_ids(b)
+    assert "referencedFieldIds" not in b["actionParams"]
+
+
+@pytest.mark.unit
+def test_populate_empty_list_when_no_tokens():
+    b = _minimal_behavior()
+    b["actionParams"]["aiBehaviorParams"]["instruction"] = "Just text."
+    populate_referenced_field_ids(b)
+    assert b["actionParams"]["aiBehaviorParams"]["referencedFieldIds"] == []


### PR DESCRIPTION
## Summary
- Ensures `referencedFieldIds` is populated **after** slug-to-internal-id resolution so instructions mixing `%{field:<numeric>}` and `%{field:<slug>}` include every field the runtime needs.
- Adds `resolve_and_populate_field_refs` and wires it into AI agent create/update flows.
- Adjusts `populate_referenced_field_ids` guard so a second pass can add ids when the instruction is rewritten.
- Unit tests for slug resolution and placeholder interpolation (regression).

## Testing
- `uv run ruff check src/` && `uv run ruff format --check src/`
- `uv run pytest -m "not integration"` (1813 passed)

## Merge target
**Base:** `pipe-full-toolset`