### PR TITLE
chore(release): Task 6 release infra and pipefy-sdk rename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,29 @@ jobs:
         enable-cache: true
     - name: Install dependencies
       run: uv sync --locked --all-extras --dev
+    - name: Verify package versions are in lockstep
+      run: |
+        uv run python <<'PY'
+        import re
+        from pathlib import Path
+
+        paths = {
+            "sdk": Path("packages/sdk/src/pipefy_sdk/__init__.py"),
+            "mcp": Path("packages/mcp/src/pipefy_mcp/__init__.py"),
+            "cli": Path("packages/cli/src/pipefy_cli/__init__.py"),
+        }
+        rx = re.compile(r'^__version__\s*=\s*["\']([^"\']+)["\']', re.M)
+        found = {}
+        for name, path in paths.items():
+            text = path.read_text(encoding="utf-8")
+            m = rx.search(text)
+            if not m:
+                raise SystemExit(f"missing __version__ in {path}")
+            found[name] = m.group(1)
+        versions = list(found.values())
+        if len(set(versions)) != 1:
+            raise SystemExit(f"version mismatch across packages: {found}")
+        PY
     - name: Lint (full tree)
       run: uv run ruff check packages/sdk/src packages/mcp/src packages/cli/src
     - name: Check formatting

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,107 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - name: Verify tag matches package version
+        run: |
+          python <<'PY'
+          import os
+          import re
+          import sys
+          from pathlib import Path
+
+          tag = os.environ["GITHUB_REF_NAME"]
+          expected = tag.removeprefix("v")
+          path = Path("packages/sdk/src/pipefy_sdk/__init__.py")
+          m = re.search(
+              r'^__version__\s*=\s*["\']([^"\']+)["\']',
+              path.read_text(encoding="utf-8"),
+              re.M,
+          )
+          if not m or m.group(1) != expected:
+              got = m.group(1) if m else "MISSING"
+              print(f"Tag {tag!r} does not match SDK __version__ {got!r}", file=sys.stderr)
+              sys.exit(1)
+          PY
+      - name: Build release notes body for this tag
+        run: |
+          python <<'PY'
+          import os
+          import re
+          import sys
+          from pathlib import Path
+
+          tag = os.environ["GITHUB_REF_NAME"]
+          ver = tag.removeprefix("v")
+          text = Path("CHANGELOG.md").read_text(encoding="utf-8")
+          pat = rf"(?ms)^## \[{re.escape(ver)}\][^\n]*\n.*?(?=^## |\Z)"
+          m = re.search(pat, text)
+          if not m:
+              print(
+                  f"No CHANGELOG section found for version {ver!r} "
+                  f"(expected a heading like ## [{ver}] ...).",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+          Path("CHANGELOG_RELEASE_BODY.md").write_text(
+              m.group(0).rstrip() + "\n",
+              encoding="utf-8",
+          )
+          PY
+      - name: Build wheels and sdist (all workspace packages)
+        run: uv build --all-packages -o dist --wheel --sdist
+      - name: Verify expected wheels in dist/
+        run: |
+          python <<'PY'
+          import sys
+          from pathlib import Path
+
+          dist = Path("dist")
+          for prefix in ("pipefy_sdk", "pipefy_mcp_server", "pipefy_cli"):
+              wheels = list(dist.glob(f"{prefix}-*.whl"))
+              if len(wheels) != 1:
+                  print(
+                      f"expected exactly one wheel matching {prefix}-*.whl, got {wheels!r}",
+                      file=sys.stderr,
+                  )
+                  sys.exit(1)
+          PY
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*.whl
+          body_path: CHANGELOG_RELEASE_BODY.md
+      - name: Stage PyPI wheels (CLI + MCP only)
+        if: startsWith(github.ref_name, 'v1.')
+        run: |
+          mkdir -p dist-pypi
+          shopt -s nullglob
+          cli=(dist/pipefy_cli-*.whl)
+          mcp=(dist/pipefy_mcp_server-*.whl)
+          if [ "${#cli[@]}" -ne 1 ] || [ "${#mcp[@]}" -ne 1 ]; then
+            echo "Expected exactly one CLI wheel and one MCP wheel in dist/, got cli=${#cli[@]} mcp=${#mcp[@]}"
+            ls -la dist || true
+            exit 1
+          fi
+          cp "${cli[0]}" "${mcp[0]}" dist-pypi/
+      - name: Upload to PyPI
+        if: startsWith(github.ref_name, 'v1.')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist-pypi/

--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,6 @@ wheels/
 # Ruff stuff:
 .ruff_cache/
 
-# Generated version file
-packages/mcp/src/pipefy_mcp/_version.py
-
 # Unit test / coverage reports
 htmlcov/
 .tox/
@@ -37,15 +34,16 @@ env.bak/
 venv.bak/
 .mise.toml
 
-# Local test scripts (scripts/ kept for ad-hoc testing)
-scripts/
-
 # IDEs and editors
 .cursor/
 .claude/
 CLAUDE.md
 # Cursor MCP workspace config (machine-specific paths or local server entries)
 .mcp.json
+
+# Tracked release tooling only (ignore ad-hoc local scripts and smoke artifacts)
+scripts/*
+!scripts/bump_version.py
 
 # macOS
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this repository are documented in this file.
 
-Releases are versioned in lockstep across workspace members (`pipefy-ai-sdk`, `pipefy-mcp-server`, `pipefy-cli`).
+Releases are versioned in lockstep across workspace members (`pipefy-sdk`, `pipefy-mcp-server`, `pipefy-cli`).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **SDK**: PyPI distribution renamed from `pipefy-ai-sdk` to `pipefy-sdk` (import package remains `pipefy_sdk`). Update installs and `uv add` / `pip install` references accordingly.
 - Internal: repository reorganized as a uv workspace; ``pipefy-mcp-server`` distribution and runtime behavior unchanged.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This repository is a **uv workspace** (see the root [`pyproject.toml`](pyproject
 
 | Directory | PyPI / distribution name | Purpose |
 |-----------|--------------------------|---------|
-| [`packages/sdk/`](packages/sdk/) | `pipefy-ai-sdk` | GraphQL client, services, queries, and shared Pydantic models consumed by the MCP server (and, later, the CLI). |
+| [`packages/sdk/`](packages/sdk/) | `pipefy-sdk` | GraphQL client, services, queries, and shared Pydantic models consumed by the MCP server (and, later, the CLI). |
 | [`packages/mcp/`](packages/mcp/) | `pipefy-mcp-server` | The installable MCP server and `pipefy_mcp` package. |
 | [`packages/cli/`](packages/cli/) | `pipefy-cli` (placeholder) | Reserved for the future Typer-based `pipefy` CLI. |
 
@@ -95,11 +95,11 @@ cp .env.example .env
 
 ### Why these dependencies?
 
-The runtime stack in [`pyproject.toml`](pyproject.toml) is small on purpose. GraphQL, OAuth transport, and spreadsheet parsing for exports live in the **`pipefy-ai-sdk`** workspace dependency ([`packages/sdk/pyproject.toml`](packages/sdk/pyproject.toml)). For a longer rationale (code references and security notes), see **[Dependencies](docs/dependencies.md)**. Summary:
+The runtime stack in [`pyproject.toml`](pyproject.toml) is small on purpose. GraphQL, OAuth transport, and spreadsheet parsing for exports live in the **`pipefy-sdk`** workspace dependency ([`packages/sdk/pyproject.toml`](packages/sdk/pyproject.toml)). For a longer rationale (code references and security notes), see **[Dependencies](docs/dependencies.md)**. Summary:
 
 | Package | Role in this server |
 |--------|---------------------|
-| **pipefy-ai-sdk** | Shared GraphQL stack (`gql` + `httpx`), Pipefy OAuth (`httpx-auth`), models, and service layer used by MCP tools. |
+| **pipefy-sdk** | Shared GraphQL stack (`gql` + `httpx`), Pipefy OAuth (`httpx-auth`), models, and service layer used by MCP tools. |
 | **httpx** | Direct async HTTP used by MCP tools (e.g. attachment flows) alongside the SDK’s GraphQL transport. |
 | **mcp** | Model Context Protocol server runtime (`FastMCP`, tool registration). |
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,62 @@
+# Release process
+
+Workspace distributions (`pipefy-sdk`, `pipefy-mcp-server`, `pipefy-cli`) share a single **lockstep** version string in each package’s `__init__.py`. CI fails if those values diverge.
+
+## Pre-launch (v0.x): GitHub Release only
+
+PyPI publishing is **disabled** for tags that do not start with `v1.`. Pre-release installs use git references (for example `uvx --from git+https://github.com/<owner>/<repo>.git@vX.Y.Z --refresh pipefy-cli`).
+
+1. Merge work to `main` and ensure `CHANGELOG.md` has everything under `## [Unreleased]`.
+2. Bump the shared version (updates all three `__init__.py` files):
+
+   ```bash
+   uv run python scripts/bump_version.py patch
+   ```
+
+   Supported arguments: `major`, `minor`, `patch`, `prerelease`, or `version=X.Y.Z` (optional `v` prefix on `X.Y.Z`).
+
+3. In `CHANGELOG.md`, replace the `## [Unreleased]` heading with `## [X.Y.Z] - YYYY-MM-DD` matching the new version and date (the Release workflow uses this section as the GitHub Release notes body).
+4. Commit:
+
+   ```bash
+   git add -A && git commit -m "chore: release vX.Y.Z"
+   ```
+
+5. Tag and push:
+
+   ```bash
+   git tag vX.Y.Z && git push origin main && git push origin vX.Y.Z
+   ```
+
+6. Wait for the **Release** workflow (`.github/workflows/release.yml`) to finish.
+7. Confirm the GitHub Release lists the built wheels (`pipefy_cli-*.whl`, `pipefy_mcp_server-*.whl`, and `pipefy_sdk-*.whl` when produced). Optionally verify install from the tag, for example:
+
+   ```bash
+   uvx --from git+https://github.com/<owner>/<repo>.git@vX.Y.Z --refresh pipefy-cli --version
+   ```
+
+## v1.0 and later: GitHub Release + PyPI
+
+Same steps as above. For tags whose name starts with **`v1.`** (for example `v1.0.0` or `v1.0.0rc1`), the release workflow also runs **Trusted Publishing** to upload the **`pipefy-cli`** and **`pipefy-mcp-server`** wheels to PyPI via `pypa/gh-action-pypi-publish` (the `pipefy-sdk` wheel is built for the GitHub Release but is **not** uploaded to PyPI until task 12.3 / ADR decides otherwise).
+
+**Repository setup (maintainers):**
+
+- Configure [Trusted Publishers](https://docs.pypi.org/trusted-publishers/using-a-publisher/) on PyPI for **`pipefy-cli`** and **`pipefy-mcp-server`** (and `pipefy-sdk` later if you enable it in the workflow).
+- No long-lived PyPI token is required when using OIDC; the workflow requests `id-token: write`.
+
+**After a v1.x tag:**
+
+1. Confirm the new versions appear on PyPI for each published package.
+2. Smoke-test a clean install, for example:
+
+    ```bash
+    uv tool install pipefy-cli
+    ```
+
+## Automation reference
+
+| Piece | Role |
+| --- | --- |
+| `scripts/bump_version.py` | Reads the SDK `__version__`, applies the bump, writes the same value to SDK, MCP, and CLI `__init__.py`. |
+| `.github/workflows/ci.yml` | Asserts the three `__version__` strings match. |
+| `.github/workflows/release.yml` | On `v*` tags: asserts the tag matches SDK `__version__`, extracts the matching `CHANGELOG.md` section as the GitHub Release body, builds wheels and sdists with `uv build --all-packages -o dist --wheel --sdist`, attaches wheels to the GitHub Release, and publishes CLI + MCP wheels to PyPI only when `github.ref_name` starts with `v1.`. |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # pipefy-cli
 
-Typer-based CLI for Pipefy. Consumes **`pipefy-ai-sdk`** for GraphQL calls.
+Typer-based CLI for Pipefy. Consumes **`pipefy-sdk`** for GraphQL calls.
 
 Install via the workspace root (`uv sync`) or build this package's wheel from the repo.
 
@@ -15,6 +15,10 @@ pipefy card get 12345 --json
 ```
 
 Bearer tokens: prefer `PIPEFY_TOKEN` over `--token` so secrets do not appear in shell history or process listings.
+
+## Development
+
+Dependencies use `typer>=0.12` (no `typer[all]` extra): Rich, shellingham, and click are pulled in by Typer itself, so do not re-add `[all]` hoping to "fix" completion.
 
 ## Shell completion
 

--- a/packages/cli/pyproject.toml
+++ b/packages/cli/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "pipefy-cli"
-version = "0.1.0"
-description = "Typer CLI for Pipefy (pipefy-ai-sdk)."
+dynamic = ["version"]
+description = "Typer CLI for Pipefy (pipefy-sdk)."
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "pipefy-ai-sdk",
-    "typer[all]>=0.12",
+    "pipefy-sdk",
+    "typer>=0.12",
     "rich>=13",
     "pydantic-settings>=2.8.1",
 ]
@@ -15,7 +15,7 @@ dependencies = [
 pipefy = "pipefy_cli.main:app"
 
 [tool.uv.sources]
-pipefy-ai-sdk = { workspace = true }
+pipefy-sdk = { workspace = true }
 
 [dependency-groups]
 dev = [
@@ -30,6 +30,9 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/pipefy_cli"]
+
+[tool.hatch.version]
+path = "src/pipefy_cli/__init__.py"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/packages/cli/src/pipefy_cli/__init__.py
+++ b/packages/cli/src/pipefy_cli/__init__.py
@@ -1,12 +1,7 @@
-"""Typer CLI entry surface for Pipefy (pipefy-ai-sdk)."""
+"""Typer CLI entry surface for Pipefy (pipefy-sdk)."""
 
 from __future__ import annotations
 
-from importlib.metadata import PackageNotFoundError, version
-
-try:
-    __version__ = version("pipefy-cli")
-except PackageNotFoundError:
-    __version__ = "0.1.0"
+__version__ = "0.1.0"
 
 __all__ = ["__version__"]

--- a/packages/cli/src/pipefy_cli/main.py
+++ b/packages/cli/src/pipefy_cli/main.py
@@ -20,7 +20,7 @@ from pipefy_cli.config import resolve_pipefy_settings
 
 app = typer.Typer(
     name="pipefy",
-    help="Pipefy CLI (GraphQL via pipefy-ai-sdk).",
+    help="Pipefy CLI (GraphQL via pipefy-sdk).",
     no_args_is_help=True,
 )
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -4,4 +4,4 @@ MCP server package for Pipefy. See the [repository README](../../README.md) for 
 
 ## Development
 
-From the **repository root**, run `uv sync --all-packages --dev` (or `uv sync`) so workspace members (`pipefy-ai-sdk`, this package) resolve correctly. Then run tests with `uv run pytest packages/mcp/tests` from the root, or `cd packages/mcp && uv run pytest tests/` after sync—the MCP package’s pytest config adds `packages/sdk/tests` on `pythonpath` so `_shared` live-credential helpers resolve without installing a separate test bundle.
+From the **repository root**, run `uv sync --all-packages --dev` (or `uv sync`) so workspace members (`pipefy-sdk`, this package) resolve correctly. Then run tests with `uv run pytest packages/mcp/tests` from the root, or `cd packages/mcp && uv run pytest tests/` after sync—the MCP package’s pytest config adds `packages/sdk/tests` on `pythonpath` so `_shared` live-credential helpers resolve without installing a separate test bundle.

--- a/packages/mcp/pyproject.toml
+++ b/packages/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipefy-mcp-server"
-version = "0.1.0"
+dynamic = ["version"]
 description = "MCP server that exposes Pipefy's GraphQL API."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -8,13 +8,13 @@ dependencies = [
     "httpx>=0.27.0",
     "mcp[cli]>=1.25.0",
     # Workspace resolves version in dev; standalone PyPI install needs Phase 6 (bundle or co-publish SDK). PRD Non-Goals and FR-6.3.
-    "pipefy-ai-sdk",
+    "pipefy-sdk",
     "pydantic>=2.11.3",
     "pydantic-settings>=2.8.1",
 ]
 
 [tool.uv.sources]
-pipefy-ai-sdk = { workspace = true }
+pipefy-sdk = { workspace = true }
 
 [project.scripts]
 pipefy-mcp-server = "pipefy_mcp.main:main"
@@ -31,18 +31,14 @@ dev = [
 ]
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/pipefy_mcp"]
 
 [tool.hatch.version]
-source = "vcs"
-raw-options = { version_scheme = "no-guess-dev" }
-
-[tool.hatch.build.hooks.vcs]
-version-file = "src/pipefy_mcp/_version.py"
+path = "src/pipefy_mcp/__init__.py"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -61,8 +57,6 @@ markers = [
 
 [tool.ruff]
 lint.extend-select = ["I", "TID251"]
-lint.exclude = ["src/pipefy_mcp/_version.py"]
-format.exclude = ["src/pipefy_mcp/_version.py"]
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "pipefy_cli".msg = "pipefy_mcp must not import the CLI package; keep MCP independent of pipefy-cli."

--- a/packages/mcp/src/pipefy_mcp/__init__.py
+++ b/packages/mcp/src/pipefy_mcp/__init__.py
@@ -1,5 +1,16 @@
 """Pipefy MCP Server package."""
 
-from pipefy_mcp._version import __version__, version, version_tuple
+from __future__ import annotations
+
+import re
+
+__version__ = "0.1.0"
+version = __version__
+
+m = re.match(r"^(\d+)\.(\d+)\.(\d+)", __version__)
+if not m:
+    msg = f"__version__ must start with MAJOR.MINOR.PATCH, got {__version__!r}"
+    raise ValueError(msg)
+version_tuple = (int(m[1]), int(m[2]), int(m[3]))
 
 __all__ = ["__version__", "version", "version_tuple"]

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,4 +1,4 @@
-# pipefy-ai-sdk
+# pipefy-sdk
 
 GraphQL client, Pydantic models, and service layer shared by the Pipefy MCP server and CLI.
 

--- a/packages/sdk/pyproject.toml
+++ b/packages/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
-name = "pipefy-ai-sdk"
-version = "0.1.0"
+name = "pipefy-sdk"
+dynamic = ["version"]
 description = "Pipefy GraphQL client, models, and services (shared by MCP and CLI)."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -30,6 +30,9 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/pipefy_sdk"]
+
+[tool.hatch.version]
+path = "src/pipefy_sdk/__init__.py"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/packages/sdk/src/pipefy_sdk/__init__.py
+++ b/packages/sdk/src/pipefy_sdk/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+__version__ = "0.1.0"
+
 from pipefy_sdk.client import PipefyClient
 from pipefy_sdk.exceptions import PipefyAPIError, PipefyError
 from pipefy_sdk.models import (
@@ -43,6 +45,7 @@ from pipefy_sdk.services.types import AiAgentGraphPayload, CardSearch, copy_card
 from pipefy_sdk.settings import PipefySettings
 
 __all__ = [
+    "__version__",
     "AiAgentGraphPayload",
     "AiAutomationService",
     "UPDATE_TABLE_RECORD_ALLOWED_FIELD_KEYS",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,13 +13,13 @@ package = false
 members = ["packages/sdk", "packages/mcp", "packages/cli"]
 
 [tool.uv.sources]
-pipefy-ai-sdk = { workspace = true }
+pipefy-sdk = { workspace = true }
 pipefy-mcp-server = { workspace = true }
 pipefy-cli = { workspace = true }
 
 [dependency-groups]
 dev = [
-    "pipefy-ai-sdk",
+    "pipefy-sdk",
     "pipefy-mcp-server",
     "pipefy-cli",
     "aiohttp>=3.11.16",
@@ -33,8 +33,6 @@ dev = [
 
 [tool.ruff]
 lint.extend-select = ["I"]
-lint.exclude = ["packages/mcp/src/pipefy_mcp/_version.py"]
-format.exclude = ["packages/mcp/src/pipefy_mcp/_version.py"]
 
 [tool.pytest.ini_options]
 testpaths = ["packages/sdk/tests", "packages/mcp/tests", "packages/cli/tests"]

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Bump the lockstep workspace version across SDK, MCP, and CLI packages."""
+
+from __future__ import annotations
+
+import re
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INIT_PATHS = (
+    REPO_ROOT / "packages/sdk/src/pipefy_sdk/__init__.py",
+    REPO_ROOT / "packages/mcp/src/pipefy_mcp/__init__.py",
+    REPO_ROOT / "packages/cli/src/pipefy_cli/__init__.py",
+)
+
+VERSION_ASSIGN_RE = re.compile(
+    r'^(__version__\s*=\s*)["\']([^"\']+)["\']',
+    re.MULTILINE,
+)
+
+CORE_VER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)")
+
+
+def read_sdk_version() -> str:
+    """Return the current ``__version__`` from the SDK package (source of truth)."""
+    text = INIT_PATHS[0].read_text(encoding="utf-8")
+    m = VERSION_ASSIGN_RE.search(text)
+    if not m:
+        msg = f"No __version__ assignment found in {INIT_PATHS[0]}"
+        raise ValueError(msg)
+    return m.group(2)
+
+
+def write_version_to_all_files(new_version: str) -> None:
+    """Replace ``__version__`` in each package ``__init__.py``."""
+    for path in INIT_PATHS:
+        text = path.read_text(encoding="utf-8")
+        new_text, count = VERSION_ASSIGN_RE.subn(
+            rf'\1"{new_version}"',
+            text,
+            count=1,
+        )
+        if count != 1:
+            msg = f"Expected one __version__ assignment in {path}, replaced {count}"
+            raise ValueError(msg)
+        path.write_text(new_text, encoding="utf-8")
+
+
+def parse_core(version: str) -> tuple[int, int, int]:
+    """Parse leading ``X.Y.Z`` from a version string."""
+    m = CORE_VER_RE.match(version.strip())
+    if not m:
+        msg = f"Version must start with MAJOR.MINOR.PATCH, got {version!r}"
+        raise ValueError(msg)
+    return int(m.group(1)), int(m.group(2)), int(m.group(3))
+
+
+def suffix_after_core(version: str) -> str:
+    """Return the substring after ``X.Y.Z`` (e.g. ``a1``, ``rc2``), or empty."""
+    m = CORE_VER_RE.match(version.strip())
+    if not m:
+        msg = f"Version must start with MAJOR.MINOR.PATCH, got {version!r}"
+        raise ValueError(msg)
+    return version.strip()[m.end() :]
+
+
+def bump_major(current: str) -> str:
+    x, y, z = parse_core(current)
+    return f"{x + 1}.0.0"
+
+
+def bump_minor(current: str) -> str:
+    x, y, z = parse_core(current)
+    return f"{x}.{y + 1}.0"
+
+
+def bump_patch(current: str) -> str:
+    x, y, z = parse_core(current)
+    return f"{x}.{y}.{z + 1}"
+
+
+def bump_prerelease(current: str) -> str:
+    """Increment or introduce a PEP-440-style pre-release suffix (``aN`` / ``bN`` / ``rcN``).
+
+    When the current version has no suffix (e.g. ``0.1.0``), the next value is the first alpha
+    of the *next* patch (e.g. ``0.1.1a1``), not an alpha of the same patch.
+    """
+    x, y, z = parse_core(current)
+    rest = suffix_after_core(current)
+    if not rest:
+        return f"{x}.{y}.{z + 1}a1"
+    rest_norm = rest.lstrip("._-")
+    m = re.match(r"^(a|b|rc)(\d+)$", rest_norm, re.IGNORECASE)
+    if not m:
+        msg = (
+            f"Cannot bump prerelease: unrecognized suffix {rest_norm!r} on {current!r}"
+        )
+        raise ValueError(msg)
+    kind, num_s = m.groups()
+    kind = kind.lower()
+    n = int(num_s)
+    if kind == "rc":
+        return f"{x}.{y}.{z}rc{n + 1}"
+    return f"{x}.{y}.{z}{kind}{n + 1}"
+
+
+def parse_explicit_version(arg: str) -> str:
+    """Parse ``version=X.Y.Z`` (optional leading ``v`` on the version)."""
+    lowered = arg.lower()
+    if not lowered.startswith("version="):
+        msg = f"Expected version=X.Y.Z, got {arg!r}"
+        raise ValueError(msg)
+    raw = arg[len("version=") :].strip()
+    if raw.startswith("v") or raw.startswith("V"):
+        raw = raw[1:]
+    parse_core(raw)
+    return raw
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(
+            "Usage: bump_version.py <major|minor|patch|prerelease|version=X.Y.Z>",
+            file=sys.stderr,
+        )
+        return 2
+
+    token = sys.argv[1]
+    current = read_sdk_version()
+
+    bumpers: dict[str, Callable[[str], str]] = {
+        "major": bump_major,
+        "minor": bump_minor,
+        "patch": bump_patch,
+        "prerelease": bump_prerelease,
+    }
+
+    if token.lower().startswith("version="):
+        new_version = parse_explicit_version(token)
+    elif token in bumpers:
+        new_version = bumpers[token](current)
+    else:
+        print(
+            f"Unknown argument {token!r}. "
+            "Use major, minor, patch, prerelease, or version=X.Y.Z",
+            file=sys.stderr,
+        )
+        return 2
+
+    write_version_to_all_files(new_version)
+    print(f"Bumped {current} -> {new_version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -8,9 +8,9 @@ resolution-markers = [
 
 [manifest]
 members = [
-    "pipefy-ai-sdk",
     "pipefy-cli",
     "pipefy-mcp-server",
+    "pipefy-sdk",
     "pipefy-workspace",
 ]
 
@@ -696,8 +696,81 @@ wheels = [
 ]
 
 [[package]]
-name = "pipefy-ai-sdk"
-version = "0.1.0"
+name = "pipefy-cli"
+source = { editable = "packages/cli" }
+dependencies = [
+    { name = "pipefy-sdk" },
+    { name = "pydantic-settings" },
+    { name = "rich" },
+    { name = "typer" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pipefy-sdk", editable = "packages/sdk" },
+    { name = "pydantic-settings", specifier = ">=2.8.1" },
+    { name = "rich", specifier = ">=13" },
+    { name = "typer", specifier = ">=0.12" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-asyncio", specifier = ">=0.26.0" },
+    { name = "ruff", specifier = ">=0.11.4" },
+]
+
+[[package]]
+name = "pipefy-mcp-server"
+source = { editable = "packages/mcp" }
+dependencies = [
+    { name = "httpx" },
+    { name = "mcp", extra = ["cli"] },
+    { name = "pipefy-sdk" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "aiohttp" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pytest-mock" },
+    { name = "respx" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.25.0" },
+    { name = "pipefy-sdk", editable = "packages/sdk" },
+    { name = "pydantic", specifier = ">=2.11.3" },
+    { name = "pydantic-settings", specifier = ">=2.8.1" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "aiohttp", specifier = ">=3.11.16" },
+    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-asyncio", specifier = ">=0.26.0" },
+    { name = "pytest-cov", specifier = ">=6.1.1" },
+    { name = "pytest-mock", specifier = ">=3.14.0" },
+    { name = "respx", specifier = ">=0.22.0" },
+    { name = "ruff", specifier = ">=0.11.4" },
+]
+
+[[package]]
+name = "pipefy-sdk"
 source = { editable = "packages/sdk" }
 dependencies = [
     { name = "gql", extra = ["httpx"] },
@@ -741,82 +814,6 @@ dev = [
 ]
 
 [[package]]
-name = "pipefy-cli"
-version = "0.1.0"
-source = { editable = "packages/cli" }
-dependencies = [
-    { name = "pipefy-ai-sdk" },
-    { name = "pydantic-settings" },
-    { name = "rich" },
-    { name = "typer" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "ruff" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "pipefy-ai-sdk", editable = "packages/sdk" },
-    { name = "pydantic-settings", specifier = ">=2.8.1" },
-    { name = "rich", specifier = ">=13" },
-    { name = "typer", extras = ["all"], specifier = ">=0.12" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=8.3.5" },
-    { name = "pytest-asyncio", specifier = ">=0.26.0" },
-    { name = "ruff", specifier = ">=0.11.4" },
-]
-
-[[package]]
-name = "pipefy-mcp-server"
-version = "0.1.0"
-source = { editable = "packages/mcp" }
-dependencies = [
-    { name = "httpx" },
-    { name = "mcp", extra = ["cli"] },
-    { name = "pipefy-ai-sdk" },
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "aiohttp" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-    { name = "pytest-mock" },
-    { name = "respx" },
-    { name = "ruff" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "httpx", specifier = ">=0.27.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.25.0" },
-    { name = "pipefy-ai-sdk", editable = "packages/sdk" },
-    { name = "pydantic", specifier = ">=2.11.3" },
-    { name = "pydantic-settings", specifier = ">=2.8.1" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "aiohttp", specifier = ">=3.11.16" },
-    { name = "pytest", specifier = ">=8.3.5" },
-    { name = "pytest-asyncio", specifier = ">=0.26.0" },
-    { name = "pytest-cov", specifier = ">=6.1.1" },
-    { name = "pytest-mock", specifier = ">=3.14.0" },
-    { name = "respx", specifier = ">=0.22.0" },
-    { name = "ruff", specifier = ">=0.11.4" },
-]
-
-[[package]]
 name = "pipefy-workspace"
 version = "0.1.0"
 source = { virtual = "." }
@@ -824,9 +821,9 @@ source = { virtual = "." }
 [package.dev-dependencies]
 dev = [
     { name = "aiohttp" },
-    { name = "pipefy-ai-sdk" },
     { name = "pipefy-cli" },
     { name = "pipefy-mcp-server" },
+    { name = "pipefy-sdk" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -840,9 +837,9 @@ dev = [
 [package.metadata.requires-dev]
 dev = [
     { name = "aiohttp", specifier = ">=3.11.16" },
-    { name = "pipefy-ai-sdk", editable = "packages/sdk" },
     { name = "pipefy-cli", editable = "packages/cli" },
     { name = "pipefy-mcp-server", editable = "packages/mcp" },
+    { name = "pipefy-sdk", editable = "packages/sdk" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-asyncio", specifier = ">=0.26.0" },
     { name = "pytest-cov", specifier = ">=6.1.1" },


### PR DESCRIPTION
## Summary

Implements Phase 6 release infrastructure (lockstep `__version__`, bump script, CI sync, tag-driven GitHub Release, PyPI gated to `v1.*`) and addresses the code review in `.cursor/dev-planning/specs/pipefy-labs/code-review/dev-task-6-release-infra.md`.

## Commits (atomic)

1. **feat(workspace)!** — Rename distribution `pipefy-ai-sdk` → `pipefy-sdk`, dynamic versions in package `__init__.py`, remove MCP hatch-vcs, CLI static `__version__`.
2. **chore(scripts)** — `scripts/bump_version.py` and scoped `.gitignore` for `scripts/`.
3. **docs** — Root `README.md` and `CHANGELOG.md` aligned with `pipefy-sdk`.
4. **ci** — Verify three packages share the same `__version__` (`uv run python`).
5. **chore(release)** — `.github/workflows/release.yml` (tag vs version, CHANGELOG section body, wheel/sdist build, artifact checks) and `RELEASE.md`.

## Testing

- `uv run pytest -m "not integration"` (passed locally before commit).

## Notes

- **BREAKING CHANGE** for PyPI consumers: install name is now `pipefy-sdk` (import `pipefy_sdk` unchanged).
- Release workflow requires a `CHANGELOG.md` heading `## [X.Y.Z]` matching the tag (without `v`).