### PR TITLE
fix(cli): transport UX, dashed ids, field conditions, and formatter parity

### DIFF
--- a/packages/cli/src/pipefy_cli/commands/_common.py
+++ b/packages/cli/src/pipefy_cli/commands/_common.py
@@ -10,6 +10,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any, TypeVar
 
 import typer
+from gql.transport.exceptions import TransportError, TransportQueryError
 from pipefy_sdk import PipefyClient, PipefySettings, stream_bytes
 from pipefy_sdk.exceptions import PipefyError
 
@@ -20,6 +21,14 @@ _T = TypeVar("_T")
 _R = TypeVar("_R")
 
 DEFAULT_EXPORT_MAX_BYTES = 50 * 1024 * 1024
+
+# Pipefy occasionally encodes ids with a leading hyphen (e.g. table id "-ZocGcM0").
+# Click parses tokens starting with "-" as short options by default, which breaks
+# every `<sub> get/update/delete <ID>` command. Setting ignore_unknown_options on
+# the command relaxes the parser so the dashed token is consumed as the positional
+# id; unknown LONG options (typos like ``--yez``) still surface as errors because
+# Click attempts to bind them to the (single) positional slot.
+ID_POSITIONAL_CONTEXT_SETTINGS = {"ignore_unknown_options": True}
 
 
 def export_poll_max_rounds(
@@ -127,6 +136,26 @@ def run_pipefy_client_coroutine(
     except PipefyError as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(1) from exc
+    except TransportQueryError as exc:
+        typer.echo(_format_transport_query_error(exc), err=True)
+        raise typer.Exit(1) from exc
+    except TransportError as exc:
+        typer.echo(f"Pipefy transport error: {exc}", err=True)
+        raise typer.Exit(1) from exc
+
+
+def _format_transport_query_error(exc: TransportQueryError) -> str:
+    """Render a GraphQL transport error as a clean single-line message for the CLI.
+
+    Falls back to ``str(exc)`` when the structured ``errors`` payload is missing or empty.
+    """
+    errors = getattr(exc, "errors", None) or []
+    if not errors:
+        return str(exc)
+    first = errors[0] if isinstance(errors[0], dict) else {"message": str(errors[0])}
+    message = first.get("message") or str(exc)
+    code = (first.get("extensions") or {}).get("code")
+    return f"{message} ({code})" if code else message
 
 
 def settings_and_token(ctx: typer.Context) -> tuple[PipefySettings, str | None]:
@@ -175,7 +204,7 @@ def run_cli_command(
     json_out: bool,
     coro_factory: Callable[[PipefyClient], Awaitable[_R]],
     *,
-    exit_code_2_on_value_error: bool = False,
+    exit_code_2_on_value_error: bool = True,
 ) -> None:
     """Run an async coroutine factory with a configured client and render the result.
 
@@ -195,6 +224,12 @@ def run_cli_command(
         data = asyncio.run(_run())
     except PipefyError as exc:
         typer.echo(str(exc), err=True)
+        raise typer.Exit(1) from exc
+    except TransportQueryError as exc:
+        typer.echo(_format_transport_query_error(exc), err=True)
+        raise typer.Exit(1) from exc
+    except TransportError as exc:
+        typer.echo(f"Pipefy transport error: {exc}", err=True)
         raise typer.Exit(1) from exc
     except ValueError as exc:
         if exit_code_2_on_value_error:

--- a/packages/cli/src/pipefy_cli/commands/agent.py
+++ b/packages/cli/src/pipefy_cli/commands/agent.py
@@ -20,6 +20,7 @@ from pipefy_sdk.behavior_placeholders import (
 from pydantic import ValidationError
 
 from pipefy_cli.commands._common import (
+    ID_POSITIONAL_CONTEXT_SETTINGS,
     confirm_destructive,
     parse_json_value,
     run_cli_command,
@@ -68,7 +69,7 @@ def agent_list(
     run_cli_command(ctx, json_out, factory)
 
 
-@agent_app.command("get")
+@agent_app.command("get", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def agent_get(
     ctx: typer.Context,
     uuid: str = typer.Argument(..., help="Agent UUID."),
@@ -257,7 +258,7 @@ def agent_update(
     run_cli_command(ctx, json_out, factory)
 
 
-@agent_app.command("delete")
+@agent_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def agent_delete(
     ctx: typer.Context,
     uuid: str = typer.Argument(..., help="Agent UUID."),
@@ -273,7 +274,7 @@ def agent_delete(
     run_cli_command(ctx, json_out, factory)
 
 
-@agent_app.command("toggle")
+@agent_app.command("toggle", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def agent_toggle(
     ctx: typer.Context,
     uuid: str = typer.Argument(..., help="Agent UUID."),
@@ -314,7 +315,7 @@ def agent_logs_list(
     run_cli_command(ctx, json_out, factory)
 
 
-@logs_app.command("get")
+@logs_app.command("get", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def agent_logs_get(
     ctx: typer.Context,
     log_id: str = typer.Argument(..., help="Log UUID."),

--- a/packages/cli/src/pipefy_cli/commands/ai_automation.py
+++ b/packages/cli/src/pipefy_cli/commands/ai_automation.py
@@ -17,6 +17,7 @@ from pipefy_sdk.ai_preflight import (
 from pydantic import ValidationError
 
 from pipefy_cli.commands._common import (
+    ID_POSITIONAL_CONTEXT_SETTINGS,
     confirm_destructive,
     parse_json_object,
     parse_json_value,
@@ -56,6 +57,25 @@ def _parse_field_ids(raw: str) -> list[str]:
     return list(parsed)
 
 
+def _extract_existing_prompt_and_field_ids(
+    row: dict[str, Any],
+) -> tuple[str | None, list[str] | None]:
+    """Return ``(prompt, field_ids)`` from a ``generate_with_ai`` automation row.
+
+    Returns ``(None, None)`` for non-AI rows or rows missing the ``aiParams`` block;
+    callers must surface that as a clear user error.
+    """
+    action_params = row.get("action_params") or row.get("actionParams") or {}
+    ai_params = action_params.get("aiParams") or action_params.get("ai_params") or {}
+    prompt = ai_params.get("value")
+    field_ids = ai_params.get("fieldIds") or ai_params.get("field_ids")
+    if not isinstance(prompt, str):
+        prompt = None
+    if isinstance(field_ids, list) and all(isinstance(x, str) for x in field_ids):
+        return prompt, list(field_ids)
+    return prompt, None
+
+
 @ai_automation_app.command("list")
 def ai_automation_list(
     ctx: typer.Context,
@@ -78,7 +98,7 @@ def ai_automation_list(
     run_cli_command(ctx, json_out, factory)
 
 
-@ai_automation_app.command("get")
+@ai_automation_app.command("get", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def ai_automation_get(
     ctx: typer.Context,
     automation_id: str = typer.Argument(..., help="Automation rule id."),
@@ -193,7 +213,7 @@ def ai_automation_create(
     run_cli_command(ctx, json_out, factory)
 
 
-@ai_automation_app.command("update")
+@ai_automation_app.command("update", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def ai_automation_update(
     ctx: typer.Context,
     automation_id: str = typer.Argument(..., help="Automation rule id."),
@@ -203,12 +223,17 @@ def ai_automation_update(
         help="Pipe id for validate-prompt pre-flight.",
     ),
     prompt: str | None = typer.Option(
-        None, "--prompt", help="New prompt (for pre-flight + patch)."
+        None,
+        "--prompt",
+        help="New prompt; omit to keep the current value (re-used in pre-flight).",
     ),
     field_ids: str | None = typer.Option(
         None,
         "--field-ids",
-        help="JSON array of output field ids (for pre-flight + patch).",
+        help=(
+            "JSON array of output field ids; omit to keep the current values "
+            "(re-used in pre-flight)."
+        ),
     ),
     name: str | None = typer.Option(None, "--name", "-n"),
     patch_active: bool | None = typer.Option(
@@ -221,13 +246,14 @@ def ai_automation_update(
     condition: str | None = typer.Option(None, "--condition"),
     json_out: bool = typer.Option(False, "--json", "-j"),
 ) -> None:
-    """Update an AI automation (``update_ai_automation``)."""
-    if prompt is None or field_ids is None:
-        raise typer.BadParameter(
-            "update requires --prompt and --field-ids for validate-prompt pre-flight "
-            "(pass current values if unchanged)."
-        )
-    fids = _parse_field_ids(field_ids)
+    """Update an AI automation (``update_ai_automation``).
+
+    ``--prompt`` and ``--field-ids`` are optional: when omitted the CLI reads
+    the current values from the existing automation and re-uses them for the
+    ``validate_ai_automation_prompt`` pre-flight. Only fields you pass
+    explicitly are sent in the patch.
+    """
+    fids: list[str] | None = _parse_field_ids(field_ids) if field_ids else None
     ep = parse_json_object(event_params, "--event-params")
     cond = parse_json_object(condition, "--condition")
     skills_raw = parse_json_value(skills_ids, "--skills-ids") if skills_ids else None
@@ -244,12 +270,20 @@ def ai_automation_update(
         row = await client.get_automation(automation_id)
         if row is None:
             return {"success": False, "message": "Automation not found."}
+        existing_prompt, existing_fids = _extract_existing_prompt_and_field_ids(row)
+        effective_prompt = prompt if prompt is not None else existing_prompt
+        effective_fids = fids if fids is not None else existing_fids
+        if not effective_prompt or not effective_fids:
+            raise typer.BadParameter(
+                "Could not infer current prompt / field_ids from the existing automation. "
+                "Pass --prompt and --field-ids explicitly."
+            )
         ev = str(row.get("event_id") or row.get("eventId") or "")
         pre = await validate_ai_automation_prompt_sdk(
             client,
             pipe.strip(),
-            prompt,
-            fids,
+            effective_prompt,
+            effective_fids,
             ev or None,
         )
         _raise_if_prompt_preflight_blocks(pre)
@@ -258,10 +292,12 @@ def ai_automation_update(
                 "automation_id": str(automation_id).strip(),
                 "name": name.strip() if name else None,
                 "active": patch_active,
-                "prompt": prompt,
-                "field_ids": fids,
                 "skills_ids": skills,
             }
+            if prompt is not None:
+                kwargs_u["prompt"] = prompt
+            if fids is not None:
+                kwargs_u["field_ids"] = fids
             if ep is not None:
                 kwargs_u["event_params"] = ep
             if cond is not None:
@@ -274,7 +310,7 @@ def ai_automation_update(
     run_cli_command(ctx, json_out, factory)
 
 
-@ai_automation_app.command("delete")
+@ai_automation_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def ai_automation_delete(
     ctx: typer.Context,
     automation_id: str = typer.Argument(..., help="Automation rule id."),

--- a/packages/cli/src/pipefy_cli/commands/automation.py
+++ b/packages/cli/src/pipefy_cli/commands/automation.py
@@ -9,6 +9,7 @@ from pipefy_sdk import CreateSendTaskAutomationInput, PipefyClient
 from pydantic import ValidationError
 
 from pipefy_cli.commands._common import (
+    ID_POSITIONAL_CONTEXT_SETTINGS,
     confirm_destructive,
     parse_json_object,
     parse_json_value,
@@ -52,7 +53,7 @@ def automation_list(
     run_cli_command(ctx, json_out, factory)
 
 
-@automation_app.command("get")
+@automation_app.command("get", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def automation_get(
     ctx: typer.Context,
     automation_id: str = typer.Argument(..., help="Automation rule id."),
@@ -84,8 +85,9 @@ def automation_create(
     name: str = typer.Option(..., "--name", "-n", help="Rule name."),
     trigger_id: str = typer.Option(
         ...,
+        "--event-id",
         "--trigger-id",
-        help="Trigger id from ``automation events list``.",
+        help="Trigger event id from ``automation events list`` (``--trigger-id`` retained as alias).",
     ),
     action_id: str = typer.Option(
         ...,
@@ -129,7 +131,7 @@ def automation_create(
     run_cli_command(ctx, json_out, factory)
 
 
-@automation_app.command("update")
+@automation_app.command("update", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def automation_update(
     ctx: typer.Context,
     automation_id: str = typer.Argument(..., help="Automation rule id."),
@@ -156,7 +158,7 @@ def automation_update(
     run_cli_command(ctx, json_out, factory)
 
 
-@automation_app.command("delete")
+@automation_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def automation_delete(
     ctx: typer.Context,
     automation_id: str = typer.Argument(..., help="Automation rule id."),
@@ -476,7 +478,7 @@ def automation_export_jobs(
     run_cli_command(ctx, json_out, factory)
 
 
-@export_app.command("status")
+@export_app.command("status", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def automation_export_status(
     ctx: typer.Context,
     export_id: str = typer.Argument(..., help="Export id from ``export jobs``."),
@@ -495,7 +497,7 @@ def automation_export_status(
     run_cli_command(ctx, json_out, factory)
 
 
-@export_app.command("csv")
+@export_app.command("csv", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def automation_export_csv(
     ctx: typer.Context,
     export_id: str = typer.Argument(..., help="Finished export id."),

--- a/packages/cli/src/pipefy_cli/commands/card.py
+++ b/packages/cli/src/pipefy_cli/commands/card.py
@@ -16,6 +16,7 @@ from pipefy_sdk import (
 from pydantic import ValidationError
 
 from pipefy_cli.commands._common import (
+    ID_POSITIONAL_CONTEXT_SETTINGS,
     confirm_destructive,
     parse_json_value,
     run_cli_command,
@@ -82,7 +83,7 @@ def _split_csv_ids(raw: str | None) -> list[str | int] | None:
     return out
 
 
-@card_app.command("get")
+@card_app.command("get", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def card_get(
     ctx: typer.Context,
     card_id: str,
@@ -218,7 +219,7 @@ def card_find(
     run_cli_command(ctx, json_out, factory)
 
 
-@card_app.command("create")
+@card_app.command("create", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def card_create(
     ctx: typer.Context,
     pipe_id: str,
@@ -257,7 +258,7 @@ def card_create(
     run_cli_command(ctx, json_out, factory)
 
 
-@card_app.command("update")
+@card_app.command("update", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def card_update(
     ctx: typer.Context,
     card_id: str,
@@ -276,7 +277,10 @@ def card_update(
     field_updates_json: str | None = typer.Option(
         None,
         "--field-updates",
-        help="JSON array of field update objects for updateCard.",
+        help=(
+            "JSON array of field update objects for updateFieldsValues. "
+            'Each object: {"field_id" (or "fieldId"): "<slug>", "value": <v>}.'
+        ),
     ),
     json_out: bool = typer.Option(False, "--json", "-j"),
 ) -> None:
@@ -297,7 +301,7 @@ def card_update(
     run_cli_command(ctx, json_out, factory)
 
 
-@card_app.command("delete")
+@card_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def card_delete(
     ctx: typer.Context,
     card_id: str,
@@ -319,7 +323,7 @@ def card_delete(
     run_cli_command(ctx, json_out, factory)
 
 
-@card_app.command("move")
+@card_app.command("move", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def card_move(
     ctx: typer.Context,
     card_id: str,
@@ -338,7 +342,7 @@ def card_move(
     run_cli_command(ctx, json_out, factory)
 
 
-@comment_app.command("add")
+@comment_app.command("add", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def card_comment_add(
     ctx: typer.Context,
     card_id: str,
@@ -359,7 +363,7 @@ def card_comment_add(
     run_cli_command(ctx, json_out, factory)
 
 
-@comment_app.command("update")
+@comment_app.command("update", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def card_comment_update(
     ctx: typer.Context,
     comment_id: str,
@@ -380,7 +384,7 @@ def card_comment_update(
     run_cli_command(ctx, json_out, factory)
 
 
-@comment_app.command("delete")
+@comment_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def card_comment_delete(
     ctx: typer.Context,
     comment_id: str,

--- a/packages/cli/src/pipefy_cli/commands/export.py
+++ b/packages/cli/src/pipefy_cli/commands/export.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import typer
 from pipefy_sdk import PipefyClient
 
-from pipefy_cli.commands._common import run_cli_command
+from pipefy_cli.commands._common import (
+    ID_POSITIONAL_CONTEXT_SETTINGS,
+    run_cli_command,
+)
 
 export_app = typer.Typer(
     help="Bulk exports (automation jobs).",
@@ -36,7 +39,9 @@ def export_automation_jobs(
     run_cli_command(ctx, json_out, factory)
 
 
-@export_app.command("automation-jobs-csv")
+@export_app.command(
+    "automation-jobs-csv", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS
+)
 def export_automation_jobs_csv(
     ctx: typer.Context,
     export_id: str = typer.Argument(..., help="Export id after status is finished."),

--- a/packages/cli/src/pipefy_cli/commands/field.py
+++ b/packages/cli/src/pipefy_cli/commands/field.py
@@ -6,6 +6,7 @@ import typer
 from pipefy_sdk import PipefyClient
 
 from pipefy_cli.commands._common import (
+    ID_POSITIONAL_CONTEXT_SETTINGS,
     confirm_destructive,
     parse_json_object,
     run_cli_command,
@@ -66,7 +67,7 @@ def field_create(
     run_cli_command(ctx, json_out, factory)
 
 
-@field_app.command("update")
+@field_app.command("update", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def field_update(
     ctx: typer.Context,
     field_id: str,
@@ -89,7 +90,7 @@ def field_update(
     run_cli_command(ctx, json_out, factory)
 
 
-@field_app.command("delete")
+@field_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def field_delete(
     ctx: typer.Context,
     field_id: str,

--- a/packages/cli/src/pipefy_cli/commands/field_condition.py
+++ b/packages/cli/src/pipefy_cli/commands/field_condition.py
@@ -89,12 +89,21 @@ def field_condition_create(
     condition: str = typer.Option(
         ...,
         "--condition",
-        help="JSON object: condition payload (expressions, expressions_structure).",
+        help=(
+            "JSON object: ConditionInput. Example: "
+            '\'{"expressions":[{"structure_id":0,"field_address":"<internal_id>",'
+            '"operation":"equals","value":"X"}],"expressions_structure":[[0]]}\'. '
+            "structure_id / expressions_structure entries are coerced to int by the SDK."
+        ),
     ),
     actions: str = typer.Option(
         ...,
         "--actions",
-        help="JSON array: action objects (e.g. phaseFieldId + actionId).",
+        help=(
+            "JSON array: action objects. Each item needs phaseFieldId (use the field's "
+            "internal_id from get_phase_fields) + actionId (hide|show). Example: "
+            '\'[{"phaseFieldId":"<internal_id>","actionId":"hide"}]\'.'
+        ),
     ),
     extra: str | None = typer.Option(
         None,

--- a/packages/cli/src/pipefy_cli/commands/field_condition.py
+++ b/packages/cli/src/pipefy_cli/commands/field_condition.py
@@ -8,6 +8,7 @@ import typer
 from pipefy_sdk import PipefyClient
 
 from pipefy_cli.commands._common import (
+    ID_POSITIONAL_CONTEXT_SETTINGS,
     confirm_destructive,
     parse_json_object,
     parse_json_value,
@@ -50,7 +51,7 @@ def field_condition_list(
     run_cli_command(ctx, json_out, factory)
 
 
-@field_condition_app.command("get")
+@field_condition_app.command("get", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def field_condition_get(
     ctx: typer.Context,
     condition_id: str = typer.Argument(..., help="Field condition id."),
@@ -133,7 +134,7 @@ def field_condition_create(
     run_cli_command(ctx, json_out, factory)
 
 
-@field_condition_app.command("update")
+@field_condition_app.command("update", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def field_condition_update(
     ctx: typer.Context,
     condition_id: str = typer.Argument(..., help="Field condition id."),
@@ -160,7 +161,7 @@ def field_condition_update(
     run_cli_command(ctx, json_out, factory)
 
 
-@field_condition_app.command("delete")
+@field_condition_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def field_condition_delete(
     ctx: typer.Context,
     condition_id: str = typer.Argument(..., help="Field condition id."),

--- a/packages/cli/src/pipefy_cli/commands/label.py
+++ b/packages/cli/src/pipefy_cli/commands/label.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import typer
 from pipefy_sdk import PipefyClient
 
-from pipefy_cli.commands._common import confirm_destructive, run_cli_command
+from pipefy_cli.commands._common import (
+    ID_POSITIONAL_CONTEXT_SETTINGS,
+    confirm_destructive,
+    run_cli_command,
+)
 
 label_app = typer.Typer(help="Pipe label operations.", no_args_is_help=True)
 
@@ -59,7 +63,7 @@ def label_create(
     run_cli_command(ctx, json_out, factory)
 
 
-@label_app.command("update")
+@label_app.command("update", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def label_update(
     ctx: typer.Context,
     label_id: str,
@@ -85,7 +89,7 @@ def label_update(
     run_cli_command(ctx, json_out, factory)
 
 
-@label_app.command("delete")
+@label_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def label_delete(
     ctx: typer.Context,
     label_id: str,

--- a/packages/cli/src/pipefy_cli/commands/member.py
+++ b/packages/cli/src/pipefy_cli/commands/member.py
@@ -128,14 +128,31 @@ def member_set_role(
     ),
     json_out: bool = typer.Option(False, "--json", "-j"),
 ) -> None:
-    """Set a member's role on a pipe."""
+    """Set a member's role on a pipe.
+
+    When ``PIPEFY_SERVICE_ACCOUNT_IDS`` includes ``--member``, the response gains
+    a ``warning`` field reminding callers to preserve write permissions on that
+    account (parity with the MCP ``set_role`` tool).
+    """
 
     rn = role_name.strip()
     if not rn:
         typer.echo("--role must be non-empty.", err=True)
         raise typer.Exit(2)
 
+    pipefy_settings, _ = settings_and_token(ctx)
+    protected_ids = pipefy_settings.service_account_ids
+
     async def factory(client: PipefyClient):
-        return await client.set_role(pipe_id, member_id, rn)
+        raw = await client.set_role(pipe_id, member_id, rn)
+        if protected_ids and member_id in protected_ids:
+            return {
+                "setRole": raw.get("setRole", raw) if isinstance(raw, dict) else raw,
+                "warning": (
+                    "Warning: you changed the role of a service account. "
+                    "Ensure the new role retains write permissions."
+                ),
+            }
+        return raw
 
     run_cli_command(ctx, json_out, factory)

--- a/packages/cli/src/pipefy_cli/commands/org.py
+++ b/packages/cli/src/pipefy_cli/commands/org.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 import typer
 from pipefy_sdk import PipefyClient
 
-from pipefy_cli.commands._common import run_cli_command
+from pipefy_cli.commands._common import (
+    ID_POSITIONAL_CONTEXT_SETTINGS,
+    run_cli_command,
+)
 
 org_app = typer.Typer(help="Organization operations.", no_args_is_help=True)
 
 
-@org_app.command("get")
+@org_app.command("get", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def org_get(
     ctx: typer.Context,
     organization_id: str = typer.Argument(..., help="Numeric organization id."),

--- a/packages/cli/src/pipefy_cli/commands/phase.py
+++ b/packages/cli/src/pipefy_cli/commands/phase.py
@@ -8,6 +8,7 @@ import typer
 from pipefy_sdk import PipefyClient
 
 from pipefy_cli.commands._common import (
+    ID_POSITIONAL_CONTEXT_SETTINGS,
     confirm_destructive,
     parse_json_object,
     run_cli_command,
@@ -16,7 +17,7 @@ from pipefy_cli.commands._common import (
 phase_app = typer.Typer(help="Pipe phase operations.", no_args_is_help=True)
 
 
-@phase_app.command("get")
+@phase_app.command("get", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def phase_get(
     ctx: typer.Context,
     phase_id: str,
@@ -75,7 +76,7 @@ def phase_create(
     run_cli_command(ctx, json_out, factory)
 
 
-@phase_app.command("update")
+@phase_app.command("update", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def phase_update(
     ctx: typer.Context,
     phase_id: str,
@@ -139,7 +140,7 @@ def phase_update(
     run_cli_command(ctx, json_out, factory)
 
 
-@phase_app.command("delete")
+@phase_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def phase_delete(
     ctx: typer.Context,
     phase_id: str,

--- a/packages/cli/src/pipefy_cli/commands/pipe.py
+++ b/packages/cli/src/pipefy_cli/commands/pipe.py
@@ -6,6 +6,7 @@ import typer
 from pipefy_sdk import PipefyClient
 
 from pipefy_cli.commands._common import (
+    ID_POSITIONAL_CONTEXT_SETTINGS,
     confirm_destructive,
     parse_json_object,
     run_cli_command,
@@ -14,7 +15,7 @@ from pipefy_cli.commands._common import (
 pipe_app = typer.Typer(help="Pipe operations.", no_args_is_help=True)
 
 
-@pipe_app.command("get")
+@pipe_app.command("get", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def pipe_get(
     ctx: typer.Context,
     pipe_id: str,
@@ -83,7 +84,7 @@ def pipe_create(
     run_cli_command(ctx, json_out, factory)
 
 
-@pipe_app.command("update")
+@pipe_app.command("update", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def pipe_update(
     ctx: typer.Context,
     pipe_id: str,
@@ -119,7 +120,7 @@ def pipe_update(
     run_cli_command(ctx, json_out, factory)
 
 
-@pipe_app.command("delete")
+@pipe_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def pipe_delete(
     ctx: typer.Context,
     pipe_id: str,
@@ -141,7 +142,7 @@ def pipe_delete(
     run_cli_command(ctx, json_out, factory)
 
 
-@pipe_app.command("clone")
+@pipe_app.command("clone", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def pipe_clone(
     ctx: typer.Context,
     template_pipe_id: str = typer.Argument(

--- a/packages/cli/src/pipefy_cli/commands/record.py
+++ b/packages/cli/src/pipefy_cli/commands/record.py
@@ -12,6 +12,7 @@ from pipefy_sdk import (
 )
 
 from pipefy_cli.commands._common import (
+    ID_POSITIONAL_CONTEXT_SETTINGS,
     confirm_destructive,
     parse_json_object,
     parse_json_value,
@@ -98,7 +99,7 @@ def record_find(
     run_cli_command(ctx, json_out, factory)
 
 
-@record_app.command("get")
+@record_app.command("get", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def record_get(
     ctx: typer.Context,
     record_id: str,
@@ -144,7 +145,7 @@ def record_create(
     run_cli_command(ctx, json_out, factory, exit_code_2_on_value_error=True)
 
 
-@record_app.command("update")
+@record_app.command("update", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def record_update(
     ctx: typer.Context,
     record_id: str,
@@ -200,7 +201,7 @@ def record_update(
     run_cli_command(ctx, json_out, factory, exit_code_2_on_value_error=True)
 
 
-@record_app.command("delete")
+@record_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def record_delete(
     ctx: typer.Context,
     record_id: str,

--- a/packages/cli/src/pipefy_cli/commands/relation.py
+++ b/packages/cli/src/pipefy_cli/commands/relation.py
@@ -6,6 +6,7 @@ import typer
 from pipefy_sdk import PipefyClient
 
 from pipefy_cli.commands._common import (
+    ID_POSITIONAL_CONTEXT_SETTINGS,
     authenticated_client_from_ctx,
     confirm_destructive,
     parse_json_object,
@@ -17,7 +18,7 @@ relation_pipe_app = typer.Typer(help="Pipe-to-pipe relations.", no_args_is_help=
 relation_card_app = typer.Typer(help="Card-to-card relations.", no_args_is_help=True)
 
 
-@relation_pipe_app.command("list")
+@relation_pipe_app.command("list", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def relation_pipe_list(
     ctx: typer.Context,
     pipe_id: str,
@@ -60,7 +61,7 @@ def relation_pipe_create(
     run_cli_command(ctx, json_out, factory)
 
 
-@relation_pipe_app.command("update")
+@relation_pipe_app.command("update", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def relation_pipe_update(
     ctx: typer.Context,
     relation_id: str,
@@ -86,7 +87,7 @@ def relation_pipe_update(
     run_cli_command(ctx, json_out, factory)
 
 
-@relation_pipe_app.command("delete")
+@relation_pipe_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def relation_pipe_delete(
     ctx: typer.Context,
     relation_id: str,
@@ -103,7 +104,7 @@ def relation_pipe_delete(
     run_cli_command(ctx, json_out, factory)
 
 
-@relation_card_app.command("list")
+@relation_card_app.command("list", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def relation_card_list(
     ctx: typer.Context,
     card_id: str,

--- a/packages/cli/src/pipefy_cli/commands/report_org.py
+++ b/packages/cli/src/pipefy_cli/commands/report_org.py
@@ -6,6 +6,7 @@ import typer
 from pipefy_sdk import PipefyClient
 
 from pipefy_cli.commands._common import (
+    ID_POSITIONAL_CONTEXT_SETTINGS,
     confirm_destructive,
     parse_json_object,
     parse_json_value,
@@ -37,7 +38,7 @@ def report_org_list(
     run_cli_command(ctx, json_out, factory)
 
 
-@report_org_app.command("get")
+@report_org_app.command("get", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def report_org_get(
     ctx: typer.Context,
     report_id: str = typer.Argument(..., help="Organization report id."),
@@ -89,7 +90,7 @@ def report_org_create(
     run_cli_command(ctx, json_out, factory)
 
 
-@report_org_app.command("update")
+@report_org_app.command("update", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def report_org_update(
     ctx: typer.Context,
     report_id: str = typer.Argument(..., help="Organization report id."),
@@ -128,7 +129,7 @@ def report_org_update(
     run_cli_command(ctx, json_out, factory)
 
 
-@report_org_app.command("delete")
+@report_org_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def report_org_delete(
     ctx: typer.Context,
     report_id: str = typer.Argument(..., help="Organization report id."),
@@ -195,6 +196,7 @@ def report_org_export(
         pids = [str(x) for x in pids]
 
     if fmt == "json":
+
         async def factory(client: PipefyClient):
             return await client.export_organization_report(
                 organization,

--- a/packages/cli/src/pipefy_cli/commands/report_pipe.py
+++ b/packages/cli/src/pipefy_cli/commands/report_pipe.py
@@ -8,6 +8,7 @@ import typer
 from pipefy_sdk import PipefyClient
 
 from pipefy_cli.commands._common import (
+    ID_POSITIONAL_CONTEXT_SETTINGS,
     confirm_destructive,
     parse_json_object,
     parse_json_value,
@@ -153,7 +154,7 @@ def report_pipe_create(
     run_cli_command(ctx, json_out, factory)
 
 
-@report_pipe_app.command("update")
+@report_pipe_app.command("update", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def report_pipe_update(
     ctx: typer.Context,
     report_id: str = typer.Argument(..., help="Pipe report id."),
@@ -190,7 +191,7 @@ def report_pipe_update(
     run_cli_command(ctx, json_out, factory)
 
 
-@report_pipe_app.command("delete")
+@report_pipe_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def report_pipe_delete(
     ctx: typer.Context,
     report_id: str = typer.Argument(..., help="Pipe report id."),
@@ -249,6 +250,7 @@ def report_pipe_export(
         raise typer.BadParameter("--columns must be a JSON array")
 
     if fmt == "json":
+
         async def factory(client: PipefyClient):
             return await client.export_pipe_report(
                 pipe,

--- a/packages/cli/src/pipefy_cli/commands/table.py
+++ b/packages/cli/src/pipefy_cli/commands/table.py
@@ -8,6 +8,7 @@ import typer
 from pipefy_sdk import PipefyClient
 
 from pipefy_cli.commands._common import (
+    ID_POSITIONAL_CONTEXT_SETTINGS,
     confirm_destructive,
     parse_json_object,
     run_cli_command,
@@ -55,7 +56,7 @@ def table_list(
     run_cli_command(ctx, json_out, factory)
 
 
-@table_app.command("get")
+@table_app.command("get", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def table_get(
     ctx: typer.Context,
     table_id: str,
@@ -99,7 +100,7 @@ def table_create(
     run_cli_command(ctx, json_out, factory)
 
 
-@table_app.command("update")
+@table_app.command("update", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def table_update(
     ctx: typer.Context,
     table_id: str,
@@ -132,7 +133,7 @@ def table_update(
     run_cli_command(ctx, json_out, factory)
 
 
-@table_app.command("delete")
+@table_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def table_delete(
     ctx: typer.Context,
     table_id: str,

--- a/packages/cli/src/pipefy_cli/commands/webhook.py
+++ b/packages/cli/src/pipefy_cli/commands/webhook.py
@@ -9,6 +9,7 @@ import typer
 from pipefy_sdk import PipefyClient
 
 from pipefy_cli.commands._common import (
+    ID_POSITIONAL_CONTEXT_SETTINGS,
     confirm_destructive,
     parse_json_object,
     run_cli_command,
@@ -78,7 +79,7 @@ def webhook_create(
     run_cli_command(ctx, json_out, factory)
 
 
-@webhook_app.command("update")
+@webhook_app.command("update", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def webhook_update(
     ctx: typer.Context,
     webhook_id: str,
@@ -122,7 +123,7 @@ def webhook_update(
     run_cli_command(ctx, json_out, factory)
 
 
-@webhook_app.command("delete")
+@webhook_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def webhook_delete(
     ctx: typer.Context,
     webhook_id: str,

--- a/packages/cli/tests/test_cli_tasks_10_11.py
+++ b/packages/cli/tests/test_cli_tasks_10_11.py
@@ -389,3 +389,148 @@ def test_ai_automation_create_requires_oauth(
     assert r.exit_code == 2
     assert "OAuth" in r.stderr
     mock_client.create_ai_automation.assert_not_called()
+
+
+@pytest.mark.parametrize("flag", ["--event-id", "--trigger-id"])
+def test_automation_create_accepts_event_id_alias(
+    runner: CliRunner, clean_pipefy_env, saved_cwd, oauth_env, flag: str
+):
+    """``automation create`` accepts ``--event-id`` (preferred) and ``--trigger-id`` (alias)."""
+    oauth_env("aut-alias")
+    mock_client = MagicMock()
+    mock_client.create_automation = AsyncMock(
+        return_value={"createAutomation": {"automation": {"id": "55"}}}
+    )
+
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        r = runner.invoke(
+            app,
+            [
+                "automation",
+                "create",
+                "--pipe",
+                "1",
+                "--name",
+                "Rule",
+                flag,
+                "card_created",
+                "--action-id",
+                "move_single_card",
+                "--no-active",
+                "--json",
+            ],
+        )
+
+    assert r.exit_code == 0, r.stderr
+    mock_client.create_automation.assert_awaited_once()
+    args, kwargs = mock_client.create_automation.call_args
+    assert args[2] == "card_created"
+    assert kwargs.get("active") is False
+
+
+def _ai_automation_row(prompt: str, field_ids: list[str]) -> dict:
+    return {
+        "id": "auto-1",
+        "event_id": "card_created",
+        "action_id": "generate_with_ai",
+        "action_params": {
+            "aiParams": {"value": prompt, "fieldIds": list(field_ids)},
+        },
+    }
+
+
+def test_ai_automation_update_auto_fetches_prompt_when_omitted(
+    runner: CliRunner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    """When ``--prompt``/``--field-ids`` are omitted, the CLI re-uses current values for pre-flight only."""
+    oauth_env("ai-up-auto")
+    existing = _ai_automation_row("Summarize: %{9}", ["9"])
+    mock_client = MagicMock()
+    mock_client.ai_automation_available = True
+    mock_client.get_automation = AsyncMock(return_value=existing)
+    mock_client.get_pipe_with_preferences = AsyncMock(
+        return_value={
+            "pipe": {
+                "phases": [
+                    {"fields": [{"internal_id": "9", "id": "f9", "label": "L"}]}
+                ],
+                "start_form_fields": [],
+                "preferences": {"aiAgentsEnabled": True},
+                "organizationId": "300",
+            }
+        }
+    )
+    mock_client.get_automation_events = AsyncMock(return_value=[{"id": "card_created"}])
+    mock_client.get_ai_credit_usage = AsyncMock(
+        return_value={"aiCreditUsageStats": {"active": True, "usage": 0, "limit": 0}}
+    )
+    mock_client.update_ai_automation = AsyncMock(
+        return_value={"updateAutomation": {"automation": {"id": "auto-1"}}}
+    )
+
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        r = runner.invoke(
+            app,
+            [
+                "ai-automation",
+                "update",
+                "auto-1",
+                "--pipe",
+                "1",
+                "--name",
+                "Renamed",
+                "--json",
+            ],
+        )
+
+    assert r.exit_code == 0, r.stderr
+    mock_client.update_ai_automation.assert_awaited_once()
+    sent_input = mock_client.update_ai_automation.call_args.args[0]
+    # When omitted, prompt/field_ids must NOT be patched on the server.
+    assert sent_input.prompt is None
+    assert sent_input.field_ids is None
+    assert sent_input.name == "Renamed"
+
+
+def test_ai_automation_update_errors_when_existing_row_missing_ai_params(
+    runner: CliRunner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    """Non-AI automation row → clear error (cannot infer fallback prompt/field_ids)."""
+    oauth_env("ai-up-missing")
+    mock_client = MagicMock()
+    mock_client.ai_automation_available = True
+    mock_client.get_automation = AsyncMock(
+        return_value={
+            "id": "auto-1",
+            "event_id": "card_created",
+            "action_id": "move_single_card",
+            "action_params": {},
+        }
+    )
+
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        r = runner.invoke(
+            app,
+            [
+                "ai-automation",
+                "update",
+                "auto-1",
+                "--pipe",
+                "1",
+                "--name",
+                "Renamed",
+                "--json",
+            ],
+        )
+
+    assert r.exit_code != 0
+    assert "infer" in r.stderr.lower() or "prompt" in r.stderr.lower()

--- a/packages/cli/tests/test_table_record_commands.py
+++ b/packages/cli/tests/test_table_record_commands.py
@@ -137,6 +137,28 @@ def test_record_update_set_field_json(runner, clean_pipefy_env, saved_cwd, oauth
     )
 
 
+def test_table_delete_accepts_leading_dash_id(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    """Pipefy can encode table ids with a leading ``-`` (e.g. ``-ZocGcM0``).
+
+    ``context_settings={"ignore_unknown_options": True}`` keeps Click from
+    treating that token as a short option so the positional id parses cleanly.
+    """
+    oauth_env("tbl-dash-id")
+    mock_client = MagicMock()
+    mock_client.delete_table = AsyncMock(
+        return_value={"deleteTable": {"success": True}}
+    )
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(app, ["table", "delete", "-ZocGcM0", "--yes", "--json"])
+    assert result.exit_code == 0, result.stderr
+    mock_client.delete_table.assert_awaited_once_with("-ZocGcM0")
+
+
 def test_record_update_unknown_field_key_exit_2(
     runner, clean_pipefy_env, saved_cwd, oauth_env
 ):

--- a/packages/mcp/src/pipefy_mcp/tools/field_condition_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/field_condition_tools.py
@@ -178,13 +178,13 @@ class FieldConditionTools:
                     condition={
                         "expressions": [
                             {
-                                "structure_id": "0",
+                                "structure_id": 0,
                                 "field_address": "425848636",
                                 "operation": "equals",
                                 "value": "Option A"
                             }
                         ],
-                        "expressions_structure": [["0"]]
+                        "expressions_structure": [[0]]
                     },
                     actions=[
                         {
@@ -194,11 +194,17 @@ class FieldConditionTools:
                     ]
                 )
 
-            ``expressions_structure`` is an array of arrays of **string** indices
-            (e.g. ``[["0"]]`` for one expression, ``[["0", "1"]]`` for AND). Each
-            expression must carry a ``structure_id`` (string) referencing its
-            position in the structure. Omitting either causes
-            ``"Structure can't be blank"``.
+            ``expressions_structure`` is an array of arrays of indices (e.g.
+            ``[[0]]`` for one expression, ``[[0, 1]]`` for AND). Each expression
+            must carry a ``structure_id`` referencing its position in the
+            structure. Omitting either causes ``"Structure can't be blank"``.
+
+            The SDK normalizes the payload before calling the API
+            (``pipefy_sdk.utils.normalize_field_condition_payload``): it drops any
+            ``id`` keys (persisted PKs cause ``RECORD_NOT_FOUND`` on create) and
+            coerces ``structure_id`` / ``expressions_structure`` entries to ``int``
+            so callers can pass either strings or integers without triggering
+            opaque ``INTERNAL_SERVER_ERROR`` responses from Pipefy.
 
             Args:
                 ctx: MCP context for debug logging.

--- a/packages/sdk/src/pipefy_sdk/exceptions.py
+++ b/packages/sdk/src/pipefy_sdk/exceptions.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-# Typed SDK errors for future service-layer raises (Task 2.5 placeholder); unused until callers adopt them.
+# Typed SDK errors for gradual service-layer migration; not all call sites raise these yet.
 
 
 class PipefyError(Exception):

--- a/packages/sdk/src/pipefy_sdk/services/pipe_config_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/pipe_config_service.py
@@ -28,6 +28,7 @@ from pipefy_sdk.queries.pipe_config_queries import (
     UPDATE_PIPE_MUTATION,
 )
 from pipefy_sdk.settings import PipefySettings
+from pipefy_sdk.utils import normalize_field_condition_payload
 
 
 class PipeConfigService(BasePipefyClient):
@@ -227,9 +228,10 @@ class PipeConfigService(BasePipefyClient):
                 keys with value ``None`` are omitted.
         """
         phase_key = phase_id.strip() if isinstance(phase_id, str) else str(phase_id)
+        normalized_condition = normalize_field_condition_payload(condition)
         input_obj: dict[str, Any] = {
             "phaseId": phase_key,
-            "condition": condition,
+            "condition": normalized_condition,
             "actions": actions,
         }
         for key, value in attrs.items():
@@ -252,7 +254,11 @@ class PipeConfigService(BasePipefyClient):
         """
         payload: dict[str, Any] = {"id": condition_id}
         for key, value in attrs.items():
-            if value is not None:
+            if value is None:
+                continue
+            if key == "condition" and isinstance(value, dict):
+                payload[key] = normalize_field_condition_payload(value)
+            else:
                 payload[key] = value
         return await self.execute_query(
             UPDATE_FIELD_CONDITION_MUTATION, {"input": payload}

--- a/packages/sdk/src/pipefy_sdk/utils/__init__.py
+++ b/packages/sdk/src/pipefy_sdk/utils/__init__.py
@@ -4,7 +4,11 @@ This package holds side-effect-free formatting/conversion helpers used by the
 service layer.
 """
 
-from .formatters import convert_fields_to_array, convert_values_to_camel_case
+from .formatters import (
+    convert_fields_to_array,
+    convert_values_to_camel_case,
+    normalize_field_condition_payload,
+)
 from .url_ssrf import (
     assert_hostname_is_not_internal,
     assert_hostname_resolves_to_public_ips,
@@ -16,5 +20,6 @@ __all__ = [
     "assert_hostname_resolves_to_public_ips",
     "convert_fields_to_array",
     "convert_values_to_camel_case",
+    "normalize_field_condition_payload",
     "validate_https_service_endpoint_url",
 ]

--- a/packages/sdk/src/pipefy_sdk/utils/formatters.py
+++ b/packages/sdk/src/pipefy_sdk/utils/formatters.py
@@ -40,6 +40,69 @@ def convert_fields_to_array(fields: Any) -> list[dict[str, Any]]:
     return [fields] if fields else []
 
 
+def normalize_field_condition_payload(
+    condition: dict[str, Any],
+) -> dict[str, Any]:
+    """Return a copy of ``ConditionInput`` ready for ``createFieldCondition``.
+
+    Pipefy's ``createFieldCondition`` mutation rejects payloads in two subtle ways
+    that show up as ``Something went wrong (INTERNAL_SERVER_ERROR)``:
+
+    1. ``ConditionExpressionInput.id`` is a persisted primary key. Sending an
+       arbitrary client-side token causes ``RECORD_NOT_FOUND``. Drop it on create.
+    2. ``structure_id`` and the inner values of ``expressions_structure`` must be
+       integers; sending strings or mixed types triggers an opaque 500 instead of
+       a clean validation error. Coerce both to ``int`` when possible.
+
+    Unknown top-level keys on the condition (e.g. ``index``) are preserved so the
+    helper stays forward-compatible.
+
+    Args:
+        condition: Caller-provided ``ConditionInput`` dict (typically with
+          ``expressions`` and ``expressions_structure``).
+
+    Returns:
+        A new dict safe to send as ``input.condition`` on ``createFieldCondition``
+        / ``updateFieldCondition``.
+    """
+
+    def _coerce_int(value: Any) -> Any:
+        try:
+            return int(value)
+        except (ValueError, TypeError):
+            return value
+
+    expressions = condition.get("expressions")
+    if not isinstance(expressions, list):
+        return dict(condition)
+
+    cleaned_expressions: list[dict[str, Any]] = []
+    for expr in expressions:
+        if not isinstance(expr, dict):
+            cleaned_expressions.append(expr)
+            continue
+        row = {k: v for k, v in expr.items() if k != "id"}
+        if "structure_id" in row and row["structure_id"] is not None:
+            row["structure_id"] = _coerce_int(row["structure_id"])
+        cleaned_expressions.append(row)
+
+    es = condition.get("expressions_structure")
+    if isinstance(es, list):
+        coerced_es: list[list[Any]] = []
+        for group in es:
+            if isinstance(group, list):
+                coerced_es.append([_coerce_int(v) for v in group])
+            else:
+                coerced_es.append([_coerce_int(group)])
+        return {
+            **condition,
+            "expressions": cleaned_expressions,
+            "expressions_structure": coerced_es,
+        }
+
+    return {**condition, "expressions": cleaned_expressions}
+
+
 def convert_values_to_camel_case(values: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Convert values to camelCase format for `updateFieldsValues` mutation.
 

--- a/packages/sdk/src/pipefy_sdk/utils/formatters.py
+++ b/packages/sdk/src/pipefy_sdk/utils/formatters.py
@@ -43,31 +43,39 @@ def convert_fields_to_array(fields: Any) -> list[dict[str, Any]]:
 def convert_values_to_camel_case(values: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Convert values to camelCase format for `updateFieldsValues` mutation.
 
-    This preserves the current behavior of `PipefyClient._convert_values_to_camel_case`:
-    - Each input dict must contain `field_id` and `value`.
+    - Each input dict must contain `field_id` (or `fieldId`) and `value`.
     - Output uses `fieldId`, `value`, `operation` (uppercased, default "REPLACE"),
       and `generatedByAi=True`.
 
+    Pipefy API responses use camelCase (`fieldId`), so accepting both keys lets
+    callers copy ids straight from a `get_cards`/`get_card` payload into the
+    `field_updates` array without manual renaming.
+
     Args:
-        values: List of dicts with `field_id`, `value`, and optional `operation`.
+        values: List of dicts with `field_id` or `fieldId`, `value`, and
+          optional `operation`.
 
     Returns:
         Formatted list of dicts for GraphQL `UpdateFieldsValuesInput.values`.
 
     Raises:
-        ValueError: If any item is missing required `field_id` or `value`.
+        ValueError: If any item is missing the required field id or `value`.
     """
 
     formatted: list[dict[str, Any]] = []
     for i, v in enumerate(values):
-        if "field_id" not in v:
-            raise ValueError(f"Value at index {i} is missing required 'field_id' key")
+        field_id = v.get("field_id", v.get("fieldId"))
+        if field_id is None:
+            raise ValueError(
+                f"Value at index {i} is missing required 'field_id' key "
+                "('fieldId' camelCase is also accepted)"
+            )
         if "value" not in v:
             raise ValueError(f"Value at index {i} is missing required 'value' key")
 
         formatted.append(
             {
-                "fieldId": v["field_id"],
+                "fieldId": field_id,
                 "value": v["value"],
                 "operation": str(v.get("operation", "REPLACE")).upper(),
                 "generatedByAi": True,

--- a/packages/sdk/tests/services/test_pipefy_formatters.py
+++ b/packages/sdk/tests/services/test_pipefy_formatters.py
@@ -3,6 +3,7 @@ import pytest
 from pipefy_sdk.utils.formatters import (
     convert_fields_to_array,
     convert_values_to_camel_case,
+    normalize_field_condition_payload,
 )
 
 
@@ -143,3 +144,105 @@ def test_convert_values_to_camel_case_snake_case_wins_over_camel_case():
     result = convert_values_to_camel_case(values)
 
     assert result[0]["fieldId"] == "snake_id"
+
+
+@pytest.mark.unit
+def test_normalize_field_condition_drops_expression_id_on_create():
+    """``ConditionExpressionInput.id`` is a persisted PK; sending tokens errors RECORD_NOT_FOUND."""
+    condition = {
+        "expressions": [
+            {
+                "id": "client-token-xyz",
+                "field_address": "f",
+                "operation": "equals",
+                "value": "v",
+                "structure_id": "1",
+            }
+        ],
+        "expressions_structure": [["1"]],
+    }
+
+    result = normalize_field_condition_payload(condition)
+
+    assert "id" not in result["expressions"][0]
+    assert result["expressions"][0]["field_address"] == "f"
+
+
+@pytest.mark.unit
+def test_normalize_field_condition_coerces_string_indices_to_int():
+    """String indices come from the MCP docstring; Pipefy's API rejects them in 5xx form."""
+    condition = {
+        "expressions": [{"structure_id": "42", "field_address": "f", "value": "v"}],
+        "expressions_structure": [["42"]],
+    }
+
+    result = normalize_field_condition_payload(condition)
+
+    assert result["expressions"][0]["structure_id"] == 42
+    assert result["expressions_structure"] == [[42]]
+
+
+@pytest.mark.unit
+def test_normalize_field_condition_passes_through_non_coercible_values():
+    """Non-numeric strings are preserved (e.g. legacy UUID-style structure ids)."""
+    condition = {
+        "expressions": [{"structure_id": "not-a-number"}],
+        "expressions_structure": [["not-a-number"]],
+    }
+
+    result = normalize_field_condition_payload(condition)
+
+    assert result["expressions"][0]["structure_id"] == "not-a-number"
+    assert result["expressions_structure"] == [["not-a-number"]]
+
+
+@pytest.mark.unit
+def test_normalize_field_condition_handles_flat_structure_group():
+    """Bare scalars in ``expressions_structure`` are wrapped in a list (legacy callers)."""
+    condition = {
+        "expressions": [{"structure_id": "0"}],
+        "expressions_structure": ["0"],
+    }
+
+    result = normalize_field_condition_payload(condition)
+
+    assert result["expressions_structure"] == [[0]]
+
+
+@pytest.mark.unit
+def test_normalize_field_condition_preserves_top_level_extras():
+    """Unknown top-level keys (e.g. ``index``) are forwarded — schema may evolve."""
+    condition = {
+        "expressions": [{"structure_id": 1}],
+        "expressions_structure": [[1]],
+        "index": 5,
+    }
+
+    result = normalize_field_condition_payload(condition)
+
+    assert result["index"] == 5
+
+
+@pytest.mark.unit
+def test_normalize_field_condition_idempotent_on_already_int_values():
+    """Re-applying the helper (e.g. MCP layer + SDK layer) must be a no-op."""
+    condition = {
+        "expressions": [{"structure_id": 7, "value": "v"}],
+        "expressions_structure": [[7]],
+    }
+
+    once = normalize_field_condition_payload(condition)
+    twice = normalize_field_condition_payload(once)
+
+    assert once == twice
+
+
+@pytest.mark.unit
+def test_normalize_field_condition_returns_copy_without_expressions():
+    """Conditions missing ``expressions`` round-trip as a shallow copy (no crash)."""
+    condition = {"only_index": 1}
+
+    result = normalize_field_condition_payload(condition)
+
+    assert result == {"only_index": 1}
+    assert result is not condition

--- a/packages/sdk/tests/services/test_pipefy_formatters.py
+++ b/packages/sdk/tests/services/test_pipefy_formatters.py
@@ -116,3 +116,30 @@ def test_convert_values_to_camel_case_missing_value_raises_value_error():
         ValueError, match="Value at index 0 is missing required 'value' key"
     ):
         convert_values_to_camel_case(values)
+
+
+@pytest.mark.unit
+def test_convert_values_to_camel_case_accepts_camelcase_field_id():
+    """Pipefy API responses use ``fieldId`` (camelCase); accept it as a synonym."""
+    values = [{"fieldId": "field_1", "value": "New Value"}]
+
+    result = convert_values_to_camel_case(values)
+
+    assert result == [
+        {
+            "fieldId": "field_1",
+            "value": "New Value",
+            "operation": "REPLACE",
+            "generatedByAi": True,
+        }
+    ]
+
+
+@pytest.mark.unit
+def test_convert_values_to_camel_case_snake_case_wins_over_camel_case():
+    """If both ``field_id`` and ``fieldId`` are present, snake_case takes precedence."""
+    values = [{"field_id": "snake_id", "fieldId": "camel_id", "value": "v"}]
+
+    result = convert_values_to_camel_case(values)
+
+    assert result[0]["fieldId"] == "snake_id"


### PR DESCRIPTION
## Summary
Merge into **`dev`**.

- **CLI:** GraphQL transport handling in shared runners, dashed Typer positionals, `automation create` `--event-id` alias, ai-automation update with inferred prompt/field ids, service-account role warning on `member set-role`, card / field-condition help.
- **SDK:** `fieldId` in `convert_values_to_camel_case`; `normalize_field_condition_payload` wired through `PipeConfigService` for field conditions.
- **MCP:** Field condition tool docs and int examples aligned with SDK normalization.
- **Tests:** Table dashed id, automation alias + ai-automation update, formatter tests.

## Testing
- `uv run ruff check .` and `uv run ruff format --check .`
- `uv run pytest -m "not integration"`
- Version lockstep + `uv build packages/mcp`