### PR TITLE
fix: address dev code review blockers (PyPI, CLI, MCP, docs)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,21 +87,31 @@ jobs:
         with:
           files: dist/*.whl
           body_path: CHANGELOG_RELEASE_BODY.md
-      - name: Stage PyPI wheels (CLI + MCP only)
-        if: startsWith(github.ref_name, 'v1.')
+      - name: Stage PyPI wheels (SDK + CLI + MCP)
+        if: startsWith(github.ref_name, 'v1.') && !contains(github.ref_name, '-')
         run: |
           mkdir -p dist-pypi
           shopt -s nullglob
+          sdk=(dist/pipefy_sdk-*.whl)
           cli=(dist/pipefy_cli-*.whl)
           mcp=(dist/pipefy_mcp_server-*.whl)
-          if [ "${#cli[@]}" -ne 1 ] || [ "${#mcp[@]}" -ne 1 ]; then
-            echo "Expected exactly one CLI wheel and one MCP wheel in dist/, got cli=${#cli[@]} mcp=${#mcp[@]}"
+          if [ "${#sdk[@]}" -ne 1 ] || [ "${#cli[@]}" -ne 1 ] || [ "${#mcp[@]}" -ne 1 ]; then
+            echo "Expected one SDK, one CLI, and one MCP wheel in dist/"
+            echo "sdk=${#sdk[@]} cli=${#cli[@]} mcp=${#mcp[@]}"
             ls -la dist || true
             exit 1
           fi
-          cp "${cli[0]}" "${mcp[0]}" dist-pypi/
+          cp "${sdk[0]}" "${cli[0]}" "${mcp[0]}" dist-pypi/
+      - name: Smoke install staged wheels (clean venv)
+        if: startsWith(github.ref_name, 'v1.') && !contains(github.ref_name, '-')
+        run: |
+          python -m venv .venv-pypi-smoke
+          .venv-pypi-smoke/bin/python -m pip install --upgrade pip
+          .venv-pypi-smoke/bin/pip install dist-pypi/*.whl
+          .venv-pypi-smoke/bin/pipefy --help
+          .venv-pypi-smoke/bin/pipefy-mcp-server --help
       - name: Upload to PyPI
-        if: startsWith(github.ref_name, 'v1.')
+        if: startsWith(github.ref_name, 'v1.') && !contains(github.ref_name, '-')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist-pypi/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **CLI**: added MCP-parity commands for core workflow domains: `pipe`, `phase`,
+  `field`, `table`, `record`, `label`, `webhook`, `relation`, and `member`.
+- **CLI**: added post-v0.1 parity domains: `attachment`, `field-condition`,
+  `email`, `audit`, `automation`, `introspect`, `graphql`, `agent`,
+  `ai-automation`, `usage`, `report-pipe`, `report-org`, `export`, and `org`.
+- **MCP / CLI**: shared SDK facade covers attachment upload, automation
+  preflight, field-condition normalization, AI prompt and behavior validation,
+  report export streaming, and service-account guard helpers.
 - **CLI**: `pipefy skills list` and `pipefy skills show <name>` for browsing the bundled
   starter pack (8 high-impact Pipefy workflows), with YAML frontmatter parsing for
   descriptions.

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,41 +1,41 @@
 # Python runtime dependencies
 
-This document explains **why** the main third-party packages in [`pyproject.toml`](../pyproject.toml) are required. It complements the short summary in the README (*Getting started → Why these dependencies?*).
+This document explains **why** the main third-party packages exist across the **uv workspace**. Values and pins live in each package’s `pyproject.toml` (`packages/sdk`, `packages/mcp`, `packages/cli`). Use **[`docs/setup.md`](setup.md)** for install and env vars.
 
-## httpx
+## pipefy-sdk (`packages/sdk`)
 
-**Role:** Async HTTP client for every non-trivial network path in the server.
+| Dependency | Role |
+| --- | --- |
+| `gql[httpx]` | Async GraphQL client; `HTTPXAsyncTransport` for Pipefy’s GraphQL endpoints. |
+| `httpx` | Shared async HTTP for transports and direct calls (timeouts, HTTP/2-capable stack via httpx). |
+| `httpx-auth` | OAuth2 client-credentials (`OAuth2ClientCredentials`) aligned with Pipefy service accounts. |
+| `pydantic` / `pydantic-settings` | Request/response models and typed configuration (`PipefySettings`). |
+| `email-validator` | Used where models validate email-shaped inputs (e.g. member invites). |
+| `rapidfuzz` | Fuzzy matching helpers used in domain logic where the SDK mirrors MCP/CLI behavior. |
+| `openpyxl` | Reads `.xlsx` exports and converts sheet data to text (CSV-like) when the API returns Excel. |
 
-**Where it is used:**
+**Security:** GraphQL and export URLs are validated against SSRF rules in SDK services; do not bypass host checks when adding download paths.
 
-- **GraphQL (public Pipefy API)** — `gql` uses `HTTPXAsyncTransport` (see `pipefy_mcp.services.pipefy.base_client`).
-- **Internal Pipefy GraphQL** — `InternalApiClient` uses `httpx.AsyncClient` with timeouts (`pipefy_mcp.services.pipefy.internal_api_client`).
-- **Attachments** — Presigned URL upload/download flows (`pipefy_mcp.services.pipefy.attachment_service`, `pipefy_mcp.tools.attachment_tools`).
-- **Exports** — Downloading signed HTTPS URLs before parsing or streaming (`pipefy_mcp.services.pipefy.observability_export_csv`).
+## pipefy-mcp-server (`packages/mcp`)
 
-**Why httpx (and not e.g. sync `requests` alone):** the codebase is async end-to-end for MCP handlers and GraphQL; one client family keeps timeouts, connection limits, and error types consistent.
+| Dependency | Role |
+| --- | --- |
+| `pipefy-sdk` | All GraphQL and domain logic (facade + services). |
+| `mcp[cli]` | MCP protocol server runtime and CLI entry for `pipefy-mcp-server`. |
+| `httpx` | Attachment downloads and any direct HTTP outside `gql` (same family as the SDK). |
+| `pydantic` / `pydantic-settings` | Tool inputs and server settings. |
 
-## httpx-auth
+## pipefy-cli (`packages/cli`)
 
-**Role:** OAuth2 **client credentials** for Pipefy service accounts (token fetch and refresh).
+| Dependency | Role |
+| --- | --- |
+| `pipefy-sdk` | Same GraphQL facade as MCP; CLI is a thin Typer layer. |
+| `typer` | Command groups, options, and exit-code mapping. |
+| `rich` | Human-readable tables and summaries when `--json` is not used. |
+| `pydantic-settings` | Loads `PIPEFY_*` the same way as MCP/SDK. |
+| `pyyaml` | Parsing bundled skill frontmatter (`pipefy skills list` / `show`). |
 
-**Where it is used:**
+## Supply-chain notes
 
-- Passed into GraphQL transport setup and into direct `httpx` clients that must use the same Pipefy OAuth settings — see imports of `OAuth2ClientCredentials` under `pipefy_mcp.services.pipefy/`.
-
-**Why a dedicated auth helper:** avoids hand-rolling refresh and header injection; aligns all authenticated HTTP with the same credential source as Pydantic Settings.
-
-## openpyxl
-
-**Role:** Read `.xlsx` workbooks and turn sheet data into text the MCP can return (CSV-like).
-
-**Where it is used:**
-
-- `pipefy_mcp.services.pipefy.observability_export_csv` — `load_workbook` on downloaded export bytes, first worksheet to CSV with optional size limits.
-
-**Why openpyxl:** some Pipefy exports are delivered as Excel files, not plain CSV; a dedicated reader is the reliable way to extract rows without fragile format guesses.
-
-## Supply-chain and security notes
-
-- Prefer **pinned versions** in `pyproject.toml` as the project already does; review upgrades in PRs with a quick grep for breaking API usage.
-- Export downloads use **HTTPS** and host allowlisting in code (see `is_allowed_pipefy_export_download_url` in `observability_export_csv`); do not bypass those checks when extending download paths.
+- Prefer **pinned versions** as committed in each `pyproject.toml`; review upgrades with a quick grep for breaking API usage.
+- Prefer **HTTPS** for every Pipefy and webhook URL; optional insecure URLs are dev-only and documented in `.env.example`.

--- a/docs/parity.md
+++ b/docs/parity.md
@@ -1,6 +1,6 @@
 # MCP tools and CLI parity
 
-This matrix is the source of truth for **MCP tool ↔ `pipefy` CLI** coverage. It is maintained alongside the rollout in `.cursor/dev-planning/specs/pipefy-ai-sdk/tasks/tasks-pipefy-ai-sdk.md` (parent task **5.0**).
+This matrix is the source of truth for **MCP tool ↔ `pipefy` CLI** coverage. It is maintained alongside the rollout in `.cursor/dev-planning/specs/pipefy-labs/tasks/tasks-pipefy-labs.md` (parent task **5.0**).
 
 **Registry source:** `PIPEFY_TOOL_NAMES` in `packages/mcp/src/pipefy_mcp/tools/registry.py` (must stay in sync with this table: **128** tools).
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -33,8 +33,9 @@ Same `PIPEFY_*` environment variables as `pipefy-mcp-server` (`.env` in CWD is l
 ```env
 PIPEFY_OAUTH_CLIENT=your_client_id
 PIPEFY_OAUTH_SECRET=your_client_secret
-PIPEFY_GRAPHQL_URL=https://api.pipefy.com/graphql
-PIPEFY_OAUTH_URL=https://auth.pipefy.com/...
+PIPEFY_GRAPHQL_URL=https://app.pipefy.com/graphql
+PIPEFY_OAUTH_URL=https://app.pipefy.com/oauth/token
+PIPEFY_INTERNAL_API_URL=https://app.pipefy.com/internal_api
 ```
 
 Full guide: [`docs/setup.md`](../../docs/setup.md). CLI-focused docs: [`docs/cli/`](../../docs/cli/README.md).

--- a/packages/cli/src/pipefy_cli/commands/_common.py
+++ b/packages/cli/src/pipefy_cli/commands/_common.py
@@ -26,9 +26,23 @@ DEFAULT_EXPORT_MAX_BYTES = 50 * 1024 * 1024
 # Click parses tokens starting with "-" as short options by default, which breaks
 # every `<sub> get/update/delete <ID>` command. Setting ignore_unknown_options on
 # the command relaxes the parser so the dashed token is consumed as the positional
-# id; unknown LONG options (typos like ``--yez``) still surface as errors because
-# Click attempts to bind them to the (single) positional slot.
+# id. Tokens starting with ``--`` must still be rejected (they look like long
+# options); use :func:`validate_positional_id` on those arguments.
 ID_POSITIONAL_CONTEXT_SETTINGS = {"ignore_unknown_options": True}
+
+
+def validate_positional_id(value: str) -> str:
+    """Reject typoed long-option tokens mistakenly captured as a resource id."""
+    if value.startswith("--"):
+        raise typer.BadParameter(
+            f"unknown option-like value {value!r}; if an id starts with '-', pass it after '--'"
+        )
+    return value
+
+
+def resource_id_argument(*, help: str) -> Any:
+    """Typer ``Argument`` for resource ids when ``ignore_unknown_options`` is enabled."""
+    return typer.Argument(..., help=help, callback=validate_positional_id)
 
 
 def export_poll_max_rounds(
@@ -112,18 +126,21 @@ async def write_export_csv_to_stdout(
 def run_pipefy_client_coroutine(
     ctx: typer.Context,
     coro_factory: Callable[[PipefyClient], Awaitable[_T]],
+    *,
+    value_error_exit_code: int | None = None,
 ) -> _T:
     """Run ``asyncio.run`` on a coroutine built with a configured :class:`PipefyClient`.
 
     Args:
         ctx: Typer context (resolves settings/token from the root app).
         coro_factory: Async callable receiving an authenticated client.
+        value_error_exit_code: When set, map ``ValueError`` from the factory to this exit code (stderr message).
 
     Returns:
         The coroutine result.
 
     Raises:
-        typer.Exit: On :class:`PipefyError` (exit code 1).
+        typer.Exit: On :class:`PipefyError` (exit code 1), optional ``ValueError`` mapping, or ``BrokenPipeError`` (exit 0).
     """
     pipefy_settings, token = settings_and_token(ctx)
 
@@ -136,6 +153,13 @@ def run_pipefy_client_coroutine(
     except PipefyError as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(1) from exc
+    except ValueError as exc:
+        if value_error_exit_code is None:
+            raise
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(value_error_exit_code) from exc
+    except BrokenPipeError:
+        raise typer.Exit(0) from None
     except TransportQueryError as exc:
         typer.echo(_format_transport_query_error(exc), err=True)
         raise typer.Exit(1) from exc

--- a/packages/cli/src/pipefy_cli/commands/agent.py
+++ b/packages/cli/src/pipefy_cli/commands/agent.py
@@ -21,6 +21,7 @@ from pipefy_cli.commands._common import (
     ID_POSITIONAL_CONTEXT_SETTINGS,
     confirm_destructive,
     parse_json_value,
+    resource_id_argument,
     run_cli_command,
     settings_and_token,
 )
@@ -70,7 +71,7 @@ def agent_list(
 @agent_app.command("get", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def agent_get(
     ctx: typer.Context,
-    uuid: str = typer.Argument(..., help="Agent UUID."),
+    uuid: str = resource_id_argument(help="Agent UUID."),
     json_out: bool = typer.Option(
         False, "--json", "-j", help="Print machine-readable JSON to stdout."
     ),
@@ -254,8 +255,10 @@ def agent_update(
 @agent_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def agent_delete(
     ctx: typer.Context,
-    uuid: str = typer.Argument(..., help="Agent UUID."),
-    yes: bool = typer.Option(False, "--yes", help="Skip interactive confirmation."),
+    uuid: str = resource_id_argument(help="Agent UUID."),
+    yes: bool = typer.Option(
+        False, "--yes", "-y", help="Skip interactive confirmation."
+    ),
     json_out: bool = typer.Option(False, "--json", "-j"),
 ) -> None:
     """Delete an AI agent (``delete_ai_agent``)."""
@@ -270,15 +273,24 @@ def agent_delete(
 @agent_app.command("toggle", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def agent_toggle(
     ctx: typer.Context,
-    uuid: str = typer.Argument(..., help="Agent UUID."),
+    uuid: str = resource_id_argument(help="Agent UUID."),
     active: bool = typer.Option(
         True,
         "--active/--inactive",
         help="Enable or disable the agent.",
     ),
+    yes: bool = typer.Option(
+        False, "--yes", "-y", help="Skip confirmation when disabling."
+    ),
     json_out: bool = typer.Option(False, "--json", "-j"),
 ) -> None:
     """Enable or disable an AI agent (``toggle_ai_agent_status``)."""
+    if not active:
+        confirm_destructive(
+            yes=yes,
+            description=f"AI agent (UUID: {uuid})",
+            verb="disable",
+        )
 
     async def factory(client: PipefyClient):
         return await client.toggle_ai_agent_status(uuid, active=active)
@@ -311,7 +323,7 @@ def agent_logs_list(
 @logs_app.command("get", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def agent_logs_get(
     ctx: typer.Context,
-    log_id: str = typer.Argument(..., help="Log UUID."),
+    log_id: str = resource_id_argument(help="Log UUID."),
     json_out: bool = typer.Option(False, "--json", "-j"),
 ) -> None:
     """Fetch one AI agent log entry (``get_ai_agent_log_details``)."""

--- a/packages/cli/src/pipefy_cli/commands/ai_automation.py
+++ b/packages/cli/src/pipefy_cli/commands/ai_automation.py
@@ -21,6 +21,7 @@ from pipefy_cli.commands._common import (
     confirm_destructive,
     parse_json_object,
     parse_json_value,
+    resource_id_argument,
     run_cli_command,
 )
 
@@ -101,7 +102,7 @@ def ai_automation_list(
 @ai_automation_app.command("get", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def ai_automation_get(
     ctx: typer.Context,
-    automation_id: str = typer.Argument(..., help="Automation rule id."),
+    automation_id: str = resource_id_argument(help="Automation rule id."),
     json_out: bool = typer.Option(False, "--json", "-j"),
 ) -> None:
     """Load one automation row (``get_ai_automation`` / ``get_automation``)."""
@@ -216,7 +217,7 @@ def ai_automation_create(
 @ai_automation_app.command("update", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def ai_automation_update(
     ctx: typer.Context,
-    automation_id: str = typer.Argument(..., help="Automation rule id."),
+    automation_id: str = resource_id_argument(help="Automation rule id."),
     pipe: str = typer.Option(
         ...,
         "--pipe",
@@ -313,8 +314,10 @@ def ai_automation_update(
 @ai_automation_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def ai_automation_delete(
     ctx: typer.Context,
-    automation_id: str = typer.Argument(..., help="Automation rule id."),
-    yes: bool = typer.Option(False, "--yes", help="Skip interactive confirmation."),
+    automation_id: str = resource_id_argument(help="Automation rule id."),
+    yes: bool = typer.Option(
+        False, "--yes", "-y", help="Skip interactive confirmation."
+    ),
     json_out: bool = typer.Option(False, "--json", "-j"),
 ) -> None:
     """Delete an AI automation (``delete_ai_automation`` / ``delete_automation``)."""

--- a/packages/cli/src/pipefy_cli/commands/automation.py
+++ b/packages/cli/src/pipefy_cli/commands/automation.py
@@ -11,6 +11,7 @@ from pipefy_cli.commands._common import (
     confirm_destructive,
     parse_json_object,
     parse_json_value,
+    resource_id_argument,
     run_cli_command,
 )
 
@@ -54,7 +55,7 @@ def automation_list(
 @automation_app.command("get", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def automation_get(
     ctx: typer.Context,
-    automation_id: str = typer.Argument(..., help="Automation rule id."),
+    automation_id: str = resource_id_argument(help="Automation rule id."),
     json_out: bool = typer.Option(
         False,
         "--json",
@@ -132,7 +133,7 @@ def automation_create(
 @automation_app.command("update", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def automation_update(
     ctx: typer.Context,
-    automation_id: str = typer.Argument(..., help="Automation rule id."),
+    automation_id: str = resource_id_argument(help="Automation rule id."),
     extra: str = typer.Option(
         ...,
         "--extra",
@@ -159,8 +160,10 @@ def automation_update(
 @automation_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def automation_delete(
     ctx: typer.Context,
-    automation_id: str = typer.Argument(..., help="Automation rule id."),
-    yes: bool = typer.Option(False, "--yes", help="Skip interactive confirmation."),
+    automation_id: str = resource_id_argument(help="Automation rule id."),
+    yes: bool = typer.Option(
+        False, "--yes", "-y", help="Skip interactive confirmation."
+    ),
     json_out: bool = typer.Option(
         False,
         "--json",
@@ -467,7 +470,7 @@ def automation_export_jobs(
 @export_app.command("status", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def automation_export_status(
     ctx: typer.Context,
-    export_id: str = typer.Argument(..., help="Export id from ``export jobs``."),
+    export_id: str = resource_id_argument(help="Export id from ``export jobs``."),
     json_out: bool = typer.Option(
         False,
         "--json",
@@ -486,7 +489,7 @@ def automation_export_status(
 @export_app.command("csv", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def automation_export_csv(
     ctx: typer.Context,
-    export_id: str = typer.Argument(..., help="Finished export id."),
+    export_id: str = resource_id_argument(help="Finished export id."),
     json_out: bool = typer.Option(
         False,
         "--json",

--- a/packages/cli/src/pipefy_cli/commands/card.py
+++ b/packages/cli/src/pipefy_cli/commands/card.py
@@ -19,6 +19,7 @@ from pipefy_cli.commands._common import (
     ID_POSITIONAL_CONTEXT_SETTINGS,
     confirm_destructive,
     parse_json_value,
+    resource_id_argument,
     run_cli_command,
 )
 
@@ -86,7 +87,7 @@ def _split_csv_ids(raw: str | None) -> list[str | int] | None:
 @card_app.command("get", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def card_get(
     ctx: typer.Context,
-    card_id: str,
+    card_id: str = resource_id_argument(help="Card id."),
     json_out: bool = typer.Option(
         False,
         "--json",
@@ -222,7 +223,7 @@ def card_find(
 @card_app.command("create", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def card_create(
     ctx: typer.Context,
-    pipe_id: str,
+    pipe_id: str = resource_id_argument(help="Pipe id."),
     title: str | None = typer.Option(
         None,
         "--title",
@@ -261,7 +262,7 @@ def card_create(
 @card_app.command("update", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def card_update(
     ctx: typer.Context,
-    card_id: str,
+    card_id: str = resource_id_argument(help="Card id."),
     title: str | None = typer.Option(None, "--title", "-t"),
     due_date: str | None = typer.Option(None, "--due-date"),
     assignee_ids: str | None = typer.Option(
@@ -304,7 +305,7 @@ def card_update(
 @card_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def card_delete(
     ctx: typer.Context,
-    card_id: str,
+    card_id: str = resource_id_argument(help="Card id."),
     yes: bool = typer.Option(
         False,
         "--yes",
@@ -326,7 +327,7 @@ def card_delete(
 @card_app.command("move", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def card_move(
     ctx: typer.Context,
-    card_id: str,
+    card_id: str = resource_id_argument(help="Card id."),
     phase_id: str = typer.Option(
         ...,
         "--phase",
@@ -345,7 +346,7 @@ def card_move(
 @comment_app.command("add", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def card_comment_add(
     ctx: typer.Context,
-    card_id: str,
+    card_id: str = resource_id_argument(help="Card id."),
     text: str = typer.Argument(..., help="Comment body (1-1000 characters)."),
     json_out: bool = typer.Option(False, "--json", "-j"),
 ) -> None:
@@ -366,7 +367,7 @@ def card_comment_add(
 @comment_app.command("update", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def card_comment_update(
     ctx: typer.Context,
-    comment_id: str,
+    comment_id: str = resource_id_argument(help="Comment id."),
     text: str = typer.Argument(..., help="New comment text."),
     json_out: bool = typer.Option(False, "--json", "-j"),
 ) -> None:
@@ -387,7 +388,7 @@ def card_comment_update(
 @comment_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def card_comment_delete(
     ctx: typer.Context,
-    comment_id: str,
+    comment_id: str = resource_id_argument(help="Comment id."),
     yes: bool = typer.Option(
         False,
         "--yes",

--- a/packages/cli/src/pipefy_cli/commands/export.py
+++ b/packages/cli/src/pipefy_cli/commands/export.py
@@ -7,6 +7,7 @@ from pipefy_sdk import PipefyClient
 
 from pipefy_cli.commands._common import (
     ID_POSITIONAL_CONTEXT_SETTINGS,
+    resource_id_argument,
     run_cli_command,
 )
 
@@ -44,7 +45,7 @@ def export_automation_jobs(
 )
 def export_automation_jobs_csv(
     ctx: typer.Context,
-    export_id: str = typer.Argument(..., help="Export id after status is finished."),
+    export_id: str = resource_id_argument(help="Export id after status is finished."),
     json_out: bool = typer.Option(
         False,
         "--json",

--- a/packages/cli/src/pipefy_cli/commands/field.py
+++ b/packages/cli/src/pipefy_cli/commands/field.py
@@ -9,6 +9,7 @@ from pipefy_cli.commands._common import (
     ID_POSITIONAL_CONTEXT_SETTINGS,
     confirm_destructive,
     parse_json_object,
+    resource_id_argument,
     run_cli_command,
 )
 
@@ -70,7 +71,7 @@ def field_create(
 @field_app.command("update", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def field_update(
     ctx: typer.Context,
-    field_id: str,
+    field_id: str = resource_id_argument(help="Phase field id."),
     extra_json: str | None = typer.Option(
         None,
         "--extra",
@@ -93,7 +94,7 @@ def field_update(
 @field_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def field_delete(
     ctx: typer.Context,
-    field_id: str,
+    field_id: str = resource_id_argument(help="Phase field id."),
     pipe_uuid: str | None = typer.Option(
         None,
         "--pipe-uuid",

--- a/packages/cli/src/pipefy_cli/commands/field_condition.py
+++ b/packages/cli/src/pipefy_cli/commands/field_condition.py
@@ -12,6 +12,7 @@ from pipefy_cli.commands._common import (
     confirm_destructive,
     parse_json_object,
     parse_json_value,
+    resource_id_argument,
     run_cli_command,
 )
 
@@ -54,7 +55,7 @@ def field_condition_list(
 @field_condition_app.command("get", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def field_condition_get(
     ctx: typer.Context,
-    condition_id: str = typer.Argument(..., help="Field condition id."),
+    condition_id: str = resource_id_argument(help="Field condition id."),
     json_out: bool = typer.Option(
         False,
         "--json",
@@ -146,7 +147,7 @@ def field_condition_create(
 @field_condition_app.command("update", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def field_condition_update(
     ctx: typer.Context,
-    condition_id: str = typer.Argument(..., help="Field condition id."),
+    condition_id: str = resource_id_argument(help="Field condition id."),
     extra: str = typer.Option(
         ...,
         "--extra",
@@ -173,10 +174,11 @@ def field_condition_update(
 @field_condition_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def field_condition_delete(
     ctx: typer.Context,
-    condition_id: str = typer.Argument(..., help="Field condition id."),
+    condition_id: str = resource_id_argument(help="Field condition id."),
     yes: bool = typer.Option(
         False,
         "--yes",
+        "-y",
         help="Skip interactive confirmation.",
     ),
     json_out: bool = typer.Option(

--- a/packages/cli/src/pipefy_cli/commands/label.py
+++ b/packages/cli/src/pipefy_cli/commands/label.py
@@ -8,6 +8,7 @@ from pipefy_sdk import PipefyClient
 from pipefy_cli.commands._common import (
     ID_POSITIONAL_CONTEXT_SETTINGS,
     confirm_destructive,
+    resource_id_argument,
     run_cli_command,
 )
 
@@ -66,7 +67,7 @@ def label_create(
 @label_app.command("update", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def label_update(
     ctx: typer.Context,
-    label_id: str,
+    label_id: str = resource_id_argument(help="Label id."),
     name: str = typer.Option(
         ..., "--name", "-n", help="New label name (required by API)."
     ),
@@ -92,7 +93,7 @@ def label_update(
 @label_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def label_delete(
     ctx: typer.Context,
-    label_id: str,
+    label_id: str = resource_id_argument(help="Label id."),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
     json_out: bool = typer.Option(False, "--json", "-j"),
 ) -> None:

--- a/packages/cli/src/pipefy_cli/commands/org.py
+++ b/packages/cli/src/pipefy_cli/commands/org.py
@@ -7,6 +7,7 @@ from pipefy_sdk import PipefyClient
 
 from pipefy_cli.commands._common import (
     ID_POSITIONAL_CONTEXT_SETTINGS,
+    resource_id_argument,
     run_cli_command,
 )
 
@@ -16,7 +17,7 @@ org_app = typer.Typer(help="Organization operations.", no_args_is_help=True)
 @org_app.command("get", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def org_get(
     ctx: typer.Context,
-    organization_id: str = typer.Argument(..., help="Numeric organization id."),
+    organization_id: str = resource_id_argument(help="Numeric organization id."),
     json_out: bool = typer.Option(False, "--json", "-j"),
 ) -> None:
     """Fetch organization details (``get_organization``)."""

--- a/packages/cli/src/pipefy_cli/commands/phase.py
+++ b/packages/cli/src/pipefy_cli/commands/phase.py
@@ -11,6 +11,7 @@ from pipefy_cli.commands._common import (
     ID_POSITIONAL_CONTEXT_SETTINGS,
     confirm_destructive,
     parse_json_object,
+    resource_id_argument,
     run_cli_command,
 )
 
@@ -20,7 +21,7 @@ phase_app = typer.Typer(help="Pipe phase operations.", no_args_is_help=True)
 @phase_app.command("get", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def phase_get(
     ctx: typer.Context,
-    phase_id: str,
+    phase_id: str = resource_id_argument(help="Phase id."),
     json_out: bool = typer.Option(
         False,
         "--json",
@@ -79,7 +80,7 @@ def phase_create(
 @phase_app.command("update", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def phase_update(
     ctx: typer.Context,
-    phase_id: str,
+    phase_id: str = resource_id_argument(help="Phase id."),
     name: str | None = typer.Option(None, "--name", "-n"),
     description: str | None = typer.Option(None, "--description", "-d"),
     done: bool | None = typer.Option(
@@ -143,7 +144,7 @@ def phase_update(
 @phase_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def phase_delete(
     ctx: typer.Context,
-    phase_id: str,
+    phase_id: str = resource_id_argument(help="Phase id."),
     yes: bool = typer.Option(
         False,
         "--yes",

--- a/packages/cli/src/pipefy_cli/commands/pipe.py
+++ b/packages/cli/src/pipefy_cli/commands/pipe.py
@@ -9,6 +9,7 @@ from pipefy_cli.commands._common import (
     ID_POSITIONAL_CONTEXT_SETTINGS,
     confirm_destructive,
     parse_json_object,
+    resource_id_argument,
     run_cli_command,
 )
 
@@ -18,7 +19,7 @@ pipe_app = typer.Typer(help="Pipe operations.", no_args_is_help=True)
 @pipe_app.command("get", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def pipe_get(
     ctx: typer.Context,
-    pipe_id: str,
+    pipe_id: str = resource_id_argument(help="Pipe id."),
     json_out: bool = typer.Option(
         False,
         "--json",
@@ -87,7 +88,7 @@ def pipe_create(
 @pipe_app.command("update", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def pipe_update(
     ctx: typer.Context,
-    pipe_id: str,
+    pipe_id: str = resource_id_argument(help="Pipe id."),
     name: str | None = typer.Option(None, "--name"),
     icon: str | None = typer.Option(None, "--icon"),
     color: str | None = typer.Option(None, "--color"),
@@ -123,7 +124,7 @@ def pipe_update(
 @pipe_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def pipe_delete(
     ctx: typer.Context,
-    pipe_id: str,
+    pipe_id: str = resource_id_argument(help="Pipe id."),
     yes: bool = typer.Option(
         False,
         "--yes",
@@ -145,8 +146,7 @@ def pipe_delete(
 @pipe_app.command("clone", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def pipe_clone(
     ctx: typer.Context,
-    template_pipe_id: str = typer.Argument(
-        ...,
+    template_pipe_id: str = resource_id_argument(
         help="Source pipe id to use as template.",
     ),
     org_id: str | None = typer.Option(

--- a/packages/cli/src/pipefy_cli/commands/record.py
+++ b/packages/cli/src/pipefy_cli/commands/record.py
@@ -16,6 +16,7 @@ from pipefy_cli.commands._common import (
     confirm_destructive,
     parse_json_object,
     parse_json_value,
+    resource_id_argument,
     run_cli_command,
 )
 
@@ -102,7 +103,7 @@ def record_find(
 @record_app.command("get", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def record_get(
     ctx: typer.Context,
-    record_id: str,
+    record_id: str = resource_id_argument(help="Table record id."),
     json_out: bool = typer.Option(False, "--json", "-j"),
 ) -> None:
     """Load one table record by id."""
@@ -148,7 +149,7 @@ def record_create(
 @record_app.command("update", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def record_update(
     ctx: typer.Context,
-    record_id: str,
+    record_id: str = resource_id_argument(help="Table record id."),
     fields_json: str | None = typer.Option(
         None,
         "--fields",
@@ -204,7 +205,7 @@ def record_update(
 @record_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def record_delete(
     ctx: typer.Context,
-    record_id: str,
+    record_id: str = resource_id_argument(help="Table record id."),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
     json_out: bool = typer.Option(False, "--json", "-j"),
 ) -> None:

--- a/packages/cli/src/pipefy_cli/commands/relation.py
+++ b/packages/cli/src/pipefy_cli/commands/relation.py
@@ -10,6 +10,7 @@ from pipefy_cli.commands._common import (
     authenticated_client_from_ctx,
     confirm_destructive,
     parse_json_object,
+    resource_id_argument,
     run_cli_command,
 )
 
@@ -21,7 +22,7 @@ relation_card_app = typer.Typer(help="Card-to-card relations.", no_args_is_help=
 @relation_pipe_app.command("list", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def relation_pipe_list(
     ctx: typer.Context,
-    pipe_id: str,
+    pipe_id: str = resource_id_argument(help="Pipe id."),
     json_out: bool = typer.Option(False, "--json", "-j"),
 ) -> None:
     """List pipe relations for a pipe."""
@@ -64,7 +65,7 @@ def relation_pipe_create(
 @relation_pipe_app.command("update", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def relation_pipe_update(
     ctx: typer.Context,
-    relation_id: str,
+    relation_id: str = resource_id_argument(help="Pipe relation id."),
     name: str = typer.Option(..., "--name", "-n", help="New relation name."),
     extra_json: str | None = typer.Option(
         None,
@@ -90,7 +91,7 @@ def relation_pipe_update(
 @relation_pipe_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def relation_pipe_delete(
     ctx: typer.Context,
-    relation_id: str,
+    relation_id: str = resource_id_argument(help="Pipe relation id."),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
     json_out: bool = typer.Option(False, "--json", "-j"),
 ) -> None:
@@ -107,7 +108,7 @@ def relation_pipe_delete(
 @relation_card_app.command("list", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def relation_card_list(
     ctx: typer.Context,
-    card_id: str,
+    card_id: str = resource_id_argument(help="Card id."),
     json_out: bool = typer.Option(False, "--json", "-j"),
 ) -> None:
     """List parent and child relations for a card (raw ``get_card_relations`` payload)."""

--- a/packages/cli/src/pipefy_cli/commands/report_org.py
+++ b/packages/cli/src/pipefy_cli/commands/report_org.py
@@ -10,6 +10,7 @@ from pipefy_cli.commands._common import (
     confirm_destructive,
     parse_json_object,
     parse_json_value,
+    resource_id_argument,
     run_cli_command,
     run_pipefy_client_coroutine,
     write_export_csv_to_stdout,
@@ -41,7 +42,7 @@ def report_org_list(
 @report_org_app.command("get", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def report_org_get(
     ctx: typer.Context,
-    report_id: str = typer.Argument(..., help="Organization report id."),
+    report_id: str = resource_id_argument(help="Organization report id."),
     json_out: bool = typer.Option(
         False, "--json", "-j", help="Print machine-readable JSON to stdout."
     ),
@@ -93,7 +94,7 @@ def report_org_create(
 @report_org_app.command("update", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def report_org_update(
     ctx: typer.Context,
-    report_id: str = typer.Argument(..., help="Organization report id."),
+    report_id: str = resource_id_argument(help="Organization report id."),
     name: str | None = typer.Option(None, "--name", "-n"),
     color: str | None = typer.Option(None, "--color"),
     fields: str | None = typer.Option(None, "--fields"),
@@ -132,8 +133,8 @@ def report_org_update(
 @report_org_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def report_org_delete(
     ctx: typer.Context,
-    report_id: str = typer.Argument(..., help="Organization report id."),
-    yes: bool = typer.Option(False, "--yes"),
+    report_id: str = resource_id_argument(help="Organization report id."),
+    yes: bool = typer.Option(False, "--yes", "-y"),
     json_out: bool = typer.Option(
         False, "--json", "-j", help="Print machine-readable JSON to stdout."
     ),
@@ -236,4 +237,4 @@ def report_org_export(
             poll_timeout_seconds=poll_timeout,
         )
 
-    run_pipefy_client_coroutine(ctx, csv_factory)
+    run_pipefy_client_coroutine(ctx, csv_factory, value_error_exit_code=1)

--- a/packages/cli/src/pipefy_cli/commands/report_pipe.py
+++ b/packages/cli/src/pipefy_cli/commands/report_pipe.py
@@ -12,6 +12,7 @@ from pipefy_cli.commands._common import (
     confirm_destructive,
     parse_json_object,
     parse_json_value,
+    resource_id_argument,
     run_cli_command,
     run_pipefy_client_coroutine,
     write_export_csv_to_stdout,
@@ -157,7 +158,7 @@ def report_pipe_create(
 @report_pipe_app.command("update", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def report_pipe_update(
     ctx: typer.Context,
-    report_id: str = typer.Argument(..., help="Pipe report id."),
+    report_id: str = resource_id_argument(help="Pipe report id."),
     name: str | None = typer.Option(None, "--name", "-n"),
     color: str | None = typer.Option(None, "--color"),
     fields: str | None = typer.Option(None, "--fields"),
@@ -194,8 +195,8 @@ def report_pipe_update(
 @report_pipe_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def report_pipe_delete(
     ctx: typer.Context,
-    report_id: str = typer.Argument(..., help="Pipe report id."),
-    yes: bool = typer.Option(False, "--yes"),
+    report_id: str = resource_id_argument(help="Pipe report id."),
+    yes: bool = typer.Option(False, "--yes", "-y"),
     json_out: bool = typer.Option(
         False, "--json", "-j", help="Print machine-readable JSON to stdout."
     ),
@@ -285,4 +286,4 @@ def report_pipe_export(
             poll_timeout_seconds=poll_timeout,
         )
 
-    run_pipefy_client_coroutine(ctx, csv_factory)
+    run_pipefy_client_coroutine(ctx, csv_factory, value_error_exit_code=1)

--- a/packages/cli/src/pipefy_cli/commands/table.py
+++ b/packages/cli/src/pipefy_cli/commands/table.py
@@ -11,6 +11,7 @@ from pipefy_cli.commands._common import (
     ID_POSITIONAL_CONTEXT_SETTINGS,
     confirm_destructive,
     parse_json_object,
+    resource_id_argument,
     run_cli_command,
 )
 
@@ -59,7 +60,7 @@ def table_list(
 @table_app.command("get", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def table_get(
     ctx: typer.Context,
-    table_id: str,
+    table_id: str = resource_id_argument(help="Table id."),
     json_out: bool = typer.Option(False, "--json", "-j"),
 ) -> None:
     """Load one table by id."""
@@ -103,7 +104,7 @@ def table_create(
 @table_app.command("update", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def table_update(
     ctx: typer.Context,
-    table_id: str,
+    table_id: str = resource_id_argument(help="Table id."),
     name: str | None = typer.Option(None, "--name"),
     description: str | None = typer.Option(None, "--description", "-d"),
     extra_json: str | None = typer.Option(
@@ -136,7 +137,7 @@ def table_update(
 @table_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def table_delete(
     ctx: typer.Context,
-    table_id: str,
+    table_id: str = resource_id_argument(help="Table id."),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
     json_out: bool = typer.Option(False, "--json", "-j"),
 ) -> None:

--- a/packages/cli/src/pipefy_cli/commands/webhook.py
+++ b/packages/cli/src/pipefy_cli/commands/webhook.py
@@ -12,6 +12,7 @@ from pipefy_cli.commands._common import (
     ID_POSITIONAL_CONTEXT_SETTINGS,
     confirm_destructive,
     parse_json_object,
+    resource_id_argument,
     run_cli_command,
 )
 
@@ -82,7 +83,7 @@ def webhook_create(
 @webhook_app.command("update", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def webhook_update(
     ctx: typer.Context,
-    webhook_id: str,
+    webhook_id: str = resource_id_argument(help="Webhook id."),
     name: str | None = typer.Option(None, "--name"),
     url: str | None = typer.Option(None, "--url"),
     actions_json: str | None = typer.Option(
@@ -126,7 +127,7 @@ def webhook_update(
 @webhook_app.command("delete", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def webhook_delete(
     ctx: typer.Context,
-    webhook_id: str,
+    webhook_id: str = resource_id_argument(help="Webhook id."),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
     json_out: bool = typer.Option(False, "--json", "-j"),
 ) -> None:

--- a/packages/cli/tests/test_cli_tasks_10_11.py
+++ b/packages/cli/tests/test_cli_tasks_10_11.py
@@ -436,6 +436,63 @@ def test_agent_create_blocks_when_preflight_invalid(
     mock_client.update_ai_agent.assert_not_called()
 
 
+def test_agent_toggle_inactive_aborts_when_user_denies_confirm(
+    runner: CliRunner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("ag-toggle-deny")
+    mock_client = MagicMock()
+    mock_client.toggle_ai_agent_status = AsyncMock(return_value={"success": True})
+
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        r = runner.invoke(
+            app,
+            [
+                "agent",
+                "toggle",
+                "00000000-0000-0000-0000-000000000099",
+                "--inactive",
+                "--json",
+            ],
+            input="n\n",
+        )
+
+    assert r.exit_code != 0
+    mock_client.toggle_ai_agent_status.assert_not_called()
+
+
+def test_agent_toggle_inactive_yes_skips_confirm(
+    runner: CliRunner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("ag-toggle-yes")
+    mock_client = MagicMock()
+    mock_client.toggle_ai_agent_status = AsyncMock(return_value={"success": True})
+
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        r = runner.invoke(
+            app,
+            [
+                "agent",
+                "toggle",
+                "00000000-0000-0000-0000-000000000099",
+                "--inactive",
+                "--yes",
+                "--json",
+            ],
+        )
+
+    assert r.exit_code == 0, r.stderr
+    mock_client.toggle_ai_agent_status.assert_awaited_once_with(
+        "00000000-0000-0000-0000-000000000099",
+        active=False,
+    )
+
+
 def test_ai_automation_create_requires_oauth(
     runner: CliRunner, clean_pipefy_env, saved_cwd, oauth_env
 ):

--- a/packages/cli/tests/test_common_helpers.py
+++ b/packages/cli/tests/test_common_helpers.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import sys
 from collections.abc import AsyncIterator
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import typer
 
 from pipefy_cli.commands._common import (
     export_poll_max_rounds,
@@ -205,3 +206,41 @@ def test_run_pipefy_client_coroutine_maps_pipefy_error_to_exit_1(monkeypatch):
         run_pipefy_client_coroutine(MagicMock(), factory)
 
     assert excinfo.value.exit_code == 1
+
+
+def test_run_pipefy_client_coroutine_maps_value_error_when_configured(monkeypatch):
+    """Optional ``value_error_exit_code`` maps export failures to stderr + exit."""
+    from pipefy_cli.commands import _common
+    from pipefy_cli.commands._common import run_pipefy_client_coroutine
+
+    monkeypatch.setattr(
+        _common, "get_authenticated_client", lambda settings, *, bearer_token: object()
+    )
+    monkeypatch.setattr(_common, "settings_and_token", lambda ctx: (object(), None))
+
+    async def factory(client: object) -> None:
+        raise ValueError("Export failed (state='failed').")
+
+    with pytest.raises(typer.Exit) as excinfo:
+        run_pipefy_client_coroutine(MagicMock(), factory, value_error_exit_code=1)
+
+    assert excinfo.value.exit_code == 1
+
+
+def test_run_pipefy_client_coroutine_broken_pipe_exits_0(monkeypatch):
+    """``BrokenPipeError`` (e.g. ``| head``) exits 0 without a traceback."""
+    from pipefy_cli.commands import _common
+    from pipefy_cli.commands._common import run_pipefy_client_coroutine
+
+    monkeypatch.setattr(
+        _common, "get_authenticated_client", lambda settings, *, bearer_token: object()
+    )
+    monkeypatch.setattr(_common, "settings_and_token", lambda ctx: (object(), None))
+
+    async def factory(client: object) -> None:
+        raise BrokenPipeError()
+
+    with pytest.raises(typer.Exit) as excinfo:
+        run_pipefy_client_coroutine(MagicMock(), factory, value_error_exit_code=1)
+
+    assert excinfo.value.exit_code == 0

--- a/packages/cli/tests/test_pipe_commands.py
+++ b/packages/cli/tests/test_pipe_commands.py
@@ -8,6 +8,40 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from pipefy_cli.main import app
 
 
+def test_pipe_get_rejects_option_like_positional_exit_2(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("pipe-get-bad-opt")
+    mock_client = MagicMock()
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(app, ["pipe", "get", "--bad", "--json"])
+    assert result.exit_code == 2
+    mock_client.get_pipe.assert_not_called()
+
+
+def test_table_delete_accepts_leading_hyphen_table_id(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("table-del-hyphen")
+    mock_client = MagicMock()
+    mock_client.delete_table = AsyncMock(
+        return_value={"deleteTable": {"success": True}}
+    )
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["table", "delete", "-ZocGcM0", "--yes", "--json"],
+        )
+    assert result.exit_code == 0, result.stderr
+    mock_client.delete_table.assert_awaited_once_with("-ZocGcM0")
+
+
 def test_pipe_get_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
     oauth_env("pipe-get")
     payload = {"pipe": {"id": "10", "name": "P"}}

--- a/packages/cli/tests/test_v8_v9_cli_commands.py
+++ b/packages/cli/tests/test_v8_v9_cli_commands.py
@@ -371,3 +371,79 @@ def test_report_pipe_export_csv_exits_1_when_export_id_missing(
 
     assert r.exit_code == 1
     assert "export id" in r.stderr.lower()
+
+
+def test_report_pipe_export_csv_exits_1_when_poll_reports_failed(
+    runner: CliRunner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    """Failed export state surfaces as exit 1 with a stderr message (no traceback)."""
+    oauth_env("rpcsv-fail")
+    mock_client = MagicMock()
+    mock_client.export_pipe_report = AsyncMock(
+        return_value={"exportPipeReport": {"pipeReportExport": {"id": "exp-f"}}}
+    )
+    mock_client.get_pipe_report_export = AsyncMock(
+        return_value={"pipeReportExport": {"state": "failed"}}
+    )
+
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        r = runner.invoke(
+            app,
+            [
+                "report-pipe",
+                "export",
+                "--pipe",
+                "p1",
+                "--report-id",
+                "r1",
+                "--format",
+                "csv",
+                "--poll-timeout",
+                "2.0",
+            ],
+        )
+
+    assert r.exit_code == 1
+    assert "failed" in r.stderr.lower()
+    mock_client.export_pipe_report.assert_awaited_once()
+
+
+def test_report_org_export_csv_exits_1_when_poll_reports_failed(
+    runner: CliRunner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("rocsv-fail")
+    mock_client = MagicMock()
+    mock_client.export_organization_report = AsyncMock(
+        return_value={
+            "exportOrganizationReport": {"organizationReportExport": {"id": "exp-o"}}
+        }
+    )
+    mock_client.get_organization_report_export = AsyncMock(
+        return_value={"organizationReportExport": {"state": "failed"}}
+    )
+
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        r = runner.invoke(
+            app,
+            [
+                "report-org",
+                "export",
+                "--organization",
+                "org1",
+                "--organization-report-id",
+                "rep1",
+                "--format",
+                "csv",
+                "--poll-timeout",
+                "2.0",
+            ],
+        )
+
+    assert r.exit_code == 1
+    assert "failed" in r.stderr.lower()

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -17,9 +17,9 @@ Set the following environment variables (or add to a `.env` file in your working
 ```env
 PIPEFY_OAUTH_CLIENT=your_client_id
 PIPEFY_OAUTH_SECRET=your_client_secret
-PIPEFY_GRAPHQL_URL=https://api.pipefy.com/graphql
-PIPEFY_OAUTH_URL=https://auth.pipefy.com/...
-PIPEFY_INTERNAL_API_URL=https://app.pipefy.com/graphql
+PIPEFY_GRAPHQL_URL=https://app.pipefy.com/graphql
+PIPEFY_OAUTH_URL=https://app.pipefy.com/oauth/token
+PIPEFY_INTERNAL_API_URL=https://app.pipefy.com/internal_api
 ```
 
 Full guide: [`docs/setup.md`](../../docs/setup.md).

--- a/packages/mcp/pyproject.toml
+++ b/packages/mcp/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
     "httpx>=0.27.0",
     "mcp[cli]>=1.25.0",
-    # Workspace resolves version in dev; standalone PyPI install needs Phase 6 (bundle or co-publish SDK). PRD Non-Goals and FR-6.3.
+    # Workspace resolves version in dev; PyPI releases stage this wheel alongside CLI/MCP (see release workflow).
     "pipefy-sdk",
     "pydantic>=2.11.3",
     "pydantic-settings>=2.8.1",

--- a/packages/mcp/src/pipefy_mcp/tools/attachment_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/attachment_tools.py
@@ -9,7 +9,7 @@ import ipaddress
 import socket
 from collections.abc import Awaitable, Callable
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 import httpx
 from mcp.server.fastmcp import Context, FastMCP
@@ -119,8 +119,9 @@ async def _download_file_bytes(url: str) -> bytes:
                     location = response.headers.get("location")
                     if not location:
                         raise ValueError("Redirect without Location header")
-                    await _validate_url_safe(location)
-                    current_url = location
+                    resolved = urljoin(current_url, location.strip())
+                    await _validate_url_safe(resolved)
+                    current_url = resolved
                     continue
 
                 response.raise_for_status()

--- a/packages/mcp/tests/tools/test_attachment_tools.py
+++ b/packages/mcp/tests/tools/test_attachment_tools.py
@@ -245,6 +245,23 @@ async def test_download_follows_safe_redirect_chain():
 
 
 @pytest.mark.anyio
+async def test_download_follows_relative_redirect_resolving_against_current_url():
+    """Relative ``Location`` headers are resolved with ``urljoin`` before SSRF validation."""
+    r1 = _make_response(status_code=302, headers={"location": "/files/a.pdf"})
+    r2 = _make_response(status_code=200, headers={}, body=b"relative-ok")
+    mock_cm = _httpx_multi_response_cm_mock(r1, r2)
+    with (
+        patch(
+            "pipefy_mcp.tools.attachment_tools.httpx.AsyncClient", return_value=mock_cm
+        ),
+        patch(_VALIDATE_PATCH) as mock_validate,
+    ):
+        result = await _download_file_bytes("https://example.com/start/here")
+    assert result == b"relative-ok"
+    assert mock_validate.await_count == 2
+
+
+@pytest.mark.anyio
 async def test_download_rejects_too_many_redirects():
     """Redirect loop / chain longer than _MAX_REDIRECTS is rejected."""
     # 5 redirects, all pointing forward — exceeds _MAX_REDIRECTS = 3.


### PR DESCRIPTION
## Summary

Implements fixes from `.cursor/dev-planning/specs/pipefy-labs/code-review/dev.md`:

- **Release**: Stage `pipefy-sdk` + CLI + MCP wheels for PyPI; restrict uploads to stable `v1.*` tags (no `-rc` suffix); smoke-install staged wheels in a clean venv before publish.
- **CLI**: Reject `--`-like tokens mistaken for resource IDs when `ignore_unknown_options` is on; map CSV export `ValueError` / `BrokenPipeError` via `run_pipefy_client_coroutine`; confirm before `agent toggle --inactive` with `--yes`/`-y`; add `-y` where missing on destructive flows.
- **MCP**: Resolve relative HTTP redirects with `urljoin` before SSRF validation on attachment downloads.
- **Docs**: Expand Unreleased changelog bullets; refresh `docs/dependencies.md` by package; fix parity doc task path; align package README env examples with `docs/setup.md` / `.env.example`.

## Test plan

- [x] `uv run ruff check packages/cli packages/mcp`
- [x] `uv run pytest` (2051 passed, 24 skipped)
