### PR TITLE
fix(sdk): skip malformed field definitions in create_form_model

### DIFF
--- a/packages/cli/src/pipefy_cli/skills/pipefy-introspection.md
+++ b/packages/cli/src/pipefy_cli/skills/pipefy-introspection.md
@@ -24,10 +24,10 @@ This is **Tier 2** in the resolution strategy: when a dedicated MCP tool fails o
 
 | Tool (MCP) | CLI | Read-only | Purpose |
 |------------|-----|-----------|---------|
-| `introspect_type` | `pipefy introspect type` | Yes | Discover a type's shape: `fields`, `inputFields`, `enumValues`. |
-| `introspect_query` | `pipefy introspect query` | Yes | Get a query's argument types and return shape. |
-| `introspect_mutation` | `pipefy introspect mutation` | Yes | Get a mutation's argument types and return shape. |
-| `search_schema` | `pipefy introspect schema search` | Yes | Keyword search across type / query / mutation names. |
+| `introspect_type` | `pipefy introspect type` | Yes | Type shape: `fields`, `inputFields`, `enumValues`. Optional `max_depth`. |
+| `introspect_query` | `pipefy introspect query` | Yes | Root query arguments and return type. Optional `max_depth`. |
+| `introspect_mutation` | `pipefy introspect mutation` | Yes | Root mutation arguments and return type. Optional `max_depth`. |
+| `search_schema` | `pipefy introspect schema search` | Yes | Keyword search on type names/descriptions. Optional `kind` filter. |
 | `execute_graphql` | `pipefy graphql exec` | No | Execute arbitrary GraphQL (`--yes` required for mutations). |
 | `get_organization` | `pipefy org get` | Yes | Load organization info (name, plan, UUID, member count, pipe count). |
 
@@ -41,6 +41,39 @@ This is **Tier 2** in the resolution strategy: when a dedicated MCP tool fails o
 - **`true`:** response includes **both** `result` (the raw JSON string) AND `data` (the parsed dict). Drill into `data` programmatically; keep `result` to forward verbatim.
 
 Use `include_parsed=true` whenever you plan to read nested fields (e.g. iterating over `phases[].fields[]`). Leave it off for one-shot reads where the raw string is sufficient.
+
+## `max_depth` (introspect_type / query / mutation)
+
+MCP tools accept `max_depth` (default `1`). CLI: `--max-depth`.
+
+- **`1`** — type/field info only (no inlined sub-types).
+- **`2+`** — resolves referenced input/output types inline (`resolvedType`), so one call can replace introspecting the mutation then each input type separately.
+
+Example (CLI):
+
+```bash
+pipefy introspect mutation createCard --max-depth 2 --json
+```
+
+Example (MCP):
+
+```
+introspect_mutation mutation_name="createCard" max_depth=2 include_parsed=true
+```
+
+Scalars (`ID`, `String`, `Int`, …) are never expanded.
+
+## `kind` on `search_schema`
+
+Optional filter: `OBJECT`, `INPUT_OBJECT`, `ENUM`, `SCALAR`, `INTERFACE`, `UNION`.
+
+```
+search_schema keyword="automation" kind="INPUT_OBJECT"
+```
+
+```bash
+pipefy introspect schema search automation --kind INPUT_OBJECT --json
+```
 
 ---
 
@@ -189,5 +222,6 @@ For long-running agent sessions, the MCP can reuse the fetched GraphQL schema ac
 
 ## See also
 
+- [docs/mcp/tools/introspection.md](../../../docs/mcp/tools/introspection.md) — MCP parameters, query/mutation mismatch hints on `execute_graphql`.
 - [skills/api-troubleshoot/pipefy-api-fallback/SKILL.md](../../api-troubleshoot/pipefy-api-fallback/SKILL.md) — Tier 3: direct HTTP fallback when MCP is unavailable.
 - [skills/pipes-and-cards/pipefy-pipes-and-cards/SKILL.md](../../pipes-and-cards/pipefy-pipes-and-cards/SKILL.md) — most common dedicated tools (prefer over `execute_graphql`).

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_tool_helpers.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_tool_helpers.py
@@ -5,6 +5,7 @@ from typing import Any, Literal, cast
 
 from pipefy_sdk import CardSearch, PipefyClient
 from pipefy_sdk.models.comment import MAX_COMMENT_TEXT_LENGTH
+from pipefy_sdk.models.form import ensure_valid_field_definitions
 from pydantic import ValidationError
 from typing_extensions import TypedDict
 
@@ -434,6 +435,7 @@ def _filter_fields_by_definitions(
     fields: dict[str, object] | None, field_definitions: list[dict]
 ) -> dict[str, object]:
     """Filter provided field values to editable field IDs."""
+    ensure_valid_field_definitions(field_definitions, action="filter field values")
     if not fields:
         return {}
     editable_ids = {field_def["id"] for field_def in field_definitions}

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_tool_helpers.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_tool_helpers.py
@@ -5,7 +5,6 @@ from typing import Any, Literal, cast
 
 from pipefy_sdk import CardSearch, PipefyClient
 from pipefy_sdk.models.comment import MAX_COMMENT_TEXT_LENGTH
-from pipefy_sdk.models.form import ensure_valid_field_definitions
 from pydantic import ValidationError
 from typing_extensions import TypedDict
 
@@ -435,7 +434,6 @@ def _filter_fields_by_definitions(
     fields: dict[str, object] | None, field_definitions: list[dict]
 ) -> dict[str, object]:
     """Filter provided field values to editable field IDs."""
-    ensure_valid_field_definitions(field_definitions, action="filter field values")
     if not fields:
         return {}
     editable_ids = {field_def["id"] for field_def in field_definitions}

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
@@ -159,9 +159,7 @@ class PipeTools:
                 except UserCancelledError:
                     return tool_error("Card creation cancelled by user.")
             elif expected_fields:
-                card_data = _filter_fields_by_definitions(
-                    card_data, expected_fields
-                )
+                card_data = _filter_fields_by_definitions(card_data, expected_fields)
 
             try:
                 result = await client.create_card(pipe_id, card_data)
@@ -1032,9 +1030,7 @@ class PipeTools:
                 except UserCancelledError:
                     return tool_error("Phase field update cancelled by user.")
             elif expected_fields:
-                field_data = _filter_fields_by_definitions(
-                    field_data, expected_fields
-                )
+                field_data = _filter_fields_by_definitions(field_data, expected_fields)
 
             if not field_data:
                 return {

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
@@ -17,6 +17,7 @@ from pipefy_sdk import (
     copy_card_search,
     create_form_model,
 )
+from pipefy_sdk.models.form import MalformedFieldDefinitionError
 from pydantic import ValidationError
 
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
@@ -150,10 +151,17 @@ class PipeTools:
                         expected_fields=expected_fields,
                         ctx=ctx,
                     )
+                except MalformedFieldDefinitionError as exc:
+                    return tool_error(str(exc))
                 except UserCancelledError:
                     return tool_error("Card creation cancelled by user.")
             elif expected_fields:
-                card_data = _filter_fields_by_definitions(card_data, expected_fields)
+                try:
+                    card_data = _filter_fields_by_definitions(
+                        card_data, expected_fields
+                    )
+                except MalformedFieldDefinitionError as exc:
+                    return tool_error(str(exc))
 
             try:
                 result = await client.create_card(pipe_id, card_data)
@@ -1016,10 +1024,17 @@ class PipeTools:
                         expected_fields=expected_fields,
                         ctx=ctx,
                     )
+                except MalformedFieldDefinitionError as exc:
+                    return tool_error(str(exc))
                 except UserCancelledError:
                     return tool_error("Phase field update cancelled by user.")
             elif expected_fields:
-                field_data = _filter_fields_by_definitions(field_data, expected_fields)
+                try:
+                    field_data = _filter_fields_by_definitions(
+                        field_data, expected_fields
+                    )
+                except MalformedFieldDefinitionError as exc:
+                    return tool_error(str(exc))
 
             if not field_data:
                 return {

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
@@ -129,9 +129,12 @@ class PipeTools:
                 skip_elicitation: When True, bypass interactive elicitation and send
                     ``fields`` directly to the API. Recommended for AI agent workflows.
             """
-            form_fields = await client.get_start_form_fields(
-                pipe_id, required_fields_only
-            )
+            try:
+                form_fields = await client.get_start_form_fields(
+                    pipe_id, required_fields_only
+                )
+            except MalformedFieldDefinitionError as exc:
+                return tool_error(str(exc))
 
             expected_fields = _filter_editable_field_definitions(
                 form_fields.get("start_form_fields", [])
@@ -156,12 +159,9 @@ class PipeTools:
                 except UserCancelledError:
                     return tool_error("Card creation cancelled by user.")
             elif expected_fields:
-                try:
-                    card_data = _filter_fields_by_definitions(
-                        card_data, expected_fields
-                    )
-                except MalformedFieldDefinitionError as exc:
-                    return tool_error(str(exc))
+                card_data = _filter_fields_by_definitions(
+                    card_data, expected_fields
+                )
 
             try:
                 result = await client.create_card(pipe_id, card_data)
@@ -1002,9 +1002,12 @@ class PipeTools:
             Returns:
                 dict: GraphQL response with success status and updated card information.
             """
-            phase_fields_result = await client.get_phase_fields(
-                phase_id, required_fields_only
-            )
+            try:
+                phase_fields_result = await client.get_phase_fields(
+                    phase_id, required_fields_only
+                )
+            except MalformedFieldDefinitionError as exc:
+                return tool_error(str(exc))
             expected_fields = _filter_editable_field_definitions(
                 phase_fields_result.get("fields", [])
             )
@@ -1029,12 +1032,9 @@ class PipeTools:
                 except UserCancelledError:
                     return tool_error("Phase field update cancelled by user.")
             elif expected_fields:
-                try:
-                    field_data = _filter_fields_by_definitions(
-                        field_data, expected_fields
-                    )
-                except MalformedFieldDefinitionError as exc:
-                    return tool_error(str(exc))
+                field_data = _filter_fields_by_definitions(
+                    field_data, expected_fields
+                )
 
             if not field_data:
                 return {

--- a/packages/mcp/tests/tools/test_pipe_tool_helpers.py
+++ b/packages/mcp/tests/tools/test_pipe_tool_helpers.py
@@ -9,7 +9,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pipefy_sdk import CommentInput
-from pipefy_sdk.models.form import MalformedFieldDefinitionError
 from pydantic import ValidationError
 
 from pipefy_mcp.tools.graphql_error_helpers import (
@@ -483,13 +482,6 @@ def test_filter_fields_by_definitions_keeps_only_editable_ids():
     defs = [{"id": "a", "type": "short_text"}, {"id": "c", "type": "short_text"}]
     result = _filter_fields_by_definitions(fields, defs)
     assert result == {"a": 1, "c": 3}
-
-
-@pytest.mark.unit
-def test_filter_fields_by_definitions_raises_on_malformed_definitions():
-    """Malformed definitions fail before filtering field values."""
-    with pytest.raises(MalformedFieldDefinitionError, match="filter field values"):
-        _filter_fields_by_definitions({"a": 1}, [{"label": "A", "type": "short_text"}])
 
 
 # =============================================================================

--- a/packages/mcp/tests/tools/test_pipe_tool_helpers.py
+++ b/packages/mcp/tests/tools/test_pipe_tool_helpers.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pipefy_sdk import CommentInput
+from pipefy_sdk.models.form import MalformedFieldDefinitionError
 from pydantic import ValidationError
 
 from pipefy_mcp.tools.graphql_error_helpers import (
@@ -464,14 +465,14 @@ def test_filter_editable_field_definitions_skips_non_dict():
 @pytest.mark.unit
 def test_filter_fields_by_definitions_none_returns_empty():
     """None fields returns empty dict."""
-    defs = [{"id": "a"}]
+    defs = [{"id": "a", "type": "short_text"}]
     assert _filter_fields_by_definitions(None, defs) == {}
 
 
 @pytest.mark.unit
 def test_filter_fields_by_definitions_empty_returns_empty():
     """Empty fields returns empty dict."""
-    defs = [{"id": "a"}]
+    defs = [{"id": "a", "type": "short_text"}]
     assert _filter_fields_by_definitions({}, defs) == {}
 
 
@@ -479,9 +480,16 @@ def test_filter_fields_by_definitions_empty_returns_empty():
 def test_filter_fields_by_definitions_keeps_only_editable_ids():
     """Only field IDs present in definitions are kept."""
     fields = {"a": 1, "b": 2, "c": 3}
-    defs = [{"id": "a"}, {"id": "c"}]
+    defs = [{"id": "a", "type": "short_text"}, {"id": "c", "type": "short_text"}]
     result = _filter_fields_by_definitions(fields, defs)
     assert result == {"a": 1, "c": 3}
+
+
+@pytest.mark.unit
+def test_filter_fields_by_definitions_raises_on_malformed_definitions():
+    """Malformed definitions fail before filtering field values."""
+    with pytest.raises(MalformedFieldDefinitionError, match="filter field values"):
+        _filter_fields_by_definitions({"a": 1}, [{"label": "A", "type": "short_text"}])
 
 
 # =============================================================================

--- a/packages/mcp/tests/tools/test_pipe_tools.py
+++ b/packages/mcp/tests/tools/test_pipe_tools.py
@@ -2439,10 +2439,16 @@ class TestSkipElicitation:
     async def test_create_card_skip_elicitation_returns_error_for_malformed_fields(
         self, client_session, mock_pipefy_client, pipe_id, extract_payload
     ):
-        """skip_elicitation=True still rejects malformed pipe field definitions."""
-        mock_pipefy_client.get_start_form_fields.return_value = {
-            "start_form_fields": [{"label": "Status", "type": "select"}]
-        }
+        """skip_elicitation=True surfaces SDK field-definition validation errors."""
+        from pipefy_sdk.models.field_definition import MalformedFieldDefinitionError
+
+        mock_pipefy_client.get_start_form_fields.side_effect = (
+            MalformedFieldDefinitionError(
+                "Cannot return start form fields: 1 field definition(s) from Pipefy "
+                "are missing required 'id' or 'type'. "
+                "The pipe configuration may be incomplete or unsupported."
+            )
+        )
 
         async with client_session as session:
             result = await session.call_tool(
@@ -2456,7 +2462,7 @@ class TestSkipElicitation:
 
         payload = extract_payload(result)
         assert payload.get("success") is False
-        assert "filter field values" in tool_error_message(payload).lower()
+        assert "return start form fields" in tool_error_message(payload).lower()
         mock_pipefy_client.create_card.assert_not_called()
 
     @pytest.mark.parametrize(

--- a/packages/mcp/tests/tools/test_pipe_tools.py
+++ b/packages/mcp/tests/tools/test_pipe_tools.py
@@ -173,6 +173,30 @@ class TestCreateCardTool:
             assert result.isError is False, "Unexpected tool result"
             mock_pipefy_client.create_card.assert_not_called()
 
+    @pytest.mark.parametrize(
+        "client_session",
+        [elicitation_callback_for(action="accept", content={})],
+        indirect=True,
+    )
+    async def test_create_card_returns_friendly_error_for_malformed_form_fields(
+        self,
+        client_session,
+        mock_pipefy_client,
+        pipe_id,
+        extract_payload,
+    ):
+        mock_pipefy_client.get_start_form_fields.return_value = {
+            "start_form_fields": [{"label": "Status", "type": "select"}]
+        }
+
+        async with client_session as session:
+            result = await session.call_tool("create_card", {"pipe_id": pipe_id})
+
+        payload = extract_payload(result)
+        assert payload.get("success") is False
+        assert "interactive form" in tool_error_message(payload).lower()
+        mock_pipefy_client.create_card.assert_not_called()
+
     @pytest.mark.parametrize("client_session", [None], indirect=True)
     async def test_without_elicitation(
         self,
@@ -2410,6 +2434,30 @@ class TestSkipElicitation:
         mock_pipefy_client.create_card.assert_called_once_with(
             str(pipe_id), {"f1": "a"}
         )
+
+    @pytest.mark.parametrize("client_session", [None], indirect=True)
+    async def test_create_card_skip_elicitation_returns_error_for_malformed_fields(
+        self, client_session, mock_pipefy_client, pipe_id, extract_payload
+    ):
+        """skip_elicitation=True still rejects malformed pipe field definitions."""
+        mock_pipefy_client.get_start_form_fields.return_value = {
+            "start_form_fields": [{"label": "Status", "type": "select"}]
+        }
+
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_card",
+                {
+                    "pipe_id": pipe_id,
+                    "fields": {"status": "open"},
+                    "skip_elicitation": True,
+                },
+            )
+
+        payload = extract_payload(result)
+        assert payload.get("success") is False
+        assert "filter field values" in tool_error_message(payload).lower()
+        mock_pipefy_client.create_card.assert_not_called()
 
     @pytest.mark.parametrize(
         "client_session",

--- a/packages/sdk/src/pipefy_sdk/models/field_definition.py
+++ b/packages/sdk/src/pipefy_sdk/models/field_definition.py
@@ -1,0 +1,76 @@
+"""Pipefy start-form and phase field shapes from GraphQL."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from pipefy_sdk.models.validators import NonBlankStr
+
+
+class MalformedFieldDefinitionError(ValueError):
+    """Raised when Pipefy field definitions cannot be used for forms or filtering."""
+
+
+class FieldDefinition(BaseModel):
+    """Minimum validated shape for a Pipefy field returned by GraphQL.
+
+    Extra keys (``internal_id``, ``uuid``, ``help``, etc.) are preserved so
+    callers keep the full API payload after validation.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    id: NonBlankStr
+    type: NonBlankStr
+    required: bool = False
+    label: str | None = None
+    editable: bool | None = None
+    options: list[str] | None = None
+    description: str | None = None
+    help: str | None = None
+
+
+def parse_field_definitions(
+    field_definitions: list[Any],
+    *,
+    action: str,
+) -> list[dict[str, Any]]:
+    """Validate and normalize field definitions at the SDK boundary.
+
+    Args:
+        field_definitions: Raw list from ``GET_START_FORM_FIELDS_QUERY`` /
+            ``GET_PHASE_FIELDS_QUERY`` (or test doubles).
+        action: User-facing verb phrase, e.g. ``return start form fields``.
+
+    Returns:
+        Serialized field dicts with guaranteed non-empty ``id`` and ``type``.
+
+    Raises:
+        MalformedFieldDefinitionError: When any entry is not a dict or lacks
+            ``id`` / ``type`` (including GraphQL ``null`` values).
+    """
+    if not field_definitions:
+        return []
+
+    parsed: list[dict[str, Any]] = []
+    malformed = 0
+    for raw in field_definitions:
+        if not isinstance(raw, dict):
+            malformed += 1
+            continue
+        try:
+            parsed.append(
+                FieldDefinition.model_validate(raw).model_dump(exclude_none=True)
+            )
+        except (ValidationError, TypeError):
+            malformed += 1
+
+    if malformed:
+        raise MalformedFieldDefinitionError(
+            f"Cannot {action}: {malformed} field "
+            "definition(s) from Pipefy are missing required 'id' or 'type'. "
+            "The pipe configuration may be incomplete or unsupported."
+        )
+    return parsed

--- a/packages/sdk/src/pipefy_sdk/models/field_definition.py
+++ b/packages/sdk/src/pipefy_sdk/models/field_definition.py
@@ -24,7 +24,7 @@ class FieldDefinition(BaseModel):
 
     id: NonBlankStr
     type: NonBlankStr
-    required: bool = False
+    required: bool | None = None
     label: str | None = None
     editable: bool | None = None
     options: list[str] | None = None

--- a/packages/sdk/src/pipefy_sdk/models/form.py
+++ b/packages/sdk/src/pipefy_sdk/models/form.py
@@ -1,6 +1,13 @@
+from __future__ import annotations
+
 from typing import Any
 
 from pydantic import BaseModel, Field, create_model
+
+from pipefy_sdk.models.field_definition import (
+    MalformedFieldDefinitionError,
+    parse_field_definitions,
+)
 
 FIELD_TYPES = {
     "short_text": str,
@@ -16,6 +23,29 @@ FIELD_FORMATS = {
     "datetime": "date-time",
     "email": "email",
 }
+
+__all__ = [
+    "MalformedFieldDefinitionError",
+    "create_form_model",
+    "ensure_valid_field_definitions",
+]
+
+
+def ensure_valid_field_definitions(
+    field_definitions: list,
+    *,
+    action: str,
+) -> None:
+    """Raise when field definitions lack the minimum shape for form handling.
+
+    Args:
+        field_definitions: Field definitions from Pipefy API.
+        action: User-facing verb phrase, e.g. ``build the interactive form``.
+
+    Raises:
+        MalformedFieldDefinitionError: When any definition lacks ``id`` or ``type``.
+    """
+    parse_field_definitions(field_definitions, action=action)
 
 
 def _get_default_value(
@@ -40,12 +70,19 @@ def create_form_model(
 
     Returns:
         A Pydantic model class for validating form input
+
+    Raises:
+        MalformedFieldDefinitionError: When any field definition lacks ``id`` or ``type``.
     """
+    validated_fields = parse_field_definitions(
+        field_definitions, action="build the interactive form"
+    )
+
     fields: dict[str, Any] = {}
-    for field_def in field_definitions:
+    for field_def in validated_fields:
         field_id = field_def["id"]
         field_type = field_def["type"]
-        required = field_def["required"]
+        required = field_def.get("required", False)
         options = field_def.get("options", [])
 
         pydantic_type = FIELD_TYPES.get(field_type, str)
@@ -56,7 +93,7 @@ def create_form_model(
             pydantic_type,
             Field(
                 default=default_value,
-                title=field_def["label"],
+                title=field_def.get("label") or field_id,
                 description=field_def.get("description", ""),
                 json_schema_extra=_create_json_schema_extra(
                     options, required, schema_format

--- a/packages/sdk/src/pipefy_sdk/models/form.py
+++ b/packages/sdk/src/pipefy_sdk/models/form.py
@@ -27,25 +27,7 @@ FIELD_FORMATS = {
 __all__ = [
     "MalformedFieldDefinitionError",
     "create_form_model",
-    "ensure_valid_field_definitions",
 ]
-
-
-def ensure_valid_field_definitions(
-    field_definitions: list,
-    *,
-    action: str,
-) -> None:
-    """Raise when field definitions lack the minimum shape for form handling.
-
-    Args:
-        field_definitions: Field definitions from Pipefy API.
-        action: User-facing verb phrase, e.g. ``build the interactive form``.
-
-    Raises:
-        MalformedFieldDefinitionError: When any definition lacks ``id`` or ``type``.
-    """
-    parse_field_definitions(field_definitions, action=action)
 
 
 def _get_default_value(

--- a/packages/sdk/src/pipefy_sdk/services/pipe_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/pipe_service.py
@@ -4,6 +4,7 @@ from httpx import Auth
 from rapidfuzz import fuzz
 
 from pipefy_sdk.base_client import BasePipefyClient
+from pipefy_sdk.models.field_definition import parse_field_definitions
 from pipefy_sdk.queries.pipe_queries import (
     GET_PHASE_ALLOWED_MOVES_QUERY,
     GET_PHASE_CARDS_COUNT_QUERY,
@@ -80,6 +81,9 @@ class PipeService(BasePipefyClient):
         result = await self.execute_query(GET_START_FORM_FIELDS_QUERY, variables)
 
         fields = result.get("pipe", {}).get("start_form_fields", [])
+
+        if fields:
+            fields = parse_field_definitions(fields, action="return start form fields")
 
         if not fields:
             return {
@@ -265,6 +269,9 @@ class PipeService(BasePipefyClient):
 
         phase = result.get("phase", {})
         fields = phase.get("fields", [])
+
+        if fields:
+            fields = parse_field_definitions(fields, action="return phase fields")
 
         empty_reason = ""
 

--- a/packages/sdk/tests/models/test_field_definition.py
+++ b/packages/sdk/tests/models/test_field_definition.py
@@ -33,6 +33,15 @@ def test_parse_field_definitions_preserves_extra_keys():
 
 
 @pytest.mark.unit
+def test_parse_field_definitions_accepts_null_required():
+    parsed = parse_field_definitions(
+        [{"id": "title", "type": "short_text", "required": None}],
+        action="test",
+    )
+    assert "required" not in parsed[0]
+
+
+@pytest.mark.unit
 def test_parse_field_definitions_raises_with_action():
     with pytest.raises(MalformedFieldDefinitionError, match="filter phase fields"):
         parse_field_definitions(

--- a/packages/sdk/tests/models/test_field_definition.py
+++ b/packages/sdk/tests/models/test_field_definition.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+
+from pipefy_sdk.models.field_definition import (
+    MalformedFieldDefinitionError,
+    parse_field_definitions,
+)
+
+
+@pytest.mark.unit
+def test_parse_field_definitions_rejects_null_id():
+    with pytest.raises(MalformedFieldDefinitionError):
+        parse_field_definitions(
+            [{"id": None, "type": "select"}],
+            action="validate fields",
+        )
+
+
+@pytest.mark.unit
+def test_parse_field_definitions_preserves_extra_keys():
+    raw = [
+        {
+            "id": "title",
+            "type": "short_text",
+            "internal_id": "99",
+            "uuid": "abc",
+        }
+    ]
+    parsed = parse_field_definitions(raw, action="test")
+    assert parsed[0]["internal_id"] == "99"
+    assert parsed[0]["uuid"] == "abc"
+
+
+@pytest.mark.unit
+def test_parse_field_definitions_raises_with_action():
+    with pytest.raises(MalformedFieldDefinitionError, match="filter phase fields"):
+        parse_field_definitions(
+            [{"label": "Status", "type": "select"}],
+            action="filter phase fields",
+        )

--- a/packages/sdk/tests/models/test_form.py
+++ b/packages/sdk/tests/models/test_form.py
@@ -1,6 +1,10 @@
 import pytest
 
-from pipefy_sdk.models.form import create_form_model
+from pipefy_sdk.models.form import (
+    MalformedFieldDefinitionError,
+    create_form_model,
+    ensure_valid_field_definitions,
+)
 
 
 @pytest.mark.unit
@@ -154,3 +158,47 @@ def test_form_model_with_default_values():
     description_field_no_default = FormModelWithoutDefaults.model_fields["description"]
     assert description_field_no_default.is_required() is False
     assert description_field_no_default.get_default() is None
+
+
+@pytest.mark.unit
+def test_create_form_model_raises_on_malformed_field_definitions():
+    """Malformed API field shapes return a clear error instead of crashing (issue #30)."""
+    field_definitions = [
+        {"label": "Status", "type": "select"},
+        "not a dict",
+        None,
+        {"id": "name", "type": "short_text", "label": "Name", "required": True},
+    ]
+
+    with pytest.raises(MalformedFieldDefinitionError, match="3 field definition"):
+        create_form_model(field_definitions)
+
+
+@pytest.mark.unit
+def test_create_form_model_raises_when_all_definitions_malformed():
+    """All-malformed input must fail before building an empty interactive form."""
+    with pytest.raises(MalformedFieldDefinitionError, match="1 field definition"):
+        create_form_model([{"label": "Status", "type": "select"}])
+
+
+@pytest.mark.unit
+def test_ensure_valid_field_definitions_uses_action_in_message():
+    """Shared validator includes the caller action in the error message."""
+    with pytest.raises(MalformedFieldDefinitionError, match="filter field values"):
+        ensure_valid_field_definitions(
+            [{"label": "Status", "type": "select"}],
+            action="filter field values",
+        )
+
+
+@pytest.mark.unit
+def test_create_form_model_uses_field_id_as_label_fallback():
+    """Fields without label still produce a valid model using id as title."""
+    field_definitions = [
+        {"id": "status", "type": "select", "required": False},
+    ]
+
+    FormModel = create_form_model(field_definitions)
+
+    assert "status" in FormModel.model_fields
+    assert FormModel.model_fields["status"].title == "status"

--- a/packages/sdk/tests/models/test_form.py
+++ b/packages/sdk/tests/models/test_form.py
@@ -3,7 +3,6 @@ import pytest
 from pipefy_sdk.models.form import (
     MalformedFieldDefinitionError,
     create_form_model,
-    ensure_valid_field_definitions,
 )
 
 
@@ -179,16 +178,6 @@ def test_create_form_model_raises_when_all_definitions_malformed():
     """All-malformed input must fail before building an empty interactive form."""
     with pytest.raises(MalformedFieldDefinitionError, match="1 field definition"):
         create_form_model([{"label": "Status", "type": "select"}])
-
-
-@pytest.mark.unit
-def test_ensure_valid_field_definitions_uses_action_in_message():
-    """Shared validator includes the caller action in the error message."""
-    with pytest.raises(MalformedFieldDefinitionError, match="filter field values"):
-        ensure_valid_field_definitions(
-            [{"label": "Status", "type": "select"}],
-            action="filter field values",
-        )
 
 
 @pytest.mark.unit

--- a/packages/sdk/tests/services/test_pipe_service.py
+++ b/packages/sdk/tests/services/test_pipe_service.py
@@ -114,8 +114,8 @@ async def test_get_start_form_fields_required_only_filters_and_returns_message_w
     """Test get_start_form_fields with required_only=True returns message when all optional."""
     pipe_id = 303181849
     mock_fields = [
-        {"id": "priority", "required": False},
-        {"id": "notes", "required": False},
+        {"id": "priority", "type": "select", "required": False},
+        {"id": "notes", "type": "long_text", "required": False},
     ]
 
     service = _make_service(mock_settings, {"pipe": {"start_form_fields": mock_fields}})
@@ -129,25 +129,37 @@ async def test_get_start_form_fields_required_only_filters_and_returns_message_w
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_get_start_form_fields_raises_on_malformed_graphql_fields(mock_settings):
+    """Null or missing id/type from GraphQL are rejected at the SDK boundary."""
+    from pipefy_sdk.models.field_definition import MalformedFieldDefinitionError
+
+    pipe_id = 303181849
+    mock_fields = [{"id": None, "type": "select", "label": "Status"}]
+
+    service = _make_service(mock_settings, {"pipe": {"start_form_fields": mock_fields}})
+
+    with pytest.raises(MalformedFieldDefinitionError, match="return start form fields"):
+        await service.get_start_form_fields(pipe_id)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_get_start_form_fields_required_only_returns_only_required(mock_settings):
     """Test get_start_form_fields with required_only=True filters correctly."""
     pipe_id = 303181849
     mock_fields = [
-        {"id": "title", "required": True},
-        {"id": "priority", "required": False},
-        {"id": "due_date", "required": True},
+        {"id": "title", "type": "short_text", "required": True},
+        {"id": "priority", "type": "select", "required": False},
+        {"id": "due_date", "type": "date", "required": True},
     ]
 
     service = _make_service(mock_settings, {"pipe": {"start_form_fields": mock_fields}})
     result = await service.get_start_form_fields(pipe_id, required_only=True)
 
-    expected_fields = [
-        {"id": "title", "required": True},
-        {"id": "due_date", "required": True},
-    ]
-    assert result == {"start_form_fields": expected_fields}, (
-        "Expected only required fields"
-    )
+    assert len(result["start_form_fields"]) == 2
+    assert {f["id"] for f in result["start_form_fields"]} == {"title", "due_date"}
+    assert all(f["type"] for f in result["start_form_fields"])
+    assert all(f["required"] for f in result["start_form_fields"])
 
 
 @pytest.fixture

--- a/skills/introspection/pipefy-introspection/SKILL.md
+++ b/skills/introspection/pipefy-introspection/SKILL.md
@@ -24,10 +24,10 @@ This is **Tier 2** in the resolution strategy: when a dedicated MCP tool fails o
 
 | Tool (MCP) | CLI | Read-only | Purpose |
 |------------|-----|-----------|---------|
-| `introspect_type` | `pipefy introspect type` | Yes | Discover a type's shape: `fields`, `inputFields`, `enumValues`. |
-| `introspect_query` | `pipefy introspect query` | Yes | Get a query's argument types and return shape. |
-| `introspect_mutation` | `pipefy introspect mutation` | Yes | Get a mutation's argument types and return shape. |
-| `search_schema` | `pipefy introspect schema search` | Yes | Keyword search across type / query / mutation names. |
+| `introspect_type` | `pipefy introspect type` | Yes | Type shape: `fields`, `inputFields`, `enumValues`. Optional `max_depth`. |
+| `introspect_query` | `pipefy introspect query` | Yes | Root query arguments and return type. Optional `max_depth`. |
+| `introspect_mutation` | `pipefy introspect mutation` | Yes | Root mutation arguments and return type. Optional `max_depth`. |
+| `search_schema` | `pipefy introspect schema search` | Yes | Keyword search on type names/descriptions. Optional `kind` filter. |
 | `execute_graphql` | `pipefy graphql exec` | No | Execute arbitrary GraphQL (`--yes` required for mutations). |
 | `get_organization` | `pipefy org get` | Yes | Load organization info (name, plan, UUID, member count, pipe count). |
 
@@ -41,6 +41,39 @@ This is **Tier 2** in the resolution strategy: when a dedicated MCP tool fails o
 - **`true`:** response includes **both** `result` (the raw JSON string) AND `data` (the parsed dict). Drill into `data` programmatically; keep `result` to forward verbatim.
 
 Use `include_parsed=true` whenever you plan to read nested fields (e.g. iterating over `phases[].fields[]`). Leave it off for one-shot reads where the raw string is sufficient.
+
+## `max_depth` (introspect_type / query / mutation)
+
+MCP tools accept `max_depth` (default `1`). CLI: `--max-depth`.
+
+- **`1`** — type/field info only (no inlined sub-types).
+- **`2+`** — resolves referenced input/output types inline (`resolvedType`), so one call can replace introspecting the mutation then each input type separately.
+
+Example (CLI):
+
+```bash
+pipefy introspect mutation createCard --max-depth 2 --json
+```
+
+Example (MCP):
+
+```
+introspect_mutation mutation_name="createCard" max_depth=2 include_parsed=true
+```
+
+Scalars (`ID`, `String`, `Int`, …) are never expanded.
+
+## `kind` on `search_schema`
+
+Optional filter: `OBJECT`, `INPUT_OBJECT`, `ENUM`, `SCALAR`, `INTERFACE`, `UNION`.
+
+```
+search_schema keyword="automation" kind="INPUT_OBJECT"
+```
+
+```bash
+pipefy introspect schema search automation --kind INPUT_OBJECT --json
+```
 
 ---
 
@@ -189,5 +222,6 @@ For long-running agent sessions, the MCP can reuse the fetched GraphQL schema ac
 
 ## See also
 
+- [docs/mcp/tools/introspection.md](../../../docs/mcp/tools/introspection.md) — MCP parameters, query/mutation mismatch hints on `execute_graphql`.
 - [skills/api-troubleshoot/pipefy-api-fallback/SKILL.md](../../api-troubleshoot/pipefy-api-fallback/SKILL.md) — Tier 3: direct HTTP fallback when MCP is unavailable.
 - [skills/pipes-and-cards/pipefy-pipes-and-cards/SKILL.md](../../pipes-and-cards/pipefy-pipes-and-cards/SKILL.md) — most common dedicated tools (prefer over `execute_graphql`).


### PR DESCRIPTION
## Summary
- Introduce `MalformedFieldDefinitionError` and `ensure_valid_field_definitions()` in the SDK.
- `create_form_model` fails fast with a clear message when Pipefy returns incomplete field shapes (`id` / `type` missing, non-dict entries).
- MCP tools `create_card` and `fill_card_phase_fields` return `tool_error` on both elicitation and `skip_elicitation` paths.
- Fields without `label` still work (fallback to `field_id` as title).

Closes #30

Follow-up improvements tracked in a separate issue (field-filter gap, comment parsing, automation false success, etc.).

## Test plan
- [x] `uv run pytest packages/sdk/tests/models/test_form.py -v`
- [x] `uv run pytest packages/mcp/tests/tools/test_pipe_tool_helpers.py -k filter_fields`
- [x] `uv run pytest packages/mcp/tests/tools/test_pipe_tools.py -k malformed`
- [x] `uv run ruff check .`
- [x] CI green (lint + test)