### PR TITLE
feat: CLI/MCP --version, MCP --help, comment error codes

### DIFF
--- a/packages/cli/src/pipefy_cli/main.py
+++ b/packages/cli/src/pipefy_cli/main.py
@@ -6,6 +6,7 @@ import os
 
 import typer
 
+from pipefy_cli import __version__ as _cli_version
 from pipefy_cli.commands.agent import agent_app
 from pipefy_cli.commands.ai_automation import ai_automation_app
 from pipefy_cli.commands.attachment import attachment_app
@@ -40,6 +41,12 @@ app = typer.Typer(
 )
 
 
+def _print_version(value: bool) -> None:
+    if value:
+        typer.echo(_cli_version)
+        raise typer.Exit()
+
+
 @app.callback()
 def main(
     ctx: typer.Context,
@@ -57,6 +64,13 @@ def main(
         False,
         "--allow-insecure-urls",
         help="Allow http:// and private hosts (overrides env for this process).",
+    ),
+    version: bool = typer.Option(
+        False,
+        "--version",
+        callback=_print_version,
+        is_eager=True,
+        help="Print the pipefy-cli version and exit.",
     ),
 ) -> None:
     """Global options apply to all subcommands."""

--- a/packages/cli/tests/fixtures/cli_help_golden.txt
+++ b/packages/cli/tests/fixtures/cli_help_golden.txt
@@ -9,6 +9,7 @@ Usage: pipefy [OPTIONS] COMMAND [ARGS]...
 │                                    Overrides PIPEFY_TOKEN if both are set.   │
 │ --allow-insecure-urls              Allow http:// and private hosts           │
 │                                    (overrides env for this process).         │
+│ --version                          Print the pipefy-cli version and exit.    │
 │ --install-completion               Install completion for the current shell. │
 │ --show-completion                  Show completion for the current shell, to │
 │                                    copy it or customize the installation.    │

--- a/packages/cli/tests/test_table_record_commands.py
+++ b/packages/cli/tests/test_table_record_commands.py
@@ -3,9 +3,16 @@
 from __future__ import annotations
 
 import json
+import re
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from pipefy_cli.main import app
+
+# Rich/Typer renders option names like ``--ids`` in bold by default, splitting
+# the two dashes with ``\x1b[1m`` ANSI codes on Linux CI runners under
+# ``FORCE_COLOR=1``. Strip those codes before the substring assert so the test
+# passes on both macOS and Linux without depending on env vars.
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
 
 
 def test_table_list_search_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
@@ -49,7 +56,7 @@ def test_table_list_ids_only_commas_bad_parameter(
     ):
         result = runner.invoke(app, ["table", "list", "--ids", ",", "--json"])
     assert result.exit_code == 2
-    assert "--ids must list" in (result.stdout + result.stderr)
+    assert "--ids must list" in _ANSI_ESCAPE_RE.sub("", result.stdout + result.stderr)
     mock_client.get_tables.assert_not_called()
 
 

--- a/packages/cli/tests/test_version_flag.py
+++ b/packages/cli/tests/test_version_flag.py
@@ -1,0 +1,18 @@
+"""``pipefy --version`` prints the installed CLI version and exits cleanly."""
+
+from __future__ import annotations
+
+from pipefy_cli import __version__
+from pipefy_cli.main import app
+
+
+def test_version_flag_prints_and_exits(runner, clean_pipefy_env, saved_cwd):
+    """``--version`` is eager — it must not require auth or settings.
+
+    The release smoke (`uvx --from git+... pipefy-cli --version`) relies on this
+    flag returning the version without booting the auth/OAuth stack, so we
+    invoke it with no PIPEFY_* env vars set (``clean_pipefy_env``).
+    """
+    result = runner.invoke(app, ["--version"], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert result.stdout.strip() == __version__

--- a/packages/mcp/src/pipefy_mcp/main.py
+++ b/packages/mcp/src/pipefy_mcp/main.py
@@ -1,15 +1,47 @@
-import logging
+"""Console-script entry point for ``pipefy-mcp-server``.
 
+The server itself talks MCP over stdio with no flags, but the binary accepts
+``--help`` / ``--version`` so packaging smoke tests (and humans) can introspect
+it without entering the stdio loop. Any other argv runs the server as before.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from typing import Sequence
+
+from pipefy_mcp import __version__
 from pipefy_mcp.server import run_server
 
 logger = logging.getLogger(__name__)
 
+_HELP = (
+    f"pipefy-mcp-server {__version__}\n"
+    "\n"
+    "Usage: pipefy-mcp-server [--help] [--version]\n"
+    "\n"
+    "Runs the Pipefy MCP server over stdio. With no flags, the process speaks\n"
+    "the Model Context Protocol on stdin/stdout and is intended to be launched\n"
+    "by an MCP client (e.g. an IDE extension or `uv run`).\n"
+    "\n"
+    "Options:\n"
+    "  --help     Show this message and exit.\n"
+    "  --version  Show the installed version and exit.\n"
+)
 
-def main():
-    """Main entry point for the pipefy-mcp-server script defined in pyproject.toml"""
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Entry point declared in ``packages/mcp/pyproject.toml``."""
+    args = sys.argv[1:] if argv is None else list(argv)
+    if any(a in {"-h", "--help"} for a in args):
+        sys.stdout.write(_HELP)
+        return
+    if any(a == "--version" for a in args):
+        sys.stdout.write(f"{__version__}\n")
+        return
 
     logger.info("Starting Pipefy MCP server")
-
     run_server()
 
 

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_tool_helpers.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_tool_helpers.py
@@ -309,17 +309,22 @@ def map_delete_comment_error_to_message(exc: BaseException) -> str:
     )
 
 
-def _build_comment_error_payload(message: str) -> dict:
-    return tool_error(message)
+def _build_comment_error_payload(message: str, code: str | None = None) -> dict:
+    return tool_error(message, code=code)
 
 
-def build_add_card_comment_error_payload(*, message: str) -> AddCardCommentErrorPayload:
+def build_add_card_comment_error_payload(
+    *, message: str, code: str | None = None
+) -> AddCardCommentErrorPayload:
     """add_card_comment failure envelope.
 
     Args:
         message: User-visible failure reason.
+        code: Optional machine-friendly code (e.g. ``INVALID_ARGUMENTS``).
     """
-    return cast(AddCardCommentErrorPayload, _build_comment_error_payload(message))
+    return cast(
+        AddCardCommentErrorPayload, _build_comment_error_payload(message, code=code)
+    )
 
 
 def build_update_comment_success_payload(*, comment_id: object) -> dict[str, Any]:
@@ -334,13 +339,18 @@ def build_update_comment_success_payload(*, comment_id: object) -> dict[str, Any
     return {"success": True, "comment_id": cid}
 
 
-def build_update_comment_error_payload(*, message: str) -> UpdateCommentErrorPayload:
+def build_update_comment_error_payload(
+    *, message: str, code: str | None = None
+) -> UpdateCommentErrorPayload:
     """update_comment failure envelope.
 
     Args:
         message: User-visible failure reason.
+        code: Optional machine-friendly code (e.g. ``INVALID_ARGUMENTS``).
     """
-    return cast(UpdateCommentErrorPayload, _build_comment_error_payload(message))
+    return cast(
+        UpdateCommentErrorPayload, _build_comment_error_payload(message, code=code)
+    )
 
 
 def build_delete_comment_success_payload() -> dict[str, Any]:
@@ -350,13 +360,18 @@ def build_delete_comment_success_payload() -> dict[str, Any]:
     return {"success": True}
 
 
-def build_delete_comment_error_payload(*, message: str) -> DeleteCommentErrorPayload:
+def build_delete_comment_error_payload(
+    *, message: str, code: str | None = None
+) -> DeleteCommentErrorPayload:
     """delete_comment failure envelope.
 
     Args:
         message: User-visible failure reason.
+        code: Optional machine-friendly code (e.g. ``RESOURCE_NOT_FOUND``).
     """
-    return cast(DeleteCommentErrorPayload, _build_comment_error_payload(message))
+    return cast(
+        DeleteCommentErrorPayload, _build_comment_error_payload(message, code=code)
+    )
 
 
 def build_delete_card_success_payload(

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
@@ -307,7 +307,8 @@ class PipeTools:
                 return build_add_card_comment_error_payload(
                     message=message_for_add_card_comment_validation_error(
                         exc, raw_text=text
-                    )
+                    ),
+                    code="INVALID_ARGUMENTS",
                 )
 
             try:
@@ -340,7 +341,8 @@ class PipeTools:
                 update_input = UpdateCommentInput(comment_id=comment_id, text=text)
             except ValidationError:
                 return build_update_comment_error_payload(
-                    message="Invalid input. Please provide a valid 'comment_id' and non-empty 'text'."
+                    message="Invalid input. Please provide a valid 'comment_id' and non-empty 'text'.",
+                    code="INVALID_ARGUMENTS",
                 )
 
             try:
@@ -383,7 +385,8 @@ class PipeTools:
                 delete_input = DeleteCommentInput(comment_id=comment_id)
             except ValidationError:
                 return build_delete_comment_error_payload(
-                    message="Invalid input. Please provide a valid 'comment_id'."
+                    message="Invalid input. Please provide a valid 'comment_id'.",
+                    code="INVALID_ARGUMENTS",
                 )
 
             guard = await check_destructive_confirmation(

--- a/packages/mcp/tests/test_main.py
+++ b/packages/mcp/tests/test_main.py
@@ -1,5 +1,6 @@
 import pytest
 
+from pipefy_mcp import __version__
 from pipefy_mcp.main import main
 
 
@@ -8,5 +9,44 @@ def test_entrypoint(mocker):
     server_mock = mocker.patch("pipefy_mcp.main.run_server")
 
     main()
+
+    server_mock.assert_called_once()
+
+
+@pytest.mark.unit
+def test_help_skips_server(mocker, capsys):
+    """``--help`` must short-circuit before entering the stdio loop."""
+    server_mock = mocker.patch("pipefy_mcp.main.run_server")
+
+    main(["--help"])
+
+    server_mock.assert_not_called()
+    captured = capsys.readouterr()
+    assert "pipefy-mcp-server" in captured.out
+    assert "--help" in captured.out
+    assert "--version" in captured.out
+
+
+@pytest.mark.unit
+def test_version_skips_server(mocker, capsys):
+    """``--version`` must print the installed version and skip the server."""
+    server_mock = mocker.patch("pipefy_mcp.main.run_server")
+
+    main(["--version"])
+
+    server_mock.assert_not_called()
+    assert capsys.readouterr().out.strip() == __version__
+
+
+@pytest.mark.unit
+def test_unknown_flag_still_starts_server(mocker):
+    """Anything not ``--help`` / ``--version`` is delegated to ``run_server``.
+
+    The MCP transport ignores extra argv, so we keep the binary forgiving rather
+    than failing on flags that downstream tooling may inject (e.g. IDE wrappers).
+    """
+    server_mock = mocker.patch("pipefy_mcp.main.run_server")
+
+    main(["--unknown-flag"])
 
     server_mock.assert_called_once()

--- a/packages/mcp/tests/tools/test_pipe_tool_helpers.py
+++ b/packages/mcp/tests/tools/test_pipe_tool_helpers.py
@@ -350,6 +350,22 @@ def test_build_add_card_comment_error_payload():
     assert out == tool_error("Something failed")
 
 
+@pytest.mark.unit
+def test_build_add_card_comment_error_payload_with_code():
+    """``code`` flows through so validation errors carry ``INVALID_ARGUMENTS``.
+
+    Comment validation errors used to drop the ``code`` field, breaking parity
+    with every other ``error.code`` enriched response in the unified envelope.
+    """
+    out = build_add_card_comment_error_payload(
+        message="text exceeds 1000-character limit (got 1163).",
+        code="INVALID_ARGUMENTS",
+    )
+    assert out["success"] is False
+    assert out["error"]["code"] == "INVALID_ARGUMENTS"
+    assert "1000-character" in out["error"]["message"]
+
+
 # =============================================================================
 # build_delete_card_success_payload
 # =============================================================================

--- a/packages/sdk/tests/conftest.py
+++ b/packages/sdk/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Pytest defaults for ``packages/sdk/tests``.
+
+Pin the anyio backend to ``asyncio`` so ``@pytest.mark.anyio`` tests do not
+attempt to load ``trio`` (which is not a project dependency). The repo-root
+``tests/conftest.py`` defines the same fixture for the cross-package layer;
+this mirror exists so the SDK suite stays green when run in isolation
+(``uv run pytest packages/sdk/tests``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"


### PR DESCRIPTION
## Summary

- **fix(mcp):** Comment validation failures (`add_card_comment`, `update_comment`, `delete_comment`) now return `error.code` (e.g. `INVALID_ARGUMENTS`) for envelope parity with other tools.
- **feat(cli):** Global `--version` prints `pipefy-cli` version without auth; golden help fixture updated.
- **feat(mcp):** `pipefy-mcp-server` short-circuits on `--help` / `--version` before the stdio loop; unknown flags still start the server (forgiving for IDE wrappers).
- **test(sdk):** `packages/sdk/tests/conftest.py` pins `anyio_backend` to `asyncio` for isolated `pytest packages/sdk/tests`.
- **test(cli):** Table list error assertion strips ANSI so it passes under `FORCE_COLOR=1` on Linux CI.

## Test plan

- [x] `uv run pytest -m "not integration"` — 2165 passed
- [x] `uv run ruff check` on touched modules