### PR TITLE
feat(cli): Task 5 CLI domain parity (SDK/MCP alignment)

### DIFF
--- a/docs/parity.md
+++ b/docs/parity.md
@@ -1,0 +1,162 @@
+# MCP tools and CLI parity
+
+This matrix is the source of truth for **MCP tool ↔ `pipefy` CLI** coverage. It is maintained alongside the rollout in `.cursor/dev-planning/specs/pipefy-ai-sdk/tasks/tasks-pipefy-ai-sdk.md` (parent task **5.0**).
+
+**Registry source:** `PIPEFY_TOOL_NAMES` in `packages/mcp/src/pipefy_mcp/tools/registry.py` (must stay in sync with this table: **128** tools).
+
+## Status legend
+
+| Status | Meaning |
+| --- | --- |
+| **shipped** | CLI command exists in `packages/cli` today. |
+| **pending** | Planned CLI coverage not shipped yet (see matrix). |
+| **deferred** | Not targeted for the initial CLI parity wave; see **Notes**. |
+| **N/A** | MCP- or IDE-oriented surface with no first-class CLI twin planned. |
+
+## Parity matrix
+
+| MCP tool name | CLI command (or target) | Status | Notes |
+| --- | --- | --- | --- |
+| `add_card_comment` | `pipefy card comment add` | shipped | Task **5.2**. |
+| `clone_pipe` | `pipefy pipe clone` | shipped | Task **5.3**; optional `--org`. |
+| `create_ai_agent` | — | deferred | AI Agents domain; post-v0.1 CLI unless explicitly rescoped. |
+| `create_ai_automation` | — | deferred | AI Automations domain; post-v0.1 CLI unless explicitly rescoped. |
+| `create_automation` | — | deferred | Automations domain; post-v0.1 CLI unless explicitly rescoped. |
+| `create_card` | `pipefy card create` | shipped | Task **5.2** (`--fields` JSON, optional `--title`). |
+| `create_card_relation` | `pipefy relation card create` | shipped | Task **5.10**. |
+| `create_field_condition` | — | deferred | Field conditions / AI-adjacent building blocks; not in FR-5.2 launch list. |
+| `create_label` | `pipefy label create` | shipped | Task **5.8**. |
+| `create_organization_report` | — | deferred | Organization reports; organization-level ops out of v0.1 parity. |
+| `create_phase` | `pipefy phase create` | shipped | Task **5.4**. |
+| `create_phase_field` | `pipefy field create` | shipped | Task **5.5** (phase fields). |
+| `create_pipe` | `pipefy pipe create` | shipped | Task **5.3** (`--org`). |
+| `create_pipe_relation` | `pipefy relation pipe create` | shipped | Task **5.10**. |
+| `create_pipe_report` | — | deferred | Reports domain; deferred from v0.1 CLI parity. |
+| `create_send_task_automation` | — | deferred | Automations domain. |
+| `create_table` | `pipefy table create` | shipped | Task **5.6**. |
+| `create_table_field` | — | deferred | Table fields; not in FR-5.2 launch list (table CRUD only). |
+| `create_table_record` | `pipefy record create` | shipped | Task **5.7**. |
+| `create_webhook` | `pipefy webhook create` | shipped | Task **5.9**. |
+| `delete_ai_agent` | — | deferred | AI Agents domain. |
+| `delete_ai_automation` | — | deferred | AI Automations domain. |
+| `delete_automation` | — | deferred | Automations domain. |
+| `delete_card` | `pipefy card delete` | shipped | Task **5.2**; destructive: `--yes` or interactive confirm. |
+| `delete_card_relation` | `pipefy relation card delete` | shipped | Task **5.10**; requires OAuth (internal API); `--yes`. |
+| `delete_comment` | `pipefy card comment delete` | shipped | Task **5.2**; destructive: `--yes` or confirm. |
+| `delete_field_condition` | — | deferred | Field conditions; not in launch list. |
+| `delete_label` | `pipefy label delete` | shipped | Task **5.8**; destructive: `--yes`. |
+| `delete_organization_report` | — | deferred | Organization reports. |
+| `delete_phase` | `pipefy phase delete` | shipped | Task **5.4**; destructive: `--yes`. |
+| `delete_phase_field` | `pipefy field delete` | shipped | Task **5.5**; destructive: `--yes`. |
+| `delete_pipe` | `pipefy pipe delete` | shipped | Task **5.3**; `--yes` or confirm. |
+| `delete_pipe_relation` | `pipefy relation pipe delete` | shipped | Task **5.10**; destructive: `--yes`. |
+| `delete_pipe_report` | — | deferred | Reports domain. |
+| `delete_table` | `pipefy table delete` | shipped | Task **5.6**; destructive: `--yes`. |
+| `delete_table_field` | — | deferred | Table fields; not in launch list. |
+| `delete_table_record` | `pipefy record delete` | shipped | Task **5.7**; destructive: `--yes`. |
+| `delete_webhook` | `pipefy webhook delete` | shipped | Task **5.9**; destructive: `--yes`. |
+| `execute_graphql` | — | N/A | Raw GraphQL escape hatch; MCP-oriented. |
+| `export_automation_jobs` | — | deferred | Exports domain; deferred from v0.1 CLI parity. |
+| `export_organization_report` | — | deferred | Exports + organization reports. |
+| `export_pipe_audit_logs` | — | deferred | Exports domain. |
+| `export_pipe_report` | — | deferred | Exports + reports. |
+| `fill_card_phase_fields` | — | deferred | Card bulk fill; not in FR-5.2 launch command list (may follow **5.2**). |
+| `find_cards` | `pipefy card find` | shipped | Task **5.2** (`--pipe`, `--field`, `--value`). |
+| `find_records` | `pipefy record find` | shipped | Task **5.7** (`--filter` JSON with `field_id` + `field_value`). |
+| `get_agents_usage` | — | deferred | AI Agents observability; not v0.1 CLI. |
+| `get_ai_agent` | — | deferred | AI Agents domain. |
+| `get_ai_agent_log_details` | — | deferred | AI Agents domain. |
+| `get_ai_agent_logs` | — | deferred | AI Agents domain. |
+| `get_ai_agents` | — | deferred | AI Agents domain. |
+| `get_ai_automation` | — | deferred | AI Automations domain. |
+| `get_ai_automations` | — | deferred | AI Automations domain. |
+| `get_ai_credit_usage` | — | deferred | AI billing / usage; not v0.1 CLI. |
+| `get_automation` | — | deferred | Automations domain. |
+| `get_automation_actions` | — | deferred | Automations domain. |
+| `get_automation_events` | — | deferred | Automations domain. |
+| `get_automation_jobs_export` | — | deferred | Automations + export-shaped. |
+| `get_automation_jobs_export_csv` | — | deferred | Automations + export-shaped. |
+| `get_automation_logs` | — | deferred | Automations domain. |
+| `get_automation_logs_by_repo` | — | deferred | Automations domain. |
+| `get_automations` | — | deferred | Automations domain. |
+| `get_automations_usage` | — | deferred | Automations usage. |
+| `get_card` | `pipefy card get` | shipped | Task **4.6**; `--include-fields` added in **5.2**. |
+| `get_card_inbox_emails` | — | deferred | Inbox/email surface; not in FR-5.2 launch list. |
+| `get_card_relations` | `pipefy relation card list` | shipped | Task **5.10** (raw ``get_card_relations`` payload). |
+| `get_cards` | `pipefy card list` | shipped | Task **5.2** + post-5.0 closure: ``list`` maps to ``get_cards`` (``--pipe``, ``--title``, ``--search`` JSON / ``CardSearch``, ``--include-fields``, ``--first`` / ``--after``). Use ``pipefy card find`` for ``find_cards`` (single field equality). |
+| `get_email_templates` | — | deferred | Email templates; `send_email` family deferred from v0.1. |
+| `get_field_condition` | — | deferred | Field conditions; not in launch list. |
+| `get_field_conditions` | — | deferred | Field conditions; not in launch list. |
+| `get_labels` | `pipefy label list` | shipped | Task **5.8**. |
+| `get_organization` | — | deferred | Organization-level read; out of v0.1 parity per task **5.1** spec. |
+| `get_organization_report` | — | deferred | Organization reports. |
+| `get_organization_report_export` | — | deferred | Organization reports + export-shaped. |
+| `get_organization_reports` | — | deferred | Organization reports. |
+| `get_phase_fields` | `pipefy field list --phase` | shipped | Task **5.5**; ``pipefy phase get`` returns the same shape. |
+| `get_pipe` | `pipefy pipe get` | shipped | Task **5.3**. |
+| `get_pipe_members` | `pipefy member list` | shipped | Task **5.11**. |
+| `get_pipe_relations` | `pipefy relation pipe list` | shipped | Task **5.10**. |
+| `get_pipe_report` | — | deferred | Reports domain. |
+| `get_pipe_report_columns` | — | deferred | Reports domain. |
+| `get_pipe_report_export` | — | deferred | Reports + exports. |
+| `get_pipe_report_filterable_fields` | — | deferred | Reports domain. |
+| `get_pipe_reports` | — | deferred | Reports domain. |
+| `get_start_form_fields` | — | deferred | Pipe configuration / building; not in FR-5.2 launch list. |
+| `get_table` | `pipefy table get` | shipped | Task **5.6**. |
+| `get_table_record` | `pipefy record get` | shipped | Task **5.7**. |
+| `get_table_records` | `pipefy record find` | shipped | Task **5.7** (omit `field_id`/`field_value` in `--filter`; uses ``--first`` / ``--after``). |
+| `get_table_relations` | — | deferred | Table relations helper; not in FR-5.2 launch list. |
+| `get_tables` | `pipefy table list --ids` | shipped | Task **5.6**; name search uses the same command without ``--ids``. |
+| `get_webhooks` | `pipefy webhook list` | shipped | Task **5.9**. |
+| `introspect_mutation` | — | N/A | Schema introspection for MCP clients / agents. |
+| `introspect_query` | — | N/A | Schema introspection for MCP clients / agents. |
+| `introspect_type` | — | N/A | Schema introspection for MCP clients / agents. |
+| `invite_members` | `pipefy member invite` | shipped | Task **5.11**. |
+| `move_card_to_phase` | `pipefy card move` | shipped | Task **5.2** (`--phase`). |
+| `remove_member_from_pipe` | `pipefy member remove` | shipped | Task **5.11**; ``PIPEFY_SERVICE_ACCOUNT_IDS`` guard like MCP. |
+| `search_pipes` | `pipefy pipe list` | shipped | Task **5.3** (`--name`, `--max-per-org`). |
+| `search_schema` | — | N/A | IDE/agent introspection helper. |
+| `search_tables` | `pipefy table list` | shipped | Task **5.6** (without ``--ids``). |
+| `send_email_with_template` | — | deferred | Email send; explicitly deferred from v0.1 parity. |
+| `send_inbox_email` | — | deferred | Email send; explicitly deferred from v0.1 parity. |
+| `set_role` | `pipefy member set-role` | shipped | Task **5.11**. |
+| `set_table_record_field_value` | `pipefy record update` | shipped | Task **5.7** (``--field-id`` + ``--value``). |
+| `simulate_automation` | — | deferred | Automation simulation; explicitly deferred from v0.1 parity. |
+| `toggle_ai_agent_status` | — | deferred | AI Agents domain. |
+| `update_ai_agent` | — | deferred | AI Agents domain. |
+| `update_ai_automation` | — | deferred | AI Automations domain. |
+| `update_automation` | — | deferred | Automations domain. |
+| `update_card` | `pipefy card update` | shipped | Task **5.2** (`--field-updates` JSON, optional title/labels/assignees/due-date). |
+| `update_card_field` | `pipefy card update` | shipped | Use `--field-updates` JSON array (task **5.2**). |
+| `update_comment` | `pipefy card comment update` | shipped | Task **5.2**. |
+| `update_field_condition` | — | deferred | Field conditions; not in launch list. |
+| `update_label` | `pipefy label update` | shipped | Task **5.8**. |
+| `update_organization_report` | — | deferred | Organization reports. |
+| `update_phase` | `pipefy phase update` | shipped | Task **5.4**. |
+| `update_phase_field` | `pipefy field update` | shipped | Task **5.5** (``--extra`` JSON). |
+| `update_pipe` | `pipefy pipe update` | shipped | Task **5.3** (`--name`, `--icon`, `--color`, `--preferences` JSON). |
+| `update_pipe_relation` | `pipefy relation pipe update` | shipped | Task **5.10**. |
+| `update_pipe_report` | — | deferred | Reports domain. |
+| `update_table` | `pipefy table update` | shipped | Task **5.6**. |
+| `update_table_field` | — | deferred | Table fields; not in launch list. |
+| `update_table_record` | `pipefy record update` | shipped | Task **5.7** (``--fields`` JSON). |
+| `update_webhook` | `pipefy webhook update` | shipped | Task **5.9**. |
+| `upload_attachment_to_card` | — | deferred | Attachments; not in FR-5.2 launch list. |
+| `upload_attachment_to_table_record` | — | deferred | Attachments; not in FR-5.2 launch list. |
+| `validate_ai_agent_behaviors` | — | deferred | AI Agents validation tooling. |
+| `validate_ai_automation_prompt` | — | deferred | AI Automations validation tooling. |
+
+## Row count check
+
+```bash
+uv run python -c "import ast, pathlib; p=pathlib.Path('packages/mcp/src/pipefy_mcp/tools/registry.py'); m=ast.parse(p.read_text());
+for n in m.body:
+    if isinstance(n, ast.Assign) and any(isinstance(t, ast.Name) and t.id=='PIPEFY_TOOL_NAMES' for t in n.targets):
+        v=n.value
+        if isinstance(v, ast.Call) and getattr(v.func,'id',None)=='frozenset':
+            print(len(v.args[0].elts))"
+```
+
+Expect **128** tool names in `PIPEFY_TOOL_NAMES` and **128** data rows in the parity table (excluding the header rows).
+
+When adding or removing an MCP tool, update **this file** and `PIPEFY_TOOL_NAMES` in the same change set.

--- a/packages/cli/src/pipefy_cli/auth.py
+++ b/packages/cli/src/pipefy_cli/auth.py
@@ -3,7 +3,12 @@
 from __future__ import annotations
 
 import typer
-from pipefy_sdk import PipefyClient, PipefySettings
+from pipefy_sdk import (
+    AiAutomationService,
+    InternalApiClient,
+    PipefyClient,
+    PipefySettings,
+)
 
 from pipefy_cli._docs import DOCS_SETUP_REF
 from pipefy_cli.config import (
@@ -12,6 +17,8 @@ from pipefy_cli.config import (
 )
 
 _cached_signature: tuple[object, ...] | None = None
+# One-shot CLIs reuse this; long-lived programmatic use should call
+# ``clear_authenticated_client_cache`` between logical sessions (tests reset via fixture).
 _cached_client: PipefyClient | None = None
 
 
@@ -88,6 +95,15 @@ def get_authenticated_client(
         raise typer.Exit(2)
 
     client = PipefyClient(pipefy_settings)
+    internal_client = InternalApiClient(
+        url=pipefy_settings.internal_api_url,
+        oauth_url=pipefy_settings.oauth_url,
+        oauth_client=pipefy_settings.oauth_client,
+        oauth_secret=pipefy_settings.oauth_secret,
+        allow_insecure_urls=pipefy_settings.allow_insecure_urls,
+    )
+    client.set_internal_api_client(internal_client)
+    client.set_ai_automation_service(AiAutomationService(client=internal_client))
     _cached_signature = key
     _cached_client = client
     return client

--- a/packages/cli/src/pipefy_cli/commands/_common.py
+++ b/packages/cli/src/pipefy_cli/commands/_common.py
@@ -1,0 +1,94 @@
+"""Shared Typer helpers for domain command modules."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import typer
+from pipefy_sdk import PipefyClient, PipefySettings
+from pipefy_sdk.exceptions import PipefyError
+
+from pipefy_cli.auth import get_authenticated_client
+from pipefy_cli.output import render_json, render_rich
+
+
+def settings_and_token(ctx: typer.Context) -> tuple[PipefySettings, str | None]:
+    """Resolve root CLI context object into settings and optional bearer token."""
+    root = ctx.find_root()
+    obj = root.obj
+    return obj["pipefy_settings"], obj.get("token")
+
+
+def authenticated_client_from_ctx(ctx: typer.Context) -> PipefyClient:
+    """Build a :class:`PipefyClient` using the same auth path as ``run_cli_command``."""
+    pipefy_settings, token = settings_and_token(ctx)
+    return get_authenticated_client(pipefy_settings, bearer_token=token)
+
+
+def parse_json_value(raw: str | None, option_name: str) -> Any:
+    """Parse a JSON value from a CLI string option (empty input returns ``None``)."""
+    if raw is None or raw.strip() == "":
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise typer.BadParameter(f"Invalid JSON for {option_name}: {exc}") from exc
+
+
+def parse_json_object(raw: str | None, option_name: str) -> dict[str, Any] | None:
+    """Parse a JSON object from a CLI string option (empty input returns ``None``)."""
+    if raw is None or raw.strip() == "":
+        return None
+    parsed = parse_json_value(raw, option_name)
+    if not isinstance(parsed, dict):
+        raise typer.BadParameter(f"{option_name} must be a JSON object")
+    return parsed
+
+
+def confirm_destructive(*, yes: bool, description: str, verb: str = "delete") -> None:
+    """Prompt before a destructive action unless ``yes`` is True."""
+    if yes:
+        return
+    if not typer.confirm(f"Permanently {verb} {description}?"):
+        raise typer.Abort()
+
+
+def run_cli_command(
+    ctx: typer.Context,
+    json_out: bool,
+    coro_factory: Callable[[PipefyClient], Awaitable[Any]],
+    *,
+    exit_code_2_on_value_error: bool = False,
+) -> None:
+    """Run an async coroutine factory with a configured client and render the result.
+
+    Args:
+        ctx: Typer context (resolves settings/token from the root app).
+        json_out: When True, print JSON; otherwise Rich rendering.
+        coro_factory: Async callable receiving ``PipefyClient``.
+        exit_code_2_on_value_error: Map ``ValueError`` to process exit code 2 (stderr).
+    """
+    pipefy_settings, token = settings_and_token(ctx)
+
+    async def _run() -> Any:
+        client = get_authenticated_client(pipefy_settings, bearer_token=token)
+        return await coro_factory(client)
+
+    try:
+        data = asyncio.run(_run())
+    except PipefyError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(1) from exc
+    except ValueError as exc:
+        if exit_code_2_on_value_error:
+            typer.echo(str(exc), err=True)
+            raise typer.Exit(2) from exc
+        raise
+
+    if json_out:
+        render_json(data)
+    else:
+        render_rich(data)

--- a/packages/cli/src/pipefy_cli/commands/card.py
+++ b/packages/cli/src/pipefy_cli/commands/card.py
@@ -2,15 +2,84 @@
 
 from __future__ import annotations
 
-import asyncio
+from typing import Any
 
 import typer
-from pipefy_sdk.exceptions import PipefyError
+from pipefy_sdk import (
+    CardSearch,
+    CommentInput,
+    DeleteCommentInput,
+    PipefyClient,
+    UpdateCommentInput,
+    copy_card_search,
+)
+from pydantic import ValidationError
 
-from pipefy_cli.auth import get_authenticated_client
-from pipefy_cli.output import render_json, render_rich
+from pipefy_cli.commands._common import (
+    confirm_destructive,
+    parse_json_value,
+    run_cli_command,
+)
 
 card_app = typer.Typer(help="Card operations.", no_args_is_help=True)
+comment_app = typer.Typer(help="Card comments.", no_args_is_help=True)
+
+
+def _parse_card_search_json(raw: str | None) -> CardSearch | None:
+    """Parse ``--search`` into a ``CardSearch`` (unknown keys dropped, MCP-aligned)."""
+    if raw is None or raw.strip() == "":
+        return None
+    parsed = parse_json_value(raw, "--search")
+    if not isinstance(parsed, dict):
+        raise typer.BadParameter("--search must be a JSON object")
+    return copy_card_search(parsed)
+
+
+_CARDS_FIRST_MIN = 1
+_CARDS_FIRST_MAX = 500
+
+
+def _validate_cards_page_size(first: int | None) -> int | None:
+    if first is None:
+        return None
+    if first < _CARDS_FIRST_MIN or first > _CARDS_FIRST_MAX:
+        raise typer.BadParameter(
+            f"--first must be between {_CARDS_FIRST_MIN} and {_CARDS_FIRST_MAX} (inclusive)."
+        )
+    return first
+
+
+def _parse_fields_json(raw: str | None) -> dict[str, Any] | list[dict[str, Any]] | None:
+    if raw is None or raw.strip() == "":
+        return None
+    parsed = parse_json_value(raw, "--fields")
+    if isinstance(parsed, dict | list):
+        return parsed
+    raise typer.BadParameter("--fields must be a JSON object or array")
+
+
+def _parse_field_updates_json(raw: str | None) -> list[dict[str, Any]] | None:
+    if raw is None or raw.strip() == "":
+        return None
+    parsed = parse_json_value(raw, "--field-updates")
+    if not isinstance(parsed, list):
+        raise typer.BadParameter("--field-updates must be a JSON array")
+    return parsed
+
+
+def _split_csv_ids(raw: str | None) -> list[str | int] | None:
+    if raw is None or not raw.strip():
+        return None
+    parts = [p.strip() for p in raw.split(",") if p.strip()]
+    if not parts:
+        return None
+    out: list[str | int] = []
+    for p in parts:
+        if p.isdigit():
+            out.append(int(p))
+        else:
+            out.append(p)
+    return out
 
 
 @card_app.command("get")
@@ -23,24 +92,320 @@ def card_get(
         "-j",
         help="Print machine-readable JSON to stdout.",
     ),
+    include_fields: bool = typer.Option(
+        False,
+        "--include-fields",
+        help="Include custom field name/value pairs on the card.",
+    ),
 ) -> None:
     """Fetch a card by id."""
-    root = ctx.find_root()
-    obj = root.obj
-    pipefy_settings = obj["pipefy_settings"]
-    token: str | None = obj.get("token")
 
-    async def _run():
-        client = get_authenticated_client(pipefy_settings, bearer_token=token)
-        return await client.get_card(card_id)
+    async def factory(client: PipefyClient):
+        return await client.get_card(card_id, include_fields=include_fields)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@card_app.command("list")
+def card_list(
+    ctx: typer.Context,
+    pipe_id: str = typer.Option(..., "--pipe", help="Pipe id whose cards to load."),
+    title: str | None = typer.Option(
+        None,
+        "--title",
+        "-t",
+        help="Filter by title substring (merged into search; same shortcut as MCP get_cards).",
+    ),
+    search_json: str | None = typer.Option(
+        None,
+        "--search",
+        help="Optional JSON object: CardSearch keys (title, assignee_ids, label_ids, ignore_ids, include_done, inbox_emails_read). Unknown keys are ignored.",
+    ),
+    include_fields: bool = typer.Option(
+        False,
+        "--include-fields",
+        help="Include each card's custom fields (name, value).",
+    ),
+    first: int | None = typer.Option(
+        None,
+        "--first",
+        help=f"Max cards per page ({_CARDS_FIRST_MIN}-{_CARDS_FIRST_MAX}).",
+    ),
+    after: str | None = typer.Option(
+        None,
+        "--after",
+        help="Pagination cursor (pageInfo.endCursor from a previous page).",
+    ),
+    json_out: bool = typer.Option(
+        False,
+        "--json",
+        "-j",
+        help="Print machine-readable JSON to stdout.",
+    ),
+) -> None:
+    """List cards in a pipe (get_cards): browse, filter, and paginate.
+
+    Use ``card find`` when matching a single custom field value (find_cards).
+    """
+
+    search_from_json = _parse_card_search_json(search_json)
+    merged: CardSearch = dict(search_from_json) if search_from_json is not None else {}
+    if title is not None and title.strip():
+        merged["title"] = title.strip()
+    effective_search: CardSearch | None = merged if merged else None
+    first_validated = _validate_cards_page_size(first)
+
+    async def factory(client: PipefyClient):
+        return await client.get_cards(
+            pipe_id,
+            effective_search,
+            include_fields=include_fields,
+            first=first_validated,
+            after=after,
+        )
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@card_app.command("find")
+def card_find(
+    ctx: typer.Context,
+    pipe_id: str = typer.Option(..., "--pipe", help="Pipe id to search in."),
+    field_id: str = typer.Option(
+        ...,
+        "--field",
+        help="Field id (slug) from start form or phase fields.",
+    ),
+    field_value: str = typer.Option(
+        ...,
+        "--value",
+        help="Value to match for that field.",
+    ),
+    include_fields: bool = typer.Option(
+        False,
+        "--include-fields",
+        help="Include each card's custom fields.",
+    ),
+    first: int | None = typer.Option(
+        None,
+        "--first",
+        help="Max cards per page.",
+    ),
+    after: str | None = typer.Option(
+        None,
+        "--after",
+        help="Pagination cursor (pageInfo.endCursor).",
+    ),
+    json_out: bool = typer.Option(
+        False,
+        "--json",
+        "-j",
+        help="Print machine-readable JSON to stdout.",
+    ),
+) -> None:
+    """Find cards in a pipe where a custom field equals a value."""
+
+    async def factory(client: PipefyClient):
+        return await client.find_cards(
+            pipe_id,
+            field_id,
+            field_value,
+            include_fields=include_fields,
+            first=first,
+            after=after,
+        )
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@card_app.command("create")
+def card_create(
+    ctx: typer.Context,
+    pipe_id: str,
+    title: str | None = typer.Option(
+        None,
+        "--title",
+        "-t",
+        help="Optional title (applied via update after create).",
+    ),
+    fields_json: str | None = typer.Option(
+        None,
+        "--fields",
+        help="JSON object or array: start-form field values for createCard.",
+    ),
+    json_out: bool = typer.Option(
+        False,
+        "--json",
+        "-j",
+        help="Print machine-readable JSON to stdout.",
+    ),
+) -> None:
+    """Create a card in a pipe (start-form fields via --fields JSON when required)."""
+
+    fields = _parse_fields_json(fields_json)
+
+    async def factory(client: PipefyClient):
+        payload = fields if fields is not None else {}
+        result = await client.create_card(pipe_id, payload)
+        card_node = (result.get("createCard") or {}).get("card") or {}
+        cid = card_node.get("id")
+        if title and cid:
+            await client.update_card(str(cid), title=title)
+            card_node["title"] = title
+        return result
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@card_app.command("update")
+def card_update(
+    ctx: typer.Context,
+    card_id: str,
+    title: str | None = typer.Option(None, "--title", "-t"),
+    due_date: str | None = typer.Option(None, "--due-date"),
+    assignee_ids: str | None = typer.Option(
+        None,
+        "--assignee-ids",
+        help="Comma-separated assignee user ids.",
+    ),
+    label_ids: str | None = typer.Option(
+        None,
+        "--label-ids",
+        help="Comma-separated label ids.",
+    ),
+    field_updates_json: str | None = typer.Option(
+        None,
+        "--field-updates",
+        help="JSON array of field update objects for updateCard.",
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Update a card (title, assignees, labels, due date, and/or field updates)."""
+
+    field_updates = _parse_field_updates_json(field_updates_json)
+
+    async def factory(client: PipefyClient):
+        return await client.update_card(
+            card_id,
+            title=title,
+            assignee_ids=_split_csv_ids(assignee_ids),
+            label_ids=_split_csv_ids(label_ids),
+            due_date=due_date,
+            field_updates=field_updates,
+        )
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@card_app.command("delete")
+def card_delete(
+    ctx: typer.Context,
+    card_id: str,
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip confirmation prompt.",
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Delete a card permanently."""
+
+    confirm_destructive(yes=yes, description=f"card {card_id}")
+
+    async def factory(client: PipefyClient):
+        return await client.delete_card(card_id)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@card_app.command("move")
+def card_move(
+    ctx: typer.Context,
+    card_id: str,
+    phase_id: str = typer.Option(
+        ...,
+        "--phase",
+        help="Destination phase id.",
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Move a card to another phase."""
+
+    async def factory(client: PipefyClient):
+        return await client.move_card_to_phase(card_id, phase_id)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@comment_app.command("add")
+def card_comment_add(
+    ctx: typer.Context,
+    card_id: str,
+    text: str = typer.Argument(..., help="Comment body (1-1000 characters)."),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Add a text comment to a card."""
 
     try:
-        data = asyncio.run(_run())
-    except PipefyError as exc:
+        validated = CommentInput(card_id=card_id, text=text)
+    except ValidationError as exc:
         typer.echo(str(exc), err=True)
-        raise typer.Exit(1) from exc
+        raise typer.Exit(2) from exc
 
-    if json_out:
-        render_json(data)
-    else:
-        render_rich(data)
+    async def factory(client: PipefyClient):
+        return await client.add_card_comment(validated.card_id, validated.text)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@comment_app.command("update")
+def card_comment_update(
+    ctx: typer.Context,
+    comment_id: str,
+    text: str = typer.Argument(..., help="New comment text."),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Update an existing comment by id."""
+
+    try:
+        validated = UpdateCommentInput(comment_id=comment_id, text=text)
+    except ValidationError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(2) from exc
+
+    async def factory(client: PipefyClient):
+        return await client.update_comment(validated.comment_id, validated.text)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@comment_app.command("delete")
+def card_comment_delete(
+    ctx: typer.Context,
+    comment_id: str,
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip confirmation prompt.",
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Delete a comment by id."""
+
+    try:
+        validated = DeleteCommentInput(comment_id=comment_id)
+    except ValidationError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(2) from exc
+
+    confirm_destructive(yes=yes, description=f"comment {validated.comment_id}")
+
+    async def factory(client: PipefyClient):
+        return await client.delete_comment(validated.comment_id)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+card_app.add_typer(comment_app, name="comment")

--- a/packages/cli/src/pipefy_cli/commands/field.py
+++ b/packages/cli/src/pipefy_cli/commands/field.py
@@ -1,0 +1,111 @@
+"""Phase field subcommands."""
+
+from __future__ import annotations
+
+import typer
+from pipefy_sdk import PipefyClient
+
+from pipefy_cli.commands._common import (
+    confirm_destructive,
+    parse_json_object,
+    run_cli_command,
+)
+
+field_app = typer.Typer(help="Phase field operations.", no_args_is_help=True)
+
+
+@field_app.command("list")
+def field_list(
+    ctx: typer.Context,
+    phase_id: str = typer.Option(..., "--phase", help="Phase id."),
+    required_only: bool = typer.Option(
+        False,
+        "--required-only",
+        help="Return only required fields.",
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """List fields on a phase (``get_phase_fields``)."""
+
+    async def factory(client: PipefyClient):
+        return await client.get_phase_fields(phase_id, required_only=required_only)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@field_app.command("create")
+def field_create(
+    ctx: typer.Context,
+    phase_id: str = typer.Option(..., "--phase", help="Phase id."),
+    label: str = typer.Option(..., "--label", "-l", help="Field label in the UI."),
+    field_type: str = typer.Option(
+        ...,
+        "--type",
+        "-t",
+        help="Pipefy field type (e.g. short_text, number).",
+    ),
+    extra_json: str | None = typer.Option(
+        None,
+        "--extra",
+        help="JSON object of extra CreatePhaseFieldInput fields.",
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Create a field on a phase."""
+
+    extra = parse_json_object(extra_json, "--extra") or {}
+    lab = label.strip()
+    ft = field_type.strip()
+    if not lab or not ft:
+        typer.echo("--label and --type must be non-empty.", err=True)
+        raise typer.Exit(2)
+
+    async def factory(client: PipefyClient):
+        return await client.create_phase_field(phase_id, lab, ft, **extra)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@field_app.command("update")
+def field_update(
+    ctx: typer.Context,
+    field_id: str,
+    extra_json: str | None = typer.Option(
+        None,
+        "--extra",
+        help="JSON object of UpdatePhaseFieldInput fields (snake_case / API keys).",
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Update a phase field (pass attributes via ``--extra`` JSON)."""
+
+    extra = parse_json_object(extra_json, "--extra")
+    if not extra:
+        raise typer.BadParameter("Provide --extra with a non-empty JSON object.")
+
+    async def factory(client: PipefyClient):
+        return await client.update_phase_field(field_id, **extra)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@field_app.command("delete")
+def field_delete(
+    ctx: typer.Context,
+    field_id: str,
+    pipe_uuid: str | None = typer.Option(
+        None,
+        "--pipe-uuid",
+        help="Optional pipe UUID (passed through to the API when required).",
+    ),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Delete a phase field permanently."""
+
+    confirm_destructive(yes=yes, description=f"phase field {field_id}")
+
+    async def factory(client: PipefyClient):
+        return await client.delete_phase_field(field_id, pipe_uuid=pipe_uuid)
+
+    run_cli_command(ctx, json_out, factory)

--- a/packages/cli/src/pipefy_cli/commands/label.py
+++ b/packages/cli/src/pipefy_cli/commands/label.py
@@ -1,0 +1,102 @@
+"""Pipe label subcommands."""
+
+from __future__ import annotations
+
+import typer
+from pipefy_sdk import PipefyClient
+
+from pipefy_cli.commands._common import confirm_destructive, run_cli_command
+
+label_app = typer.Typer(help="Pipe label operations.", no_args_is_help=True)
+
+
+@label_app.command("list")
+def label_list(
+    ctx: typer.Context,
+    pipe_id: str = typer.Option(..., "--pipe", help="Pipe id."),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """List labels on a pipe (from ``get_pipe``); JSON shape matches MCP ``get_labels``."""
+
+    async def factory(client: PipefyClient):
+        raw = await client.get_pipe(pipe_id)
+        pipe_node = (raw or {}).get("pipe")
+        if pipe_node is None:
+            return {"success": False, "error": "Pipe not found or access denied."}
+        labels = pipe_node.get("labels")
+        if labels is None:
+            labels = []
+        return {
+            "success": True,
+            "message": "Labels loaded.",
+            "labels": labels,
+        }
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@label_app.command("create")
+def label_create(
+    ctx: typer.Context,
+    pipe_id: str = typer.Option(..., "--pipe", help="Pipe id."),
+    name: str = typer.Option(..., "--name", "-n", help="Label name."),
+    color: str = typer.Option(
+        ..., "--color", "-c", help="Label color (per Pipefy API)."
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Create a label on a pipe."""
+
+    nm = name.strip()
+    col = color.strip()
+    if not nm or not col:
+        typer.echo("--name and --color must be non-empty.", err=True)
+        raise typer.Exit(2)
+
+    async def factory(client: PipefyClient):
+        return await client.create_label(pipe_id, nm, col)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@label_app.command("update")
+def label_update(
+    ctx: typer.Context,
+    label_id: str,
+    name: str = typer.Option(
+        ..., "--name", "-n", help="New label name (required by API)."
+    ),
+    color: str = typer.Option(
+        ..., "--color", "-c", help="New label color (required by API)."
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Update a label (name and color are both required by Pipefy)."""
+
+    nm = name.strip()
+    col = color.strip()
+    if not nm or not col:
+        typer.echo("--name and --color must be non-empty.", err=True)
+        raise typer.Exit(2)
+
+    async def factory(client: PipefyClient):
+        return await client.update_label(label_id, name=nm, color=col)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@label_app.command("delete")
+def label_delete(
+    ctx: typer.Context,
+    label_id: str,
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Delete a label permanently."""
+
+    confirm_destructive(yes=yes, description=f"label {label_id}")
+
+    async def factory(client: PipefyClient):
+        return await client.delete_label(label_id)
+
+    run_cli_command(ctx, json_out, factory)

--- a/packages/cli/src/pipefy_cli/commands/member.py
+++ b/packages/cli/src/pipefy_cli/commands/member.py
@@ -1,0 +1,141 @@
+"""Pipe member subcommands."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import typer
+from pipefy_sdk import (
+    PipefyClient,
+    format_service_account_removal_block_message,
+    service_account_removal_blocked_user_ids,
+)
+
+from pipefy_cli.commands._common import (
+    confirm_destructive,
+    run_cli_command,
+    settings_and_token,
+)
+
+member_app = typer.Typer(help="Pipe member operations.", no_args_is_help=True)
+
+
+def _parse_members_json(raw: str) -> list[dict[str, Any]]:
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise typer.BadParameter(f"Invalid JSON for --members: {exc}") from exc
+    if not isinstance(parsed, list) or not parsed:
+        raise typer.BadParameter("--members must be a non-empty JSON array of objects.")
+    for i, item in enumerate(parsed):
+        if not isinstance(item, dict):
+            raise typer.BadParameter(f"--members[{i}] must be an object.")
+        if "email" not in item or "role_name" not in item:
+            raise typer.BadParameter(
+                f"--members[{i}] must include 'email' and 'role_name'."
+            )
+    return parsed
+
+
+def _parse_user_ids(raw: str) -> list[str]:
+    parts = [p.strip() for p in raw.replace(",", " ").split() if p.strip()]
+    if not parts:
+        raise typer.BadParameter(
+            "Provide at least one user id (comma-separated or space-separated)."
+        )
+    return parts
+
+
+@member_app.command("list")
+def member_list(
+    ctx: typer.Context,
+    pipe_id: str = typer.Option(..., "--pipe", help="Pipe id."),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """List members of a pipe."""
+
+    async def factory(client: PipefyClient):
+        return await client.get_pipe_members(pipe_id)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@member_app.command("invite")
+def member_invite(
+    ctx: typer.Context,
+    pipe_id: str = typer.Option(..., "--pipe", help="Pipe id."),
+    members_json: str = typer.Option(
+        ...,
+        "--members",
+        help='JSON array: [{"email":"a@b.com","role_name":"admin"}, ...].',
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Invite users to a pipe."""
+
+    members = _parse_members_json(members_json)
+
+    async def factory(client: PipefyClient):
+        return await client.invite_members(pipe_id, members)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@member_app.command("remove")
+def member_remove(
+    ctx: typer.Context,
+    pipe_id: str = typer.Option(..., "--pipe", help="Pipe id."),
+    user_ids: str = typer.Option(
+        ...,
+        "--user-ids",
+        help="Comma-separated Pipefy user ids or UUIDs to remove from the pipe.",
+    ),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Remove users from a pipe (same service-account guard as MCP when env is set)."""
+
+    pipefy_settings, _token = settings_and_token(ctx)
+    ids = _parse_user_ids(user_ids)
+    blocked = service_account_removal_blocked_user_ids(
+        ids, pipefy_settings.service_account_ids
+    )
+    if blocked:
+        typer.echo(
+            format_service_account_removal_block_message(blocked),
+            err=True,
+        )
+        raise typer.Exit(2)
+
+    confirm_destructive(
+        yes=yes, verb="remove", description=f"{len(ids)} member(s) from pipe {pipe_id}"
+    )
+
+    async def factory(client: PipefyClient):
+        return await client.remove_members_from_pipe(pipe_id, ids)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@member_app.command("set-role")
+def member_set_role(
+    ctx: typer.Context,
+    pipe_id: str = typer.Option(..., "--pipe", help="Pipe id."),
+    member_id: str = typer.Option(..., "--member", help="Member user id."),
+    role_name: str = typer.Option(
+        ..., "--role", help="Role name (e.g. member, admin)."
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Set a member's role on a pipe."""
+
+    rn = role_name.strip()
+    if not rn:
+        typer.echo("--role must be non-empty.", err=True)
+        raise typer.Exit(2)
+
+    async def factory(client: PipefyClient):
+        return await client.set_role(pipe_id, member_id, rn)
+
+    run_cli_command(ctx, json_out, factory)

--- a/packages/cli/src/pipefy_cli/commands/phase.py
+++ b/packages/cli/src/pipefy_cli/commands/phase.py
@@ -1,0 +1,161 @@
+"""Phase subcommands."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import typer
+from pipefy_sdk import PipefyClient
+
+from pipefy_cli.commands._common import (
+    confirm_destructive,
+    parse_json_object,
+    run_cli_command,
+)
+
+phase_app = typer.Typer(help="Pipe phase operations.", no_args_is_help=True)
+
+
+@phase_app.command("get")
+def phase_get(
+    ctx: typer.Context,
+    phase_id: str,
+    json_out: bool = typer.Option(
+        False,
+        "--json",
+        "-j",
+        help="Print machine-readable JSON to stdout.",
+    ),
+    required_only: bool = typer.Option(
+        False,
+        "--required-only",
+        help="Return only required fields (same query as MCP get_phase_fields).",
+    ),
+) -> None:
+    """Load phase metadata and fields by id (via ``get_phase_fields``)."""
+
+    async def factory(client: PipefyClient):
+        return await client.get_phase_fields(phase_id, required_only=required_only)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@phase_app.command("create")
+def phase_create(
+    ctx: typer.Context,
+    pipe_id: str = typer.Option(
+        ..., "--pipe", help="Pipe id that will contain the phase."
+    ),
+    name: str = typer.Option(..., "--name", "-n", help="Phase display name."),
+    done: bool = typer.Option(False, "--done", help="Mark as a final/done phase."),
+    index: float | None = typer.Option(
+        None,
+        "--index",
+        help="Optional position index within the pipe.",
+    ),
+    description: str | None = typer.Option(None, "--description", "-d"),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Create a phase in a pipe."""
+
+    stripped = name.strip()
+    if not stripped:
+        typer.echo("Phase name must be non-empty.", err=True)
+        raise typer.Exit(2)
+
+    async def factory(client: PipefyClient):
+        return await client.create_phase(
+            pipe_id,
+            stripped,
+            done=done,
+            index=index,
+            description=description,
+        )
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@phase_app.command("update")
+def phase_update(
+    ctx: typer.Context,
+    phase_id: str,
+    name: str | None = typer.Option(None, "--name", "-n"),
+    description: str | None = typer.Option(None, "--description", "-d"),
+    done: bool | None = typer.Option(
+        None,
+        "--done/--no-done",
+        help="Set or clear the final-phase flag.",
+    ),
+    color: str | None = typer.Option(None, "--color"),
+    lateness_time: int | None = typer.Option(None, "--lateness-time"),
+    can_receive_from_draft: bool | None = typer.Option(
+        None,
+        "--can-receive-from-draft/--no-can-receive-from-draft",
+    ),
+    extra_json: str | None = typer.Option(
+        None,
+        "--extra",
+        help="JSON object merged into UpdatePhaseInput (snake_case keys).",
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Update a phase (Pipefy ``UpdatePhaseInput``). Resolves current name when omitted."""
+
+    extra = parse_json_object(extra_json, "--extra")
+    update_attrs: dict[str, Any] = {}
+    if name is not None:
+        update_attrs["name"] = name
+    if description is not None:
+        update_attrs["description"] = description
+    if done is not None:
+        update_attrs["done"] = done
+    if color is not None:
+        update_attrs["color"] = color
+    if lateness_time is not None:
+        update_attrs["lateness_time"] = lateness_time
+    if can_receive_from_draft is not None:
+        update_attrs["can_receive_card_directly_from_draft"] = can_receive_from_draft
+    if extra:
+        update_attrs.update(extra)
+    if not update_attrs:
+        typer.echo(
+            "Provide at least one of: --name, --description, --done, --color, "
+            "--lateness-time, --can-receive-from-draft, --extra.",
+            err=True,
+        )
+        raise typer.Exit(2)
+
+    async def factory(client: PipefyClient):
+        if "name" not in update_attrs:
+            phase_info = await client.get_phase_fields(phase_id)
+            current = phase_info.get("phase_name")
+            if not current:
+                raise typer.BadParameter(
+                    f"Phase {phase_id} not found or has no name; pass --name explicitly."
+                )
+            update_attrs["name"] = current
+        return await client.update_phase(phase_id, **update_attrs)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@phase_app.command("delete")
+def phase_delete(
+    ctx: typer.Context,
+    phase_id: str,
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip confirmation prompt.",
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Delete a phase permanently."""
+
+    confirm_destructive(yes=yes, description=f"phase {phase_id}")
+
+    async def factory(client: PipefyClient):
+        return await client.delete_phase(phase_id)
+
+    run_cli_command(ctx, json_out, factory)

--- a/packages/cli/src/pipefy_cli/commands/pipe.py
+++ b/packages/cli/src/pipefy_cli/commands/pipe.py
@@ -1,0 +1,166 @@
+"""Pipe subcommands."""
+
+from __future__ import annotations
+
+import typer
+from pipefy_sdk import PipefyClient
+
+from pipefy_cli.commands._common import (
+    confirm_destructive,
+    parse_json_object,
+    run_cli_command,
+)
+
+pipe_app = typer.Typer(help="Pipe operations.", no_args_is_help=True)
+
+
+@pipe_app.command("get")
+def pipe_get(
+    ctx: typer.Context,
+    pipe_id: str,
+    json_out: bool = typer.Option(
+        False,
+        "--json",
+        "-j",
+        help="Print machine-readable JSON to stdout.",
+    ),
+) -> None:
+    """Load a pipe by id (phases, labels, start form)."""
+
+    async def factory(client: PipefyClient):
+        return await client.get_pipe(pipe_id)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@pipe_app.command("list")
+def pipe_list(
+    ctx: typer.Context,
+    name: str | None = typer.Option(
+        None,
+        "--name",
+        "-n",
+        help="Optional pipe name filter (fuzzy match server-side).",
+    ),
+    max_per_org: int = typer.Option(
+        500,
+        "--max-per-org",
+        min=1,
+        max=500,
+        help="Maximum pipes returned per organization (1-500).",
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Search pipes across organizations (same as MCP ``search_pipes``)."""
+
+    async def factory(client: PipefyClient):
+        return await client.search_pipes(name, max_pipes_per_org=max_per_org)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@pipe_app.command("create")
+def pipe_create(
+    ctx: typer.Context,
+    name: str = typer.Argument(..., help="Display name for the new pipe."),
+    org_id: str = typer.Option(
+        ...,
+        "--org",
+        help="Organization id that will own the pipe.",
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Create an empty pipe in an organization."""
+
+    stripped = name.strip()
+    if not stripped:
+        typer.echo("Pipe name must be non-empty.", err=True)
+        raise typer.Exit(2)
+
+    async def factory(client: PipefyClient):
+        return await client.create_pipe(stripped, org_id)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@pipe_app.command("update")
+def pipe_update(
+    ctx: typer.Context,
+    pipe_id: str,
+    name: str | None = typer.Option(None, "--name"),
+    icon: str | None = typer.Option(None, "--icon"),
+    color: str | None = typer.Option(None, "--color"),
+    preferences_json: str | None = typer.Option(
+        None,
+        "--preferences",
+        help="JSON object for pipe preferences (UpdatePipeInput).",
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Update pipe settings (pass at least one attribute)."""
+
+    preferences = parse_json_object(preferences_json, "--preferences")
+    if preferences == {}:
+        preferences = None
+    if all(x is None for x in (name, icon, color, preferences)):
+        raise typer.BadParameter(
+            "Provide at least one of: --name, --icon, --color, --preferences (non-empty)."
+        )
+
+    async def factory(client: PipefyClient):
+        return await client.update_pipe(
+            pipe_id,
+            name=name,
+            icon=icon,
+            color=color,
+            preferences=preferences,
+        )
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@pipe_app.command("delete")
+def pipe_delete(
+    ctx: typer.Context,
+    pipe_id: str,
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip confirmation prompt.",
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Delete a pipe permanently."""
+
+    confirm_destructive(yes=yes, description=f"pipe {pipe_id}")
+
+    async def factory(client: PipefyClient):
+        return await client.delete_pipe(pipe_id)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@pipe_app.command("clone")
+def pipe_clone(
+    ctx: typer.Context,
+    template_pipe_id: str = typer.Argument(
+        ...,
+        help="Source pipe id to use as template.",
+    ),
+    org_id: str | None = typer.Option(
+        None,
+        "--org",
+        help="Optional organization id for the cloned pipe.",
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Clone a pipe from a template pipe id."""
+
+    async def factory(client: PipefyClient):
+        return await client.clone_pipe(
+            template_pipe_id,
+            organization_id=org_id,
+        )
+
+    run_cli_command(ctx, json_out, factory)

--- a/packages/cli/src/pipefy_cli/commands/record.py
+++ b/packages/cli/src/pipefy_cli/commands/record.py
@@ -1,0 +1,217 @@
+"""Database table record subcommands."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import typer
+from pipefy_sdk import (
+    UPDATE_TABLE_RECORD_ALLOWED_FIELD_KEYS,
+    UPDATE_TABLE_RECORD_FIELDS_ERROR_MESSAGE,
+    PipefyClient,
+)
+
+from pipefy_cli.commands._common import (
+    confirm_destructive,
+    parse_json_object,
+    parse_json_value,
+    run_cli_command,
+)
+
+record_app = typer.Typer(help="Table record operations.", no_args_is_help=True)
+
+_TABLE_RECORDS_FIRST_MAX = 200
+
+
+def _parse_fields_json(raw: str | None) -> dict[str, Any] | list[dict[str, Any]] | None:
+    if raw is None or raw.strip() == "":
+        return None
+    parsed = parse_json_value(raw, "--fields")
+    if isinstance(parsed, dict | list):
+        return parsed
+    raise typer.BadParameter("--fields must be a JSON object or array")
+
+
+@record_app.command("find")
+def record_find(
+    ctx: typer.Context,
+    table_id: str = typer.Option(..., "--table", help="Database table id."),
+    filter_json: str | None = typer.Option(
+        None,
+        "--filter",
+        help=(
+            'JSON object: either {"field_id":"...","field_value":"..."} for findRecords, '
+            "or omit field_id/field_value to page all records (get_table_records)."
+        ),
+    ),
+    first: int | None = typer.Option(
+        None,
+        "--first",
+        help="Page size (1-200 for listing; optional for field search).",
+    ),
+    after: str | None = typer.Option(None, "--after", help="Pagination cursor."),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Find records: field match (``find_records``) or list page (``get_table_records``)."""
+
+    filt = parse_json_object(filter_json, "--filter") if filter_json else {}
+    has_field_id = "field_id" in filt
+    has_field_value = "field_value" in filt
+    if has_field_id != has_field_value:
+        raise typer.BadParameter(
+            "--filter must include both 'field_id' and 'field_value' as strings, or neither."
+        )
+    if has_field_id:
+        fid = filt["field_id"]
+        fval = filt["field_value"]
+        if not (isinstance(fid, str) and isinstance(fval, str)):
+            raise typer.BadParameter(
+                "filter.field_id and filter.field_value must be strings."
+            )
+        nfirst = first
+        if nfirst is not None and (nfirst < 1 or nfirst > _TABLE_RECORDS_FIRST_MAX):
+            raise typer.BadParameter(
+                f"--first must be between 1 and {_TABLE_RECORDS_FIRST_MAX}."
+            )
+
+        async def factory(client: PipefyClient):
+            return await client.find_records(
+                table_id,
+                fid.strip(),
+                fval,
+                first=nfirst,
+                after=after,
+            )
+
+        run_cli_command(ctx, json_out, factory)
+        return
+
+    nfirst = first if first is not None else 50
+    if nfirst < 1 or nfirst > _TABLE_RECORDS_FIRST_MAX:
+        raise typer.BadParameter(
+            f"--first must be between 1 and {_TABLE_RECORDS_FIRST_MAX} (default 50)."
+        )
+
+    async def factory(client: PipefyClient):
+        return await client.get_table_records(table_id, first=nfirst, after=after)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@record_app.command("get")
+def record_get(
+    ctx: typer.Context,
+    record_id: str,
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Load one table record by id."""
+
+    async def factory(client: PipefyClient):
+        return await client.get_table_record(record_id)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@record_app.command("create")
+def record_create(
+    ctx: typer.Context,
+    table_id: str = typer.Option(..., "--table", help="Database table id."),
+    fields_json: str | None = typer.Option(
+        None,
+        "--fields",
+        help="JSON object or array of field values for the new record.",
+    ),
+    title: str | None = typer.Option(None, "--title", "-t"),
+    extra_json: str | None = typer.Option(
+        None,
+        "--extra",
+        help="JSON object of extra CreateTableRecordInput keys.",
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Create a table record."""
+
+    fields = _parse_fields_json(fields_json)
+    extra = parse_json_object(extra_json, "--extra") or {}
+    payload = fields if fields is not None else {}
+    merged: dict[str, Any] = {**extra}
+    if title is not None:
+        merged["title"] = title
+
+    async def factory(client: PipefyClient):
+        return await client.create_table_record(table_id, payload, **merged)
+
+    run_cli_command(ctx, json_out, factory, exit_code_2_on_value_error=True)
+
+
+@record_app.command("update")
+def record_update(
+    ctx: typer.Context,
+    record_id: str,
+    fields_json: str | None = typer.Option(
+        None,
+        "--fields",
+        help="JSON object: title, due_date, status_id or statusId (update_table_record).",
+    ),
+    field_id: str | None = typer.Option(
+        None,
+        "--field-id",
+        help="When set with --value, calls set_table_record_field_value instead.",
+    ),
+    value_json: str | None = typer.Option(
+        None,
+        "--value",
+        help="JSON value for --field-id (string, number, array, or object).",
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Update record core fields or one custom field."""
+
+    if field_id is not None:
+        if not field_id.strip():
+            raise typer.BadParameter("--field-id must be non-empty when provided.")
+        if value_json is None:
+            raise typer.BadParameter("Provide --value JSON when using --field-id.")
+        parsed_val = parse_json_value(value_json, "--value")
+
+        async def factory_set(client: PipefyClient):
+            return await client.set_table_record_field_value(
+                record_id, field_id.strip(), parsed_val
+            )
+
+        run_cli_command(ctx, json_out, factory_set, exit_code_2_on_value_error=True)
+        return
+
+    fields = parse_json_object(fields_json, "--fields")
+    if not fields:
+        raise typer.BadParameter(
+            "Provide --fields for title/due_date/status or --field-id and --value."
+        )
+    if not any(
+        key in UPDATE_TABLE_RECORD_ALLOWED_FIELD_KEYS and value is not None
+        for key, value in fields.items()
+    ):
+        typer.echo(UPDATE_TABLE_RECORD_FIELDS_ERROR_MESSAGE, err=True)
+        raise typer.Exit(2)
+
+    async def factory(client: PipefyClient):
+        return await client.update_table_record(record_id, fields)
+
+    run_cli_command(ctx, json_out, factory, exit_code_2_on_value_error=True)
+
+
+@record_app.command("delete")
+def record_delete(
+    ctx: typer.Context,
+    record_id: str,
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Delete a table record permanently."""
+
+    confirm_destructive(yes=yes, description=f"table record {record_id}")
+
+    async def factory(client: PipefyClient):
+        return await client.delete_table_record(record_id)
+
+    run_cli_command(ctx, json_out, factory, exit_code_2_on_value_error=True)

--- a/packages/cli/src/pipefy_cli/commands/relation.py
+++ b/packages/cli/src/pipefy_cli/commands/relation.py
@@ -1,0 +1,182 @@
+"""Pipe and card relation subcommands."""
+
+from __future__ import annotations
+
+import typer
+from pipefy_sdk import PipefyClient
+
+from pipefy_cli.commands._common import (
+    authenticated_client_from_ctx,
+    confirm_destructive,
+    parse_json_object,
+    run_cli_command,
+)
+
+relation_app = typer.Typer(help="Pipe and card relations.", no_args_is_help=True)
+relation_pipe_app = typer.Typer(help="Pipe-to-pipe relations.", no_args_is_help=True)
+relation_card_app = typer.Typer(help="Card-to-card relations.", no_args_is_help=True)
+
+
+@relation_pipe_app.command("list")
+def relation_pipe_list(
+    ctx: typer.Context,
+    pipe_id: str,
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """List pipe relations for a pipe."""
+
+    async def factory(client: PipefyClient):
+        return await client.get_pipe_relations(pipe_id)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@relation_pipe_app.command("create")
+def relation_pipe_create(
+    ctx: typer.Context,
+    parent_id: str = typer.Option(..., "--parent", help="Parent pipe id."),
+    child_id: str = typer.Option(..., "--child", help="Child pipe id."),
+    name: str = typer.Option(..., "--name", "-n", help="Relation name."),
+    extra_json: str | None = typer.Option(
+        None,
+        "--extra",
+        help="JSON object merged into CreatePipeRelationInput.",
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Create a pipe relation."""
+
+    nm = name.strip()
+    if not nm:
+        typer.echo("--name must be non-empty.", err=True)
+        raise typer.Exit(2)
+    extra = parse_json_object(extra_json, "--extra")
+
+    async def factory(client: PipefyClient):
+        return await client.create_pipe_relation(
+            parent_id, child_id, nm, extra_input=extra
+        )
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@relation_pipe_app.command("update")
+def relation_pipe_update(
+    ctx: typer.Context,
+    relation_id: str,
+    name: str = typer.Option(..., "--name", "-n", help="New relation name."),
+    extra_json: str | None = typer.Option(
+        None,
+        "--extra",
+        help="JSON object merged into UpdatePipeRelationInput.",
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Update a pipe relation."""
+
+    nm = name.strip()
+    if not nm:
+        typer.echo("--name must be non-empty.", err=True)
+        raise typer.Exit(2)
+    extra = parse_json_object(extra_json, "--extra")
+
+    async def factory(client: PipefyClient):
+        return await client.update_pipe_relation(relation_id, nm, extra_input=extra)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@relation_pipe_app.command("delete")
+def relation_pipe_delete(
+    ctx: typer.Context,
+    relation_id: str,
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Delete a pipe relation permanently."""
+
+    confirm_destructive(yes=yes, description=f"pipe relation {relation_id}")
+
+    async def factory(client: PipefyClient):
+        return await client.delete_pipe_relation(relation_id)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@relation_card_app.command("list")
+def relation_card_list(
+    ctx: typer.Context,
+    card_id: str,
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """List parent and child relations for a card (raw ``get_card_relations`` payload)."""
+
+    async def factory(client: PipefyClient):
+        return await client.get_card_relations(card_id)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@relation_card_app.command("create")
+def relation_card_create(
+    ctx: typer.Context,
+    parent_id: str = typer.Option(..., "--parent", help="Parent card id."),
+    child_id: str = typer.Option(..., "--child", help="Child card id."),
+    source_id: str = typer.Option(
+        ...,
+        "--source",
+        help="Pipe relation id from ``relation pipe list``.",
+    ),
+    extra_json: str | None = typer.Option(
+        None,
+        "--extra",
+        help="JSON object merged into CreateCardRelationInput.",
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Link two cards via an existing pipe relation."""
+
+    extra = parse_json_object(extra_json, "--extra")
+
+    async def factory(client: PipefyClient):
+        return await client.create_card_relation(
+            parent_id, child_id, source_id, extra_input=extra
+        )
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@relation_card_app.command("delete")
+def relation_card_delete(
+    ctx: typer.Context,
+    child_id: str = typer.Option(..., "--child", help="Child card id."),
+    parent_id: str = typer.Option(..., "--parent", help="Parent card id."),
+    source_id: str = typer.Option(..., "--source", help="Pipe relation id."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Remove a card relation (requires OAuth; internal API)."""
+
+    client = authenticated_client_from_ctx(ctx)
+    if not client.internal_api_available:
+        typer.echo(
+            "delete_card_relation requires OAuth credentials "
+            "(PIPEFY_OAUTH_CLIENT, PIPEFY_OAUTH_SECRET, PIPEFY_OAUTH_URL). "
+            "The deleteCardRelation mutation is only available on the internal API.",
+            err=True,
+        )
+        raise typer.Exit(2)
+
+    confirm_destructive(
+        yes=yes,
+        description=f"card relation (child={child_id}, parent={parent_id}, source={source_id})",
+    )
+
+    async def factory(c: PipefyClient):
+        return await c.delete_card_relation(child_id, parent_id, source_id)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+relation_app.add_typer(relation_pipe_app, name="pipe")
+relation_app.add_typer(relation_card_app, name="card")

--- a/packages/cli/src/pipefy_cli/commands/table.py
+++ b/packages/cli/src/pipefy_cli/commands/table.py
@@ -1,0 +1,149 @@
+"""Database table subcommands."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import typer
+from pipefy_sdk import PipefyClient
+
+from pipefy_cli.commands._common import (
+    confirm_destructive,
+    parse_json_object,
+    run_cli_command,
+)
+
+table_app = typer.Typer(help="Database table operations.", no_args_is_help=True)
+
+
+@table_app.command("list")
+def table_list(
+    ctx: typer.Context,
+    ids: str | None = typer.Option(
+        None,
+        "--ids",
+        help="Comma-separated table ids; when set, loads those tables via get_tables.",
+    ),
+    name: str | None = typer.Option(
+        None,
+        "--name",
+        "-n",
+        help="Optional table name filter (ignored when --ids is set).",
+    ),
+    first: int = typer.Option(
+        100,
+        "--first",
+        min=1,
+        max=500,
+        help="Max tables per organization when searching (1-500, default 100).",
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Search tables across organizations, or fetch specific tables by id."""
+
+    id_list: list[str] | None = None
+    if ids is not None and ids.strip():
+        id_list = [p.strip() for p in ids.split(",") if p.strip()]
+        if not id_list:
+            raise typer.BadParameter("--ids must list at least one table id.")
+
+    async def factory(client: PipefyClient):
+        if id_list is not None:
+            return await client.get_tables(id_list)
+        return await client.search_tables(name, first=first)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@table_app.command("get")
+def table_get(
+    ctx: typer.Context,
+    table_id: str,
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Load one table by id."""
+
+    async def factory(client: PipefyClient):
+        return await client.get_table(table_id)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@table_app.command("create")
+def table_create(
+    ctx: typer.Context,
+    name: str = typer.Argument(..., help="Table display name."),
+    org_id: str = typer.Option(
+        ...,
+        "--org",
+        help="Organization id that will own the table.",
+    ),
+    extra_json: str | None = typer.Option(
+        None,
+        "--extra",
+        help="JSON object of extra CreateTableInput fields.",
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Create a database table."""
+
+    stripped = name.strip()
+    if not stripped:
+        typer.echo("Table name must be non-empty.", err=True)
+        raise typer.Exit(2)
+    extra = parse_json_object(extra_json, "--extra") or {}
+
+    async def factory(client: PipefyClient):
+        return await client.create_table(stripped, org_id, **extra)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@table_app.command("update")
+def table_update(
+    ctx: typer.Context,
+    table_id: str,
+    name: str | None = typer.Option(None, "--name"),
+    description: str | None = typer.Option(None, "--description", "-d"),
+    extra_json: str | None = typer.Option(
+        None,
+        "--extra",
+        help="JSON object merged into UpdateTableInput.",
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Update table attributes."""
+
+    extra = parse_json_object(extra_json, "--extra") or {}
+    attrs: dict[str, Any] = {}
+    if name is not None:
+        attrs["name"] = name
+    if description is not None:
+        attrs["description"] = description
+    attrs.update(extra)
+    if not attrs:
+        raise typer.BadParameter(
+            "Provide at least one of: --name, --description, --extra (non-empty)."
+        )
+
+    async def factory(client: PipefyClient):
+        return await client.update_table(table_id, **attrs)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@table_app.command("delete")
+def table_delete(
+    ctx: typer.Context,
+    table_id: str,
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Delete a database table permanently."""
+
+    confirm_destructive(yes=yes, description=f"table {table_id}")
+
+    async def factory(client: PipefyClient):
+        return await client.delete_table(table_id)
+
+    run_cli_command(ctx, json_out, factory)

--- a/packages/cli/src/pipefy_cli/commands/webhook.py
+++ b/packages/cli/src/pipefy_cli/commands/webhook.py
@@ -1,0 +1,139 @@
+"""Webhook subcommands."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import typer
+from pipefy_sdk import PipefyClient
+
+from pipefy_cli.commands._common import (
+    confirm_destructive,
+    parse_json_object,
+    run_cli_command,
+)
+
+webhook_app = typer.Typer(help="Pipe webhook operations.", no_args_is_help=True)
+
+
+def _parse_actions_json(raw: str) -> list[str]:
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise typer.BadParameter(f"Invalid JSON for --actions: {exc}") from exc
+    if not isinstance(parsed, list) or not parsed:
+        raise typer.BadParameter("--actions must be a non-empty JSON array of strings.")
+    out: list[str] = []
+    for item in parsed:
+        if not isinstance(item, str) or not item.strip():
+            raise typer.BadParameter("Each action must be a non-empty string.")
+        out.append(item.strip())
+    return out
+
+
+@webhook_app.command("list")
+def webhook_list(
+    ctx: typer.Context,
+    pipe_id: str = typer.Option(..., "--pipe", help="Pipe id."),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """List webhooks on a pipe."""
+
+    async def factory(client: PipefyClient):
+        return await client.get_webhooks(pipe_id)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@webhook_app.command("create")
+def webhook_create(
+    ctx: typer.Context,
+    pipe_id: str = typer.Option(..., "--pipe", help="Pipe id."),
+    url: str = typer.Option(..., "--url", help="HTTPS callback URL."),
+    actions_json: str = typer.Option(
+        ...,
+        "--actions",
+        help='JSON array of event action strings, e.g. \'["card.create","card.move"]\'.',
+    ),
+    extra_json: str | None = typer.Option(
+        None,
+        "--extra",
+        help="JSON object of extra CreateWebhookInput fields.",
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Create a webhook."""
+
+    actions = _parse_actions_json(actions_json)
+    extra = parse_json_object(extra_json, "--extra") or {}
+    u = url.strip()
+    if not u:
+        typer.echo("--url must be non-empty.", err=True)
+        raise typer.Exit(2)
+
+    async def factory(client: PipefyClient):
+        return await client.create_webhook(pipe_id, u, actions, **extra)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@webhook_app.command("update")
+def webhook_update(
+    ctx: typer.Context,
+    webhook_id: str,
+    name: str | None = typer.Option(None, "--name"),
+    url: str | None = typer.Option(None, "--url"),
+    actions_json: str | None = typer.Option(
+        None,
+        "--actions",
+        help="JSON array of event action strings (non-empty when provided).",
+    ),
+    headers_json: str | None = typer.Option(
+        None,
+        "--headers",
+        help="JSON object of custom HTTP headers.",
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Update a webhook (pass at least one attribute)."""
+
+    kwargs: dict[str, Any] = {}
+    if name is not None:
+        if not name.strip():
+            raise typer.BadParameter("--name, when provided, must be non-empty.")
+        kwargs["name"] = name.strip()
+    if url is not None:
+        if not url.strip():
+            raise typer.BadParameter("--url, when provided, must be non-empty.")
+        kwargs["url"] = url.strip()
+    if actions_json is not None:
+        kwargs["actions"] = _parse_actions_json(actions_json)
+    if headers_json is not None:
+        kwargs["headers"] = parse_json_object(headers_json, "--headers") or {}
+    if not kwargs:
+        raise typer.BadParameter(
+            "Provide at least one of: --name, --url, --actions, --headers."
+        )
+
+    async def factory(client: PipefyClient):
+        return await client.update_webhook(webhook_id, **kwargs)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@webhook_app.command("delete")
+def webhook_delete(
+    ctx: typer.Context,
+    webhook_id: str,
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Delete a webhook permanently."""
+
+    confirm_destructive(yes=yes, description=f"webhook {webhook_id}")
+
+    async def factory(client: PipefyClient):
+        return await client.delete_webhook(webhook_id)
+
+    run_cli_command(ctx, json_out, factory)

--- a/packages/cli/src/pipefy_cli/main.py
+++ b/packages/cli/src/pipefy_cli/main.py
@@ -7,6 +7,15 @@ import os
 import typer
 
 from pipefy_cli.commands.card import card_app
+from pipefy_cli.commands.field import field_app
+from pipefy_cli.commands.label import label_app
+from pipefy_cli.commands.member import member_app
+from pipefy_cli.commands.phase import phase_app
+from pipefy_cli.commands.pipe import pipe_app
+from pipefy_cli.commands.record import record_app
+from pipefy_cli.commands.relation import relation_app
+from pipefy_cli.commands.table import table_app
+from pipefy_cli.commands.webhook import webhook_app
 from pipefy_cli.config import resolve_pipefy_settings
 
 app = typer.Typer(
@@ -53,3 +62,12 @@ def main(
 
 
 app.add_typer(card_app, name="card")
+app.add_typer(pipe_app, name="pipe")
+app.add_typer(phase_app, name="phase")
+app.add_typer(field_app, name="field")
+app.add_typer(table_app, name="table")
+app.add_typer(record_app, name="record")
+app.add_typer(label_app, name="label")
+app.add_typer(webhook_app, name="webhook")
+app.add_typer(relation_app, name="relation")
+app.add_typer(member_app, name="member")

--- a/packages/cli/tests/conftest.py
+++ b/packages/cli/tests/conftest.py
@@ -22,6 +22,25 @@ _PIPEFY_ENV_KEYS = (
 
 
 @pytest.fixture
+def oauth_env(monkeypatch: pytest.MonkeyPatch):
+    """Set minimal OAuth + GraphQL URLs for CLI commands that require OAuth mode."""
+
+    def _set(host: str) -> None:
+        monkeypatch.setenv("PIPEFY_GRAPHQL_URL", f"https://{host}.example.com/graphql")
+        monkeypatch.setenv(
+            "PIPEFY_INTERNAL_API_URL",
+            f"https://{host}.example.com/internal_api",
+        )
+        monkeypatch.setenv(
+            "PIPEFY_OAUTH_URL", f"https://{host}.example.com/oauth/token"
+        )
+        monkeypatch.setenv("PIPEFY_OAUTH_CLIENT", "cid")
+        monkeypatch.setenv("PIPEFY_OAUTH_SECRET", "sec")
+
+    return _set
+
+
+@pytest.fixture
 def clean_pipefy_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Remove canonical ``PIPEFY_*`` keys so each test controls env explicitly."""
 

--- a/packages/cli/tests/test_auth.py
+++ b/packages/cli/tests/test_auth.py
@@ -76,7 +76,7 @@ def test_cli_uses_pipefy_token_env_when_no_flag(
     mock_client = MagicMock()
     mock_client.get_card = AsyncMock(return_value={"id": "77"})
     with patch(
-        "pipefy_cli.commands.card.get_authenticated_client",
+        "pipefy_cli.commands._common.get_authenticated_client",
         return_value=mock_client,
     ) as mock_gc:
         result = runner.invoke(app, ["card", "get", "77"])

--- a/packages/cli/tests/test_card_commands.py
+++ b/packages/cli/tests/test_card_commands.py
@@ -1,0 +1,347 @@
+"""Tests for ``pipefy card`` subcommands beyond ``get``."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pipefy_cli.main import app
+
+
+def test_card_list_minimal_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("list-cards")
+    payload = {"cards": {"edges": []}}
+    mock_client = MagicMock()
+    mock_client.get_cards = AsyncMock(return_value=payload)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["card", "list", "--pipe", "303", "--json"],
+        )
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+    assert json.loads(result.stdout) == payload
+    mock_client.get_cards.assert_awaited_once_with(
+        "303",
+        None,
+        include_fields=False,
+        first=None,
+        after=None,
+    )
+
+
+def test_card_list_title_search_and_pagination(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("list-cards-2")
+    payload = {"cards": {"edges": [{"node": {"id": "1"}}]}}
+    mock_client = MagicMock()
+    mock_client.get_cards = AsyncMock(return_value=payload)
+    search = json.dumps({"label_ids": ["abc"], "include_done": True})
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "card",
+                "list",
+                "--pipe",
+                "9",
+                "--title",
+                " Acme ",
+                "--search",
+                search,
+                "--include-fields",
+                "--first",
+                "50",
+                "--after",
+                "cursor1",
+                "--json",
+            ],
+        )
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+    mock_client.get_cards.assert_awaited_once()
+    args, kwargs = mock_client.get_cards.await_args
+    assert args[0] == "9"
+    assert args[1] == {"label_ids": ["abc"], "include_done": True, "title": "Acme"}
+    assert kwargs == {
+        "include_fields": True,
+        "first": 50,
+        "after": "cursor1",
+    }
+
+
+def test_card_list_first_out_of_range_exit_2(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("list-bad-first")
+    mock_client = MagicMock()
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["card", "list", "--pipe", "1", "--first", "501", "--json"],
+        )
+    assert result.exit_code == 2
+    mock_client.get_cards.assert_not_called()
+
+
+def test_card_find_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("find-cards")
+    payload = {"findCards": {"edges": []}}
+    mock_client = MagicMock()
+    mock_client.find_cards = AsyncMock(return_value=payload)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "card",
+                "find",
+                "--pipe",
+                "303",
+                "--field",
+                "status",
+                "--value",
+                "Open",
+                "--json",
+            ],
+        )
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+    assert json.loads(result.stdout) == payload
+    mock_client.find_cards.assert_awaited_once_with(
+        "303",
+        "status",
+        "Open",
+        include_fields=False,
+        first=None,
+        after=None,
+    )
+
+
+def test_card_create_with_title_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("create-card")
+    create_resp = {"createCard": {"card": {"id": "777", "title": "Draft"}}}
+    mock_client = MagicMock()
+    mock_client.create_card = AsyncMock(return_value=create_resp)
+    mock_client.update_card = AsyncMock(return_value={"updateCard": {"card": {}}})
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "card",
+                "create",
+                "303",
+                "--fields",
+                '{"field_x": "y"}',
+                "--title",
+                "Hello",
+                "--json",
+            ],
+        )
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+    mock_client.create_card.assert_awaited_once_with("303", {"field_x": "y"})
+    mock_client.update_card.assert_awaited_once_with("777", title="Hello")
+
+
+def test_card_create_title_update_failure_exit_1(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("create-card-fail-title")
+    from pipefy_sdk.exceptions import PipefyError
+
+    create_resp = {"createCard": {"card": {"id": "777", "title": "Draft"}}}
+    mock_client = MagicMock()
+    mock_client.create_card = AsyncMock(return_value=create_resp)
+    mock_client.update_card = AsyncMock(side_effect=PipefyError("update failed"))
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "card",
+                "create",
+                "303",
+                "--title",
+                "Hello",
+                "--json",
+            ],
+        )
+    assert result.exit_code == 1
+    mock_client.create_card.assert_awaited_once()
+    mock_client.update_card.assert_awaited_once_with("777", title="Hello")
+
+
+def test_card_create_invalid_fields_exit_2(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("bad-json")
+    mock_client = MagicMock()
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["card", "create", "303", "--fields", "not-json", "--json"],
+        )
+    assert result.exit_code == 2
+    mock_client.create_card.assert_not_called()
+
+
+def test_card_update_field_updates(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("upd-card")
+    payload = {"updateCard": {"success": True}}
+    mock_client = MagicMock()
+    mock_client.update_card = AsyncMock(return_value=payload)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "card",
+                "update",
+                "501",
+                "--field-updates",
+                json.dumps([{"fieldId": "f1", "value": "v"}]),
+                "--json",
+            ],
+        )
+    assert result.exit_code == 0
+    mock_client.update_card.assert_awaited_once()
+    kwargs = mock_client.update_card.await_args.kwargs
+    assert kwargs["field_updates"] == [{"fieldId": "f1", "value": "v"}]
+
+
+def test_card_delete_with_yes(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("del-card")
+    payload = {"deleteCard": {"success": True}}
+    mock_client = MagicMock()
+    mock_client.delete_card = AsyncMock(return_value=payload)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["card", "delete", "501", "--yes", "--json"],
+        )
+    assert result.exit_code == 0
+    mock_client.delete_card.assert_awaited_once_with("501")
+
+
+def test_card_move_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("move-card")
+    payload = {"moveCardToPhase": {"card": {"id": "501"}}}
+    mock_client = MagicMock()
+    mock_client.move_card_to_phase = AsyncMock(return_value=payload)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["card", "move", "501", "--phase", "999", "--json"],
+        )
+    assert result.exit_code == 0
+    mock_client.move_card_to_phase.assert_awaited_once_with("501", "999")
+
+
+def test_card_comment_update_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("cmt-upd")
+    payload = {"updateComment": {"comment": {"id": "c1"}}}
+    mock_client = MagicMock()
+    mock_client.update_comment = AsyncMock(return_value=payload)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["card", "comment", "update", "c1", "New body", "--json"],
+        )
+    assert result.exit_code == 0
+    mock_client.update_comment.assert_awaited_once_with("c1", "New body")
+
+
+def test_card_comment_add_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("cmt-add")
+    payload = {"createComment": {"comment": {"id": "c1"}}}
+    mock_client = MagicMock()
+    mock_client.add_card_comment = AsyncMock(return_value=payload)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["card", "comment", "add", "501", "Hello from CLI", "--json"],
+        )
+    assert result.exit_code == 0
+    mock_client.add_card_comment.assert_awaited_once_with("501", "Hello from CLI")
+
+
+def test_card_comment_add_validation_exit_2(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("cmt-bad")
+    mock_client = MagicMock()
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["card", "comment", "add", "501", ""],
+        )
+    assert result.exit_code == 2
+    mock_client.add_card_comment.assert_not_called()
+
+
+def test_card_comment_delete_yes(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("cmt-del")
+    payload = {"deleteComment": {"success": True}}
+    mock_client = MagicMock()
+    mock_client.delete_comment = AsyncMock(return_value=payload)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["card", "comment", "delete", "42", "--yes", "--json"],
+        )
+    assert result.exit_code == 0
+    mock_client.delete_comment.assert_awaited_once_with("42")
+
+
+def test_card_get_include_fields(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("get-inc")
+    payload = {"card": {"id": "1", "fields": []}}
+    mock_client = MagicMock()
+    mock_client.get_card = AsyncMock(return_value=payload)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["card", "get", "1", "--include-fields", "--json"],
+        )
+    assert result.exit_code == 0
+    mock_client.get_card.assert_awaited_once_with("1", include_fields=True)

--- a/packages/cli/tests/test_card_get.py
+++ b/packages/cli/tests/test_card_get.py
@@ -19,7 +19,7 @@ def _patch_get_client(card_payload: dict):
     mock_client.get_card = AsyncMock(return_value=card_payload)
     return (
         patch(
-            "pipefy_cli.commands.card.get_authenticated_client",
+            "pipefy_cli.commands._common.get_authenticated_client",
             return_value=mock_client,
         ),
         mock_client,
@@ -52,7 +52,7 @@ def test_card_get_json_stdout(runner, clean_pipefy_env, saved_cwd, monkeypatch):
     assert result.exit_code == 0, result.stdout + (result.stderr or "")
     out = json.loads(result.stdout)
     assert out == payload
-    mock_client.get_card.assert_awaited_once_with("501")
+    mock_client.get_card.assert_awaited_once_with("501", include_fields=False)
 
 
 def test_card_get_rich_stdout(runner, clean_pipefy_env, saved_cwd, monkeypatch):
@@ -101,7 +101,7 @@ def test_card_get_sdk_error_stderr_exit_1(
     mock_client = MagicMock()
     mock_client.get_card = AsyncMock(side_effect=PipefyAPIError("GraphQL failure"))
     with patch(
-        "pipefy_cli.commands.card.get_authenticated_client",
+        "pipefy_cli.commands._common.get_authenticated_client",
         return_value=mock_client,
     ):
         result = runner.invoke(app, ["card", "get", "999", "--json"])

--- a/packages/cli/tests/test_cli_domain_integration_smoke.py
+++ b/packages/cli/tests/test_cli_domain_integration_smoke.py
@@ -1,0 +1,181 @@
+"""Optional live CLI smoke tests (one read per domain when env IDs are present)."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from _shared.live_settings import require_live_creds
+from typer.testing import CliRunner
+
+from pipefy_cli.main import app
+
+
+def _pipe_id() -> str | None:
+    return os.environ.get("PIPE_BUILDING_LIVE_PIPE_ID")
+
+
+def _phase_id() -> str | None:
+    return os.environ.get("PIPE_FIELD_CONDITION_LIVE_PHASE_ID")
+
+
+@pytest.mark.integration
+def test_cli_live_card_list_skips_without_pipe_id(monkeypatch, tmp_path):
+    require_live_creds()
+    if not _pipe_id():
+        pytest.skip("Set PIPE_BUILDING_LIVE_PIPE_ID for card list live smoke.")
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        app,
+        ["card", "list", "--pipe", _pipe_id(), "--first", "1", "--json"],
+        env=os.environ.copy(),
+    )
+    assert result.exit_code == 0
+
+
+@pytest.mark.integration
+def test_cli_live_pipe_get_skips_without_pipe_id(monkeypatch, tmp_path):
+    require_live_creds()
+    if not _pipe_id():
+        pytest.skip("Set PIPE_BUILDING_LIVE_PIPE_ID for pipe get live smoke.")
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        app,
+        ["pipe", "get", _pipe_id(), "--json"],
+        env=os.environ.copy(),
+    )
+    assert result.exit_code == 0
+
+
+@pytest.mark.integration
+def test_cli_live_pipe_list_requires_only_oauth(monkeypatch, tmp_path):
+    require_live_creds()
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        app,
+        ["pipe", "list", "--max-per-org", "1", "--json"],
+        env=os.environ.copy(),
+    )
+    assert result.exit_code == 0
+
+
+@pytest.mark.integration
+def test_cli_live_label_list_skips_without_pipe_id(monkeypatch, tmp_path):
+    require_live_creds()
+    if not _pipe_id():
+        pytest.skip("Set PIPE_BUILDING_LIVE_PIPE_ID for label list live smoke.")
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        app,
+        ["label", "list", "--pipe", _pipe_id(), "--json"],
+        env=os.environ.copy(),
+    )
+    assert result.exit_code == 0
+
+
+@pytest.mark.integration
+def test_cli_live_webhook_list_skips_without_pipe_id(monkeypatch, tmp_path):
+    require_live_creds()
+    if not _pipe_id():
+        pytest.skip("Set PIPE_BUILDING_LIVE_PIPE_ID for webhook list live smoke.")
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        app,
+        ["webhook", "list", "--pipe", _pipe_id(), "--json"],
+        env=os.environ.copy(),
+    )
+    assert result.exit_code == 0
+
+
+@pytest.mark.integration
+def test_cli_live_member_list_skips_without_pipe_id(monkeypatch, tmp_path):
+    require_live_creds()
+    if not _pipe_id():
+        pytest.skip("Set PIPE_BUILDING_LIVE_PIPE_ID for member list live smoke.")
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        app,
+        ["member", "list", "--pipe", _pipe_id(), "--json"],
+        env=os.environ.copy(),
+    )
+    assert result.exit_code == 0
+
+
+@pytest.mark.integration
+def test_cli_live_relation_pipe_list_skips_without_pipe_id(monkeypatch, tmp_path):
+    require_live_creds()
+    if not _pipe_id():
+        pytest.skip("Set PIPE_BUILDING_LIVE_PIPE_ID for relation pipe list live smoke.")
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        app,
+        ["relation", "pipe", "list", _pipe_id(), "--json"],
+        env=os.environ.copy(),
+    )
+    assert result.exit_code == 0
+
+
+@pytest.mark.integration
+def test_cli_live_table_list_requires_only_oauth(monkeypatch, tmp_path):
+    require_live_creds()
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        app,
+        ["table", "list", "--first", "1", "--json"],
+        env=os.environ.copy(),
+    )
+    assert result.exit_code == 0
+
+
+@pytest.mark.integration
+def test_cli_live_phase_get_skips_without_phase_id(monkeypatch, tmp_path):
+    require_live_creds()
+    if not _phase_id():
+        pytest.skip("Set PIPE_FIELD_CONDITION_LIVE_PHASE_ID for phase get live smoke.")
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        app,
+        ["phase", "get", _phase_id(), "--json"],
+        env=os.environ.copy(),
+    )
+    assert result.exit_code == 0
+
+
+@pytest.mark.integration
+def test_cli_live_field_list_skips_without_phase_id(monkeypatch, tmp_path):
+    require_live_creds()
+    if not _phase_id():
+        pytest.skip("Set PIPE_FIELD_CONDITION_LIVE_PHASE_ID for field list live smoke.")
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        app,
+        ["field", "list", "--phase", _phase_id(), "--json"],
+        env=os.environ.copy(),
+    )
+    assert result.exit_code == 0
+
+
+@pytest.mark.integration
+def test_cli_live_record_find_skips_without_table_id(monkeypatch, tmp_path):
+    require_live_creds()
+    table_id = os.environ.get("CLI_LIVE_TABLE_ID")
+    if not table_id:
+        pytest.skip("Set CLI_LIVE_TABLE_ID for record find live smoke.")
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        app,
+        ["record", "find", "--table", table_id, "--first", "1", "--json"],
+        env=os.environ.copy(),
+    )
+    assert result.exit_code == 0

--- a/packages/cli/tests/test_cli_domain_integration_smoke.py
+++ b/packages/cli/tests/test_cli_domain_integration_smoke.py
@@ -19,163 +19,119 @@ def _phase_id() -> str | None:
     return os.environ.get("PIPE_FIELD_CONDITION_LIVE_PHASE_ID")
 
 
+# Tests do not chdir to ``tmp_path`` and do not override ``env=`` on
+# ``runner.invoke`` so the CLI loads ``.env`` from the repo root via
+# ``PipefySettings`` — the same source ``require_live_creds`` reads.
+
+
 @pytest.mark.integration
-def test_cli_live_card_list_skips_without_pipe_id(monkeypatch, tmp_path):
+def test_cli_live_card_list_skips_without_pipe_id():
     require_live_creds()
     if not _pipe_id():
         pytest.skip("Set PIPE_BUILDING_LIVE_PIPE_ID for card list live smoke.")
-    monkeypatch.chdir(tmp_path)
     runner = CliRunner(mix_stderr=False)
     result = runner.invoke(
         app,
         ["card", "list", "--pipe", _pipe_id(), "--first", "1", "--json"],
-        env=os.environ.copy(),
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
 
 
 @pytest.mark.integration
-def test_cli_live_pipe_get_skips_without_pipe_id(monkeypatch, tmp_path):
+def test_cli_live_pipe_get_skips_without_pipe_id():
     require_live_creds()
     if not _pipe_id():
         pytest.skip("Set PIPE_BUILDING_LIVE_PIPE_ID for pipe get live smoke.")
-    monkeypatch.chdir(tmp_path)
     runner = CliRunner(mix_stderr=False)
-    result = runner.invoke(
-        app,
-        ["pipe", "get", _pipe_id(), "--json"],
-        env=os.environ.copy(),
-    )
-    assert result.exit_code == 0
+    result = runner.invoke(app, ["pipe", "get", _pipe_id(), "--json"])
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
 
 
 @pytest.mark.integration
-def test_cli_live_pipe_list_requires_only_oauth(monkeypatch, tmp_path):
+def test_cli_live_pipe_list_requires_only_oauth():
     require_live_creds()
-    monkeypatch.chdir(tmp_path)
     runner = CliRunner(mix_stderr=False)
-    result = runner.invoke(
-        app,
-        ["pipe", "list", "--max-per-org", "1", "--json"],
-        env=os.environ.copy(),
-    )
-    assert result.exit_code == 0
+    result = runner.invoke(app, ["pipe", "list", "--max-per-org", "1", "--json"])
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
 
 
 @pytest.mark.integration
-def test_cli_live_label_list_skips_without_pipe_id(monkeypatch, tmp_path):
+def test_cli_live_label_list_skips_without_pipe_id():
     require_live_creds()
     if not _pipe_id():
         pytest.skip("Set PIPE_BUILDING_LIVE_PIPE_ID for label list live smoke.")
-    monkeypatch.chdir(tmp_path)
     runner = CliRunner(mix_stderr=False)
-    result = runner.invoke(
-        app,
-        ["label", "list", "--pipe", _pipe_id(), "--json"],
-        env=os.environ.copy(),
-    )
-    assert result.exit_code == 0
+    result = runner.invoke(app, ["label", "list", "--pipe", _pipe_id(), "--json"])
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
 
 
 @pytest.mark.integration
-def test_cli_live_webhook_list_skips_without_pipe_id(monkeypatch, tmp_path):
+def test_cli_live_webhook_list_skips_without_pipe_id():
     require_live_creds()
     if not _pipe_id():
         pytest.skip("Set PIPE_BUILDING_LIVE_PIPE_ID for webhook list live smoke.")
-    monkeypatch.chdir(tmp_path)
     runner = CliRunner(mix_stderr=False)
-    result = runner.invoke(
-        app,
-        ["webhook", "list", "--pipe", _pipe_id(), "--json"],
-        env=os.environ.copy(),
-    )
-    assert result.exit_code == 0
+    result = runner.invoke(app, ["webhook", "list", "--pipe", _pipe_id(), "--json"])
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
 
 
 @pytest.mark.integration
-def test_cli_live_member_list_skips_without_pipe_id(monkeypatch, tmp_path):
+def test_cli_live_member_list_skips_without_pipe_id():
     require_live_creds()
     if not _pipe_id():
         pytest.skip("Set PIPE_BUILDING_LIVE_PIPE_ID for member list live smoke.")
-    monkeypatch.chdir(tmp_path)
     runner = CliRunner(mix_stderr=False)
-    result = runner.invoke(
-        app,
-        ["member", "list", "--pipe", _pipe_id(), "--json"],
-        env=os.environ.copy(),
-    )
-    assert result.exit_code == 0
+    result = runner.invoke(app, ["member", "list", "--pipe", _pipe_id(), "--json"])
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
 
 
 @pytest.mark.integration
-def test_cli_live_relation_pipe_list_skips_without_pipe_id(monkeypatch, tmp_path):
+def test_cli_live_relation_pipe_list_skips_without_pipe_id():
     require_live_creds()
     if not _pipe_id():
         pytest.skip("Set PIPE_BUILDING_LIVE_PIPE_ID for relation pipe list live smoke.")
-    monkeypatch.chdir(tmp_path)
     runner = CliRunner(mix_stderr=False)
-    result = runner.invoke(
-        app,
-        ["relation", "pipe", "list", _pipe_id(), "--json"],
-        env=os.environ.copy(),
-    )
-    assert result.exit_code == 0
+    result = runner.invoke(app, ["relation", "pipe", "list", _pipe_id(), "--json"])
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
 
 
 @pytest.mark.integration
-def test_cli_live_table_list_requires_only_oauth(monkeypatch, tmp_path):
+def test_cli_live_table_list_requires_only_oauth():
     require_live_creds()
-    monkeypatch.chdir(tmp_path)
     runner = CliRunner(mix_stderr=False)
-    result = runner.invoke(
-        app,
-        ["table", "list", "--first", "1", "--json"],
-        env=os.environ.copy(),
-    )
-    assert result.exit_code == 0
+    result = runner.invoke(app, ["table", "list", "--first", "1", "--json"])
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
 
 
 @pytest.mark.integration
-def test_cli_live_phase_get_skips_without_phase_id(monkeypatch, tmp_path):
+def test_cli_live_phase_get_skips_without_phase_id():
     require_live_creds()
     if not _phase_id():
         pytest.skip("Set PIPE_FIELD_CONDITION_LIVE_PHASE_ID for phase get live smoke.")
-    monkeypatch.chdir(tmp_path)
     runner = CliRunner(mix_stderr=False)
-    result = runner.invoke(
-        app,
-        ["phase", "get", _phase_id(), "--json"],
-        env=os.environ.copy(),
-    )
-    assert result.exit_code == 0
+    result = runner.invoke(app, ["phase", "get", _phase_id(), "--json"])
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
 
 
 @pytest.mark.integration
-def test_cli_live_field_list_skips_without_phase_id(monkeypatch, tmp_path):
+def test_cli_live_field_list_skips_without_phase_id():
     require_live_creds()
     if not _phase_id():
         pytest.skip("Set PIPE_FIELD_CONDITION_LIVE_PHASE_ID for field list live smoke.")
-    monkeypatch.chdir(tmp_path)
     runner = CliRunner(mix_stderr=False)
-    result = runner.invoke(
-        app,
-        ["field", "list", "--phase", _phase_id(), "--json"],
-        env=os.environ.copy(),
-    )
-    assert result.exit_code == 0
+    result = runner.invoke(app, ["field", "list", "--phase", _phase_id(), "--json"])
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
 
 
 @pytest.mark.integration
-def test_cli_live_record_find_skips_without_table_id(monkeypatch, tmp_path):
+def test_cli_live_record_find_skips_without_table_id():
     require_live_creds()
     table_id = os.environ.get("CLI_LIVE_TABLE_ID")
     if not table_id:
         pytest.skip("Set CLI_LIVE_TABLE_ID for record find live smoke.")
-    monkeypatch.chdir(tmp_path)
     runner = CliRunner(mix_stderr=False)
     result = runner.invoke(
         app,
         ["record", "find", "--table", table_id, "--first", "1", "--json"],
-        env=os.environ.copy(),
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")

--- a/packages/cli/tests/test_label_webhook_commands.py
+++ b/packages/cli/tests/test_label_webhook_commands.py
@@ -1,0 +1,123 @@
+"""Tests for ``pipefy label`` and ``pipefy webhook`` subcommands."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pipefy_cli.main import app
+
+
+def test_label_list_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("lbl")
+    mock_client = MagicMock()
+    mock_client.get_pipe = AsyncMock(
+        return_value={"pipe": {"labels": [{"id": "1", "name": "Bug"}]}}
+    )
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(app, ["label", "list", "--pipe", "8", "--json"])
+    assert result.exit_code == 0
+    out = json.loads(result.stdout)
+    assert out["success"] is True
+    assert out["message"] == "Labels loaded."
+    assert out["labels"] == [{"id": "1", "name": "Bug"}]
+
+
+def test_label_list_pipe_denied_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("lbl-denied")
+    mock_client = MagicMock()
+    mock_client.get_pipe = AsyncMock(return_value={"pipe": None})
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(app, ["label", "list", "--pipe", "8", "--json"])
+    assert result.exit_code == 0
+    out = json.loads(result.stdout)
+    assert out["success"] is False
+    assert "error" in out
+
+
+def test_webhook_create_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("wh")
+    mock_client = MagicMock()
+    mock_client.create_webhook = AsyncMock(return_value={"createWebhook": {}})
+    actions = json.dumps(["card.create"])
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "webhook",
+                "create",
+                "--pipe",
+                "1",
+                "--url",
+                "https://example.com/hook",
+                "--actions",
+                actions,
+                "--json",
+            ],
+        )
+    assert result.exit_code == 0
+    mock_client.create_webhook.assert_awaited_once_with(
+        "1",
+        "https://example.com/hook",
+        ["card.create"],
+    )
+
+
+def test_webhook_create_actions_empty_array_bad_parameter(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("wh-bad-act")
+    mock_client = MagicMock()
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "webhook",
+                "create",
+                "--pipe",
+                "1",
+                "--url",
+                "https://example.com/hook",
+                "--actions",
+                "[]",
+                "--json",
+            ],
+        )
+    assert result.exit_code == 2
+    mock_client.create_webhook.assert_not_called()
+
+
+def test_webhook_update_name_whitespace_bad_parameter(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("wh-bad-name")
+    mock_client = MagicMock()
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "webhook",
+                "update",
+                "w1",
+                "--name",
+                "   ",
+                "--json",
+            ],
+        )
+    assert result.exit_code == 2
+    mock_client.update_webhook.assert_not_called()

--- a/packages/cli/tests/test_phase_field_commands.py
+++ b/packages/cli/tests/test_phase_field_commands.py
@@ -1,0 +1,134 @@
+"""Tests for ``pipefy phase`` and ``pipefy field`` subcommands."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pipefy_cli.main import app
+
+
+def test_phase_get_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("ph-get")
+    payload = {"phase_id": "1", "phase_name": "Backlog", "fields": []}
+    mock_client = MagicMock()
+    mock_client.get_phase_fields = AsyncMock(return_value=payload)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(app, ["phase", "get", "1", "--json"])
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == payload
+    mock_client.get_phase_fields.assert_awaited_once_with("1", required_only=False)
+
+
+def test_phase_create_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("ph-cr")
+    payload = {"createPhase": {}}
+    mock_client = MagicMock()
+    mock_client.create_phase = AsyncMock(return_value=payload)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["phase", "create", "--pipe", "9", "--name", "Review", "--json"],
+        )
+    assert result.exit_code == 0
+    mock_client.create_phase.assert_awaited_once_with(
+        "9", "Review", done=False, index=None, description=None
+    )
+
+
+def test_phase_update_resolves_name_json(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("ph-upd")
+    mock_client = MagicMock()
+    mock_client.get_phase_fields = AsyncMock(
+        return_value={"phase_name": "Todo", "fields": []}
+    )
+    mock_client.update_phase = AsyncMock(return_value={"updatePhase": {}})
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["phase", "update", "3", "--description", "x", "--json"],
+        )
+    assert result.exit_code == 0
+    mock_client.update_phase.assert_awaited_once_with("3", description="x", name="Todo")
+
+
+def test_phase_delete_yes(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("ph-del")
+    mock_client = MagicMock()
+    mock_client.delete_phase = AsyncMock(return_value={"deletePhase": {}})
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(app, ["phase", "delete", "3", "--yes", "--json"])
+    assert result.exit_code == 0
+    mock_client.delete_phase.assert_awaited_once_with("3")
+
+
+def test_field_list_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("fld-list")
+    payload = {"phase_id": "1", "fields": []}
+    mock_client = MagicMock()
+    mock_client.get_phase_fields = AsyncMock(return_value=payload)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(app, ["field", "list", "--phase", "1", "--json"])
+    assert result.exit_code == 0
+    mock_client.get_phase_fields.assert_awaited_once_with("1", required_only=False)
+
+
+def test_field_create_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("fld-cr")
+    mock_client = MagicMock()
+    mock_client.create_phase_field = AsyncMock(return_value={"createPhaseField": {}})
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "field",
+                "create",
+                "--phase",
+                "2",
+                "--label",
+                "Owner",
+                "--type",
+                "assignee_select",
+                "--json",
+            ],
+        )
+    assert result.exit_code == 0
+    mock_client.create_phase_field.assert_awaited_once_with(
+        "2", "Owner", "assignee_select"
+    )
+
+
+def test_field_delete_yes(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("fld-del")
+    mock_client = MagicMock()
+    mock_client.delete_phase_field = AsyncMock(return_value={"deletePhaseField": {}})
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["field", "delete", "fid-1", "--yes", "--json"],
+        )
+    assert result.exit_code == 0
+    mock_client.delete_phase_field.assert_awaited_once_with("fid-1", pipe_uuid=None)

--- a/packages/cli/tests/test_pipe_commands.py
+++ b/packages/cli/tests/test_pipe_commands.py
@@ -1,0 +1,183 @@
+"""Tests for ``pipefy pipe`` subcommands."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pipefy_cli.main import app
+
+
+def test_pipe_get_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("pipe-get")
+    payload = {"pipe": {"id": "10", "name": "P"}}
+    mock_client = MagicMock()
+    mock_client.get_pipe = AsyncMock(return_value=payload)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(app, ["pipe", "get", "10", "--json"])
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == payload
+    mock_client.get_pipe.assert_awaited_once_with("10")
+
+
+def test_pipe_list_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("pipe-list")
+    payload = {"organizations": []}
+    mock_client = MagicMock()
+    mock_client.search_pipes = AsyncMock(return_value=payload)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["pipe", "list", "--name", "Invoices", "--max-per-org", "50", "--json"],
+        )
+    assert result.exit_code == 0
+    mock_client.search_pipes.assert_awaited_once_with(
+        "Invoices",
+        max_pipes_per_org=50,
+    )
+
+
+def test_pipe_create_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("pipe-create")
+    payload = {"createPipe": {"pipe": {"id": "99"}}}
+    mock_client = MagicMock()
+    mock_client.create_pipe = AsyncMock(return_value=payload)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["pipe", "create", "My Pipe", "--org", "555", "--json"],
+        )
+    assert result.exit_code == 0
+    mock_client.create_pipe.assert_awaited_once_with("My Pipe", "555")
+
+
+def test_pipe_create_whitespace_name_exit_2(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("pipe-bad-name")
+    mock_client = MagicMock()
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(app, ["pipe", "create", "   ", "--org", "1", "--json"])
+    assert result.exit_code == 2
+    mock_client.create_pipe.assert_not_called()
+
+
+def test_pipe_update_preferences_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("pipe-upd")
+    payload = {"updatePipe": {"pipe": {"id": "10"}}}
+    mock_client = MagicMock()
+    mock_client.update_pipe = AsyncMock(return_value=payload)
+    prefs = {"foo": "bar"}
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "pipe",
+                "update",
+                "10",
+                "--preferences",
+                json.dumps(prefs),
+                "--json",
+            ],
+        )
+    assert result.exit_code == 0
+    mock_client.update_pipe.assert_awaited_once_with(
+        "10", name=None, icon=None, color=None, preferences=prefs
+    )
+
+
+def test_pipe_update_no_attributes_exit_2(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("pipe-upd-none")
+    mock_client = MagicMock()
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(app, ["pipe", "update", "10", "--json"])
+    assert result.exit_code == 2
+    mock_client.update_pipe.assert_not_called()
+
+
+def test_pipe_delete_yes(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("pipe-del")
+    payload = {"deletePipe": {"success": True}}
+    mock_client = MagicMock()
+    mock_client.delete_pipe = AsyncMock(return_value=payload)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(app, ["pipe", "delete", "10", "--yes", "--json"])
+    assert result.exit_code == 0
+    mock_client.delete_pipe.assert_awaited_once_with("10")
+
+
+def test_pipe_clone_with_org(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("pipe-clone")
+    payload = {"clonePipes": {}}
+    mock_client = MagicMock()
+    mock_client.clone_pipe = AsyncMock(return_value=payload)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["pipe", "clone", "301", "--org", "777", "--json"],
+        )
+    assert result.exit_code == 0
+    mock_client.clone_pipe.assert_awaited_once_with(
+        "301",
+        organization_id="777",
+    )
+
+
+def test_pipe_clone_without_org_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("pipe-clone-no-org")
+    payload = {"clonePipes": {}}
+    mock_client = MagicMock()
+    mock_client.clone_pipe = AsyncMock(return_value=payload)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(app, ["pipe", "clone", "301", "--json"])
+    assert result.exit_code == 0
+    mock_client.clone_pipe.assert_awaited_once_with(
+        "301",
+        organization_id=None,
+    )
+
+
+def test_pipe_update_preferences_empty_object_bad_parameter(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("pipe-upd-empty-pref")
+    mock_client = MagicMock()
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["pipe", "update", "10", "--preferences", "{}", "--json"],
+        )
+    assert result.exit_code == 2
+    mock_client.update_pipe.assert_not_called()

--- a/packages/cli/tests/test_relation_member_commands.py
+++ b/packages/cli/tests/test_relation_member_commands.py
@@ -1,0 +1,205 @@
+"""Tests for ``pipefy relation`` and ``pipefy member`` subcommands."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pipefy_cli.main import app
+
+
+def test_relation_pipe_list_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("rel-p")
+    payload = {"pipe": {"relations": []}}
+    mock_client = MagicMock()
+    mock_client.get_pipe_relations = AsyncMock(return_value=payload)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(app, ["relation", "pipe", "list", "10", "--json"])
+    assert result.exit_code == 0
+    mock_client.get_pipe_relations.assert_awaited_once_with("10")
+
+
+def test_relation_card_delete_requires_internal_api(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("rel-c")
+    mock_client = MagicMock()
+    mock_client.internal_api_available = False
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "relation",
+                "card",
+                "delete",
+                "--child",
+                "1",
+                "--parent",
+                "2",
+                "--source",
+                "3",
+                "--yes",
+                "--json",
+            ],
+        )
+    assert result.exit_code == 2
+    mock_client.delete_card_relation.assert_not_called()
+
+
+def test_member_remove_blocks_service_account(
+    runner, clean_pipefy_env, saved_cwd, oauth_env, monkeypatch
+):
+    oauth_env("mem-guard")
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_IDS", "svc-1")
+    mock_client = MagicMock()
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "member",
+                "remove",
+                "--pipe",
+                "44",
+                "--user-ids",
+                "svc-1",
+                "--yes",
+                "--json",
+            ],
+        )
+    assert result.exit_code == 2
+    assert "Cannot remove service account" in (result.stderr or "")
+    mock_client.remove_members_from_pipe.assert_not_called()
+
+
+def test_member_invite_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("mem-inv")
+    mock_client = MagicMock()
+    mock_client.invite_members = AsyncMock(return_value={"inviteMembers": {}})
+    members = json.dumps([{"email": "a@b.com", "role_name": "admin"}])
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["member", "invite", "--pipe", "1", "--members", members, "--json"],
+        )
+    assert result.exit_code == 0
+    mock_client.invite_members.assert_awaited_once_with(
+        "1", [{"email": "a@b.com", "role_name": "admin"}]
+    )
+
+
+def test_member_remove_happy_path_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("mem-rm-ok")
+    mock_client = MagicMock()
+    mock_client.remove_members_from_pipe = AsyncMock(
+        return_value={"removeMembersFromPipe": {}}
+    )
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "member",
+                "remove",
+                "--pipe",
+                "1",
+                "--user-ids",
+                "u1,u2",
+                "--yes",
+                "--json",
+            ],
+        )
+    assert result.exit_code == 0
+    mock_client.remove_members_from_pipe.assert_awaited_once_with("1", ["u1", "u2"])
+
+
+def test_member_invite_members_missing_role_bad_parameter(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("mem-inv-bad")
+    mock_client = MagicMock()
+    members = json.dumps([{"email": "a@b.com"}])
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["member", "invite", "--pipe", "1", "--members", members, "--json"],
+        )
+    assert result.exit_code == 2
+    mock_client.invite_members.assert_not_called()
+
+
+def test_relation_pipe_create_empty_name_exit_2(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("rel-pc-empty")
+    mock_client = MagicMock()
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "relation",
+                "pipe",
+                "create",
+                "--parent",
+                "1",
+                "--child",
+                "2",
+                "--name",
+                "   ",
+                "--json",
+            ],
+        )
+    assert result.exit_code == 2
+    mock_client.create_pipe_relation.assert_not_called()
+
+
+def test_relation_card_delete_internal_api_json(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("rel-cc-del")
+    mock_client = MagicMock()
+    mock_client.internal_api_available = True
+    mock_client.delete_card_relation = AsyncMock(
+        return_value={"deleteCardRelation": {}}
+    )
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "relation",
+                "card",
+                "delete",
+                "--child",
+                "1",
+                "--parent",
+                "2",
+                "--source",
+                "3",
+                "--yes",
+                "--json",
+            ],
+        )
+    assert result.exit_code == 0
+    mock_client.delete_card_relation.assert_awaited_once_with("1", "2", "3")

--- a/packages/cli/tests/test_table_record_commands.py
+++ b/packages/cli/tests/test_table_record_commands.py
@@ -1,0 +1,161 @@
+"""Tests for ``pipefy table`` and ``pipefy record`` subcommands."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pipefy_cli.main import app
+
+
+def test_table_list_search_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("tbl-list")
+    payload = {"organizations": []}
+    mock_client = MagicMock()
+    mock_client.search_tables = AsyncMock(return_value=payload)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app, ["table", "list", "--name", "Assets", "--first", "20", "--json"]
+        )
+    assert result.exit_code == 0
+    mock_client.search_tables.assert_awaited_once_with("Assets", first=20)
+
+
+def test_table_list_with_ids_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("tbl-ids")
+    payload = {"tables": []}
+    mock_client = MagicMock()
+    mock_client.get_tables = AsyncMock(return_value=payload)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(app, ["table", "list", "--ids", "10,20", "--json"])
+    assert result.exit_code == 0
+    mock_client.get_tables.assert_awaited_once_with(["10", "20"])
+
+
+def test_table_list_ids_only_commas_bad_parameter(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("tbl-bad-ids")
+    mock_client = MagicMock()
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(app, ["table", "list", "--ids", ",", "--json"])
+    assert result.exit_code == 2
+    assert "--ids must list" in (result.stdout + result.stderr)
+    mock_client.get_tables.assert_not_called()
+
+
+def test_record_find_by_field_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("rec-find")
+    payload = {"findRecords": {}}
+    mock_client = MagicMock()
+    mock_client.find_records = AsyncMock(return_value=payload)
+    filt = json.dumps({"field_id": "f1", "field_value": "abc"})
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["record", "find", "--table", "99", "--filter", filt, "--json"],
+        )
+    assert result.exit_code == 0
+    mock_client.find_records.assert_awaited_once_with(
+        "99", "f1", "abc", first=None, after=None
+    )
+
+
+def test_record_find_filter_field_mismatch_bad_parameter(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("rec-bad-filt")
+    mock_client = MagicMock()
+    filt = json.dumps({"field_id": "f1"})
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["record", "find", "--table", "99", "--filter", filt, "--json"],
+        )
+    assert result.exit_code == 2
+    mock_client.find_records.assert_not_called()
+
+
+def test_record_find_list_page_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("rec-page")
+    payload = {"table_records": {}}
+    mock_client = MagicMock()
+    mock_client.get_table_records = AsyncMock(return_value=payload)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["record", "find", "--table", "99", "--first", "10", "--json"],
+        )
+    assert result.exit_code == 0
+    mock_client.get_table_records.assert_awaited_once_with("99", first=10, after=None)
+
+
+def test_record_update_set_field_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("rec-set")
+    mock_client = MagicMock()
+    mock_client.set_table_record_field_value = AsyncMock(
+        return_value={"setTableRecordFieldValue": {}}
+    )
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "record",
+                "update",
+                "501",
+                "--field-id",
+                "f2",
+                "--value",
+                '"hello"',
+                "--json",
+            ],
+        )
+    assert result.exit_code == 0
+    mock_client.set_table_record_field_value.assert_awaited_once_with(
+        "501", "f2", "hello"
+    )
+
+
+def test_record_update_unknown_field_key_exit_2(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("rec-upd-bad")
+    mock_client = MagicMock()
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "record",
+                "update",
+                "501",
+                "--fields",
+                '{"unknown_key": 1}',
+                "--json",
+            ],
+        )
+    assert result.exit_code == 2
+    mock_client.update_table_record.assert_not_called()

--- a/packages/mcp/src/pipefy_mcp/tools/member_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/member_tools.py
@@ -7,7 +7,12 @@ from typing import Any
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
 from mcp.types import ToolAnnotations
-from pipefy_sdk import PipefyClient, PipefyId
+from pipefy_sdk import (
+    PipefyClient,
+    PipefyId,
+    format_service_account_removal_block_message,
+    service_account_removal_blocked_user_ids,
+)
 
 from pipefy_mcp.settings import settings
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
@@ -114,23 +119,13 @@ class MemberTools:
                 )
 
             protected_ids = settings.pipefy.service_account_ids
-            if protected_ids:
-                protected_set = set(protected_ids)
-                blocked = [uid for uid in user_ids if uid in protected_set]
-                if blocked:
-                    if len(blocked) == 1:
-                        msg = (
-                            f"Cannot remove service account {blocked[0]} - "
-                            "this would break all write operations for this pipe. "
-                            "Remove it via the Pipefy UI if intentional."
-                        )
-                    else:
-                        msg = (
-                            f"Cannot remove service accounts {', '.join(blocked)} - "
-                            "this would break all write operations for this pipe. "
-                            "Remove it via the Pipefy UI if intentional."
-                        )
-                    return build_member_error_payload(message=msg)
+            blocked = service_account_removal_blocked_user_ids(
+                list(user_ids), list(protected_ids)
+            )
+            if blocked:
+                return build_member_error_payload(
+                    message=format_service_account_removal_block_message(blocked),
+                )
 
             guard = await check_destructive_confirmation(
                 ctx,

--- a/packages/mcp/src/pipefy_mcp/tools/table_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/table_tools.py
@@ -7,10 +7,11 @@ from typing import Any
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
 from mcp.types import ToolAnnotations
-from pipefy_sdk import PipefyClient, PipefyId
-from pipefy_sdk.services.table_service import (
+from pipefy_sdk import (
     UPDATE_TABLE_RECORD_ALLOWED_FIELD_KEYS,
     UPDATE_TABLE_RECORD_FIELDS_ERROR_MESSAGE,
+    PipefyClient,
+    PipefyId,
 )
 
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation

--- a/packages/sdk/src/pipefy_sdk/__init__.py
+++ b/packages/sdk/src/pipefy_sdk/__init__.py
@@ -31,12 +31,22 @@ from pipefy_sdk.services.automation_graphql_types import (
     AutomationRuleSummary,
 )
 from pipefy_sdk.services.internal_api_client import InternalApiClient
+from pipefy_sdk.services.member_service import (
+    format_service_account_removal_block_message,
+    service_account_removal_blocked_user_ids,
+)
+from pipefy_sdk.services.table_service import (
+    UPDATE_TABLE_RECORD_ALLOWED_FIELD_KEYS,
+    UPDATE_TABLE_RECORD_FIELDS_ERROR_MESSAGE,
+)
 from pipefy_sdk.services.types import AiAgentGraphPayload, CardSearch, copy_card_search
 from pipefy_sdk.settings import PipefySettings
 
 __all__ = [
     "AiAgentGraphPayload",
     "AiAutomationService",
+    "UPDATE_TABLE_RECORD_ALLOWED_FIELD_KEYS",
+    "UPDATE_TABLE_RECORD_FIELDS_ERROR_MESSAGE",
     "AutomationActionRow",
     "AutomationConditionInput",
     "AutomationEventParamsInput",
@@ -64,5 +74,7 @@ __all__ = [
     "UploadAttachmentToTableRecordInput",
     "copy_card_search",
     "create_form_model",
+    "format_service_account_removal_block_message",
     "infer_content_type",
+    "service_account_removal_blocked_user_ids",
 ]

--- a/packages/sdk/src/pipefy_sdk/services/member_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/member_service.py
@@ -128,3 +128,38 @@ class MemberService(BasePipefyClient):
                 }
             },
         )
+
+
+def service_account_removal_blocked_user_ids(
+    user_ids: list[str],
+    protected_ids: list[str],
+) -> list[str]:
+    """Return user ids that cannot be removed because they appear in ``protected_ids``.
+
+    Args:
+        user_ids: Candidate user IDs to remove from a pipe.
+        protected_ids: Service account IDs from settings (e.g. ``PIPEFY_SERVICE_ACCOUNT_IDS``).
+    """
+    if not protected_ids:
+        return []
+    protected_set = set(protected_ids)
+    return [uid for uid in user_ids if uid.strip() in protected_set]
+
+
+def format_service_account_removal_block_message(blocked: list[str]) -> str:
+    """Format the user-facing error when removal targets protected service accounts.
+
+    Args:
+        blocked: Non-empty list of user ids that matched the protected set.
+    """
+    if len(blocked) == 1:
+        return (
+            f"Cannot remove service account {blocked[0]} - "
+            "this would break all write operations for this pipe. "
+            "Remove it via the Pipefy UI if intentional."
+        )
+    return (
+        f"Cannot remove service accounts {', '.join(blocked)} - "
+        "this would break all write operations for this pipe. "
+        "Remove it via the Pipefy UI if intentional."
+    )

--- a/packages/sdk/tests/services/test_member_removal_policy.py
+++ b/packages/sdk/tests/services/test_member_removal_policy.py
@@ -1,0 +1,30 @@
+"""Unit tests for service-account removal policy helpers."""
+
+from __future__ import annotations
+
+from pipefy_sdk.services.member_service import (
+    format_service_account_removal_block_message,
+    service_account_removal_blocked_user_ids,
+)
+
+
+def test_blocked_user_ids_empty_when_no_protected() -> None:
+    assert service_account_removal_blocked_user_ids(["a", "b"], []) == []
+
+
+def test_blocked_user_ids_matches_protected() -> None:
+    out = service_account_removal_blocked_user_ids(
+        ["x", "svc", "y"],
+        ["svc"],
+    )
+    assert out == ["svc"]
+
+
+def test_format_block_message_singular() -> None:
+    msg = format_service_account_removal_block_message(["one"])
+    assert "Cannot remove service account one" in msg
+
+
+def test_format_block_message_plural() -> None:
+    msg = format_service_account_removal_block_message(["a", "b"])
+    assert "Cannot remove service accounts a, b" in msg


### PR DESCRIPTION
## Summary
Task 5.0: CLI parity with MCP tools — new Typer domains, shared `_common` helpers, SDK re-exports, MCP import cleanup, parity doc, tests (unit + optional integration smoke).

## Commits (atomic)
- `feat(sdk)`: export table record update constants and member SA guard helpers
- `refactor(mcp)`: import table/member policy from `pipefy_sdk`
- `feat(cli)`: `_common` + OAuth wiring
- `feat(cli)`: pipe/phase/field/table/record/label/webhook/relation/member subcommands + `main`
- `refactor(cli)`: card via `_common`; strict title on create
- `docs`: MCP vs CLI parity matrix
- `test(cli)`: fixtures, patches, validation, integration smoke
- `test(cli)`: integration smoke uses repo `.env` / process env

## Testing
- `uv run pytest packages/cli/tests -m "not integration"`
- `uv run pytest packages/sdk/tests/services/test_member_removal_policy.py`
- `uv run pytest packages/mcp/tests/tools/test_member_tools.py`
- Integration: `uv run pytest packages/cli/tests/test_cli_domain_integration_smoke.py -m integration` (requires `PIPEFY_*` + optional IDs in `.env`)

Base branch: **dev**.