### PR TITLE
test/docs: parity CI, CLI help golden, deprecation + v0.2.0-beta notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   lint:

--- a/README.md
+++ b/README.md
@@ -32,9 +32,16 @@
 
 ## Install
 
-### Pre-launch (v0.1 → v0.5) — install from git
+### Pre-launch (v0.x, including public betas) — install from git
 
-> **These commands are temporary.** At v1.0 the canonical install moves to PyPI.
+> **These commands are temporary.** At **v1.0** the canonical install moves to PyPI.
+
+The next **public beta** on this monorepo follows the **`v0.2.0-beta.*`** tag line (first tag: **`v0.2.0-beta.1`**), after the standalone [`v0.1.0-beta.1`](https://github.com/gbrlcustodio/pipefy-mcp-server/releases/tag/v0.1.0-beta.1). Pin installs to that tag when you want the beta snapshot instead of floating `main`:
+
+```sh
+uvx --from git+https://github.com/<owner>/pipefy-labs@v0.2.0-beta.1 --refresh pipefy-mcp-server --help
+uvx --from git+https://github.com/<owner>/pipefy-labs@v0.2.0-beta.1 --refresh pipefy-cli --version
+```
 
 **MCP server** (for Cursor, Claude Desktop, etc.):
 
@@ -68,6 +75,8 @@ uv tool install pipefy-cli
 **Setup, env vars, and MCP client config:** see **[docs/setup.md](docs/setup.md)** for first-time install, Pydantic / `.env` precedence, and Cursor / Claude Desktop examples.
 
 **Documentation index** (MCP vs CLI vs SDK): **[docs/README.md](docs/README.md)**.
+
+**Post-1.0 deprecation and semver:** **[docs/DEPRECATION.md](docs/DEPRECATION.md)**.
 
 ---
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,12 @@ Workspace distributions (`pipefy-sdk`, `pipefy-mcp-server`, `pipefy-cli`) share 
 
 PyPI publishing is **disabled** for tags that do not start with `v1.`. Pre-release installs use git references (for example `uvx --from git+https://github.com/<owner>/<repo>.git@vX.Y.Z --refresh pipefy-cli`).
 
+### Public beta line (`v0.2.0-beta.*`)
+
+The next **GitHub pre-release** after the standalone repo’s [`v0.1.0-beta.1`](https://github.com/gbrlcustodio/pipefy-mcp-server/releases/tag/v0.1.0-beta.1) is the **`v0.2.0-beta.*`** series on this monorepo (first cut: **`v0.2.0-beta.1`** unless you intentionally reuse another suffix). Same mechanics as any other **v0.x** tag: attach wheels to the GitHub Release; **no PyPI** until **`v1.`**.
+
+The Release workflow requires the git tag (without leading `v`) to **exactly match** `__version__` in `packages/sdk/src/pipefy_sdk/__init__.py` (and the MCP/CLI copies). For example tag **`v0.2.0-beta.1`** implies **`__version__ = "0.2.0-beta.1"`** in all three packages before you push the tag (set via step 2 below using `version=0.2.0-beta.1`, or edit the three `__init__.py` files together).
+
 1. Merge work to `main` and ensure `CHANGELOG.md` has everything under `## [Unreleased]`.
 2. Bump the shared version (updates all three `__init__.py` files):
 
@@ -14,6 +20,8 @@ PyPI publishing is **disabled** for tags that do not start with `v1.`. Pre-relea
    ```
 
    Supported arguments: `major`, `minor`, `patch`, `prerelease`, or `version=X.Y.Z` (optional `v` prefix on `X.Y.Z`).
+
+   For a **`v0.2.0-beta.*`** Git tag, pass the exact PEP-440 string (for example `version=0.2.0-beta.1`) so it matches `GITHUB_REF_NAME` without the leading `v`.
 
 3. If any skills in `skills/` changed since the last release, sync the bundled starter pack into the CLI package:
 

--- a/docs/DEPRECATION.md
+++ b/docs/DEPRECATION.md
@@ -1,0 +1,44 @@
+# Deprecation and versioning (post-1.0)
+
+This policy applies **after v1.0.0**, when published `pipefy-cli` and `pipefy-mcp-server` follow public [semantic versioning](https://semver.org/) on PyPI. Before that milestone, interfaces may still change without the guarantees below.
+
+## Version bumps
+
+| Kind | When it ships | Allowed changes |
+| --- | --- | --- |
+| **MAJOR** (`X.0.0`) | Rare | **Breaking** removals or incompatible contract changes (see [Breaking changes](#breaking-changes-major-only)). |
+| **MINOR** (`1.x.0`) | Regular cadence | **Additive** behavior: new CLI subcommands, new MCP tools, new optional SDK entry points, new documented JSON fields. Existing documented behavior stays compatible unless covered by an active [deprecation](#deprecation-period). |
+| **PATCH** (`1.x.y`) | As needed | **Bug fixes** and documentation corrections only — no intentional contract changes that would break scripts or agents relying on **documented** semantics. |
+
+## Surfaces in scope
+
+1. **CLI** (`pipefy`): command and subcommand names, flag names and meanings, documented exit codes, and **machine-readable** output when `--json` is used (documented keys and value types).
+2. **MCP** (`pipefy-mcp-server`): tool names, documented argument shapes, and stable fields in tool responses where `docs/mcp/` describes a contract.
+3. **`pipefy-sdk` public API** (when consumed as a library): symbols and behaviors described as public in `docs/sdk/` and package `__init__` exports.
+
+Responses from Pipefy’s GraphQL API may gain or reshape fields at any time; consumers should ignore unknown keys and follow vendor docs for domain semantics.
+
+## Deprecation period
+
+When maintainers intend to remove or incompatibly change a stable contract:
+
+1. Record a **deprecation** in `CHANGELOG.md` under the next release section: what is deprecated, the replacement (if any), and that the change is governed by this file.
+2. Keep the deprecated path **working** for at least **two MINOR releases** after the release that **first** documents the deprecation (warning emitted when practical). Removal or breaking change may occur no earlier than the third subsequent minor line (e.g. deprecated in `1.4.0` → earliest removal in `1.7.0`).
+
+Patch releases must not skip or shorten this window.
+
+## Breaking changes (MAJOR only)
+
+These require a **MAJOR** version when applied to **stable, documented** behavior:
+
+- Removing or renaming CLI commands or flags, or changing `--json` output incompatibly (removing documented fields or changing documented types).
+- Removing or renaming MCP tools, or breaking documented tool input/output contracts.
+- Removing or renaming public SDK APIs, or incompatible signature / behavior changes on documented public types and functions.
+
+Non-breaking examples: clearer error strings, help text fixes, purely additive JSON fields, Rich layout tweaks that do not change `--json`.
+
+## Related docs
+
+- [`docs/setup.md`](setup.md) — install and environment variables
+- [`docs/parity.md`](parity.md) — MCP tool ↔ CLI matrix
+- [`docs/MIGRATION.md`](MIGRATION.md) — packaging and config moves between eras

--- a/packages/cli/tests/fixtures/cli_help_golden.txt
+++ b/packages/cli/tests/fixtures/cli_help_golden.txt
@@ -1,0 +1,2525 @@
+### HELP _
+Usage: pipefy [OPTIONS] COMMAND [ARGS]...
+
+ Pipefy CLI (GraphQL via pipefy-sdk).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --graphql-url                TEXT  Override PIPEFY_GRAPHQL_URL.              │
+│ --token                      TEXT  Bearer token for GraphQL (skips OAuth).   │
+│                                    Overrides PIPEFY_TOKEN if both are set.   │
+│ --allow-insecure-urls              Allow http:// and private hosts           │
+│                                    (overrides env for this process).         │
+│ --install-completion               Install completion for the current shell. │
+│ --show-completion                  Show completion for the current shell, to │
+│                                    copy it or customize the installation.    │
+│ --help                             Show this message and exit.               │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ agent             AI Agents (repo-scoped).                                   │
+│ ai-automation     AI Automations (generate_with_ai; requires OAuth).         │
+│ attachment        Attachment uploads (presigned URL + field update).         │
+│ audit             Pipe audit log exports.                                    │
+│ automation        Traditional automations and related exports.               │
+│ card              Card operations.                                           │
+│ email             Inbox emails and email templates.                          │
+│ field-condition   Field conditions (dynamic form rules on phases).           │
+│ pipe              Pipe operations.                                           │
+│ phase             Pipe phase operations.                                     │
+│ field             Phase field operations.                                    │
+│ table             Database table operations.                                 │
+│ record            Table record operations.                                   │
+│ label             Pipe label operations.                                     │
+│ webhook           Pipe webhook operations.                                   │
+│ relation          Pipe and card relations.                                   │
+│ member            Pipe member operations.                                    │
+│ skills            Browse bundled agent skill playbooks.                      │
+│ graphql           Execute arbitrary GraphQL (mutations require --yes). See   │
+│                   docs/cli/self-healing.md.                                  │
+│ introspect        Discover GraphQL types and operations (JSON default).      │
+│ export            Bulk exports (automation jobs).                            │
+│ org               Organization operations.                                   │
+│ report-org        Organization reports.                                      │
+│ report-pipe       Pipe reports.                                              │
+│ usage             AI and automation usage metrics.                           │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP agent
+Usage: pipefy agent [OPTIONS] COMMAND [ARGS]...
+
+ AI Agents (repo-scoped).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ list                 List AI agents for a pipe (``get_ai_agents``).          │
+│ get                  Fetch one AI agent (``get_ai_agent``).                  │
+│ create               Create and configure an AI agent (``create_ai_agent`` + │
+│                      ``update_ai_agent`` chain).                             │
+│ update               Replace AI agent configuration (``update_ai_agent``).   │
+│ delete               Delete an AI agent (``delete_ai_agent``).               │
+│ toggle               Enable or disable an AI agent                           │
+│                      (``toggle_ai_agent_status``).                           │
+│ validate-behaviors   Dry-run behavior validation                             │
+│                      (``validate_ai_agent_behaviors``).                      │
+│ logs                 AI Agent execution logs.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP agent/create
+Usage: pipefy agent create [OPTIONS]
+
+ Create and configure an AI agent (``create_ai_agent`` + ``update_ai_agent``
+ chain).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --repo-uuid                        TEXT  Pipe UUID. [required]            │
+│ *  --name          -n                 TEXT  Agent display name. [required]   │
+│ *  --instruction                      TEXT  Agent-level instruction          │
+│                                             (token-normalized).              │
+│                                             [required]                       │
+│ *  --behaviors                        TEXT  JSON array of behavior objects.  │
+│                                             [required]                       │
+│ *  --pipe                             TEXT  Numeric pipe id for              │
+│                                             validate-behaviors pre-flight.   │
+│                                             [required]                       │
+│    --data-sources                     TEXT  Optional JSON array of           │
+│                                             knowledge-source id strings.     │
+│    --strict            --no-strict          Pre-flight strictness: when      │
+│                                             --strict (default), unknown      │
+│                                             actionType values block; with    │
+│                                             --no-strict they become warnings │
+│                                             only.                            │
+│                                             [default: strict]                │
+│    --json          -j                       Print machine-readable JSON to   │
+│                                             stdout.                          │
+│    --help                                   Show this message and exit.      │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP agent/delete
+Usage: pipefy agent delete [OPTIONS] UUID
+
+ Delete an AI agent (``delete_ai_agent``).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    uuid      TEXT  Agent UUID. [required]                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --yes   -y        Skip interactive confirmation.                             │
+│ --json  -j                                                                   │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP agent/get
+Usage: pipefy agent get [OPTIONS] UUID
+
+ Fetch one AI agent (``get_ai_agent``).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    uuid      TEXT  Agent UUID. [required]                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --json  -j        Print machine-readable JSON to stdout.                     │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP agent/list
+Usage: pipefy agent list [OPTIONS]
+
+ List AI agents for a pipe (``get_ai_agents``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --repo          TEXT  Pipe UUID (repoUuid). [required]                    │
+│    --json  -j            Print machine-readable JSON to stdout.              │
+│    --help                Show this message and exit.                         │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP agent/logs
+Usage: pipefy agent logs [OPTIONS] COMMAND [ARGS]...
+
+ AI Agent execution logs.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ list   List AI agent execution logs (``get_ai_agent_logs``).                 │
+│ get    Fetch one AI agent log entry (``get_ai_agent_log_details``).          │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP agent/logs/get
+Usage: pipefy agent logs get [OPTIONS] LOG_ID
+
+ Fetch one AI agent log entry (``get_ai_agent_log_details``).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    log_id      TEXT  Log UUID. [required]                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --json  -j                                                                   │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP agent/logs/list
+Usage: pipefy agent logs list [OPTIONS]
+
+ List AI agent execution logs (``get_ai_agent_logs``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --repo            TEXT     Pipe UUID. [required]                          │
+│    --first           INTEGER  Page size. [default: 30]                       │
+│    --after           TEXT     Pagination cursor.                             │
+│    --status          TEXT     processing|failed|success                      │
+│    --search          TEXT     Free-text search.                              │
+│    --json    -j                                                              │
+│    --help                     Show this message and exit.                    │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP agent/toggle
+Usage: pipefy agent toggle [OPTIONS] UUID
+
+ Enable or disable an AI agent (``toggle_ai_agent_status``).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    uuid      TEXT  Agent UUID. [required]                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --active      --inactive      Enable or disable the agent. [default: active] │
+│ --yes     -y                  Skip confirmation when disabling.              │
+│ --json    -j                                                                 │
+│ --help                        Show this message and exit.                    │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP agent/update
+Usage: pipefy agent update [OPTIONS]
+
+ Replace AI agent configuration (``update_ai_agent``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --uuid                             TEXT  Agent UUID. [required]           │
+│ *  --name          -n                 TEXT  Agent display name. [required]   │
+│ *  --repo-uuid                        TEXT  Pipe UUID. [required]            │
+│ *  --instruction                      TEXT  Agent-level instruction.         │
+│                                             [required]                       │
+│ *  --behaviors                        TEXT  JSON array of behavior objects.  │
+│                                             [required]                       │
+│ *  --pipe                             TEXT  Numeric pipe id for              │
+│                                             validate-behaviors pre-flight.   │
+│                                             [required]                       │
+│    --data-sources                     TEXT  Optional JSON array of           │
+│                                             knowledge-source id strings.     │
+│    --strict            --no-strict          Pre-flight strictness: --strict  │
+│                                             (default) blocks on unknown      │
+│                                             actionType values; --no-strict   │
+│                                             converts them to warnings.       │
+│                                             [default: strict]                │
+│    --json          -j                                                        │
+│    --help                                   Show this message and exit.      │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP agent/validate-behaviors
+Usage: pipefy agent validate-behaviors [OPTIONS]
+
+ Dry-run behavior validation (``validate_ai_agent_behaviors``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --pipe                          TEXT  Numeric pipe id. [required]         │
+│ *  --behaviors                     TEXT  JSON array of behavior objects.     │
+│                                          [required]                          │
+│    --strict         --no-strict          Pre-flight strictness: --strict     │
+│                                          (default) reports unknown           │
+│                                          actionType values as problems;      │
+│                                          --no-strict reports them as         │
+│                                          warnings only.                      │
+│                                          [default: strict]                   │
+│    --json       -j                                                           │
+│    --help                                Show this message and exit.         │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP ai-automation
+Usage: pipefy ai-automation [OPTIONS] COMMAND [ARGS]...
+
+ AI Automations (generate_with_ai; requires OAuth).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ list              List AI automations for a pipe (``get_ai_automations`` /   │
+│                   filtered ``get_automations``).                             │
+│ get               Load one automation row (``get_ai_automation`` /           │
+│                   ``get_automation``).                                       │
+│ validate-prompt   Pre-flight prompt validation                               │
+│                   (``validate_ai_automation_prompt``).                       │
+│ create            Create an AI automation (``create_ai_automation``).        │
+│ update            Update an AI automation (``update_ai_automation``).        │
+│ delete            Delete an AI automation (``delete_ai_automation`` /        │
+│                   ``delete_automation``).                                    │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP ai-automation/create
+Usage: pipefy ai-automation create [OPTIONS]
+
+ Create an AI automation (``create_ai_automation``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --pipe                  TEXT  Pipe id. [required]                         │
+│ *  --name          -n      TEXT  Automation name. [required]                 │
+│ *  --event-id              TEXT  Trigger event id. [required]                │
+│ *  --prompt                TEXT  AI prompt with %{internal_id} refs.         │
+│                                  [required]                                  │
+│ *  --field-ids             TEXT  JSON array of output field ids. [required]  │
+│    --action-repo           TEXT  Optional action repo id (defaults to        │
+│                                  --pipe).                                    │
+│    --skills-ids            TEXT  Optional JSON array of skill id strings.    │
+│    --event-params          TEXT  Optional JSON object.                       │
+│    --condition             TEXT  Optional JSON object (omit for default      │
+│                                  placeholder).                               │
+│    --json          -j                                                        │
+│    --help                        Show this message and exit.                 │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP ai-automation/delete
+Usage: pipefy ai-automation delete [OPTIONS] AUTOMATION_ID
+
+ Delete an AI automation (``delete_ai_automation`` / ``delete_automation``).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    automation_id      TEXT  Automation rule id. [required]                 │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --yes   -y        Skip interactive confirmation.                             │
+│ --json  -j                                                                   │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP ai-automation/get
+Usage: pipefy ai-automation get [OPTIONS] AUTOMATION_ID
+
+ Load one automation row (``get_ai_automation`` / ``get_automation``).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    automation_id      TEXT  Automation rule id. [required]                 │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --json  -j                                                                   │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP ai-automation/list
+Usage: pipefy ai-automation list [OPTIONS]
+
+ List AI automations for a pipe (``get_ai_automations`` / filtered
+ ``get_automations``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --pipe                        TEXT  Pipe id. [required]                   │
+│    --organization,--org          TEXT  Optional organization id.             │
+│    --json                -j                                                  │
+│    --help                              Show this message and exit.           │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP ai-automation/update
+Usage: pipefy ai-automation update [OPTIONS] AUTOMATION_ID
+
+ Update an AI automation (``update_ai_automation``).
+
+ ``--prompt`` and ``--field-ids`` are optional: when omitted the CLI reads the
+ current values from the existing automation and re-uses them for the
+ ``validate_ai_automation_prompt`` pre-flight. Only fields you pass explicitly
+ are sent in the patch.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    automation_id      TEXT  Automation rule id. [required]                 │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --pipe                                   TEXT  Pipe id for                │
+│                                                   validate-prompt            │
+│                                                   pre-flight.                │
+│                                                   [required]                 │
+│    --prompt                                 TEXT  New prompt; omit to keep   │
+│                                                   the current value (re-used │
+│                                                   in pre-flight).            │
+│    --field-ids                              TEXT  JSON array of output field │
+│                                                   ids; omit to keep the      │
+│                                                   current values (re-used in │
+│                                                   pre-flight).               │
+│    --name          -n                       TEXT                             │
+│    --patch-active      --no-patch-active          Toggle the enabled flag;   │
+│                                                   omit both flags to leave   │
+│                                                   unchanged.                 │
+│    --skills-ids                             TEXT                             │
+│    --event-params                           TEXT                             │
+│    --condition                              TEXT                             │
+│    --json          -j                                                        │
+│    --help                                         Show this message and      │
+│                                                   exit.                      │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP ai-automation/validate-prompt
+Usage: pipefy ai-automation validate-prompt [OPTIONS]
+
+ Pre-flight prompt validation (``validate_ai_automation_prompt``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --pipe               TEXT  Pipe id. [required]                            │
+│ *  --prompt             TEXT  Prompt with %{internal_id} tokens. [required]  │
+│ *  --field-ids          TEXT  JSON array of output field internal ids.       │
+│                               [required]                                     │
+│    --event-id           TEXT  Optional trigger id to validate against the    │
+│                               pipe catalog.                                  │
+│    --json       -j                                                           │
+│    --help                     Show this message and exit.                    │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP attachment
+Usage: pipefy attachment [OPTIONS] COMMAND [ARGS]...
+
+ Attachment uploads (presigned URL + field update).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ upload   Upload a local file to a card or table record attachment field.     │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP attachment/upload
+Usage: pipefy attachment upload [OPTIONS]
+
+ Upload a local file to a card or table record attachment field.
+
+ Uses the same SDK flow as MCP ``upload_attachment_to_card`` /
+ ``upload_attachment_to_table_record``: presigned URL, S3 PUT, then field
+ update.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --file                -f      FILE  Local file path to upload. [required] │
+│    --card                        TEXT  Target card id (mutually exclusive    │
+│                                        with --record).                       │
+│    --record                      TEXT  Target table record id (mutually      │
+│                                        exclusive with --card).               │
+│ *  --organization,--org          TEXT  Organization id (required for         │
+│                                        presigned URL).                       │
+│                                        [required]                            │
+│ *  --field                       TEXT  Attachment field slug on the card or  │
+│                                        table record.                         │
+│                                        [required]                            │
+│    --content-type                TEXT  Optional MIME type (defaults from     │
+│                                        file name).                           │
+│    --json                -j            Print machine-readable JSON to        │
+│                                        stdout.                               │
+│    --help                              Show this message and exit.           │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP audit
+Usage: pipefy audit [OPTIONS] COMMAND [ARGS]...
+
+ Pipe audit log exports.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ export   Queue a pipe audit log export (``export_pipe_audit_logs``).         │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP audit/export
+Usage: pipefy audit export [OPTIONS]
+
+ Queue a pipe audit log export (``export_pipe_audit_logs``).
+
+ The GraphQL API returns only ``success``; Pipefy delivers the export outside
+ this mutation (no CSV stream in the SDK response).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --pipe            TEXT  Pipe UUID for the audit export. [required]        │
+│    --search          TEXT  Optional search term filter passed to the API.    │
+│    --output  -o      PATH  Write JSON response to this path instead of       │
+│                            stdout.                                           │
+│    --json    -j            When using stdout, print JSON instead of Rich     │
+│                            (file output is always JSON).                     │
+│    --help                  Show this message and exit.                       │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP automation
+Usage: pipefy automation [OPTIONS] COMMAND [ARGS]...
+
+ Traditional automations and related exports.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ list        List automation rules (``get_automations``).                     │
+│ get         Load one automation (``get_automation``).                        │
+│ create      Create an automation rule (``create_automation``).               │
+│ update      Update an automation (``update_automation``).                    │
+│ delete      Delete an automation rule (``delete_automation``).               │
+│ simulate    Dry-run an automation against a card (``simulate_automation``).  │
+│ logs        List automation execution logs (``get_automation_logs`` or       │
+│             ``get_automation_logs_by_repo``).                                │
+│ usage       Automation usage for an org in a date range                      │
+│             (``get_automations_usage``).                                     │
+│ send-task   Send-a-task automation helper.                                   │
+│ export      Automation jobs export (async).                                  │
+│ events      Automation trigger catalog.                                      │
+│ actions     Automation action catalog.                                       │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP automation/actions
+Usage: pipefy automation actions [OPTIONS] COMMAND [ARGS]...
+
+ Automation action catalog.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ list   List action types for a pipe (``get_automation_actions``).            │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP automation/actions/list
+Usage: pipefy automation actions list [OPTIONS]
+
+ List action types for a pipe (``get_automation_actions``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --pipe          TEXT  Pipe id. [required]                                 │
+│    --json  -j            Print machine-readable JSON to stdout.              │
+│    --help                Show this message and exit.                         │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP automation/create
+Usage: pipefy automation create [OPTIONS]
+
+ Create an automation rule (``create_automation``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --pipe                                      TEXT  Source pipe id (trigger │
+│                                                      context).               │
+│                                                      [required]              │
+│ *  --name                   -n                 TEXT  Rule name. [required]   │
+│ *  --event-id,--trigger-id                     TEXT  Trigger event id from   │
+│                                                      ``automation events     │
+│                                                      list``                  │
+│                                                      (``--trigger-id``       │
+│                                                      retained as alias).     │
+│                                                      [required]              │
+│ *  --action-id                                 TEXT  Action id from          │
+│                                                      ``automation actions    │
+│                                                      list``.                 │
+│                                                      [required]              │
+│    --active                     --no-active          Create enabled or       │
+│                                                      disabled.               │
+│                                                      [default: active]       │
+│    --action-repo                               TEXT  Destination pipe id for │
+│                                                      cross-pipe actions      │
+│                                                      (defaults to --pipe).   │
+│    --extra                                     TEXT  Optional JSON object:   │
+│                                                      extra                   │
+│                                                      CreateAutomationInput   │
+│                                                      fields (camelCase).     │
+│    --json                   -j                       Print machine-readable  │
+│                                                      JSON to stdout.         │
+│    --help                                            Show this message and   │
+│                                                      exit.                   │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP automation/delete
+Usage: pipefy automation delete [OPTIONS] AUTOMATION_ID
+
+ Delete an automation rule (``delete_automation``).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    automation_id      TEXT  Automation rule id. [required]                 │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --yes   -y        Skip interactive confirmation.                             │
+│ --json  -j        Print machine-readable JSON to stdout.                     │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP automation/events
+Usage: pipefy automation events [OPTIONS] COMMAND [ARGS]...
+
+ Automation trigger catalog.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ list   List trigger events (``get_automation_events``).                      │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP automation/events/list
+Usage: pipefy automation events list [OPTIONS]
+
+ List trigger events (``get_automation_events``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --pipe          TEXT  Pipe id (context for catalog). [required]           │
+│    --json  -j            Print machine-readable JSON to stdout.              │
+│    --help                Show this message and exit.                         │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP automation/export
+Usage: pipefy automation export [OPTIONS] COMMAND [ARGS]...
+
+ Automation jobs export (async).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ jobs     Start automation jobs export (``export_automation_jobs``).          │
+│ status   Poll export status / signed URL (``get_automation_jobs_export``).   │
+│ csv      Download finished export as CSV text                                │
+│          (``get_automation_jobs_export_csv``).                               │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP automation/export/csv
+Usage: pipefy automation export csv [OPTIONS] EXPORT_ID
+
+ Download finished export as CSV text (``get_automation_jobs_export_csv``).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    export_id      TEXT  Finished export id. [required]                     │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --json  -j        Print machine-readable JSON to stdout.                     │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP automation/export/jobs
+Usage: pipefy automation export jobs [OPTIONS]
+
+ Start automation jobs export (``export_automation_jobs``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --organization,--org          TEXT  Organization id. [required]           │
+│ *  --period                      TEXT  Period filter: current_month,         │
+│                                        last_month, or last_3_months.         │
+│                                        [required]                            │
+│    --json                -j            Print machine-readable JSON to        │
+│                                        stdout.                               │
+│    --help                              Show this message and exit.           │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP automation/export/status
+Usage: pipefy automation export status [OPTIONS] EXPORT_ID
+
+ Poll export status / signed URL (``get_automation_jobs_export``).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    export_id      TEXT  Export id from ``export jobs``. [required]         │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --json  -j        Print machine-readable JSON to stdout.                     │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP automation/get
+Usage: pipefy automation get [OPTIONS] AUTOMATION_ID
+
+ Load one automation (``get_automation``).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    automation_id      TEXT  Automation rule id. [required]                 │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --json  -j        Print machine-readable JSON to stdout.                     │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP automation/list
+Usage: pipefy automation list [OPTIONS]
+
+ List automation rules (``get_automations``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --organization,--org          TEXT  Optional organization id filter.         │
+│ --pipe                        TEXT  Optional pipe id filter.                 │
+│ --json                -j            Print machine-readable JSON to stdout.   │
+│ --help                              Show this message and exit.              │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP automation/logs
+Usage: pipefy automation logs [OPTIONS]
+
+ List automation execution logs (``get_automation_logs`` or
+ ``get_automation_logs_by_repo``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --automation          TEXT     Automation id (use this or --repo, not both). │
+│ --repo                TEXT     Pipe id: list logs for all automations in the │
+│                                repo (``get_automation_logs_by_repo``).       │
+│ --first               INTEGER  Page size. [default: 30]                      │
+│ --after               TEXT     Pagination cursor.                            │
+│ --status              TEXT     Log status filter.                            │
+│ --search              TEXT     Free-text search.                             │
+│ --json        -j               Print machine-readable JSON to stdout.        │
+│ --help                         Show this message and exit.                   │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP automation/send-task
+Usage: pipefy automation send-task [OPTIONS] COMMAND [ARGS]...
+
+ Send-a-task automation helper.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ create   Create a send-a-task automation (``create_send_task_automation``).  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP automation/send-task/create
+Usage: pipefy automation send-task create [OPTIONS]
+
+ Create a send-a-task automation (``create_send_task_automation``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --pipe                             TEXT  Pipe id. [required]              │
+│ *  --name          -n                 TEXT  Rule name. [required]            │
+│ *  --event-id                         TEXT  Trigger event id. [required]     │
+│ *  --task-title                       TEXT  Task title. [required]           │
+│ *  --recipients                       TEXT  Recipient emails                 │
+│                                             (comma-separated).               │
+│                                             [required]                       │
+│    --active            --no-active          Create enabled or disabled.      │
+│                                             [default: active]                │
+│    --event-params                     TEXT  Optional JSON object.            │
+│    --condition                        TEXT  Optional JSON object.            │
+│    --json          -j                       Print machine-readable JSON to   │
+│                                             stdout.                          │
+│    --help                                   Show this message and exit.      │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP automation/simulate
+Usage: pipefy automation simulate [OPTIONS]
+
+ Dry-run an automation against a card (``simulate_automation``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --pipe                   TEXT  Pipe id (event/action repo defaults).      │
+│                                   [required]                                 │
+│ *  --action-id              TEXT  Simulation action id (e.g.                 │
+│                                   generate_with_ai).                         │
+│                                   [required]                                 │
+│ *  --sample-card            TEXT  Card id for the dry-run. [required]        │
+│    --event-id               TEXT  Optional trigger event id.                 │
+│    --event-params           TEXT  Optional JSON object.                      │
+│    --action-params          TEXT  Optional JSON object.                      │
+│    --condition              TEXT  Optional JSON object.                      │
+│    --name                   TEXT  Optional simulation name.                  │
+│    --extra                  TEXT  Optional JSON object merged into           │
+│                                   simulation input.                          │
+│    --json           -j            Print machine-readable JSON to stdout.     │
+│    --help                         Show this message and exit.                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP automation/update
+Usage: pipefy automation update [OPTIONS] AUTOMATION_ID
+
+ Update an automation (``update_automation``).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    automation_id      TEXT  Automation rule id. [required]                 │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --extra          TEXT  JSON object: fields to patch                       │
+│                           (UpdateAutomationInput, camelCase).                │
+│                           [required]                                         │
+│    --json   -j            Print machine-readable JSON to stdout.             │
+│    --help                 Show this message and exit.                        │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP automation/usage
+Usage: pipefy automation usage [OPTIONS]
+
+ Automation usage for an org in a date range (``get_automations_usage``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --organization,--org          TEXT  Organization UUID or numeric id       │
+│                                        (resolved like MCP).                  │
+│                                        [required]                            │
+│ *  --from                        TEXT  Range start (ISO8601), maps to        │
+│                                        filter_date.from.                     │
+│                                        [required]                            │
+│ *  --to                          TEXT  Range end (ISO8601), maps to          │
+│                                        filter_date.to.                       │
+│                                        [required]                            │
+│    --filters                     TEXT  Optional JSON object (FilterParams).  │
+│    --search                      TEXT  Optional free-text search.            │
+│    --sort                        TEXT  Optional JSON object (SortCriteria).  │
+│    --json                -j            Print machine-readable JSON to        │
+│                                        stdout.                               │
+│    --help                              Show this message and exit.           │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP card
+Usage: pipefy card [OPTIONS] COMMAND [ARGS]...
+
+ Card operations.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ get       Fetch a card by id.                                                │
+│ list      List cards in a pipe (get_cards): browse, filter, and paginate.    │
+│ find      Find cards in a pipe where a custom field equals a value.          │
+│ create    Create a card in a pipe (start-form fields via --fields JSON when  │
+│           required).                                                         │
+│ update    Update a card (title, assignees, labels, due date, and/or field    │
+│           updates).                                                          │
+│ delete    Delete a card permanently.                                         │
+│ move      Move a card to another phase.                                      │
+│ comment   Card comments.                                                     │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP card/comment
+Usage: pipefy card comment [OPTIONS] COMMAND [ARGS]...
+
+ Card comments.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ add      Add a text comment to a card.                                       │
+│ update   Update an existing comment by id.                                   │
+│ delete   Delete a comment by id.                                             │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP card/comment/add
+Usage: pipefy card comment add [OPTIONS] CARD_ID TEXT
+
+ Add a text comment to a card.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    card_id      TEXT  Card id. [required]                                  │
+│ *    text         TEXT  Comment body (1-1000 characters). [required]         │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --json  -j                                                                   │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP card/comment/delete
+Usage: pipefy card comment delete [OPTIONS] COMMENT_ID
+
+ Delete a comment by id.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    comment_id      TEXT  Comment id. [required]                            │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --yes   -y        Skip confirmation prompt.                                  │
+│ --json  -j                                                                   │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP card/comment/update
+Usage: pipefy card comment update [OPTIONS] COMMENT_ID TEXT
+
+ Update an existing comment by id.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    comment_id      TEXT  Comment id. [required]                            │
+│ *    text            TEXT  New comment text. [required]                      │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --json  -j                                                                   │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP card/create
+Usage: pipefy card create [OPTIONS] PIPE_ID
+
+ Create a card in a pipe (start-form fields via --fields JSON when required).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    pipe_id      TEXT  Pipe id. [required]                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --title   -t      TEXT  Optional title (applied via update after create).    │
+│ --fields          TEXT  JSON object or array: start-form field values for    │
+│                         createCard.                                          │
+│ --json    -j            Print machine-readable JSON to stdout.               │
+│ --help                  Show this message and exit.                          │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP card/delete
+Usage: pipefy card delete [OPTIONS] CARD_ID
+
+ Delete a card permanently.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    card_id      TEXT  Card id. [required]                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --yes   -y        Skip confirmation prompt.                                  │
+│ --json  -j                                                                   │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP card/find
+Usage: pipefy card find [OPTIONS]
+
+ Find cards in a pipe where a custom field equals a value.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --pipe                    TEXT     Pipe id to search in. [required]       │
+│ *  --field                   TEXT     Field id (slug) from start form or     │
+│                                       phase fields.                          │
+│                                       [required]                             │
+│ *  --value                   TEXT     Value to match for that field.         │
+│                                       [required]                             │
+│    --include-fields                   Include each card's custom fields.     │
+│    --first                   INTEGER  Max cards per page.                    │
+│    --after                   TEXT     Pagination cursor                      │
+│                                       (pageInfo.endCursor).                  │
+│    --json            -j               Print machine-readable JSON to stdout. │
+│    --help                             Show this message and exit.            │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP card/get
+Usage: pipefy card get [OPTIONS] CARD_ID
+
+ Fetch a card by id.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    card_id      TEXT  Card id. [required]                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --json            -j        Print machine-readable JSON to stdout.           │
+│ --include-fields            Include custom field name/value pairs on the     │
+│                             card.                                            │
+│ --help                      Show this message and exit.                      │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP card/list
+Usage: pipefy card list [OPTIONS]
+
+ List cards in a pipe (get_cards): browse, filter, and paginate.
+
+ Use ``card find`` when matching a single custom field value (find_cards).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --pipe                    TEXT     Pipe id whose cards to load.           │
+│                                       [required]                             │
+│    --title           -t      TEXT     Filter by title substring (merged into │
+│                                       search; same shortcut as MCP           │
+│                                       get_cards).                            │
+│    --search                  TEXT     Optional JSON object: CardSearch keys  │
+│                                       (title, assignee_ids, label_ids,       │
+│                                       ignore_ids, include_done,              │
+│                                       inbox_emails_read). Unknown keys are   │
+│                                       ignored.                               │
+│    --include-fields                   Include each card's custom fields      │
+│                                       (name, value).                         │
+│    --first                   INTEGER  Max cards per page (1-500).            │
+│    --after                   TEXT     Pagination cursor (pageInfo.endCursor  │
+│                                       from a previous page).                 │
+│    --json            -j               Print machine-readable JSON to stdout. │
+│    --help                             Show this message and exit.            │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP card/move
+Usage: pipefy card move [OPTIONS] CARD_ID
+
+ Move a card to another phase.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    card_id      TEXT  Card id. [required]                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --phase          TEXT  Destination phase id. [required]                   │
+│    --json   -j                                                               │
+│    --help                 Show this message and exit.                        │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP card/update
+Usage: pipefy card update [OPTIONS] CARD_ID
+
+ Update a card (title, assignees, labels, due date, and/or field updates).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    card_id      TEXT  Card id. [required]                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --title          -t      TEXT                                                │
+│ --due-date               TEXT                                                │
+│ --assignee-ids           TEXT  Comma-separated assignee user ids.            │
+│ --label-ids              TEXT  Comma-separated label ids.                    │
+│ --field-updates          TEXT  JSON array of field update objects for        │
+│                                updateFieldsValues. Each object: {"field_id"  │
+│                                (or "fieldId"): "<slug>", "value": <v>}.      │
+│ --json           -j                                                          │
+│ --help                         Show this message and exit.                   │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP email
+Usage: pipefy email [OPTIONS] COMMAND [ARGS]...
+
+ Inbox emails and email templates.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ inbox      Card inbox (sent/received).                                       │
+│ template   Email templates bound to a pipe or table (repo).                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP email/inbox
+Usage: pipefy email inbox [OPTIONS] COMMAND [ARGS]...
+
+ Card inbox (sent/received).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ list   List inbox emails for a card (``get_card_inbox_emails``).             │
+│ send   Send an inbox email from a card (``send_inbox_email``).               │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP email/inbox/list
+Usage: pipefy email inbox list [OPTIONS]
+
+ List inbox emails for a card (``get_card_inbox_emails``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --card          TEXT  Card id with inbox enabled. [required]              │
+│    --type          TEXT  Optional filter: sent or received.                  │
+│    --json  -j            Print machine-readable JSON to stdout.              │
+│    --help                Show this message and exit.                         │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP email/inbox/send
+Usage: pipefy email inbox send [OPTIONS]
+
+ Send an inbox email from a card (``send_inbox_email``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --card                TEXT  Card id. [required]                           │
+│ *  --to                  TEXT  Recipient emails (comma-separated).           │
+│                                [required]                                    │
+│ *  --subject     -s      TEXT  Email subject. [required]                     │
+│ *  --body        -b      TEXT  Plain-text body. [required]                   │
+│ *  --from-email          TEXT  Sender email address (required by API).       │
+│                                [required]                                    │
+│    --extra               TEXT  Optional JSON object: extra                   │
+│                                CreateAndSendInboxEmailInput fields.          │
+│    --json        -j            Print machine-readable JSON to stdout.        │
+│    --help                      Show this message and exit.                   │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP email/template
+Usage: pipefy email template [OPTIONS] COMMAND [ARGS]...
+
+ Email templates bound to a pipe or table (repo).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ list   List email templates for a repo (``get_email_templates``).            │
+│ send   Send using an email template (``send_email_with_template``).          │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP email/template/list
+Usage: pipefy email template list [OPTIONS]
+
+ List email templates for a repo (``get_email_templates``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --repo           TEXT     Pipe or table id whose templates to list.       │
+│                              [required]                                      │
+│    --name           TEXT     Optional substring filter on template name.     │
+│    --first          INTEGER  Max templates to return. [default: 50]          │
+│    --json   -j               Print machine-readable JSON to stdout.          │
+│    --help                    Show this message and exit.                     │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP email/template/send
+Usage: pipefy email template send [OPTIONS]
+
+ Send using an email template (``send_email_with_template``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --card                TEXT  Card id (inbox sender context). [required]    │
+│ *  --template            TEXT  Email template id. [required]                 │
+│    --to                  TEXT  Optional comma-separated override recipients. │
+│    --from-email          TEXT  Optional sender override.                     │
+│    --extra               TEXT  Optional JSON object: extra send fields (cc,  │
+│                                bcc, repoId, etc.).                           │
+│    --json        -j            Print machine-readable JSON to stdout.        │
+│    --help                      Show this message and exit.                   │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP export
+Usage: pipefy export [OPTIONS] COMMAND [ARGS]...
+
+ Bulk exports (automation jobs).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ automation-jobs       Queue automation jobs export                           │
+│                       (``export_automation_jobs``).                          │
+│ automation-jobs-csv   Download finished export as CSV text                   │
+│                       (``get_automation_jobs_export_csv``).                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP export/automation-jobs
+Usage: pipefy export automation-jobs [OPTIONS]
+
+ Queue automation jobs export (``export_automation_jobs``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --organization,--org          TEXT  Organization id. [required]           │
+│ *  --period                      TEXT  current_month | last_month |          │
+│                                        last_3_months                         │
+│                                        [required]                            │
+│    --json                -j            Print machine-readable JSON to        │
+│                                        stdout.                               │
+│    --help                              Show this message and exit.           │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP export/automation-jobs-csv
+Usage: pipefy export automation-jobs-csv [OPTIONS] EXPORT_ID
+
+ Download finished export as CSV text (``get_automation_jobs_export_csv``).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    export_id      TEXT  Export id after status is finished. [required]     │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --json  -j        Print JSON envelope with CSV text; default is Rich table   │
+│                   output.                                                    │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP field
+Usage: pipefy field [OPTIONS] COMMAND [ARGS]...
+
+ Phase field operations.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ list     List fields on a phase (``get_phase_fields``).                      │
+│ create   Create a field on a phase.                                          │
+│ update   Update a phase field (pass attributes via ``--extra`` JSON).        │
+│ delete   Delete a phase field permanently.                                   │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP field-condition
+Usage: pipefy field-condition [OPTIONS] COMMAND [ARGS]...
+
+ Field conditions (dynamic form rules on phases).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ list     List field conditions on a phase (``get_field_conditions``).        │
+│ get      Load one field condition by id (``get_field_condition``).           │
+│ create   Create a field condition (``create_field_condition``).              │
+│ update   Update a field condition (``update_field_condition``).              │
+│ delete   Delete a field condition permanently (``delete_field_condition``).  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP field-condition/create
+Usage: pipefy field-condition create [OPTIONS]
+
+ Create a field condition (``create_field_condition``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --phase              TEXT  Phase id. [required]                           │
+│ *  --name       -n      TEXT  Rule name (required by API). [required]        │
+│ *  --condition          TEXT  JSON object: ConditionInput. Example:          │
+│                               '{"expressions":[{"structure_id":0,"field_add… │
+│                               structure_id / expressions_structure entries   │
+│                               are coerced to int by the SDK.                 │
+│                               [required]                                     │
+│ *  --actions            TEXT  JSON array: action objects. Each item needs    │
+│                               phaseFieldId (use the field's internal_id from │
+│                               get_phase_fields) + actionId (hide|show).      │
+│                               Example:                                       │
+│                               '[{"phaseFieldId":"<internal_id>","actionId":… │
+│                               [required]                                     │
+│    --extra              TEXT  Optional JSON object merged into create input  │
+│                               (camelCase keys).                              │
+│    --json       -j            Print machine-readable JSON to stdout.         │
+│    --help                     Show this message and exit.                    │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP field-condition/delete
+Usage: pipefy field-condition delete [OPTIONS] CONDITION_ID
+
+ Delete a field condition permanently (``delete_field_condition``).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    condition_id      TEXT  Field condition id. [required]                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --yes   -y        Skip interactive confirmation.                             │
+│ --json  -j        Print machine-readable JSON to stdout.                     │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP field-condition/get
+Usage: pipefy field-condition get [OPTIONS] CONDITION_ID
+
+ Load one field condition by id (``get_field_condition``).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    condition_id      TEXT  Field condition id. [required]                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --json  -j        Print machine-readable JSON to stdout.                     │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP field-condition/list
+Usage: pipefy field-condition list [OPTIONS]
+
+ List field conditions on a phase (``get_field_conditions``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --phase          TEXT  Phase id that owns the conditions. [required]      │
+│    --json   -j            Print machine-readable JSON to stdout.             │
+│    --help                 Show this message and exit.                        │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP field-condition/update
+Usage: pipefy field-condition update [OPTIONS] CONDITION_ID
+
+ Update a field condition (``update_field_condition``).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    condition_id      TEXT  Field condition id. [required]                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --extra          TEXT  JSON object: fields to patch (camelCase keys for   │
+│                           UpdateFieldConditionInput).                        │
+│                           [required]                                         │
+│    --json   -j            Print machine-readable JSON to stdout.             │
+│    --help                 Show this message and exit.                        │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP field/create
+Usage: pipefy field create [OPTIONS]
+
+ Create a field on a phase.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --phase          TEXT  Phase id. [required]                               │
+│ *  --label  -l      TEXT  Field label in the UI. [required]                  │
+│ *  --type   -t      TEXT  Pipefy field type (e.g. short_text, number).       │
+│                           [required]                                         │
+│    --extra          TEXT  JSON object of extra CreatePhaseFieldInput fields. │
+│    --json   -j                                                               │
+│    --help                 Show this message and exit.                        │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP field/delete
+Usage: pipefy field delete [OPTIONS] FIELD_ID
+
+ Delete a phase field permanently.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    field_id      TEXT  Phase field id. [required]                          │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --pipe-uuid          TEXT  Optional pipe UUID (passed through to the API     │
+│                            when required).                                   │
+│ --yes        -y            Skip confirmation prompt.                         │
+│ --json       -j                                                              │
+│ --help                     Show this message and exit.                       │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP field/list
+Usage: pipefy field list [OPTIONS]
+
+ List fields on a phase (``get_phase_fields``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --phase                  TEXT  Phase id. [required]                       │
+│    --required-only                Return only required fields.               │
+│    --json           -j                                                       │
+│    --help                         Show this message and exit.                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP field/update
+Usage: pipefy field update [OPTIONS] FIELD_ID
+
+ Update a phase field (pass attributes via ``--extra`` JSON).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    field_id      TEXT  Phase field id. [required]                          │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --extra          TEXT  JSON object of UpdatePhaseFieldInput fields           │
+│                        (snake_case / API keys).                              │
+│ --json   -j                                                                  │
+│ --help                 Show this message and exit.                           │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP graphql
+Usage: pipefy graphql [OPTIONS] COMMAND [ARGS]...
+
+ Execute arbitrary GraphQL (mutations require --yes). See
+ docs/cli/self-healing.md.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ exec   Execute GraphQL via the SDK (``execute_graphql``).                    │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP graphql/exec
+Usage: pipefy graphql exec [OPTIONS]
+
+ Execute GraphQL via the SDK (``execute_graphql``).
+
+ Pass variables as JSON with ``--vars '{"key":"value"}'`` (not
+ ``--variables``).
+ Mutations are rejected unless ``--yes`` is set (exit code 2). Pair with
+ ``pipefy introspect`` to discover operation shapes (see
+ docs/cli/self-healing.md).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --query  -q      TEXT  GraphQL document string (query or mutation).       │
+│                           [required]                                         │
+│    --vars           TEXT  Variables JSON object (default "{}" ).             │
+│    --yes                  Acknowledge and run mutations (required when the   │
+│                           document includes mutation).                       │
+│    --json   -j            Emit JSON to stdout (default is Rich for objects). │
+│    --help                 Show this message and exit.                        │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP introspect
+Usage: pipefy introspect [OPTIONS] COMMAND [ARGS]...
+
+ Discover GraphQL types and operations (JSON default).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ type       Introspect a schema type (``introspect_type``).                   │
+│ query      Introspect a root query field (``introspect_query``).             │
+│ mutation   Introspect a root mutation field (``introspect_mutation``).       │
+│ schema     Schema-wide search.                                               │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP introspect/mutation
+Usage: pipefy introspect mutation [OPTIONS] NAME
+
+ Introspect a root mutation field (``introspect_mutation``).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    name      TEXT  Root mutation field name. [required]                    │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --max-depth        INTEGER  Nested type resolution depth. [default: 1]       │
+│ --rich                      Pretty-print with Rich instead of JSON.          │
+│ --help                      Show this message and exit.                      │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP introspect/query
+Usage: pipefy introspect query [OPTIONS] NAME
+
+ Introspect a root query field (``introspect_query``).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    name      TEXT  Root query field name. [required]                       │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --max-depth        INTEGER  Nested type resolution depth. [default: 1]       │
+│ --rich                      Pretty-print with Rich instead of JSON.          │
+│ --help                      Show this message and exit.                      │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP introspect/schema
+Usage: pipefy introspect schema [OPTIONS] COMMAND [ARGS]...
+
+ Schema-wide search.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ search   Search schema types (``search_schema``).                            │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP introspect/schema/search
+Usage: pipefy introspect schema search [OPTIONS] KEYWORD
+
+ Search schema types (``search_schema``).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    keyword      TEXT  Case-insensitive substring. [required]               │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --kind        TEXT  Optional GraphQL type kind (OBJECT, INPUT_OBJECT, ENUM,  │
+│                     ...).                                                    │
+│ --rich              Pretty-print with Rich instead of JSON.                  │
+│ --help              Show this message and exit.                              │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP introspect/type
+Usage: pipefy introspect type [OPTIONS] NAME
+
+ Introspect a schema type (``introspect_type``).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    name      TEXT  GraphQL type name (e.g. Card). [required]               │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --max-depth        INTEGER  Nested type resolution depth. [default: 1]       │
+│ --rich                      Pretty-print with Rich instead of JSON.          │
+│ --help                      Show this message and exit.                      │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP label
+Usage: pipefy label [OPTIONS] COMMAND [ARGS]...
+
+ Pipe label operations.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ list     List labels on a pipe (from ``get_pipe``); JSON shape matches MCP   │
+│          ``get_labels``.                                                     │
+│ create   Create a label on a pipe.                                           │
+│ update   Update a label (name and color are both required by Pipefy).        │
+│ delete   Delete a label permanently.                                         │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP label/create
+Usage: pipefy label create [OPTIONS]
+
+ Create a label on a pipe.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --pipe           TEXT  Pipe id. [required]                                │
+│ *  --name   -n      TEXT  Label name. [required]                             │
+│ *  --color  -c      TEXT  Label color (per Pipefy API). [required]           │
+│    --json   -j                                                               │
+│    --help                 Show this message and exit.                        │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP label/delete
+Usage: pipefy label delete [OPTIONS] LABEL_ID
+
+ Delete a label permanently.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    label_id      TEXT  Label id. [required]                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --yes   -y        Skip confirmation prompt.                                  │
+│ --json  -j                                                                   │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP label/list
+Usage: pipefy label list [OPTIONS]
+
+ List labels on a pipe (from ``get_pipe``); JSON shape matches MCP
+ ``get_labels``.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --pipe          TEXT  Pipe id. [required]                                 │
+│    --json  -j                                                                │
+│    --help                Show this message and exit.                         │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP label/update
+Usage: pipefy label update [OPTIONS] LABEL_ID
+
+ Update a label (name and color are both required by Pipefy).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    label_id      TEXT  Label id. [required]                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --name   -n      TEXT  New label name (required by API). [required]       │
+│ *  --color  -c      TEXT  New label color (required by API). [required]      │
+│    --json   -j                                                               │
+│    --help                 Show this message and exit.                        │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP member
+Usage: pipefy member [OPTIONS] COMMAND [ARGS]...
+
+ Pipe member operations.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ list       List members of a pipe.                                           │
+│ invite     Invite users to a pipe.                                           │
+│ remove     Remove users from a pipe (same service-account guard as MCP when  │
+│            env is set).                                                      │
+│ set-role   Set a member's role on a pipe.                                    │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP member/invite
+Usage: pipefy member invite [OPTIONS]
+
+ Invite users to a pipe.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --pipe             TEXT  Pipe id. [required]                              │
+│ *  --members          TEXT  JSON array:                                      │
+│                             [{"email":"a@b.com","role_name":"admin"}, ...].  │
+│                             [required]                                       │
+│    --json     -j                                                             │
+│    --help                   Show this message and exit.                      │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP member/list
+Usage: pipefy member list [OPTIONS]
+
+ List members of a pipe.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --pipe          TEXT  Pipe id. [required]                                 │
+│    --json  -j                                                                │
+│    --help                Show this message and exit.                         │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP member/remove
+Usage: pipefy member remove [OPTIONS]
+
+ Remove users from a pipe (same service-account guard as MCP when env is set).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --pipe              TEXT  Pipe id. [required]                             │
+│ *  --user-ids          TEXT  Comma-separated Pipefy user ids or UUIDs to     │
+│                              remove from the pipe.                           │
+│                              [required]                                      │
+│    --yes       -y            Skip confirmation prompt.                       │
+│    --json      -j                                                            │
+│    --help                    Show this message and exit.                     │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP member/set-role
+Usage: pipefy member set-role [OPTIONS]
+
+ Set a member's role on a pipe.
+
+ When ``PIPEFY_SERVICE_ACCOUNT_IDS`` includes ``--member``, the response gains
+ a ``warning`` field reminding callers to preserve write permissions on that
+ account (parity with the MCP ``set_role`` tool).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --pipe            TEXT  Pipe id. [required]                               │
+│ *  --member          TEXT  Member user id. [required]                        │
+│ *  --role            TEXT  Role name (e.g. member, admin). [required]        │
+│    --json    -j                                                              │
+│    --help                  Show this message and exit.                       │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP org
+Usage: pipefy org [OPTIONS] COMMAND [ARGS]...
+
+ Organization operations.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ get   Fetch organization details (``get_organization``).                     │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP org/get
+Usage: pipefy org get [OPTIONS] [ORGANIZATION_ID]
+
+ Fetch organization details (``get_organization``).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│   organization_id      [ORGANIZATION_ID]  Numeric organization id. Omit when │
+│                                           PIPEFY_ORG_ID is set (see          │
+│                                           docs/setup.md).                    │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --json  -j                                                                   │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP phase
+Usage: pipefy phase [OPTIONS] COMMAND [ARGS]...
+
+ Pipe phase operations.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ get      Load phase metadata and fields by id (via ``get_phase_fields``).    │
+│ create   Create a phase in a pipe.                                           │
+│ update   Update a phase (Pipefy ``UpdatePhaseInput``). Resolves current name │
+│          when omitted.                                                       │
+│ delete   Delete a phase permanently.                                         │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP phase/create
+Usage: pipefy phase create [OPTIONS]
+
+ Create a phase in a pipe.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --pipe                 TEXT   Pipe id that will contain the phase.        │
+│                                  [required]                                  │
+│ *  --name         -n      TEXT   Phase display name. [required]              │
+│    --done                        Mark as a final/done phase.                 │
+│    --index                FLOAT  Optional position index within the pipe.    │
+│    --description  -d      TEXT                                               │
+│    --json         -j                                                         │
+│    --help                        Show this message and exit.                 │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP phase/delete
+Usage: pipefy phase delete [OPTIONS] PHASE_ID
+
+ Delete a phase permanently.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    phase_id      TEXT  Phase id. [required]                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --yes   -y        Skip confirmation prompt.                                  │
+│ --json  -j                                                                   │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP phase/get
+Usage: pipefy phase get [OPTIONS] PHASE_ID
+
+ Load phase metadata and fields by id (via ``get_phase_fields``).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    phase_id      TEXT  Phase id. [required]                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --json           -j        Print machine-readable JSON to stdout.            │
+│ --required-only            Return only required fields (same query as MCP    │
+│                            get_phase_fields).                                │
+│ --help                     Show this message and exit.                       │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP phase/update
+Usage: pipefy phase update [OPTIONS] PHASE_ID
+
+ Update a phase (Pipefy ``UpdatePhaseInput``). Resolves current name when
+ omitted.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    phase_id      TEXT  Phase id. [required]                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --name               -n                         TEXT                         │
+│ --description        -d                         TEXT                         │
+│ --done                   --no-done                       Set or clear the    │
+│                                                          final-phase flag.   │
+│ --color                                         TEXT                         │
+│ --lateness-time                                 INTEGER                      │
+│ --can-receive-from…      --no-can-receive-f…                                 │
+│ --extra                                         TEXT     JSON object merged  │
+│                                                          into                │
+│                                                          UpdatePhaseInput    │
+│                                                          (snake_case keys).  │
+│ --json               -j                                                      │
+│ --help                                                   Show this message   │
+│                                                          and exit.           │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP pipe
+Usage: pipefy pipe [OPTIONS] COMMAND [ARGS]...
+
+ Pipe operations.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ get      Load a pipe by id (phases, labels, start form).                     │
+│ list     Search pipes across organizations (same as MCP ``search_pipes``).   │
+│ create   Create an empty pipe in an organization.                            │
+│ update   Update pipe settings (pass at least one attribute).                 │
+│ delete   Delete a pipe permanently.                                          │
+│ clone    Clone a pipe from a template pipe id.                               │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP pipe/clone
+Usage: pipefy pipe clone [OPTIONS] TEMPLATE_PIPE_ID
+
+ Clone a pipe from a template pipe id.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    template_pipe_id      TEXT  Source pipe id to use as template.          │
+│                                  [required]                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --org           TEXT  Optional organization id for the cloned pipe.          │
+│ --json  -j                                                                   │
+│ --help                Show this message and exit.                            │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP pipe/create
+Usage: pipefy pipe create [OPTIONS] NAME
+
+ Create an empty pipe in an organization.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    name      TEXT  Display name for the new pipe. [required]               │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --org           TEXT  Organization id that will own the pipe. [required]  │
+│    --json  -j                                                                │
+│    --help                Show this message and exit.                         │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP pipe/delete
+Usage: pipefy pipe delete [OPTIONS] PIPE_ID
+
+ Delete a pipe permanently.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    pipe_id      TEXT  Pipe id. [required]                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --yes   -y        Skip confirmation prompt.                                  │
+│ --json  -j                                                                   │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP pipe/get
+Usage: pipefy pipe get [OPTIONS] PIPE_ID
+
+ Load a pipe by id (phases, labels, start form).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    pipe_id      TEXT  Pipe id. [required]                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --json  -j        Print machine-readable JSON to stdout.                     │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP pipe/list
+Usage: pipefy pipe list [OPTIONS]
+
+ Search pipes across organizations (same as MCP ``search_pipes``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --name         -n      TEXT                       Optional pipe name filter  │
+│                                                   (fuzzy match server-side). │
+│ --max-per-org          INTEGER RANGE [1<=x<=500]  Maximum pipes returned per │
+│                                                   organization (1-500).      │
+│                                                   [default: 500]             │
+│ --json         -j                                                            │
+│ --help                                            Show this message and      │
+│                                                   exit.                      │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP pipe/update
+Usage: pipefy pipe update [OPTIONS] PIPE_ID
+
+ Update pipe settings (pass at least one attribute).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    pipe_id      TEXT  Pipe id. [required]                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --name                 TEXT                                                  │
+│ --icon                 TEXT                                                  │
+│ --color                TEXT                                                  │
+│ --preferences          TEXT  JSON object for pipe preferences                │
+│                              (UpdatePipeInput).                              │
+│ --json         -j                                                            │
+│ --help                       Show this message and exit.                     │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP record
+Usage: pipefy record [OPTIONS] COMMAND [ARGS]...
+
+ Table record operations.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ find     Find records: field match (``find_records``) or list page           │
+│          (``get_table_records``).                                            │
+│ get      Load one table record by id.                                        │
+│ create   Create a table record.                                              │
+│ update   Update record core fields or one custom field.                      │
+│ delete   Delete a table record permanently.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP record/create
+Usage: pipefy record create [OPTIONS]
+
+ Create a table record.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --table           TEXT  Database table id. [required]                     │
+│    --fields          TEXT  JSON object or array of field values for the new  │
+│                            record.                                           │
+│    --title   -t      TEXT                                                    │
+│    --extra           TEXT  JSON object of extra CreateTableRecordInput keys. │
+│    --json    -j                                                              │
+│    --help                  Show this message and exit.                       │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP record/delete
+Usage: pipefy record delete [OPTIONS] RECORD_ID
+
+ Delete a table record permanently.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    record_id      TEXT  Table record id. [required]                        │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --yes   -y        Skip confirmation prompt.                                  │
+│ --json  -j                                                                   │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP record/find
+Usage: pipefy record find [OPTIONS]
+
+ Find records: field match (``find_records``) or list page
+ (``get_table_records``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --table           TEXT     Database table id. [required]                  │
+│    --filter          TEXT     JSON object: either                            │
+│                               {"field_id":"...","field_value":"..."} for     │
+│                               findRecords, or omit field_id/field_value to   │
+│                               page all records (get_table_records).          │
+│    --first           INTEGER  Page size (1-200 for listing; optional for     │
+│                               field search).                                 │
+│    --after           TEXT     Pagination cursor.                             │
+│    --json    -j                                                              │
+│    --help                     Show this message and exit.                    │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP record/get
+Usage: pipefy record get [OPTIONS] RECORD_ID
+
+ Load one table record by id.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    record_id      TEXT  Table record id. [required]                        │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --json  -j                                                                   │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP record/update
+Usage: pipefy record update [OPTIONS] RECORD_ID
+
+ Update record core fields or one custom field.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    record_id      TEXT  Table record id. [required]                        │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --fields            TEXT  JSON object: title, due_date, status_id or         │
+│                           statusId (update_table_record).                    │
+│ --field-id          TEXT  When set with --value, calls                       │
+│                           set_table_record_field_value instead.              │
+│ --value             TEXT  JSON value for --field-id (string, number, array,  │
+│                           or object).                                        │
+│ --json      -j                                                               │
+│ --help                    Show this message and exit.                        │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP relation
+Usage: pipefy relation [OPTIONS] COMMAND [ARGS]...
+
+ Pipe and card relations.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ pipe   Pipe-to-pipe relations.                                               │
+│ card   Card-to-card relations.                                               │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP relation/card
+Usage: pipefy relation card [OPTIONS] COMMAND [ARGS]...
+
+ Card-to-card relations.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ list     List parent and child relations for a card (raw                     │
+│          ``get_card_relations`` payload).                                    │
+│ create   Link two cards via an existing pipe relation.                       │
+│ delete   Remove a card relation (requires OAuth; internal API).              │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP relation/card/create
+Usage: pipefy relation card create [OPTIONS]
+
+ Link two cards via an existing pipe relation.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --parent          TEXT  Parent card id. [required]                        │
+│ *  --child           TEXT  Child card id. [required]                         │
+│ *  --source          TEXT  Pipe relation id from ``relation pipe list``.     │
+│                            [required]                                        │
+│    --extra           TEXT  JSON object merged into CreateCardRelationInput.  │
+│    --json    -j                                                              │
+│    --help                  Show this message and exit.                       │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP relation/card/delete
+Usage: pipefy relation card delete [OPTIONS]
+
+ Remove a card relation (requires OAuth; internal API).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --child           TEXT  Child card id. [required]                         │
+│ *  --parent          TEXT  Parent card id. [required]                        │
+│ *  --source          TEXT  Pipe relation id. [required]                      │
+│    --yes     -y            Skip confirmation prompt.                         │
+│    --json    -j                                                              │
+│    --help                  Show this message and exit.                       │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP relation/card/list
+Usage: pipefy relation card list [OPTIONS] CARD_ID
+
+ List parent and child relations for a card (raw ``get_card_relations``
+ payload).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    card_id      TEXT  Card id. [required]                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --json  -j                                                                   │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP relation/pipe
+Usage: pipefy relation pipe [OPTIONS] COMMAND [ARGS]...
+
+ Pipe-to-pipe relations.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ list     List pipe relations for a pipe.                                     │
+│ create   Create a pipe relation.                                             │
+│ update   Update a pipe relation.                                             │
+│ delete   Delete a pipe relation permanently.                                 │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP relation/pipe/create
+Usage: pipefy relation pipe create [OPTIONS]
+
+ Create a pipe relation.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --parent          TEXT  Parent pipe id. [required]                        │
+│ *  --child           TEXT  Child pipe id. [required]                         │
+│ *  --name    -n      TEXT  Relation name. [required]                         │
+│    --extra           TEXT  JSON object merged into CreatePipeRelationInput.  │
+│    --json    -j                                                              │
+│    --help                  Show this message and exit.                       │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP relation/pipe/delete
+Usage: pipefy relation pipe delete [OPTIONS] RELATION_ID
+
+ Delete a pipe relation permanently.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    relation_id      TEXT  Pipe relation id. [required]                     │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --yes   -y        Skip confirmation prompt.                                  │
+│ --json  -j                                                                   │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP relation/pipe/list
+Usage: pipefy relation pipe list [OPTIONS] PIPE_ID
+
+ List pipe relations for a pipe.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    pipe_id      TEXT  Pipe id. [required]                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --json  -j                                                                   │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP relation/pipe/update
+Usage: pipefy relation pipe update [OPTIONS] RELATION_ID
+
+ Update a pipe relation.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    relation_id      TEXT  Pipe relation id. [required]                     │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --name   -n      TEXT  New relation name. [required]                      │
+│    --extra          TEXT  JSON object merged into UpdatePipeRelationInput.   │
+│    --json   -j                                                               │
+│    --help                 Show this message and exit.                        │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP report-org
+Usage: pipefy report-org [OPTIONS] COMMAND [ARGS]...
+
+ Organization reports.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ list     List organization reports (``get_organization_reports``).           │
+│ get      Fetch one organization report (``get_organization_report``).        │
+│ create   Create an organization report (``create_organization_report``).     │
+│ update   Update an organization report (``update_organization_report``).     │
+│ delete   Delete an organization report (``delete_organization_report``).     │
+│ export   Export an organization report (``export_organization_report``).     │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP report-org/create
+Usage: pipefy report-org create [OPTIONS]
+
+ Create an organization report (``create_organization_report``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --organization,--org          TEXT  [required]                            │
+│ *  --name                -n      TEXT  [required]                            │
+│ *  --pipe-ids                    TEXT  JSON array of pipe id strings.        │
+│                                        [required]                            │
+│    --fields                      TEXT                                        │
+│    --filter                      TEXT                                        │
+│    --json                -j            Print machine-readable JSON to        │
+│                                        stdout.                               │
+│    --help                              Show this message and exit.           │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP report-org/delete
+Usage: pipefy report-org delete [OPTIONS] REPORT_ID
+
+ Delete an organization report (``delete_organization_report``).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    report_id      TEXT  Organization report id. [required]                 │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --yes   -y                                                                   │
+│ --json  -j        Print machine-readable JSON to stdout.                     │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP report-org/export
+Usage: pipefy report-org export [OPTIONS]
+
+ Export an organization report (``export_organization_report``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --organization,--org              TEXT   [required]                       │
+│    --format                          TEXT   json: return export mutation     │
+│                                             payload; csv: poll and stream    │
+│                                             download.                        │
+│                                             [default: json]                  │
+│    --organization-report-id          TEXT   Optional report id to export.    │
+│    --pipe-ids                        TEXT   Optional JSON array of pipe ids. │
+│    --sort-by                         TEXT                                    │
+│    --filter                          TEXT                                    │
+│    --columns                         TEXT                                    │
+│    --poll-timeout                    FLOAT  Seconds to poll export status    │
+│                                             before failing (CSV only).       │
+│                                             [default: 90.0]                  │
+│    --json                    -j             Print machine-readable JSON to   │
+│                                             stdout.                          │
+│    --help                                   Show this message and exit.      │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP report-org/get
+Usage: pipefy report-org get [OPTIONS] REPORT_ID
+
+ Fetch one organization report (``get_organization_report``).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    report_id      TEXT  Organization report id. [required]                 │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --json  -j        Print machine-readable JSON to stdout.                     │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP report-org/list
+Usage: pipefy report-org list [OPTIONS]
+
+ List organization reports (``get_organization_reports``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --organization,--org          TEXT     [required]                         │
+│    --first                       INTEGER  Page size. [default: 30]           │
+│    --after                       TEXT     Pagination cursor.                 │
+│    --json                -j               Print machine-readable JSON to     │
+│                                           stdout.                            │
+│    --help                                 Show this message and exit.        │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP report-org/update
+Usage: pipefy report-org update [OPTIONS] REPORT_ID
+
+ Update an organization report (``update_organization_report``).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    report_id      TEXT  Organization report id. [required]                 │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --name      -n      TEXT                                                     │
+│ --color             TEXT                                                     │
+│ --fields            TEXT                                                     │
+│ --filter            TEXT                                                     │
+│ --pipe-ids          TEXT  JSON array of pipe ids.                            │
+│ --json      -j            Print machine-readable JSON to stdout.             │
+│ --help                    Show this message and exit.                        │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP report-pipe
+Usage: pipefy report-pipe [OPTIONS] COMMAND [ARGS]...
+
+ Pipe reports.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ list                List pipe reports (``get_pipe_reports``).                │
+│ get                 Fetch one pipe report (``get_pipe_report``).             │
+│ columns             List report column definitions                           │
+│                     (``get_pipe_report_columns``).                           │
+│ filterable-fields   List filterable fields for pipe reports                  │
+│                     (``get_pipe_report_filterable_fields``).                 │
+│ create              Create a pipe report (``create_pipe_report``).           │
+│ update              Update a pipe report (``update_pipe_report``).           │
+│ delete              Delete a pipe report (``delete_pipe_report``).           │
+│ export              Start a pipe report export (``export_pipe_report``); csv │
+│                     waits and streams the file.                              │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP report-pipe/columns
+Usage: pipefy report-pipe columns [OPTIONS]
+
+ List report column definitions (``get_pipe_report_columns``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --pipe          TEXT  Pipe UUID. [required]                               │
+│    --json  -j            Print machine-readable JSON to stdout.              │
+│    --help                Show this message and exit.                         │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP report-pipe/create
+Usage: pipefy report-pipe create [OPTIONS]
+
+ Create a pipe report (``create_pipe_report``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --pipe              TEXT  Pipe id. [required]                             │
+│ *  --name      -n      TEXT  [required]                                      │
+│    --fields            TEXT  Optional JSON array of column internal names.   │
+│    --filter            TEXT  Optional JSON filter object.                    │
+│    --formulas          TEXT  Optional JSON array of arrays.                  │
+│    --json      -j            Print machine-readable JSON to stdout.          │
+│    --help                    Show this message and exit.                     │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP report-pipe/delete
+Usage: pipefy report-pipe delete [OPTIONS] REPORT_ID
+
+ Delete a pipe report (``delete_pipe_report``).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    report_id      TEXT  Pipe report id. [required]                         │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --yes   -y                                                                   │
+│ --json  -j        Print machine-readable JSON to stdout.                     │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP report-pipe/export
+Usage: pipefy report-pipe export [OPTIONS]
+
+ Start a pipe report export (``export_pipe_report``); csv waits and streams the
+ file.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --pipe                  TEXT   Pipe id. [required]                        │
+│ *  --report-id             TEXT   Pipe report id. [required]                 │
+│    --format                TEXT   json: print mutation + poll metadata; csv: │
+│                                   wait for fileURL and stream bytes.         │
+│                                   [default: json]                            │
+│    --sort-by               TEXT   JSON ReportSortDirectionInput.             │
+│    --filter                TEXT                                              │
+│    --columns               TEXT   JSON array of column ids.                  │
+│    --poll-timeout          FLOAT  Seconds to poll export status before       │
+│                                   failing (CSV only).                        │
+│                                   [default: 90.0]                            │
+│    --json          -j             Print machine-readable JSON to stdout.     │
+│    --help                         Show this message and exit.                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP report-pipe/filterable-fields
+Usage: pipefy report-pipe filterable-fields [OPTIONS]
+
+ List filterable fields for pipe reports
+ (``get_pipe_report_filterable_fields``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --pipe          TEXT  Pipe UUID. [required]                               │
+│    --json  -j            Print machine-readable JSON to stdout.              │
+│    --help                Show this message and exit.                         │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP report-pipe/get
+Usage: pipefy report-pipe get [OPTIONS]
+
+ Fetch one pipe report (``get_pipe_report``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --pipe               TEXT  Pipe UUID. [required]                          │
+│ *  --report-id          TEXT  Pipe report id. [required]                     │
+│    --json       -j            Print machine-readable JSON to stdout.         │
+│    --help                     Show this message and exit.                    │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP report-pipe/list
+Usage: pipefy report-pipe list [OPTIONS]
+
+ List pipe reports (``get_pipe_reports``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --pipe               TEXT     Pipe UUID. [required]                       │
+│    --first              INTEGER  Page size. [default: 30]                    │
+│    --after              TEXT     Pagination cursor.                          │
+│    --search             TEXT                                                 │
+│    --report-id          TEXT                                                 │
+│    --order              TEXT     JSON sort object.                           │
+│    --json       -j               Print machine-readable JSON to stdout.      │
+│    --help                        Show this message and exit.                 │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP report-pipe/update
+Usage: pipefy report-pipe update [OPTIONS] REPORT_ID
+
+ Update a pipe report (``update_pipe_report``).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    report_id      TEXT  Pipe report id. [required]                         │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --name            -n      TEXT                                               │
+│ --color                   TEXT                                               │
+│ --fields                  TEXT                                               │
+│ --filter                  TEXT                                               │
+│ --formulas                TEXT                                               │
+│ --featured-field          TEXT                                               │
+│ --json            -j            Print machine-readable JSON to stdout.       │
+│ --help                          Show this message and exit.                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP skills
+Usage: pipefy skills [OPTIONS] COMMAND [ARGS]...
+
+ Browse bundled agent skill playbooks.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ list   List all bundled skills with their one-line descriptions.             │
+│ show   Print the full content of a bundled skill to stdout.                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP skills/list
+Usage: pipefy skills list [OPTIONS]
+
+ List all bundled skills with their one-line descriptions.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP skills/show
+Usage: pipefy skills show [OPTIONS] NAME
+
+ Print the full content of a bundled skill to stdout.
+
+ Args:     name: Skill name matching the 'name' frontmatter field, the filename
+ stem,         or the slug without the ``pipefy-`` prefix (e.g.
+ ``pipes-and-cards``).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    name      TEXT  Skill name (e.g. pipefy-pipes-and-cards). [required]    │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP table
+Usage: pipefy table [OPTIONS] COMMAND [ARGS]...
+
+ Database table operations.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ list     Search tables across organizations, or fetch specific tables by id. │
+│ get      Load one table by id.                                               │
+│ create   Create a database table.                                            │
+│ update   Update table attributes.                                            │
+│ delete   Delete a database table permanently.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP table/create
+Usage: pipefy table create [OPTIONS] NAME
+
+ Create a database table.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    name      TEXT  Table display name. [required]                          │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --org            TEXT  Organization id that will own the table.           │
+│                           [required]                                         │
+│    --extra          TEXT  JSON object of extra CreateTableInput fields.      │
+│    --json   -j                                                               │
+│    --help                 Show this message and exit.                        │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP table/delete
+Usage: pipefy table delete [OPTIONS] TABLE_ID
+
+ Delete a database table permanently.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    table_id      TEXT  Table id. [required]                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --yes   -y        Skip confirmation prompt.                                  │
+│ --json  -j                                                                   │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP table/get
+Usage: pipefy table get [OPTIONS] TABLE_ID
+
+ Load one table by id.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    table_id      TEXT  Table id. [required]                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --json  -j                                                                   │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP table/list
+Usage: pipefy table list [OPTIONS]
+
+ Search tables across organizations, or fetch specific tables by id.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --ids            TEXT                       Comma-separated table ids; when  │
+│                                             set, loads those tables via      │
+│                                             get_tables.                      │
+│ --name   -n      TEXT                       Optional table name filter       │
+│                                             (ignored when --ids is set).     │
+│ --first          INTEGER RANGE [1<=x<=500]  Max tables per organization when │
+│                                             searching (1-500, default 100).  │
+│                                             [default: 100]                   │
+│ --json   -j                                                                  │
+│ --help                                      Show this message and exit.      │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP table/update
+Usage: pipefy table update [OPTIONS] TABLE_ID
+
+ Update table attributes.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    table_id      TEXT  Table id. [required]                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --name                 TEXT                                                  │
+│ --description  -d      TEXT                                                  │
+│ --extra                TEXT  JSON object merged into UpdateTableInput.       │
+│ --json         -j                                                            │
+│ --help                       Show this message and exit.                     │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP usage
+Usage: pipefy usage [OPTIONS] COMMAND [ARGS]...
+
+ AI and automation usage metrics.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ agents        AI agent usage for an org (``get_agents_usage``).              │
+│ automations   Automation usage for an org (``get_automations_usage``).       │
+│ credits       AI credit usage dashboard (``get_ai_credit_usage``).           │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP usage/agents
+Usage: pipefy usage agents [OPTIONS]
+
+ AI agent usage for an org (``get_agents_usage``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --organization,--org          TEXT  Organization UUID (or numeric id      │
+│                                        resolvable by SDK).                   │
+│                                        [required]                            │
+│ *  --from                        TEXT  ISO8601 start (filter_date.from).     │
+│                                        [required]                            │
+│ *  --to                          TEXT  ISO8601 end (filter_date.to).         │
+│                                        [required]                            │
+│    --filters                     TEXT  Optional JSON object (FilterParams    │
+│                                        shape).                               │
+│    --search                      TEXT  Optional free-text search.            │
+│    --sort                        TEXT  Optional JSON sort criteria object.   │
+│    --json                -j                                                  │
+│    --help                              Show this message and exit.           │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP usage/automations
+Usage: pipefy usage automations [OPTIONS]
+
+ Automation usage for an org (``get_automations_usage``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --organization,--org          TEXT  [required]                            │
+│ *  --from                        TEXT  [required]                            │
+│ *  --to                          TEXT  [required]                            │
+│    --filters                     TEXT                                        │
+│    --search                      TEXT                                        │
+│    --sort                        TEXT                                        │
+│    --json                -j                                                  │
+│    --help                              Show this message and exit.           │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP usage/credits
+Usage: pipefy usage credits [OPTIONS]
+
+ AI credit usage dashboard (``get_ai_credit_usage``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --organization,--org          TEXT  [required]                            │
+│    --period                      TEXT  current_month | last_month |          │
+│                                        last_3_months                         │
+│                                        [default: current_month]              │
+│    --json                -j                                                  │
+│    --help                              Show this message and exit.           │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP webhook
+Usage: pipefy webhook [OPTIONS] COMMAND [ARGS]...
+
+ Pipe webhook operations.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ list     List webhooks on a pipe.                                            │
+│ create   Create a webhook.                                                   │
+│ update   Update a webhook (pass at least one attribute).                     │
+│ delete   Delete a webhook permanently.                                       │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP webhook/create
+Usage: pipefy webhook create [OPTIONS]
+
+ Create a webhook.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --pipe             TEXT  Pipe id. [required]                              │
+│ *  --url              TEXT  HTTPS callback URL. [required]                   │
+│ *  --actions          TEXT  JSON array of event action strings, e.g.         │
+│                             '["card.create","card.move"]'.                   │
+│                             [required]                                       │
+│    --extra            TEXT  JSON object of extra CreateWebhookInput fields.  │
+│    --json     -j                                                             │
+│    --help                   Show this message and exit.                      │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP webhook/delete
+Usage: pipefy webhook delete [OPTIONS] WEBHOOK_ID
+
+ Delete a webhook permanently.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    webhook_id      TEXT  Webhook id. [required]                            │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --yes   -y        Skip confirmation prompt.                                  │
+│ --json  -j                                                                   │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP webhook/list
+Usage: pipefy webhook list [OPTIONS]
+
+ List webhooks on a pipe.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --pipe          TEXT  Pipe id. [required]                                 │
+│    --json  -j                                                                │
+│    --help                Show this message and exit.                         │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP webhook/update
+Usage: pipefy webhook update [OPTIONS] WEBHOOK_ID
+
+ Update a webhook (pass at least one attribute).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    webhook_id      TEXT  Webhook id. [required]                            │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --name             TEXT                                                      │
+│ --url              TEXT                                                      │
+│ --actions          TEXT  JSON array of event action strings (non-empty when  │
+│                          provided).                                          │
+│ --headers          TEXT  JSON object of custom HTTP headers.                 │
+│ --json     -j                                                                │
+│ --help                   Show this message and exit.                         │
+╰──────────────────────────────────────────────────────────────────────────────╯
+

--- a/packages/cli/tests/test_cli_help_golden.py
+++ b/packages/cli/tests/test_cli_help_golden.py
@@ -14,6 +14,15 @@ _FIXTURE = Path(__file__).resolve().parent / "fixtures" / "cli_help_golden.txt"
 _UPDATE_ENV = "PIPEFY_UPDATE_CLI_HELP_GOLDEN"
 
 
+def _stable_help_env():
+    """Stable terminal size for Rich / Typer across Linux CI and local dev."""
+    env = os.environ.copy()
+    env["COLUMNS"] = "80"
+    env["LINES"] = "24"
+    env["TERM"] = "dumb"
+    return env
+
+
 def _normalize_help(text):
     lines = [ln.rstrip() for ln in text.splitlines()]
     body = "\n".join(lines).strip()
@@ -42,7 +51,9 @@ def _build_golden_digest(runner):
     blocks = []
     for path, _cmd in sorted(_walk_commands([], root), key=lambda pc: _path_key(pc[0])):
         argv = [*path, "--help"] if path else ["--help"]
-        result = runner.invoke(app, argv, catch_exceptions=False)
+        result = runner.invoke(
+            app, argv, catch_exceptions=False, env=_stable_help_env()
+        )
         assert result.exit_code == 0, (
             f"help failed for {argv!r}: stderr={result.stderr!r} stdout={result.stdout!r}"
         )
@@ -90,7 +101,9 @@ def test_destructive_commands_document_skip_confirm(
     missing = []
     for path in sorted(targets, key=_path_key):
         argv = [*path, "--help"]
-        result = runner.invoke(app, argv, catch_exceptions=False)
+        result = runner.invoke(
+            app, argv, catch_exceptions=False, env=_stable_help_env()
+        )
         assert result.exit_code == 0
         out = result.stdout.lower()
         if "--yes" not in out and " -y" not in out and "\n-y" not in out:

--- a/packages/cli/tests/test_cli_help_golden.py
+++ b/packages/cli/tests/test_cli_help_golden.py
@@ -1,0 +1,101 @@
+"""Golden ``--help`` output for the full Typer tree (task 12.4 UX consistency lock)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import click
+from typer.main import get_command
+
+from pipefy_cli.main import app
+
+_FIXTURE = Path(__file__).resolve().parent / "fixtures" / "cli_help_golden.txt"
+_UPDATE_ENV = "PIPEFY_UPDATE_CLI_HELP_GOLDEN"
+
+
+def _normalize_help(text):
+    lines = [ln.rstrip() for ln in text.splitlines()]
+    body = "\n".join(lines).strip()
+    if body:
+        return body + "\n"
+    return ""
+
+
+def _walk_commands(path, cmd):
+    yield path, cmd
+    if isinstance(cmd, click.Group):
+        for name in sorted(cmd.commands):
+            sub = cmd.commands[name]
+            if getattr(sub, "hidden", False):
+                continue
+            yield from _walk_commands(path + [name], sub)
+
+
+def _path_key(path):
+    return "/".join(path) if path else "_"
+
+
+def _build_golden_digest(runner):
+    root = get_command(app)
+    assert isinstance(root, click.Group)
+    blocks = []
+    for path, _cmd in sorted(_walk_commands([], root), key=lambda pc: _path_key(pc[0])):
+        argv = [*path, "--help"] if path else ["--help"]
+        result = runner.invoke(app, argv, catch_exceptions=False)
+        assert result.exit_code == 0, (
+            f"help failed for {argv!r}: stderr={result.stderr!r} stdout={result.stdout!r}"
+        )
+        key = _path_key(path)
+        body = _normalize_help(result.stdout)
+        blocks.append(f"### HELP {key}\n{body}")
+    return "\n".join(blocks) + "\n"
+
+
+def test_cli_help_matches_golden(runner, clean_pipefy_env, saved_cwd):
+    """Compare aggregated ``--help`` text to ``fixtures/cli_help_golden.txt``.
+
+    Regenerate after intentional CLI help changes::
+
+        PIPEFY_UPDATE_CLI_HELP_GOLDEN=1 uv run pytest packages/cli/tests/test_cli_help_golden.py::test_cli_help_matches_golden -q
+    """
+
+    digest = _build_golden_digest(runner)
+    _FIXTURE.parent.mkdir(parents=True, exist_ok=True)
+    if os.environ.get(_UPDATE_ENV) == "1":
+        _FIXTURE.write_text(digest, encoding="utf-8")
+    assert _FIXTURE.is_file(), (
+        f"Missing golden file {_FIXTURE}. Generate with {_UPDATE_ENV}=1 on the test above."
+    )
+    expected = _FIXTURE.read_text(encoding="utf-8")
+    assert digest == expected, (
+        "CLI --help output drifted from golden file. "
+        f"If the change is intentional, re-run with {_UPDATE_ENV}=1 to refresh {_FIXTURE.name}."
+    )
+
+
+def test_destructive_commands_document_skip_confirm(
+    runner, clean_pipefy_env, saved_cwd
+):
+    """Destructive flows should document ``--yes`` / ``-y`` in ``--help`` (non-interactive scripts)."""
+
+    root = get_command(app)
+    assert isinstance(root, click.Group)
+    targets = []
+    for path, _cmd in _walk_commands([], root):
+        key = _path_key(path)
+        if key.endswith("/delete") or key == "member/remove" or key == "graphql/exec":
+            targets.append(path)
+
+    missing = []
+    for path in sorted(targets, key=_path_key):
+        argv = [*path, "--help"]
+        result = runner.invoke(app, argv, catch_exceptions=False)
+        assert result.exit_code == 0
+        out = result.stdout.lower()
+        if "--yes" not in out and " -y" not in out and "\n-y" not in out:
+            missing.append(_path_key(path))
+    assert not missing, (
+        "These commands use destructive or guarded flows but --help does not show --yes/-y: "
+        + ", ".join(missing)
+    )

--- a/packages/mcp/src/pipefy_mcp/tools/ai_tool_helpers.py
+++ b/packages/mcp/src/pipefy_mcp/tools/ai_tool_helpers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import Any, Literal, cast
 
 from pipefy_sdk import AiAgentGraphPayload
 from pipefy_sdk.ai_pipe_validation import (
@@ -29,9 +29,6 @@ from pipefy_mcp.tools.tool_error_envelope import (
     tool_error,
     tool_success,
 )
-
-if TYPE_CHECKING:
-    pass
 
 logger = logging.getLogger(__name__)
 

--- a/packages/mcp/src/pipefy_mcp/tools/pagination_helpers.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pagination_helpers.py
@@ -30,7 +30,7 @@ class PaginationInfo(TypedDict, total=False):
 
 
 def validate_page_size(
-    first: int | None,
+    first: int | str | None,
     *,
     arg_name: str = "first",
     max_size: int = MAX_PAGE_SIZE,
@@ -46,8 +46,8 @@ def validate_page_size(
     ``int(...)`` cannot parse yields an ``INVALID_ARGUMENTS`` error.
 
     Args:
-        first: The requested page size, or None to use the default. Accepts
-            ``int`` or a digit-string parseable by ``int(...)``.
+        first: The requested page size, or None to use the default. Accepts an
+            ``int`` or a string parseable by ``int(...)`` (e.g. digit strings from MCP clients).
         arg_name: Name of the tool argument (appears in the error message to
             help agents fix their call). Default "first".
         max_size: Upper bound. Defaults to ``MAX_PAGE_SIZE``; tools with an

--- a/packages/mcp/src/pipefy_mcp/tools/validation_envelope.py
+++ b/packages/mcp/src/pipefy_mcp/tools/validation_envelope.py
@@ -174,6 +174,6 @@ def install_pipefy_validation_envelope() -> None:
         self._tools[tool.name] = tool
         return tool
 
-    ToolManager.add_tool = _add_tool  # type: ignore[assignment]
+    setattr(ToolManager, "add_tool", _add_tool)
     setattr(ToolManager, _PATCH_SENTINEL, True)
     logger.debug("PipefyValidationTool wiring active (ToolManager.add_tool patched)")

--- a/packages/mcp/tests/tools/test_behavior_placeholder_interpolation.py
+++ b/packages/mcp/tests/tools/test_behavior_placeholder_interpolation.py
@@ -204,7 +204,7 @@ def test_placeholders_overrides_template_params_same_key():
 @pytest.mark.unit
 def test_extract_referenced_field_ids_empty_instruction():
     assert extract_referenced_field_ids("") == []
-    assert extract_referenced_field_ids(None) == []  # type: ignore[arg-type]
+    assert extract_referenced_field_ids(None) == []
 
 
 @pytest.mark.unit

--- a/packages/mcp/tests/tools/test_pagination_helpers.py
+++ b/packages/mcp/tests/tools/test_pagination_helpers.py
@@ -46,7 +46,7 @@ def test_validate_page_size_negative_returns_structured_error():
 
 
 def test_validate_page_size_non_integer_returns_structured_error():
-    value, err = validate_page_size("abc")  # type: ignore[arg-type]
+    value, err = validate_page_size("abc")
     assert value == 0
     assert err is not None
     assert err["error"]["code"] == "INVALID_ARGUMENTS"
@@ -56,7 +56,7 @@ def test_validate_page_size_non_integer_returns_structured_error():
 
 def test_validate_page_size_accepts_integer_string():
     # int("100") coerces successfully, so "100" is treated as 100.
-    value, err = validate_page_size("100")  # type: ignore[arg-type]
+    value, err = validate_page_size("100")
     assert value == 100
     assert err is None
 

--- a/packages/sdk/src/pipefy_sdk/behavior_placeholders.py
+++ b/packages/sdk/src/pipefy_sdk/behavior_placeholders.py
@@ -102,7 +102,7 @@ def normalize_pipefy_ai_instruction_tokens(text: str) -> str:
     return _PIPEFY_UNPREFIXED_NUMERIC_FIELD.sub(r"%{field:\1}", out)
 
 
-def extract_referenced_field_ids(instruction: str) -> list[str]:
+def extract_referenced_field_ids(instruction: str | None) -> list[str]:
     """Extract numeric field ids referenced in an instruction's ``%{field:<digits>}`` tokens.
 
     Only matches the canonical numeric form (post :func:`normalize_pipefy_ai_instruction_tokens`
@@ -117,7 +117,7 @@ def extract_referenced_field_ids(instruction: str) -> list[str]:
     change what arrives in ``BehaviorRequest.card.fields[]``.
 
     Args:
-        instruction: Behavior instruction text.
+        instruction: Behavior instruction text, or None / empty (returns no ids).
 
     Returns:
         Field ids in first-occurrence order, deduplicated, as strings.

--- a/packages/sdk/src/pipefy_sdk/models/attachment.py
+++ b/packages/sdk/src/pipefy_sdk/models/attachment.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import mimetypes
+from pathlib import Path
 from typing import Self
 
 from pydantic import BaseModel, ConfigDict, model_validator
@@ -15,12 +16,19 @@ APPLICATION_OCTET_STREAM = "application/octet-stream"
 # we treat that as unknown binary content.
 _MIME_FALSE_POSITIVES_FOR_UPLOAD = frozenset({"chemical/x-xyz"})
 
+# Suffixes where :mod:`mimetypes` is inconsistent across OS images (e.g. Linux slim
+# containers return ``application/octet-stream`` for ``.docx``).
+_STABLE_SUFFIX_CONTENT_TYPES: dict[str, str] = {
+    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+}
+
 
 def infer_content_type(file_name: str) -> str:
     """Infer a MIME type from ``file_name`` (typically the basename or path).
 
-    Uses :func:`mimetypes.guess_type`. Returns ``application/octet-stream`` when the type
-    is unknown or a known false positive for arbitrary ``.xyz`` files.
+    Uses :func:`mimetypes.guess_type`, with a small suffix map for types that differ
+    across platforms. Returns ``application/octet-stream`` when the type is unknown or
+    a known false positive for arbitrary ``.xyz`` files.
 
     Args:
         file_name: File name or path whose suffix is used for guessing.
@@ -28,6 +36,9 @@ def infer_content_type(file_name: str) -> str:
     Returns:
         A MIME type string suitable for ``Content-Type``-style headers.
     """
+    suffix = Path(file_name).suffix.lower()
+    if suffix in _STABLE_SUFFIX_CONTENT_TYPES:
+        return _STABLE_SUFFIX_CONTENT_TYPES[suffix]
     mime, _encoding = mimetypes.guess_type(file_name)
     if mime is None or mime in _MIME_FALSE_POSITIVES_FOR_UPLOAD:
         return APPLICATION_OCTET_STREAM

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dev = [
 lint.extend-select = ["I"]
 
 [tool.pytest.ini_options]
-testpaths = ["packages/sdk/tests", "packages/mcp/tests", "packages/cli/tests"]
+testpaths = ["tests", "packages/sdk/tests", "packages/mcp/tests", "packages/cli/tests"]
 pythonpath = [
     "packages/mcp/tests",
     "packages/sdk/tests",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,0 @@
-"""Test package (enables shared helpers under ``tests.*``)."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,8 @@
 """Shared pytest configuration for the repo-root ``tests/`` tree.
 
-This directory holds unit and integration tests for packages that still live
-under ``tests/`` (for example SDK-adjacent suites). There are no ``test_*.py``
-files at the root of ``tests/`` itself—only subpackages such as ``tests/tools``
-and ``tests/services``. MCP-focused collections live under ``packages/mcp/tests``.
+Cross-package checks live here (for example ``test_parity.py``). Keep this
+directory **without** ``__init__.py``: a root ``tests`` package would shadow
+``packages/sdk/tests`` when pytest imports modules as ``tests.test_*``.
 """
 
 import pytest

--- a/tests/test_parity.py
+++ b/tests/test_parity.py
@@ -1,0 +1,142 @@
+"""CI parity audit: MCP tool registry vs ``docs/parity.md`` and Typer CLI surface."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import click
+import pytest
+from pipefy_cli.main import app as cli_app
+from pipefy_mcp.tools.registry import PIPEFY_TOOL_NAMES
+from typer.main import get_command
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_PARITY_MD = _REPO_ROOT / "docs" / "parity.md"
+
+_ROW_RE = re.compile(
+    r"^\|\s*`([^`]+)`\s*\|\s*(.*?)\s*\|\s*(shipped|deferred|pending|N/A)\s*\|",
+    re.IGNORECASE,
+)
+_PIPEFY_CMD_RE = re.compile(r"`(pipefy[^`]*)`")
+
+
+def _parse_parity_rows(markdown):
+    """Map MCP tool name -> (status_lower, list of ``pipefy ...`` strings from the CLI column)."""
+    out = {}
+    for line in markdown.splitlines():
+        m = _ROW_RE.match(line.strip())
+        if not m:
+            continue
+        tool, cli_cell, status = m.group(1), m.group(2), m.group(3).lower()
+        specs = [s.strip() for s in _PIPEFY_CMD_RE.findall(cli_cell)]
+        out[tool] = (status, specs)
+    return out
+
+
+def _tokens_before_first_flag(pipefy_tail):
+    parts = pipefy_tail.strip().split()
+    tokens = []
+    for p in parts:
+        if p.startswith("-"):
+            break
+        tokens.append(p)
+    return tokens
+
+
+def _command_path_exists(root, tokens):
+    current = root
+    for name in tokens:
+        if not isinstance(current, click.Group):
+            return False
+        if name not in current.commands:
+            return False
+        current = current.commands[name]
+    return True
+
+
+def _click_root():
+    cmd = get_command(cli_app)
+    assert isinstance(cmd, click.Group)
+    return cmd
+
+
+def test_parity_matrix_covers_registry_and_cli_paths_exist():
+    """Every MCP tool appears in ``docs/parity.md`` with a valid status; shipped rows resolve in Typer."""
+    text = _PARITY_MD.read_text(encoding="utf-8")
+    rows = _parse_parity_rows(text)
+
+    missing_in_doc = sorted(PIPEFY_TOOL_NAMES - rows.keys())
+    assert not missing_in_doc, (
+        "MCP tools missing from docs/parity.md matrix: "
+        + ", ".join(missing_in_doc)
+        + ". Add a row for each tool in the same change set as registry edits."
+    )
+
+    extra_in_doc = sorted(rows.keys() - PIPEFY_TOOL_NAMES)
+    assert not extra_in_doc, (
+        "docs/parity.md lists unknown MCP tools (not in PIPEFY_TOOL_NAMES): "
+        + ", ".join(extra_in_doc)
+        + ". Remove stale rows or sync the registry."
+    )
+
+    root = _click_root()
+    problems = []
+
+    for tool in sorted(PIPEFY_TOOL_NAMES):
+        status, specs = rows[tool]
+        if status in {"deferred", "n/a"}:
+            continue
+        if status == "pending":
+            problems.append(
+                f"{tool}: status is 'pending' (CLI not shipped). "
+                "Ship the CLI command or mark deferred with rationale in Notes."
+            )
+            continue
+        if status != "shipped":
+            problems.append(f"{tool}: unexpected status {status!r} in docs/parity.md")
+            continue
+        if not specs:
+            problems.append(
+                f"{tool}: status shipped but no `pipefy ...` backtick command found in CLI column. "
+                "Add at least one primary `pipefy …` invocation."
+            )
+            continue
+        resolved = False
+        for spec in specs:
+            if not spec.startswith("pipefy"):
+                continue
+            tail = spec.removeprefix("pipefy").strip()
+            tokens = _tokens_before_first_flag(tail)
+            if tokens and _command_path_exists(root, tokens):
+                resolved = True
+                break
+        if not resolved:
+            joined = " ; ".join(specs)
+            problems.append(
+                f"{tool}: shipped in docs/parity.md but no listed CLI path exists on Typer app "
+                f"(tried backtick specs: {joined}). Fix docs/parity.md or register the missing Typer command."
+            )
+
+    assert not problems, "Parity audit failed:\n" + "\n".join(problems)
+
+
+@pytest.mark.parametrize("tool", sorted(PIPEFY_TOOL_NAMES))
+def test_each_mcp_tool_has_documentation_row(tool):
+    """Parametrized companion so ``pytest -k`` can target a single tool name."""
+    rows = _parse_parity_rows(_PARITY_MD.read_text(encoding="utf-8"))
+    assert tool in rows, f"{tool}: add a docs/parity.md matrix row"
+
+
+def test_registry_tool_count_matches_documented_expectation():
+    """Keep the parity doc header (``**128** tools``) honest; update docs when the registry changes."""
+    text = _PARITY_MD.read_text(encoding="utf-8")
+    m = re.search(r"\*\*(\d+)\*\*\s+tools", text)
+    assert m is not None, (
+        "docs/parity.md must document the expected MCP tool count near the top."
+    )
+    documented = int(m.group(1))
+    assert len(PIPEFY_TOOL_NAMES) == documented, (
+        f"PIPEFY_TOOL_NAMES has {len(PIPEFY_TOOL_NAMES)} tools but docs/parity.md documents {documented}. "
+        "Update the **N** tools line and the matrix together."
+    )


### PR DESCRIPTION
## Summary

- **fix(test):** Remove `tests/__init__.py` so repo-root `tests` does not shadow `packages/sdk/tests` during pytest collection.
- **test:** Add `tests/test_parity.py` plus root `testpaths` — CI parity audit (MCP registry vs `docs/parity.md` vs Typer CLI).
- **test(cli):** Golden aggregate of every `--help` and invariant that destructive paths document `--yes`.
- **docs:** `docs/DEPRECATION.md`, README links, and `RELEASE.md` / README for **`v0.2.0-beta.*`** pre-release line.
- **refactor(types):** MCP/SDK typing cleanups (same branch).

## Test plan

- [x] `uv run ruff check .` and `uv run ruff format . --check`
- [x] `uv run pytest -m "not integration"` — 2171 passed

Closes mistaken **dev → main** PR #118; this targets **`dev`** as the integration branch.
