### PR TITLE
docs: rewrite setup as uvx-based end-user install

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Pipefy MCP Server — Environment Variables
 # Copy this file: cp .env.example .env
 # Then fill in your Service Account credentials from Pipefy Admin Panel.
-# See docs/setup.md for first-time install, Pydantic precedence, and MCP client examples.
+# See docs/quickstart.md for first-time install, Pydantic precedence, and MCP client examples.
 
 PIPEFY_GRAPHQL_URL=https://app.pipefy.com/graphql
 PIPEFY_INTERNAL_API_URL=https://app.pipefy.com/internal_api

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,8 @@
 
 ## Documentation map
 - **`README.md`** — Overview for users and contributors: getting started, MCP tools summary, development, testing, and schema hygiene.
-- **`docs/setup.md`** — First-time install, environment variables, MCP client config (optional `bootstrap.sh`).
+- **`docs/setup.md`** — End-user install via `uvx`, service-account creation, environment variables, MCP client config.
+- **`docs/contributing.md`** — Development setup (clone, `uv sync`, `.env`, tests, `bootstrap.sh`, release process).
 - **`docs/dependencies.md`** — Rationale for main dependencies.
 - **`docs/tools/`** — Per-area reference (parameters, edge cases, cross-cutting behavior). Start from the filenames that match the domain you touch (e.g. `pipes-and-cards.md`, `automations-and-ai.md`, `introspection.md`).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Documentation map
 - **`README.md`** — Overview for users and contributors: getting started, MCP tools summary, development, testing, and schema hygiene.
-- **`docs/setup.md`** — End-user install via `uvx`, service-account creation, environment variables, MCP client config.
+- **`docs/quickstart.md`** — End-user install via `uvx`, service-account creation, environment variables, MCP client config.
 - **`docs/contributing.md`** — Development setup (clone, `uv sync`, `.env`, tests, `bootstrap.sh`, release process).
 - **`docs/dependencies.md`** — Rationale for main dependencies.
 - **`docs/tools/`** — Per-area reference (parameters, edge cases, cross-cutting behavior). Start from the filenames that match the domain you touch (e.g. `pipes-and-cards.md`, `automations-and-ai.md`, `introspection.md`).

--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ cd pipefy-mcp-server
 # Sync dependencies
 uv sync
 
-# Optional: copy template and edit (full guide: docs/setup.md)
+# Optional: copy template and edit (full guide: docs/quickstart.md)
 cp .env.example .env
 ```
 
-**Setup, env vars, and MCP client JSON:** use **[Setup](docs/setup.md)** — single doc for first-time install, Pydantic / `.env` precedence, and Cursor / Claude examples (keys in [`.env.example`](.env.example)). Optional: `./bootstrap.sh` runs `uv sync` and creates `.env` from `.env.example` if missing.
+**Setup, env vars, and MCP client JSON:** use **[Setup](docs/quickstart.md)** — single doc for first-time install, Pydantic / `.env` precedence, and Cursor / Claude examples (keys in [`.env.example`](.env.example)). Optional: `./bootstrap.sh` runs `uv sync` and creates `.env` from `.env.example` if missing.
 
 ### Why these dependencies?
 
@@ -105,13 +105,13 @@ The runtime stack in [`pyproject.toml`](pyproject.toml) is small on purpose. Gra
 
 ## MCP clients
 
-Step-by-step JSON samples and CLI examples are in **[Setup → MCP client setup](docs/setup.md#mcp-client-setup)**.
+Step-by-step JSON samples and CLI examples are in **[Setup → MCP client setup](docs/quickstart.md#mcp-client-setup)**.
 
 | Client | Section |
 |--------|---------|
-| **Cursor** | [Cursor](docs/setup.md#cursor) |
-| **Claude Desktop** | [Claude Desktop](docs/setup.md#claude-desktop) |
-| **Claude Code** | [Claude Code](docs/setup.md#claude-code) |
+| **Cursor** | [Cursor](docs/quickstart.md#cursor) |
+| **Claude Desktop** | [Claude Desktop](docs/quickstart.md#claude-desktop) |
+| **Claude Code** | [Claude Code](docs/quickstart.md#claude-code) |
 
 ## Development & Testing
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Development setup for people working on the Pipefy MCP server itself. If you only want to **use** the server in your MCP client, see [Setup](setup.md) — you do not need to clone this repo.
+Development setup for people working on the Pipefy MCP server itself. If you only want to **use** the server in your MCP client, see [Quickstart](quickstart.md) — you do not need to clone this repo.
 
 | Section | What it covers |
 |---------|------------------|
@@ -11,7 +11,7 @@ Development setup for people working on the Pipefy MCP server itself. If you onl
 | [Unit tests](#unit-tests) | `uv run pytest -m "not integration"` |
 | [Manual MCP testing](#manual-mcp-testing) | Cursor MCP, MCP Inspector |
 | [Bootstrap script](#bootstrap-script) | One-shot `./bootstrap.sh` |
-| [Release process](#release-process) | Tag bumps and `docs/setup.md` |
+| [Release process](#release-process) | Tag bumps and `docs/quickstart.md` |
 
 ---
 
@@ -49,7 +49,13 @@ Runtime settings come from **`pipefy_mcp.settings.Settings`** ([Pydantic Setting
 
 - **`.env`** is read from the **current working directory** when you run `uv run pipefy-mcp-server` from the clone root (or when your MCP client sets `cwd` to the clone).
 - Values already in the **process environment** override entries from `.env`.
-- The same keys work in `.env` and in an MCP client's `env` block — see [Environment variables](setup.md#environment-variables).
+- The same keys work in `.env` and in an MCP client's `env` block — see [Environment variables](quickstart.md#environment-variables).
+
+### Dev-only env overrides
+
+User-facing keys (required and optional) live in [`docs/quickstart.md` → Environment variables](quickstart.md#environment-variables). The only key meant strictly for local development is:
+
+- **`PIPEFY_ALLOW_INSECURE_URLS=true`** — allow `http://` and internal hosts for GraphQL / OAuth / internal API / webhooks. **Never enable in production**; credentials must not leave HTTPS. Off by default.
 
 ---
 
@@ -77,7 +83,7 @@ Integration tests (`-m integration`) call the live Pipefy GraphQL API and need a
 
 ## Manual MCP testing
 
-Point your MCP client at the local clone instead of the published flow in [Setup](setup.md). Use this config (replace the absolute path with your clone path):
+Point your MCP client at the local clone instead of the published flow in [Quickstart](quickstart.md). Use this config (replace the absolute path with your clone path):
 
 ```json
 {
@@ -126,4 +132,4 @@ On Windows without Git Bash, run the [Clone and install](#clone-and-install) and
 
 ## Release process
 
-When cutting a new tag, **bump the `@vX.Y.Z` references in [`docs/setup.md`](setup.md)** so end-user examples pin to the latest release. The doc currently pins to `v0.1.0`; grep for `@v` under `docs/setup.md` to find every occurrence.
+When cutting a new tag, **bump the `@vX.Y.Z` references in [`docs/quickstart.md`](quickstart.md)** so end-user examples pin to the latest release. The doc currently pins to `v0.1.0`; grep for `@v` under `docs/quickstart.md` to find every occurrence.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,129 @@
+# Contributing
+
+Development setup for people working on the Pipefy MCP server itself. If you only want to **use** the server in your MCP client, see [Setup](setup.md) — you do not need to clone this repo.
+
+| Section | What it covers |
+|---------|------------------|
+| [Prerequisites](#prerequisites) | Python, `uv`, a Pipefy Service Account |
+| [Clone and install](#clone-and-install) | `git clone`, `uv sync` |
+| [Local `.env` file](#local-env-file) | `cp .env.example .env`, Pydantic Settings precedence |
+| [Smoke test](#smoke-test) | `uv run pipefy-mcp-server` |
+| [Unit tests](#unit-tests) | `uv run pytest -m "not integration"` |
+| [Manual MCP testing](#manual-mcp-testing) | Cursor MCP, MCP Inspector |
+| [Bootstrap script](#bootstrap-script) | One-shot `./bootstrap.sh` |
+| [Release process](#release-process) | Tag bumps and `docs/setup.md` |
+
+---
+
+## Prerequisites
+
+- Python 3.11+
+- [`uv`](https://docs.astral.sh/uv/getting-started/installation/) for dependency management
+- A [Pipefy Service Account](https://developers.pipefy.com/reference/service-accounts) (Admin → Members and Permissions → Service Accounts). Add the service account to every pipe you intend to exercise.
+
+---
+
+## Clone and install
+
+```bash
+git clone https://github.com/gbrlcustodio/pipefy-mcp-server.git
+cd pipefy-mcp-server
+uv sync
+```
+
+On Windows, run the same commands in **PowerShell** or **Git Bash** (with `uv` on `PATH`).
+
+---
+
+## Local `.env` file
+
+From the repo root:
+
+```bash
+cp .env.example .env
+```
+
+Edit **`.env`** and set at least `PIPEFY_OAUTH_CLIENT` and `PIPEFY_OAUTH_SECRET` from your service account. Canonical names and defaults: **[`../.env.example`](../.env.example)**.
+
+Runtime settings come from **`pipefy_mcp.settings.Settings`** ([Pydantic Settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/)):
+
+- **`.env`** is read from the **current working directory** when you run `uv run pipefy-mcp-server` from the clone root (or when your MCP client sets `cwd` to the clone).
+- Values already in the **process environment** override entries from `.env`.
+- The same keys work in `.env` and in an MCP client's `env` block — see [Environment variables](setup.md#environment-variables).
+
+---
+
+## Smoke test
+
+Confirm the process starts (stop with Ctrl+C when satisfied):
+
+```bash
+uv run pipefy-mcp-server
+```
+
+---
+
+## Unit tests
+
+No `PIPEFY_*` credentials required:
+
+```bash
+uv run pytest -m "not integration"
+```
+
+Integration tests (`-m integration`) call the live Pipefy GraphQL API and need a real service account in `.env`.
+
+---
+
+## Manual MCP testing
+
+Point your MCP client at the local clone instead of the published flow in [Setup](setup.md). Use this config (replace the absolute path with your clone path):
+
+```json
+{
+    "mcpServers": {
+        "pipefy": {
+            "command": "uv",
+            "args": [
+                "run",
+                "--directory",
+                "/absolute/path/to/pipefy-mcp-server",
+                "pipefy-mcp-server"
+            ]
+        }
+    }
+}
+```
+
+Set `cwd` to the clone root (or include `--directory` as above) so the server reads `.env` from there; the `env` block in JSON can be empty for local dev.
+
+For protocol-level debugging without an MCP client UI:
+
+```bash
+npx @modelcontextprotocol/inspector uv --directory . run pipefy-mcp-server
+```
+
+See [AGENTS.md](../AGENTS.md) under **Manual tool testing (E2E)** for the broader conventions maintainers follow.
+
+---
+
+## Bootstrap script
+
+From the repo root, after installing `uv`:
+
+```bash
+./bootstrap.sh
+```
+
+The script:
+
+- Runs **`uv sync`**.
+- If **`.env`** is missing, copies **`.env.example`** → **`.env`** (does not overwrite an existing `.env`).
+
+On Windows without Git Bash, run the [Clone and install](#clone-and-install) and [Local `.env` file](#local-env-file) steps manually.
+
+---
+
+## Release process
+
+When cutting a new tag, **bump the `@vX.Y.Z` references in [`docs/setup.md`](setup.md)** so end-user examples pin to the latest release. The doc currently pins to `v0.1.0`; grep for `@v` under `docs/setup.md` to find every occurrence.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -46,7 +46,7 @@ Next, paste the three values into your MCP client config — see [MCP client set
 
 ## MCP client setup
 
-All three clients use the same JSON shape. The `command` is `uvx`, which fetches the server from GitHub on first run and caches it locally — no clone, no `cwd`. Pin to a release tag (`@v0.1.0` below); see [Upgrading](#upgrading) for tag bumps.
+All three clients use the same JSON shape. The `command` is `uvx`, which fetches the server from GitHub on first run and caches it locally — no clone, no `cwd`. Pin to a release tag (`@v0.1.0-beta.1` below); see [Upgrading](#upgrading) for tag bumps.
 
 ```json
 "env": {
@@ -73,7 +73,7 @@ The three URL values are the same for every Pipefy organization on the public ho
             "command": "uvx",
             "args": [
                 "--from",
-                "git+https://github.com/gbrlcustodio/pipefy-mcp-server@v0.1.0",
+                "git+https://github.com/gbrlcustodio/pipefy-mcp-server@v0.1.0-beta.1",
                 "pipefy-mcp-server"
             ],
             "env": {
@@ -104,7 +104,7 @@ MCP servers load from a JSON config file at:
             "command": "uvx",
             "args": [
                 "--from",
-                "git+https://github.com/gbrlcustodio/pipefy-mcp-server@v0.1.0",
+                "git+https://github.com/gbrlcustodio/pipefy-mcp-server@v0.1.0-beta.1",
                 "pipefy-mcp-server"
             ],
             "env": {
@@ -125,7 +125,7 @@ MCP servers load from a JSON config file at:
 
 ```bash
 claude mcp add --scope project pipefy \
-  -- uvx --from git+https://github.com/gbrlcustodio/pipefy-mcp-server@v0.1.0 pipefy-mcp-server
+  -- uvx --from git+https://github.com/gbrlcustodio/pipefy-mcp-server@v0.1.0-beta.1 pipefy-mcp-server
 ```
 
 Then set each env var (repeat per key):
@@ -147,7 +147,7 @@ claude mcp add-env pipefy PIPEFY_OAUTH_SECRET <SERVICE_ACCOUNT_CLIENT_SECRET>
             "command": "uvx",
             "args": [
                 "--from",
-                "git+https://github.com/gbrlcustodio/pipefy-mcp-server@v0.1.0",
+                "git+https://github.com/gbrlcustodio/pipefy-mcp-server@v0.1.0-beta.1",
                 "pipefy-mcp-server"
             ],
             "env": {
@@ -166,7 +166,7 @@ Commit `.mcp.json` with placeholders (or env injection) to share the same shape 
 
 ### Upgrading
 
-To pull a newer release, change `@v0.1.0` in `args` to the new tag and **restart your MCP client**. `uvx` caches the resolved git ref, so a fresh process is required to pick up the new revision. If a stale cache is suspected, run `uv cache clean` and restart the client again.
+To pull a newer release, change `@v0.1.0-beta.1` in `args` to the new tag and **restart your MCP client**. `uvx` caches the resolved git ref, so a fresh process is required to pick up the new revision. If a stale cache is suspected, run `uv cache clean` and restart the client again.
 
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,10 +1,9 @@
-# Setup
+# Quickstart
 
-Single entry point for **end-user install** of the Pipefy MCP server in your editor or AI client. Three steps: install `uv`, create a Pipefy service account, and paste a JSON block into your MCP client. No clone required.
+End-user install of the Pipefy MCP server in your editor or AI client. Three steps: install `uv`, create a Pipefy service account, and paste a JSON block into your MCP client. No clone required.
 
 | Section | What it covers |
 |--------|------------------|
-| [Quick start](#quick-start) | The three steps end-to-end |
 | [Create a Pipefy service account](#create-a-pipefy-service-account) | Admin panel walkthrough, Client ID / Secret / Token URL |
 | [MCP client setup](#mcp-client-setup) | Cursor, Claude Desktop, Claude Code; upgrading the pinned tag |
 | [Environment variables](#environment-variables) | Required and optional `PIPEFY_*` keys |
@@ -14,13 +13,15 @@ Single entry point for **end-user install** of the Pipefy MCP server in your edi
 
 ---
 
-## Quick start
-
-1. **Install [`uv`](https://docs.astral.sh/uv/getting-started/installation/)** — Astral's installer detects your OS and drops `uv` (and `uvx`) on `PATH`.
+1. **Install `uv`** — drops `uv` (and `uvx`) on `PATH`:
+   ```bash
+   curl -LsSf https://astral.sh/uv/install.sh | sh
+   ```
+   For other install methods (Homebrew, winget, pipx, Windows PowerShell), see [Astral's installation guide](https://docs.astral.sh/uv/getting-started/installation/).
 2. **[Create a Pipefy service account](#create-a-pipefy-service-account)** and copy the **Client ID**, **Client Secret**, and **Token endpoint URL**.
 3. **[Configure your MCP client](#mcp-client-setup)** — paste the JSON block for your client, fill in the three values from step 2, restart the client, and confirm the `pipefy` server shows healthy.
 
-On Windows, the same flow works in **PowerShell** or **Git Bash** (anywhere `uv` is on `PATH`).
+On Windows, run the same flow in **PowerShell** or **Git Bash** (anywhere `uv` is on `PATH`).
 
 ---
 
@@ -183,15 +184,16 @@ Set these in the MCP client's `env:` block (see [MCP client setup](#mcp-client-s
 | `PIPEFY_OAUTH_CLIENT` | Service account **Client ID**. |
 | `PIPEFY_OAUTH_SECRET` | Service account **Client Secret**. |
 
-The three URL values default to Pipefy's public host (see **[`.env.example`](../.env.example)** for the canonical defaults) and are the same for every customer on the public cloud. Only the two `PIPEFY_OAUTH_*` secrets vary per service account. URLs are **validated at startup** — `localhost` and private hosts are rejected to avoid SSRF unless you set the insecure-dev flags documented in [`.env.example`](../.env.example).
+The three URL values default to Pipefy's public host and are the same for every customer on the public cloud — paste them as shown above. Only the two `PIPEFY_OAUTH_*` secrets vary per service account. URLs are **validated at startup** to reject `localhost` and private hosts (SSRF guard); for development overrides, see [Contributing → Dev-only env overrides](contributing.md#dev-only-env-overrides).
 
 ### Optional
 
 | Key | Default | Effect |
 |-----|---------|--------|
 | `PIPEFY_SERVICE_ACCOUNT_IDS` | _unset_ | Comma-separated Pipefy user IDs treated as service accounts. Enables [Service Account Protection](tools/members-email-webhooks.md#service-account-protection) on `remove_member_from_pipe` / `set_role`, and proactive membership checks in [`validate_ai_agent_behaviors`](tools/automations-and-ai.md#ai-agent-read--delete) for cross-pipe targets. Leave unset to skip the guards. |
-
-All other optional flags (insecure dev URLs, webhooks, introspection cache, etc.) are documented in **[`.env.example`](../.env.example)** as the canonical reference manifest.
+| `PIPEFY_PERMISSION_DENIED_ENRICHMENT_TIMEOUT_SECONDS` | `5` | Max seconds spent enriching `PERMISSION_DENIED` errors with a membership hint. Lower to skip enrichment faster. |
+| `PIPEFY_GQL_REUSE_FETCHED_GRAPHQL_SCHEMA` | `false` | Cache the introspected GraphQL schema after the first request — trades one-shot freshness for faster subsequent calls. |
+| `PIPEFY_DEFAULT_WEBHOOK_NAME` | `Pipefy Webhook` | Name applied to new webhooks when the tool call omits one. |
 
 ---
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,89 +1,51 @@
 # Setup
 
-Single entry point for **first-time install**, **environment variables**, and **MCP client** wiring. Prerequisites: a [Pipefy Service Account](https://app.pipefy.com/) (Admin → Service Accounts), and add that account to every pipe the tools should use.
+Single entry point for **end-user install** of the Pipefy MCP server in your editor or AI client. Three steps: install `uv`, create a Pipefy service account, and paste a JSON block into your MCP client. No clone required.
 
 | Section | What it covers |
 |--------|------------------|
-| [Quick start](#quick-start) | Clone, `uv`, `.env`, smoke test, unit tests |
-| [How configuration is loaded](#how-configuration-is-loaded) | Pydantic Settings, CWD, precedence |
-| [Environment variables](#environment-variables) | Required vs optional `PIPEFY_*` keys |
-| [MCP client setup](#mcp-client-setup) | Cursor, Claude Desktop, Claude Code |
-| [Bootstrap script](#optional-bootstrap-script) | One-shot `uv sync` + `.env` template |
+| [Quick start](#quick-start) | The three steps end-to-end |
+| [Create a Pipefy service account](#create-a-pipefy-service-account) | Admin panel walkthrough, Client ID / Secret / Token URL |
+| [MCP client setup](#mcp-client-setup) | Cursor, Claude Desktop, Claude Code; upgrading the pinned tag |
+| [Environment variables](#environment-variables) | Required and optional `PIPEFY_*` keys |
+| [How configuration is loaded](#how-configuration-is-loaded) | Pydantic Settings and process env |
+
+> Setting up a development environment to **edit** the server? See [Contributing](contributing.md).
 
 ---
 
 ## Quick start
 
-1. **Install [uv](https://docs.astral.sh/uv/getting-started/installation/)** (it manages Python 3.11+ for this project).
+1. **Install [`uv`](https://docs.astral.sh/uv/getting-started/installation/)** — Astral's installer detects your OS and drops `uv` (and `uvx`) on `PATH`.
+2. **[Create a Pipefy service account](#create-a-pipefy-service-account)** and copy the **Client ID**, **Client Secret**, and **Token endpoint URL**.
+3. **[Configure your MCP client](#mcp-client-setup)** — paste the JSON block for your client, fill in the three values from step 2, restart the client, and confirm the `pipefy` server shows healthy.
 
-2. **Clone and install dependencies**
-   ```bash
-   git clone https://github.com/gbrlcustodio/pipefy-mcp-server.git
-   cd pipefy-mcp-server
-   uv sync
-   ```
-
-3. **Environment file** — from the repo root:
-   ```bash
-   cp .env.example .env
-   ```
-   Edit **`.env`** and set at least the OAuth client and secret from your service account. Canonical names and placeholders: **[`../.env.example`](../.env.example)**.
-
-4. **Smoke test (optional)** — confirms the process starts (stop with Ctrl+C when satisfied):
-   ```bash
-   uv run pipefy-mcp-server
-   ```
-
-5. **Tests without calling Pipefy (optional)** — no `PIPEFY_*` credentials required:
-   ```bash
-   uv run pytest -m "not integration"
-   ```
-
-6. **Register the server in your IDE** — [MCP client setup](#mcp-client-setup) below. Prefer pointing the client’s `cwd` at this repo and keeping secrets in **`.env`** so you do not duplicate them in JSON.
-
-On Windows, use the same commands in **PowerShell** or **Git Bash** (where `uv` is on `PATH`).
+On Windows, the same flow works in **PowerShell** or **Git Bash** (anywhere `uv` is on `PATH`).
 
 ---
 
-## How configuration is loaded
+## Create a Pipefy service account
 
-Runtime settings come from **`pipefy_mcp.settings.Settings`** ([Pydantic Settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/)).
+A **service account** is a non-human Pipefy identity that issues OAuth credentials for API access. Full reference: **[Service Accounts on developers.pipefy.com](https://developers.pipefy.com/reference/service-accounts)**.
 
-- **`.env`**: read from the **current working directory** (usually the repo root when you run `uv run pipefy-mcp-server` from there, or when the MCP client sets `cwd` to the clone).
-- **Precedence**: values already in the **process environment** (including the MCP client `env` block) **override** entries from `.env`.
-- **Same keys everywhere** — use the names from **[`.env.example`](../.env.example)** in `.env` or in the client JSON; the server does not care which source won, as long as the process sees the variables.
+**Prerequisite:** you need an **Admin** role on your Pipefy organization.
 
----
+1. Open the Pipefy **Admin Panel**.
+2. Go to **Members and Permissions** → **Service Accounts**.
+3. Click **[Create Service Account](https://developers.pipefy.com/reference/service-accounts)** and set the name, description, role, and expiration window (between 5 minutes and 30 days — **immutable after creation**).
+4. Copy the three values Pipefy returns:
+   - **Client ID** → `PIPEFY_OAUTH_CLIENT`
+   - **Client Secret** → `PIPEFY_OAUTH_SECRET`
+   - **Token endpoint URL** → `PIPEFY_OAUTH_URL`
+5. **Add the service account to every pipe** the MCP tools should operate on. Without this, calls return permission errors even when credentials are valid.
 
-## Environment variables
-
-### Required for API access
-
-| Key | Role |
-|-----|------|
-| `PIPEFY_GRAPHQL_URL` | Public GraphQL endpoint (default in `.env.example`). |
-| `PIPEFY_INTERNAL_API_URL` | Internal GraphQL (AI automations, some relation flows). Use the value from [`.env.example`](../.env.example). |
-| `PIPEFY_OAUTH_URL` | OAuth token URL for the service account. |
-| `PIPEFY_OAUTH_CLIENT` | Service account client ID. |
-| `PIPEFY_OAUTH_SECRET` | Service account client secret. |
-
-`PIPEFY_INTERNAL_API_URL` points at Pipefy’s internal GraphQL; it is required for tools that use that path (e.g. AI automations, some relations). Values are **validated at startup** — public Pipefy hosts are the normal case; `localhost` / private hosts are rejected to avoid SSRF unless you use the insecure-dev flags in [`.env.example`](../.env.example).
-
-### Optional
-
-| Key | Default | Effect |
-|-----|---------|--------|
-| `PIPEFY_SERVICE_ACCOUNT_IDS` | _unset_ | Comma-separated Pipefy user IDs treated as service accounts. Enables [Service Account Protection](tools/members-email-webhooks.md#service-account-protection) on `remove_member_from_pipe` / `set_role`, and proactive membership checks in [`validate_ai_agent_behaviors`](tools/automations-and-ai.md#ai-agent-read--delete) for cross-pipe targets. Leave unset to skip the guards. |
-
-All other optional flags (insecure dev URLs, webhooks, introspection cache, etc.) are documented in **[`.env.example`](../.env.example)** only.
+Next, paste the three values into your MCP client config — see [MCP client setup](#mcp-client-setup) below.
 
 ---
 
 ## MCP client setup
 
-**Recommended:** set the client’s working directory to your **clone root** and use **`.env`** for `PIPEFY_*` values. Then the JSON `env` block can be minimal or empty for local dev. If you put secrets only in JSON, use the same keys as [`.env.example`](../.env.example).
-
-Use this **`env` shape** when you need to inline values (e.g. CI or machines without a `.env` file). Include **`PIPEFY_INTERNAL_API_URL`** for parity with full tool coverage (same as [`.env.example`](../.env.example)).
+All three clients use the same JSON shape. The `command` is `uvx`, which fetches the server from GitHub on first run and caches it locally — no clone, no `cwd`. Pin to a release tag (`@v0.1.0` below); see [Upgrading](#upgrading) for tag bumps.
 
 ```json
 "env": {
@@ -95,22 +57,22 @@ Use this **`env` shape** when you need to inline values (e.g. CI or machines wit
 }
 ```
 
+The three URL values are the same for every Pipefy organization on the public host — only the two `PIPEFY_OAUTH_*` secrets vary per service account.
+
 ### Cursor
 
 1. Open **Cursor Settings → Features → MCP Servers**.
 2. Click **+ Add New MCP Server**.
-3. Use a config like the one below (replace the path and placeholders).
+3. Paste the config below (replace the two `PIPEFY_OAUTH_*` placeholders).
 
 ```json
 {
     "mcpServers": {
         "pipefy": {
-            "cwd": "/absolute/path/to/pipefy-mcp-server",
-            "command": "uv",
+            "command": "uvx",
             "args": [
-                "run",
-                "--directory",
-                ".",
+                "--from",
+                "git+https://github.com/gbrlcustodio/pipefy-mcp-server@v0.1.0",
                 "pipefy-mcp-server"
             ],
             "env": {
@@ -125,13 +87,9 @@ Use this **`env` shape** when you need to inline values (e.g. CI or machines wit
 }
 ```
 
-Set `cwd` to your clone root so the server can read **`.env`** there; you may omit keys from `env` that are already set in `.env`.
-
 ### Claude Desktop
 
-MCP servers load from a JSON config file. You can keep credentials in **`.env`** at the repo root (see [How configuration is loaded](#how-configuration-is-loaded)) and use a minimal `env` in JSON if `cwd` points at the clone.
-
-**Config paths**
+MCP servers load from a JSON config file at:
 
 | OS | File |
 |----|------|
@@ -142,11 +100,10 @@ MCP servers load from a JSON config file. You can keep credentials in **`.env`**
 {
     "mcpServers": {
         "pipefy": {
-            "command": "uv",
+            "command": "uvx",
             "args": [
-                "run",
-                "--directory",
-                "/absolute/path/to/pipefy-mcp-server",
+                "--from",
+                "git+https://github.com/gbrlcustodio/pipefy-mcp-server@v0.1.0",
                 "pipefy-mcp-server"
             ],
             "env": {
@@ -161,27 +118,23 @@ MCP servers load from a JSON config file. You can keep credentials in **`.env`**
 }
 ```
 
-Replace `/absolute/path/to/pipefy-mcp-server` with your clone path.
-
 ### Claude Code
-
-Either rely on [`.env.example`](../.env.example) → **`.env`** at the repo root, or set vars with `claude mcp add-env`.
 
 **CLI (per project)**
 
 ```bash
 claude mcp add --scope project pipefy \
-  -- uv run --directory /absolute/path/to/pipefy-mcp-server pipefy-mcp-server
+  -- uvx --from git+https://github.com/gbrlcustodio/pipefy-mcp-server@v0.1.0 pipefy-mcp-server
 ```
 
-Then (repeat for each key you need, matching [`.env.example`](../.env.example)):
+Then set each env var (repeat per key):
 
 ```bash
-claude mcp add-env pipefy PIPEFY_OAUTH_CLIENT <YOUR_CLIENT_ID>
-claude mcp add-env pipefy PIPEFY_OAUTH_SECRET <YOUR_CLIENT_SECRET>
 claude mcp add-env pipefy PIPEFY_GRAPHQL_URL https://app.pipefy.com/graphql
 claude mcp add-env pipefy PIPEFY_INTERNAL_API_URL https://app.pipefy.com/internal_api
 claude mcp add-env pipefy PIPEFY_OAUTH_URL https://app.pipefy.com/oauth/token
+claude mcp add-env pipefy PIPEFY_OAUTH_CLIENT <SERVICE_ACCOUNT_CLIENT_ID>
+claude mcp add-env pipefy PIPEFY_OAUTH_SECRET <SERVICE_ACCOUNT_CLIENT_SECRET>
 ```
 
 **`.mcp.json` (project root)**
@@ -190,11 +143,10 @@ claude mcp add-env pipefy PIPEFY_OAUTH_URL https://app.pipefy.com/oauth/token
 {
     "mcpServers": {
         "pipefy": {
-            "command": "uv",
+            "command": "uvx",
             "args": [
-                "run",
-                "--directory",
-                "/absolute/path/to/pipefy-mcp-server",
+                "--from",
+                "git+https://github.com/gbrlcustodio/pipefy-mcp-server@v0.1.0",
                 "pipefy-mcp-server"
             ],
             "env": {
@@ -209,19 +161,42 @@ claude mcp add-env pipefy PIPEFY_OAUTH_URL https://app.pipefy.com/oauth/token
 }
 ```
 
-The CLI flow is quick for local tests. Committing **`.mcp.json`** without secrets (placeholders or env injection) can help teams share the same shape.
+Commit `.mcp.json` with placeholders (or env injection) to share the same shape across the team without leaking secrets.
+
+### Upgrading
+
+To pull a newer release, change `@v0.1.0` in `args` to the new tag and **restart your MCP client**. `uvx` caches the resolved git ref, so a fresh process is required to pick up the new revision. If a stale cache is suspected, run `uv cache clean` and restart the client again.
 
 ---
 
-## Optional bootstrap script
+## Environment variables
 
-From the **repository root**, after installing `uv`, you can run:
+Set these in the MCP client's `env:` block (see [MCP client setup](#mcp-client-setup)). The server reads them from process environment on startup.
 
-`./bootstrap.sh`
+### Required for API access
 
-Purpose:
+| Key | Role |
+|-----|------|
+| `PIPEFY_GRAPHQL_URL` | Public GraphQL endpoint. |
+| `PIPEFY_INTERNAL_API_URL` | Internal GraphQL (AI automations, some relation flows). |
+| `PIPEFY_OAUTH_URL` | OAuth token URL for the service account. |
+| `PIPEFY_OAUTH_CLIENT` | Service account **Client ID**. |
+| `PIPEFY_OAUTH_SECRET` | Service account **Client Secret**. |
 
-- Run **`uv sync`**
-- If **`.env`** is missing, copy **`.env.example`** → **`.env`** (does not overwrite an existing `.env`)
+The three URL values default to Pipefy's public host (see **[`.env.example`](../.env.example)** for the canonical defaults) and are the same for every customer on the public cloud. Only the two `PIPEFY_OAUTH_*` secrets vary per service account. URLs are **validated at startup** — `localhost` and private hosts are rejected to avoid SSRF unless you set the insecure-dev flags documented in [`.env.example`](../.env.example).
 
-On Windows, run the [Quick start](#quick-start) steps manually if you do not use Git Bash.
+### Optional
+
+| Key | Default | Effect |
+|-----|---------|--------|
+| `PIPEFY_SERVICE_ACCOUNT_IDS` | _unset_ | Comma-separated Pipefy user IDs treated as service accounts. Enables [Service Account Protection](tools/members-email-webhooks.md#service-account-protection) on `remove_member_from_pipe` / `set_role`, and proactive membership checks in [`validate_ai_agent_behaviors`](tools/automations-and-ai.md#ai-agent-read--delete) for cross-pipe targets. Leave unset to skip the guards. |
+
+All other optional flags (insecure dev URLs, webhooks, introspection cache, etc.) are documented in **[`.env.example`](../.env.example)** as the canonical reference manifest.
+
+---
+
+## How configuration is loaded
+
+- The server reads from **process environment** via **`pipefy_mcp.settings.Settings`** ([Pydantic Settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/)).
+- The MCP client injects its `env:` block into the spawned subprocess — that block is the only source in the `uvx` install flow. **`.env` files are not read** from the user's machine. For dev from a clone, see [Contributing](contributing.md).
+- URL validation runs at startup; a startup failure means a malformed URL, while a runtime 401 means the service account credentials are wrong or the account is missing from a pipe.

--- a/docs/tools/cross-cutting.md
+++ b/docs/tools/cross-cutting.md
@@ -32,7 +32,7 @@ On cross-pipe operations (relations, AI agents), errors carrying `extensions.cod
 
 ## Service account protection
 
-When the optional `PIPEFY_SERVICE_ACCOUNT_IDS` env var is set (see [`.env.example`](../../.env.example)), the server guards `remove_member_from_pipe` and `set_role` against locking the service account out of its own pipes. Full contract: [Service account protection](members-email-webhooks.md#service-account-protection).
+When the optional `PIPEFY_SERVICE_ACCOUNT_IDS` env var is set in the MCP client's `env:` block (see [Environment variables](../setup.md#environment-variables); full key reference in [`.env.example`](../../.env.example)), the server guards `remove_member_from_pipe` and `set_role` against locking the service account out of its own pipes. Full contract: [Service account protection](members-email-webhooks.md#service-account-protection).
 
 ## Pre-flight validation for AI features
 

--- a/docs/tools/cross-cutting.md
+++ b/docs/tools/cross-cutting.md
@@ -32,7 +32,7 @@ On cross-pipe operations (relations, AI agents), errors carrying `extensions.cod
 
 ## Service account protection
 
-When the optional `PIPEFY_SERVICE_ACCOUNT_IDS` env var is set in the MCP client's `env:` block (see [Environment variables](../setup.md#environment-variables); full key reference in [`.env.example`](../../.env.example)), the server guards `remove_member_from_pipe` and `set_role` against locking the service account out of its own pipes. Full contract: [Service account protection](members-email-webhooks.md#service-account-protection).
+When the optional `PIPEFY_SERVICE_ACCOUNT_IDS` env var is set in the MCP client's `env:` block (see [Environment variables](../quickstart.md#environment-variables)), the server guards `remove_member_from_pipe` and `set_role` against locking the service account out of its own pipes. Full contract: [Service account protection](members-email-webhooks.md#service-account-protection).
 
 ## Pre-flight validation for AI features
 

--- a/docs/tools/members-email-webhooks.md
+++ b/docs/tools/members-email-webhooks.md
@@ -19,7 +19,7 @@ When the optional environment variable **`PIPEFY_SERVICE_ACCOUNT_IDS`** is set t
 - **`remove_member_from_pipe`** — Removal is **blocked** if any requested `user_id` is in that list. The tool returns an error explaining that removing the service account would break write operations for the pipe; use the Pipefy UI if removal is intentional. If the env var is unset or empty, this check is skipped.
 - **`set_role`** — If `member_id` is a listed service account ID, the mutation still runs (role changes are reversible), but the success payload may include a **warning** reminding you to keep a role that preserves write permissions.
 
-Configure IDs in the MCP client's `env:` block (see [Environment variables](../setup.md#environment-variables); full key reference in [`.env.example`](../../.env.example)). Omit the variable when you do not need this guard.
+Configure IDs in the MCP client's `env:` block (see [Environment variables](../quickstart.md#environment-variables)). Omit the variable when you do not need this guard.
 
 ## Email tools
 

--- a/docs/tools/members-email-webhooks.md
+++ b/docs/tools/members-email-webhooks.md
@@ -19,7 +19,7 @@ When the optional environment variable **`PIPEFY_SERVICE_ACCOUNT_IDS`** is set t
 - **`remove_member_from_pipe`** — Removal is **blocked** if any requested `user_id` is in that list. The tool returns an error explaining that removing the service account would break write operations for the pipe; use the Pipefy UI if removal is intentional. If the env var is unset or empty, this check is skipped.
 - **`set_role`** — If `member_id` is a listed service account ID, the mutation still runs (role changes are reversible), but the success payload may include a **warning** reminding you to keep a role that preserves write permissions.
 
-Configure IDs in `.env` (see `.env.example`). Omit the variable when you do not need this guard.
+Configure IDs in the MCP client's `env:` block (see [Environment variables](../setup.md#environment-variables); full key reference in [`.env.example`](../../.env.example)). Omit the variable when you do not need this guard.
 
 ## Email tools
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4,7 +4,7 @@ Typer-based CLI for Pipefy. Consumes **`pipefy-ai-sdk`** for GraphQL calls.
 
 Install via the workspace root (`uv sync`) or build this package's wheel from the repo.
 
-See the repository **`README.md`** and **`docs/setup.md`** for `PIPEFY_*` environment variables (same as `pipefy-mcp-server`).
+See the repository **`README.md`** and **`docs/quickstart.md`** for `PIPEFY_*` environment variables (same as `pipefy-mcp-server`).
 
 Example:
 

--- a/packages/cli/src/pipefy_cli/_docs.py
+++ b/packages/cli/src/pipefy_cli/_docs.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-DOCS_SETUP_REF = "docs/setup.md"
+DOCS_QUICKSTART_REF = "docs/quickstart.md"

--- a/packages/cli/src/pipefy_cli/auth.py
+++ b/packages/cli/src/pipefy_cli/auth.py
@@ -10,7 +10,7 @@ from pipefy_sdk import (
     PipefySettings,
 )
 
-from pipefy_cli._docs import DOCS_SETUP_REF
+from pipefy_cli._docs import DOCS_QUICKSTART_REF
 from pipefy_cli.config import (
     describe_missing_oauth_vars,
     ensure_public_graphql_configured,
@@ -89,7 +89,7 @@ def get_authenticated_client(
     if missing_msg:
         typer.echo(
             f"Missing OAuth configuration ({missing_msg}). "
-            f"Use --token or PIPEFY_TOKEN for a bearer token, or set OAuth per {DOCS_SETUP_REF}.",
+            f"Use --token or PIPEFY_TOKEN for a bearer token, or set OAuth per {DOCS_QUICKSTART_REF}.",
             err=True,
         )
         raise typer.Exit(2)

--- a/packages/cli/src/pipefy_cli/config.py
+++ b/packages/cli/src/pipefy_cli/config.py
@@ -11,7 +11,7 @@ from pipefy_sdk import PipefySettings
 from pydantic import Field, ValidationError
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from pipefy_cli._docs import DOCS_SETUP_REF
+from pipefy_cli._docs import DOCS_QUICKSTART_REF
 
 _ALLOW_INSECURE_ENV_KEY = "PIPEFY_ALLOW_INSECURE_URLS"
 
@@ -49,7 +49,7 @@ def _read_toml_pipefy_dict() -> dict[str, Any]:
     except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError) as exc:
         msg = (
             f"Could not read Pipefy config file at {USER_CONFIG_PATH}: {exc}. "
-            f"See {DOCS_SETUP_REF} for the expected format."
+            f"See {DOCS_QUICKSTART_REF} for the expected format."
         )
         raise ValueError(msg) from exc
     section = data.get("pipefy")
@@ -144,12 +144,12 @@ def ensure_public_graphql_configured(pipefy: PipefySettings) -> None:
     """Ensure GraphQL URL is present before building a client.
 
     Raises:
-        ValueError: With pointer to ``docs/setup.md``.
+        ValueError: With pointer to ``docs/quickstart.md``.
     """
     if _is_missing(pipefy.graphql_url):
         msg = (
             "PIPEFY_GRAPHQL_URL is required (or pass --graphql-url). "
-            f"See {DOCS_SETUP_REF} for environment variables."
+            f"See {DOCS_QUICKSTART_REF} for environment variables."
         )
         raise ValueError(msg)
 

--- a/packages/cli/tests/test_auth.py
+++ b/packages/cli/tests/test_auth.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from pipefy_sdk import PipefySettings
 
+from pipefy_cli._docs import DOCS_QUICKSTART_REF
 from pipefy_cli.auth import get_authenticated_client
 from pipefy_cli.main import app
 
@@ -51,7 +52,7 @@ def test_missing_graphql_exits_2_cli(clean_pipefy_env, saved_cwd, runner):
     result = runner.invoke(app, ["card", "get", "123"])
     assert result.exit_code == 2
     combined = (result.stderr or "") + (result.stdout or "")
-    assert "docs/setup.md" in combined
+    assert DOCS_QUICKSTART_REF in combined
 
 
 def test_missing_oauth_exits_2_cli(clean_pipefy_env, saved_cwd, monkeypatch, runner):
@@ -62,7 +63,7 @@ def test_missing_oauth_exits_2_cli(clean_pipefy_env, saved_cwd, monkeypatch, run
     result = runner.invoke(app, ["card", "get", "123"])
     assert result.exit_code == 2
     combined = (result.stderr or "") + (result.stdout or "")
-    assert "docs/setup.md" in combined
+    assert DOCS_QUICKSTART_REF in combined
 
 
 def test_cli_uses_pipefy_token_env_when_no_flag(

--- a/packages/cli/tests/test_config.py
+++ b/packages/cli/tests/test_config.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import re
 import textwrap
 
 import pytest
 
 from pipefy_cli import config as config_module
+from pipefy_cli._docs import DOCS_QUICKSTART_REF
 from pipefy_cli.config import (
     CliSettings,
     apply_toml_fallback,
@@ -113,7 +115,7 @@ def test_graphql_url_flag_overrides_env(
     assert resolved.graphql_url == "https://from-flag.example.com/graphql"
 
 
-def test_missing_graphql_url_error_points_to_setup_docs(
+def test_missing_graphql_url_error_points_to_quickstart_docs(
     clean_pipefy_env,
     saved_cwd,
 ):
@@ -122,7 +124,7 @@ def test_missing_graphql_url_error_points_to_setup_docs(
         allow_insecure_urls_flag=None,
     )
 
-    with pytest.raises(ValueError, match="docs/setup\\.md"):
+    with pytest.raises(ValueError, match=re.escape(DOCS_QUICKSTART_REF)):
         ensure_public_graphql_configured(resolved)
 
 
@@ -293,7 +295,7 @@ def test_corrupt_user_config_toml_raises_actionable_error(
     cfg_path.write_text("[pipefy\ngraphql_url = ", encoding="utf-8")
     monkeypatch.setattr(config_module, "USER_CONFIG_PATH", cfg_path)
 
-    with pytest.raises(ValueError, match="docs/setup"):
+    with pytest.raises(ValueError, match=re.escape(DOCS_QUICKSTART_REF)):
         resolve_pipefy_settings(
             graphql_url_flag=None,
             allow_insecure_urls_flag=None,


### PR DESCRIPTION
## Summary
- Reframe end-user install around `uvx --from git+...@v0.1.0 pipefy-mcp-server` — no clone, no `.env` on disk, three values from a Pipefy service account pasted into the MCP client's `env:` block.
- Rename `docs/setup.md` → `docs/quickstart.md` to match the lead-with-quickstart structure. Propagate through markdown link targets (README, AGENTS, contributing, two tool docs, `.env.example`, CLI README) and rename the CLI doc-pointer constant `DOCS_SETUP_REF` → `DOCS_QUICKSTART_REF` (`_docs.py`, `auth.py`, `config.py`, plus tests now import the constant instead of hardcoding the string).
- New **Create a Pipefy service account** section mirrors the step ordering of [developers.pipefy.com/reference/service-accounts](https://developers.pipefy.com/reference/service-accounts).
- Move clone-based development flow to new `docs/contributing.md` (`uv sync`, `.env`, smoke test, unit tests, `bootstrap.sh`, release process).
- Re-split optional env vars by audience: user-facing keys (`PIPEFY_SERVICE_ACCOUNT_IDS`, `PERMISSION_DENIED_ENRICHMENT_TIMEOUT_SECONDS`, `GQL_REUSE_FETCHED_GRAPHQL_SCHEMA`, `DEFAULT_WEBHOOK_NAME`) live in `docs/quickstart.md`. Only `PIPEFY_ALLOW_INSECURE_URLS` lives in `docs/contributing.md` under `### Dev-only env overrides`.
- Inline the `uv` install one-liner (`curl -LsSf https://astral.sh/uv/install.sh | sh`) in step 1 so readers don't have to detour to Astral's page.
- Drop the redundant `## Quick start` H2; the three-step list sits directly under the `# Quickstart` intro that already announces "Three steps".

End-user docs no longer reference `.env` / `.env.example` as a canonical reference manifest — those framings belong in the contributor doc only.

Anchors `#mcp-client-setup`, `#cursor`, `#claude-desktop`, `#claude-code` preserved so existing `README.md` links keep resolving. README rewrite, directory restructure (`docs/{mcp,cli,sdk}/`), repo move to `pipefy/pipefy`, and tagging `v0.1.0` are tracked separately. Examples currently pin to `@v0.1.0`, which must exist on the remote before this lands publicly.

## Test plan
- [ ] On a clean machine, follow the new **Quickstart** verbatim: install `uv`, create a service account in Pipefy admin, paste the Claude Desktop / Cursor JSON with real SA values, restart the client, confirm the `pipefy` server shows healthy.
- [ ] Invoke a read-only tool (e.g. `get_me`) to confirm OAuth end-to-end.
- [ ] Bump `@v0.1.0` in `args` to a different ref, restart the client, confirm `uvx` re-resolves.
- [ ] README anchor links (`#mcp-client-setup`, `#cursor`, `#claude-desktop`, `#claude-code`) still resolve in the rewritten doc.
- [ ] `docs/contributing.md` clone flow works on a fresh clone: `uv sync`, `cp .env.example .env`, `uv run pytest -m "not integration"`, `./bootstrap.sh`.
- [x] CLI unit tests pass with the renamed constant: `uv run pytest packages/cli/tests -m "not integration"` (91 passed).