### PR TITLE
refactor(cli): drop the `resolve_pipefy_settings` wrapper

### DIFF
--- a/packages/cli/src/pipefy_cli/config.py
+++ b/packages/cli/src/pipefy_cli/config.py
@@ -154,26 +154,6 @@ def resolve_cli_settings(
     return cli.model_copy(update={"pipefy": pipefy})
 
 
-def resolve_pipefy_settings(
-    *,
-    graphql_url_flag: str | None,
-    allow_insecure_urls_flag: bool | None,
-) -> PipefySettings:
-    """Merge env, ``.env``, optional user TOML, then CLI flags (flags win).
-
-    Thin wrapper around :func:`resolve_cli_settings` that returns only the
-    nested ``PipefySettings`` (same shape as MCP ``settings.pipefy``). Kept for
-    callers that don't need the auth fields.
-
-    Raises:
-        ValueError: When validation fails (e.g. SSRF guard); message is user-facing.
-    """
-    return resolve_cli_settings(
-        graphql_url_flag=graphql_url_flag,
-        allow_insecure_urls_flag=allow_insecure_urls_flag,
-    ).pipefy
-
-
 def ensure_public_graphql_configured(pipefy: PipefySettings) -> None:
     """Ensure GraphQL URL is present before building a client.
 
@@ -205,8 +185,7 @@ __all__ = [
     "DEFAULT_AUTH_CLIENT_ID",
     "USER_CONFIG_PATH",
     "apply_toml_fallback",
-    "resolve_cli_settings",
     "describe_missing_oauth_vars",
     "ensure_public_graphql_configured",
-    "resolve_pipefy_settings",
+    "resolve_cli_settings",
 ]

--- a/packages/cli/tests/test_config.py
+++ b/packages/cli/tests/test_config.py
@@ -12,7 +12,6 @@ from pipefy_cli.config import (
     apply_toml_fallback,
     ensure_public_graphql_configured,
     resolve_cli_settings,
-    resolve_pipefy_settings,
 )
 
 
@@ -33,10 +32,10 @@ def test_env_only_resolution(
     monkeypatch.setenv("PIPEFY_OAUTH_CLIENT", "env-client")
     monkeypatch.setenv("PIPEFY_OAUTH_SECRET", "env-secret")
 
-    resolved = resolve_pipefy_settings(
+    resolved = resolve_cli_settings(
         graphql_url_flag=None,
         allow_insecure_urls_flag=None,
-    )
+    ).pipefy
 
     assert resolved.graphql_url == "https://env-only.example.com/graphql"
     assert resolved.internal_api_url == "https://env-only.example.com/internal_api"
@@ -64,10 +63,10 @@ def test_dotenv_only_resolution(
         encoding="utf-8",
     )
 
-    resolved = resolve_pipefy_settings(
+    resolved = resolve_cli_settings(
         graphql_url_flag=None,
         allow_insecure_urls_flag=None,
-    )
+    ).pipefy
 
     assert resolved.graphql_url == "https://dotenv.example.com/graphql"
     assert resolved.oauth_client == "dotenv-client"
@@ -88,10 +87,10 @@ def test_process_env_overrides_dotenv(
         "https://from-process.example.com/graphql",
     )
 
-    resolved = resolve_pipefy_settings(
+    resolved = resolve_cli_settings(
         graphql_url_flag=None,
         allow_insecure_urls_flag=None,
-    )
+    ).pipefy
 
     assert resolved.graphql_url == "https://from-process.example.com/graphql"
 
@@ -106,10 +105,10 @@ def test_graphql_url_flag_overrides_env(
         "https://from-env.example.com/graphql",
     )
 
-    resolved = resolve_pipefy_settings(
+    resolved = resolve_cli_settings(
         graphql_url_flag="https://from-flag.example.com/graphql",
         allow_insecure_urls_flag=None,
-    )
+    ).pipefy
 
     assert resolved.graphql_url == "https://from-flag.example.com/graphql"
 
@@ -118,10 +117,10 @@ def test_missing_graphql_url_error_points_to_setup_docs(
     clean_pipefy_env,
     saved_cwd,
 ):
-    resolved = resolve_pipefy_settings(
+    resolved = resolve_cli_settings(
         graphql_url_flag=None,
         allow_insecure_urls_flag=None,
-    )
+    ).pipefy
 
     with pytest.raises(ValueError, match="docs/setup\\.md"):
         ensure_public_graphql_configured(resolved)
@@ -147,10 +146,10 @@ def test_allow_insecure_urls_flag_overrides_env(
     monkeypatch.setenv("PIPEFY_ALLOW_INSECURE_URLS", "false")
     monkeypatch.setenv("PIPEFY_GRAPHQL_URL", "http://127.0.0.1:9999/graphql")
 
-    resolved = resolve_pipefy_settings(
+    resolved = resolve_cli_settings(
         graphql_url_flag=None,
         allow_insecure_urls_flag=True,
-    )
+    ).pipefy
 
     assert resolved.allow_insecure_urls is True
     assert resolved.graphql_url == "http://127.0.0.1:9999/graphql"
@@ -175,10 +174,10 @@ def test_user_toml_fallback_lowest_precedence(
     )
     monkeypatch.setattr(config_module, "USER_CONFIG_PATH", cfg_path)
 
-    resolved = resolve_pipefy_settings(
+    resolved = resolve_cli_settings(
         graphql_url_flag=None,
         allow_insecure_urls_flag=None,
-    )
+    ).pipefy
 
     assert resolved.graphql_url == "https://from-toml.example.com/graphql"
     assert resolved.oauth_client == "toml-client"
@@ -207,10 +206,10 @@ def test_env_overrides_user_toml(
         "https://from-env.example.com/graphql",
     )
 
-    resolved = resolve_pipefy_settings(
+    resolved = resolve_cli_settings(
         graphql_url_flag=None,
         allow_insecure_urls_flag=None,
-    )
+    ).pipefy
 
     assert resolved.graphql_url == "https://from-env.example.com/graphql"
 
@@ -247,7 +246,7 @@ def test_graphql_url_flag_localhost_rejected_without_insecure(
     saved_cwd,
 ):
     with pytest.raises(ValueError, match="HTTPS|http"):
-        resolve_pipefy_settings(
+        resolve_cli_settings(
             graphql_url_flag="http://localhost/graphql",
             allow_insecure_urls_flag=None,
         )
@@ -257,10 +256,10 @@ def test_graphql_url_flag_localhost_allowed_with_insecure_flag(
     clean_pipefy_env,
     saved_cwd,
 ):
-    resolved = resolve_pipefy_settings(
+    resolved = resolve_cli_settings(
         graphql_url_flag="http://localhost/graphql",
         allow_insecure_urls_flag=True,
-    )
+    ).pipefy
     assert resolved.graphql_url == "http://localhost/graphql"
     assert resolved.allow_insecure_urls is True
 
@@ -279,7 +278,7 @@ def test_toml_private_graphql_url_rejected(clean_pipefy_env, saved_cwd, monkeypa
     monkeypatch.setattr(config_module, "USER_CONFIG_PATH", cfg_path)
 
     with pytest.raises(ValueError):
-        resolve_pipefy_settings(
+        resolve_cli_settings(
             graphql_url_flag=None,
             allow_insecure_urls_flag=None,
         )
@@ -295,7 +294,7 @@ def test_corrupt_user_config_toml_raises_actionable_error(
     monkeypatch.setattr(config_module, "USER_CONFIG_PATH", cfg_path)
 
     with pytest.raises(ValueError, match="docs/setup"):
-        resolve_pipefy_settings(
+        resolve_cli_settings(
             graphql_url_flag=None,
             allow_insecure_urls_flag=None,
         )


### PR DESCRIPTION
Closes #129.

## Summary

``resolve_pipefy_settings`` was kept as a thin wrapper around ``resolve_cli_settings`` during PR #125's simplify pass to avoid touching test scaffolding in the same commit. Now that #125 has landed, the wrapper has **zero production callers** and only exists to feed 13 ``test_config.py`` callsites. The shim is dead surface and its name falsely suggests a parallel resolution path.

## Changes

- Deleted ``resolve_pipefy_settings`` from ``packages/cli/src/pipefy_cli/config.py`` (function body + ``__all__`` entry).
- Migrated 9 ``resolved = resolve_pipefy_settings(...)`` assignment callsites in ``test_config.py`` to ``resolved = resolve_cli_settings(...).pipefy``.
- Migrated 3 ``with pytest.raises(...): resolve_pipefy_settings(...)`` callsites to ``resolve_cli_settings(...)`` (return value unused; no ``.pipefy`` needed).

## Verification

- ``grep -rn resolve_pipefy_settings packages/`` → no matches.
- 2 files / +22 / −44.

## Test plan

- [x] ``uv run pytest -m "not integration"`` — 2205 passed, 42 deselected
- [x] ``uv run ruff check packages/cli`` — clean
- [x] ``uv run ruff format --check packages/cli`` — clean