### PR TITLE
feat(cli): wire stored auth-login session into `get_authenticated_client`

### DIFF
--- a/packages/cli/src/pipefy_cli/auth.py
+++ b/packages/cli/src/pipefy_cli/auth.py
@@ -1,4 +1,15 @@
-"""Build an authenticated :class:`PipefyClient` from CLI configuration (OAuth or ``--token``)."""
+"""Build an authenticated :class:`PipefyClient` from CLI configuration.
+
+The precedence chain — most explicit wins:
+
+1. ``bearer_token`` arg (CLI ``--token`` flag or ``PIPEFY_TOKEN`` env).
+2. ``PIPEFY_OAUTH_*`` triple → client-credentials grant (service account).
+3. Stored user session from ``pipefy auth login`` (keychain) — refreshed
+   eagerly when the access token is within the leeway window.
+
+The cache key includes whichever bearer ultimately reaches the SDK, so a
+refresh-rotated access token naturally invalidates the cached client.
+"""
 
 from __future__ import annotations
 
@@ -15,6 +26,7 @@ from pipefy_cli.config import (
     describe_missing_oauth_vars,
     ensure_public_graphql_configured,
 )
+from pipefy_cli.oauth import RefreshError, ensure_fresh_session
 
 _cached_signature: tuple[object, ...] | None = None
 # One-shot CLIs reuse this; long-lived programmatic use should call
@@ -44,26 +56,39 @@ def _cache_key(
     )
 
 
+def _missing_auth_message(pipefy_settings: PipefySettings) -> str:
+    missing = describe_missing_oauth_vars(pipefy_settings)
+    return (
+        "Missing authentication. Use --token, set PIPEFY_TOKEN, configure "
+        f"PIPEFY_OAUTH_* ({missing}), or run `pipefy auth login`. "
+        f"See {DOCS_SETUP_REF}."
+    )
+
+
 def get_authenticated_client(
     pipefy_settings: PipefySettings,
     *,
     bearer_token: str | None = None,
+    auth_url: str | None = None,
+    auth_client_id: str | None = None,
 ) -> PipefyClient:
-    """Return a facade client using OAuth client-credentials or a static bearer token.
-
-    Uses the same OAuth wiring as ``pipefy-mcp-server`` via :class:`PipefyClient`
-    (``httpx_auth.OAuth2ClientCredentials`` when no bearer is supplied).
+    """Return a facade client using the highest-precedence available auth source.
 
     Args:
         pipefy_settings: Validated Pipefy endpoint settings (``PIPEFY_*``).
-        bearer_token: When set, skips OAuth and uses this bearer for GraphQL transports.
+        bearer_token: When set (``--token`` / ``PIPEFY_TOKEN``), skips OAuth and
+            uses this bearer directly. Highest precedence.
+        auth_url: Issuer URL for the stored user session lookup. From
+            ``PIPEFY_AUTH_URL``.
+        auth_client_id: Public client id for the stored session lookup.
 
     Returns:
-        Shared in-process instance when settings match a prior call; otherwise a new
-        client. Tokens are not written to disk.
+        Shared in-process instance when settings match a prior call; otherwise
+        a new client.
 
     Raises:
-        typer.Exit: Code 2 when configuration is incomplete for the chosen auth mode.
+        typer.Exit: Code 2 when no auth source resolves, or when a stored
+            session exists but refresh failed.
     """
     global _cached_signature, _cached_client
 
@@ -73,27 +98,45 @@ def get_authenticated_client(
         typer.echo(str(exc), err=True)
         raise typer.Exit(2) from exc
 
-    key = _cache_key(pipefy_settings, bearer_token)
+    # Resolve the effective bearer BEFORE the cache lookup so a refresh-rotated
+    # access token produces the right (new) cache signature.
+    effective_bearer = bearer_token
+    if not effective_bearer and describe_missing_oauth_vars(pipefy_settings):
+        if auth_url and auth_client_id:
+            try:
+                session = ensure_fresh_session(
+                    issuer=auth_url, client_id=auth_client_id
+                )
+            except RefreshError as exc:
+                typer.echo(
+                    f"Stored Pipefy session could not be refreshed: {exc}. "
+                    "Run `pipefy auth login` to sign in again.",
+                    err=True,
+                )
+                raise typer.Exit(2) from exc
+            if session is not None:
+                effective_bearer = session.access_token
+
+    key = _cache_key(pipefy_settings, effective_bearer)
     if _cached_client is not None and _cached_signature == key:
         return _cached_client
 
-    if bearer_token:
+    if effective_bearer:
+        # Priorities 1, 2, and 4 collapse to "use a static bearer".
+        # The bearer slot does not build an InternalApiClient — same
+        # limitation as ``--token``/``PIPEFY_TOKEN`` today.
         client: PipefyClient = PipefyClient(
-            pipefy_settings, bearer_token=bearer_token.strip()
+            pipefy_settings, bearer_token=effective_bearer.strip()
         )
         _cached_signature = key
         _cached_client = client
         return client
 
-    missing_msg = describe_missing_oauth_vars(pipefy_settings)
-    if missing_msg:
-        typer.echo(
-            f"Missing OAuth configuration ({missing_msg}). "
-            f"Use --token or PIPEFY_TOKEN for a bearer token, or set OAuth per {DOCS_SETUP_REF}.",
-            err=True,
-        )
+    if describe_missing_oauth_vars(pipefy_settings):
+        typer.echo(_missing_auth_message(pipefy_settings), err=True)
         raise typer.Exit(2)
 
+    # Priority 3: client-credentials grant.
     client = PipefyClient(pipefy_settings)
     internal_client = InternalApiClient(
         url=pipefy_settings.internal_api_url,

--- a/packages/cli/src/pipefy_cli/auth.py
+++ b/packages/cli/src/pipefy_cli/auth.py
@@ -98,24 +98,23 @@ def get_authenticated_client(
         typer.echo(str(exc), err=True)
         raise typer.Exit(2) from exc
 
+    missing_oauth = describe_missing_oauth_vars(pipefy_settings)
+
     # Resolve the effective bearer BEFORE the cache lookup so a refresh-rotated
     # access token produces the right (new) cache signature.
     effective_bearer = bearer_token
-    if not effective_bearer and describe_missing_oauth_vars(pipefy_settings):
-        if auth_url and auth_client_id:
-            try:
-                session = ensure_fresh_session(
-                    issuer=auth_url, client_id=auth_client_id
-                )
-            except RefreshError as exc:
-                typer.echo(
-                    f"Stored Pipefy session could not be refreshed: {exc}. "
-                    "Run `pipefy auth login` to sign in again.",
-                    err=True,
-                )
-                raise typer.Exit(2) from exc
-            if session is not None:
-                effective_bearer = session.access_token
+    if not effective_bearer and missing_oauth and auth_url and auth_client_id:
+        try:
+            session = ensure_fresh_session(issuer=auth_url, client_id=auth_client_id)
+        except RefreshError as exc:
+            typer.echo(
+                f"Stored Pipefy session could not be refreshed: {exc}. "
+                "Run `pipefy auth login` to sign in again.",
+                err=True,
+            )
+            raise typer.Exit(2) from exc
+        if session is not None:
+            effective_bearer = session.access_token
 
     key = _cache_key(pipefy_settings, effective_bearer)
     if _cached_client is not None and _cached_signature == key:
@@ -132,7 +131,7 @@ def get_authenticated_client(
         _cached_client = client
         return client
 
-    if describe_missing_oauth_vars(pipefy_settings):
+    if missing_oauth:
         typer.echo(_missing_auth_message(pipefy_settings), err=True)
         raise typer.Exit(2)
 

--- a/packages/cli/src/pipefy_cli/auth.py
+++ b/packages/cli/src/pipefy_cli/auth.py
@@ -1,14 +1,18 @@
 """Build an authenticated :class:`PipefyClient` from CLI configuration.
 
-The precedence chain — most explicit wins:
+The credential precedence chain (most explicit wins) is:
 
-1. ``bearer_token`` arg (CLI ``--token`` flag or ``PIPEFY_TOKEN`` env).
-2. ``PIPEFY_OAUTH_*`` triple → client-credentials grant (service account).
-3. Stored user session from ``pipefy auth login`` (keychain) — refreshed
-   eagerly when the access token is within the leeway window.
+1. ``--token`` CLI flag
+2. ``PIPEFY_TOKEN`` env var
+3. ``PIPEFY_OAUTH_*`` triple → client-credentials grant (service account)
+4. Stored user session from ``pipefy auth login`` (keychain) — refreshed
+   eagerly when the access token is within the leeway window
 
-The cache key includes whichever bearer ultimately reaches the SDK, so a
-refresh-rotated access token naturally invalidates the cached client.
+Tiers 1 and 2 reach this function collapsed into a single ``bearer_token``
+argument (resolved by the root Typer callback in ``main.py``); tier 4
+resolves into the same slot. The cache key includes whichever bearer
+ultimately reaches the SDK, so a refresh-rotated access token naturally
+invalidates the cached client.
 """
 
 from __future__ import annotations

--- a/packages/cli/src/pipefy_cli/auth.py
+++ b/packages/cli/src/pipefy_cli/auth.py
@@ -8,14 +8,15 @@ The credential precedence chain (most explicit wins) is:
 4. Stored user session from ``pipefy auth login`` (keychain) — refreshed
    eagerly when the access token is within the leeway window
 
-Tiers 1 and 2 reach this function collapsed into a single ``bearer_token``
-argument (resolved by the root Typer callback in ``main.py``); tier 4
-resolves into the same slot. The cache key includes whichever bearer
-ultimately reaches the SDK, so a refresh-rotated access token naturally
-invalidates the cached client.
+Tiers 1 and 2 reach this function collapsed into ``AuthContext.bearer_token``
+(resolved by the root Typer callback in ``main.py``); tier 4 resolves into
+the same slot. The cache key includes whichever bearer ultimately reaches the
+SDK, so a refresh-rotated access token naturally invalidates the cached client.
 """
 
 from __future__ import annotations
+
+from dataclasses import dataclass
 
 import typer
 from pipefy_sdk import (
@@ -31,6 +32,32 @@ from pipefy_cli.config import (
     ensure_public_graphql_configured,
 )
 from pipefy_cli.oauth import RefreshError, ensure_fresh_session
+
+
+@dataclass(frozen=True)
+class OidcClient:
+    """OIDC client identity: issuer URL + the public client id registered there.
+
+    The two fields are a single configurable unit; presence of an :class:`OidcClient`
+    on :class:`AuthContext` is what gates tier 4 of the credential precedence chain.
+    """
+
+    issuer_url: str
+    client_id: str
+
+
+@dataclass(frozen=True)
+class AuthContext:
+    """User-auth identity for a single CLI invocation.
+
+    Carries only identity. Where-to-call configuration (URLs, service-account
+    credentials, ``allow_insecure_urls``) lives on :class:`PipefySettings` and is
+    passed alongside.
+    """
+
+    bearer_token: str | None
+    oidc_client: OidcClient | None
+
 
 _cached_signature: tuple[object, ...] | None = None
 # One-shot CLIs reuse this; long-lived programmatic use should call
@@ -71,20 +98,17 @@ def _missing_auth_message(pipefy_settings: PipefySettings) -> str:
 
 def get_authenticated_client(
     pipefy_settings: PipefySettings,
-    *,
-    bearer_token: str | None = None,
-    auth_url: str | None = None,
-    auth_client_id: str | None = None,
+    auth: AuthContext,
 ) -> PipefyClient:
     """Return a facade client using the highest-precedence available auth source.
 
     Args:
         pipefy_settings: Validated Pipefy endpoint settings (``PIPEFY_*``).
-        bearer_token: When set (``--token`` / ``PIPEFY_TOKEN``), skips OAuth and
-            uses this bearer directly. Highest precedence.
-        auth_url: Issuer URL for the stored user session lookup. From
-            ``PIPEFY_AUTH_URL``.
-        auth_client_id: Public client id for the stored session lookup.
+        auth: User-auth identity for this invocation. ``bearer_token`` covers
+            tiers 1 and 2 (``--token`` / ``PIPEFY_TOKEN``); ``oidc_client`` covers
+            tier 4 (stored user session keyed by issuer + client id). Tier 3
+            (service-account client credentials) is resolved from
+            ``pipefy_settings`` alone.
 
     Returns:
         Shared in-process instance when settings match a prior call; otherwise
@@ -106,10 +130,13 @@ def get_authenticated_client(
 
     # Resolve the effective bearer BEFORE the cache lookup so a refresh-rotated
     # access token produces the right (new) cache signature.
-    effective_bearer = bearer_token
-    if not effective_bearer and missing_oauth and auth_url and auth_client_id:
+    effective_bearer = auth.bearer_token
+    if not effective_bearer and missing_oauth and auth.oidc_client is not None:
         try:
-            session = ensure_fresh_session(issuer=auth_url, client_id=auth_client_id)
+            session = ensure_fresh_session(
+                issuer=auth.oidc_client.issuer_url,
+                client_id=auth.oidc_client.client_id,
+            )
         except RefreshError as exc:
             typer.echo(
                 f"Stored Pipefy session could not be refreshed: {exc}. "
@@ -156,6 +183,8 @@ def get_authenticated_client(
 
 
 __all__ = [
+    "AuthContext",
+    "OidcClient",
     "clear_authenticated_client_cache",
     "get_authenticated_client",
 ]

--- a/packages/cli/src/pipefy_cli/commands/_common.py
+++ b/packages/cli/src/pipefy_cli/commands/_common.py
@@ -7,6 +7,7 @@ import json
 import math
 import sys
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from typing import Any, TypeVar
 
 import typer
@@ -16,6 +17,17 @@ from pipefy_sdk.exceptions import PipefyError
 
 from pipefy_cli.auth import get_authenticated_client
 from pipefy_cli.output import render_json, render_rich
+
+
+@dataclass(frozen=True)
+class AuthContext:
+    """All four credential-resolution inputs the auth boundary needs."""
+
+    settings: PipefySettings
+    bearer_token: str | None
+    auth_url: str | None
+    auth_client_id: str | None
+
 
 _T = TypeVar("_T")
 _R = TypeVar("_R")
@@ -142,10 +154,15 @@ def run_pipefy_client_coroutine(
     Raises:
         typer.Exit: On :class:`PipefyError` (exit code 1), optional ``ValueError`` mapping, or ``BrokenPipeError`` (exit 0).
     """
-    pipefy_settings, token = settings_and_token(ctx)
+    auth = auth_context_from_ctx(ctx)
 
     async def _run() -> _T:
-        client = get_authenticated_client(pipefy_settings, bearer_token=token)
+        client = get_authenticated_client(
+            auth.settings,
+            bearer_token=auth.bearer_token,
+            auth_url=auth.auth_url,
+            auth_client_id=auth.auth_client_id,
+        )
         return await coro_factory(client)
 
     try:
@@ -200,10 +217,26 @@ def settings_and_token(ctx: typer.Context) -> tuple[PipefySettings, str | None]:
     return obj["pipefy_settings"], obj.get("token")
 
 
+def auth_context_from_ctx(ctx: typer.Context) -> AuthContext:
+    """Resolve root ``ctx.obj`` into the full auth surface for the auth boundary."""
+    obj = ctx.find_root().obj
+    return AuthContext(
+        settings=obj["pipefy_settings"],
+        bearer_token=obj.get("token"),
+        auth_url=obj.get("auth_url"),
+        auth_client_id=obj.get("auth_client_id"),
+    )
+
+
 def authenticated_client_from_ctx(ctx: typer.Context) -> PipefyClient:
     """Build a :class:`PipefyClient` using the same auth path as ``run_cli_command``."""
-    pipefy_settings, token = settings_and_token(ctx)
-    return get_authenticated_client(pipefy_settings, bearer_token=token)
+    auth = auth_context_from_ctx(ctx)
+    return get_authenticated_client(
+        auth.settings,
+        bearer_token=auth.bearer_token,
+        auth_url=auth.auth_url,
+        auth_client_id=auth.auth_client_id,
+    )
 
 
 def parse_json_value(raw: str | None, option_name: str) -> Any:
@@ -252,11 +285,16 @@ def run_cli_command(
         format_transport_query_error: Optional override for GraphQL transport errors
             (defaults to a single-line formatter).
     """
-    pipefy_settings, token = settings_and_token(ctx)
+    auth = auth_context_from_ctx(ctx)
     transport_fmt = format_transport_query_error or _format_transport_query_error
 
     async def _run() -> _R:
-        client = get_authenticated_client(pipefy_settings, bearer_token=token)
+        client = get_authenticated_client(
+            auth.settings,
+            bearer_token=auth.bearer_token,
+            auth_url=auth.auth_url,
+            auth_client_id=auth.auth_client_id,
+        )
         return await coro_factory(client)
 
     try:

--- a/packages/cli/src/pipefy_cli/commands/_common.py
+++ b/packages/cli/src/pipefy_cli/commands/_common.py
@@ -7,7 +7,6 @@ import json
 import math
 import sys
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
 from typing import Any, TypeVar
 
 import typer
@@ -15,19 +14,8 @@ from gql.transport.exceptions import TransportError, TransportQueryError
 from pipefy_sdk import PipefyClient, PipefySettings, stream_bytes
 from pipefy_sdk.exceptions import PipefyError
 
-from pipefy_cli.auth import get_authenticated_client
+from pipefy_cli.auth import AuthContext, OidcClient, get_authenticated_client
 from pipefy_cli.output import render_json, render_rich
-
-
-@dataclass(frozen=True)
-class AuthContext:
-    """All four credential-resolution inputs the auth boundary needs."""
-
-    settings: PipefySettings
-    bearer_token: str | None
-    auth_url: str | None
-    auth_client_id: str | None
-
 
 _T = TypeVar("_T")
 _R = TypeVar("_R")
@@ -154,15 +142,10 @@ def run_pipefy_client_coroutine(
     Raises:
         typer.Exit: On :class:`PipefyError` (exit code 1), optional ``ValueError`` mapping, or ``BrokenPipeError`` (exit 0).
     """
-    auth = auth_context_from_ctx(ctx)
+    pipefy_settings, auth = settings_and_auth_from_ctx(ctx)
 
     async def _run() -> _T:
-        client = get_authenticated_client(
-            auth.settings,
-            bearer_token=auth.bearer_token,
-            auth_url=auth.auth_url,
-            auth_client_id=auth.auth_client_id,
-        )
+        client = get_authenticated_client(pipefy_settings, auth)
         return await coro_factory(client)
 
     try:
@@ -217,26 +200,25 @@ def settings_and_token(ctx: typer.Context) -> tuple[PipefySettings, str | None]:
     return obj["pipefy_settings"], obj.get("token")
 
 
-def auth_context_from_ctx(ctx: typer.Context) -> AuthContext:
-    """Resolve root ``ctx.obj`` into the full auth surface for the auth boundary."""
+def settings_and_auth_from_ctx(
+    ctx: typer.Context,
+) -> tuple[PipefySettings, AuthContext]:
+    """Resolve root ``ctx.obj`` into the (settings, auth) pair the client boundary needs."""
     obj = ctx.find_root().obj
-    return AuthContext(
-        settings=obj["pipefy_settings"],
-        bearer_token=obj.get("token"),
-        auth_url=obj.get("auth_url"),
-        auth_client_id=obj.get("auth_client_id"),
+    auth_url = obj.get("auth_url")
+    oidc_client = (
+        OidcClient(issuer_url=auth_url, client_id=obj["auth_client_id"])
+        if auth_url
+        else None
     )
+    auth = AuthContext(bearer_token=obj.get("token"), oidc_client=oidc_client)
+    return obj["pipefy_settings"], auth
 
 
 def authenticated_client_from_ctx(ctx: typer.Context) -> PipefyClient:
     """Build a :class:`PipefyClient` using the same auth path as ``run_cli_command``."""
-    auth = auth_context_from_ctx(ctx)
-    return get_authenticated_client(
-        auth.settings,
-        bearer_token=auth.bearer_token,
-        auth_url=auth.auth_url,
-        auth_client_id=auth.auth_client_id,
-    )
+    pipefy_settings, auth = settings_and_auth_from_ctx(ctx)
+    return get_authenticated_client(pipefy_settings, auth)
 
 
 def parse_json_value(raw: str | None, option_name: str) -> Any:
@@ -285,16 +267,11 @@ def run_cli_command(
         format_transport_query_error: Optional override for GraphQL transport errors
             (defaults to a single-line formatter).
     """
-    auth = auth_context_from_ctx(ctx)
+    pipefy_settings, auth = settings_and_auth_from_ctx(ctx)
     transport_fmt = format_transport_query_error or _format_transport_query_error
 
     async def _run() -> _R:
-        client = get_authenticated_client(
-            auth.settings,
-            bearer_token=auth.bearer_token,
-            auth_url=auth.auth_url,
-            auth_client_id=auth.auth_client_id,
-        )
+        client = get_authenticated_client(pipefy_settings, auth)
         return await coro_factory(client)
 
     try:

--- a/packages/cli/src/pipefy_cli/commands/auth.py
+++ b/packages/cli/src/pipefy_cli/commands/auth.py
@@ -8,6 +8,7 @@ import webbrowser
 import typer
 
 from pipefy_cli._docs import DOCS_SETUP_REF
+from pipefy_cli.commands._common import settings_and_auth_from_ctx
 from pipefy_cli.oauth import (
     LoginError,
     keychain_backend_name,
@@ -25,25 +26,6 @@ _SERVICE_ACCOUNT_ENV_KEYS = (
     "PIPEFY_OAUTH_CLIENT",
     "PIPEFY_OAUTH_SECRET",
 )
-
-
-def _auth_config_from_ctx(ctx: typer.Context) -> tuple[str, str]:
-    """Return ``(auth_url, client_id)`` from the root callback's stash.
-
-    Raises ``typer.Exit(2)`` when ``PIPEFY_AUTH_URL`` is unset.
-    """
-    obj = ctx.find_root().obj
-    auth_url = obj.get("auth_url") or ""
-    if not auth_url:
-        typer.echo(
-            "PIPEFY_AUTH_URL is required for `pipefy auth login` (the OIDC issuer "
-            "URL for Pipefy authentication, e.g. "
-            "https://signin.pipefy.com/realms/pipefy). "
-            f"See {DOCS_SETUP_REF}.",
-            err=True,
-        )
-        raise typer.Exit(2)
-    return auth_url, obj["auth_client_id"]
 
 
 def _session_masking_env_vars() -> list[str]:
@@ -92,8 +74,19 @@ def auth_login(
     # Lazy to keep keyring's ~30-80ms backend-discovery cost off every CLI startup.
     from keyring.errors import KeyringError
 
-    auth_url, client_id = _auth_config_from_ctx(ctx)
-    typer.echo(f"Signing in to Pipefy at {auth_url} ...")
+    _, auth = settings_and_auth_from_ctx(ctx)
+    if auth.oidc_client is None:
+        typer.echo(
+            "PIPEFY_AUTH_URL is required for `pipefy auth login` (the OIDC issuer "
+            "URL for Pipefy authentication, e.g. "
+            "https://signin.pipefy.com/realms/pipefy). "
+            f"See {DOCS_SETUP_REF}.",
+            err=True,
+        )
+        raise typer.Exit(2)
+    issuer_url = auth.oidc_client.issuer_url
+    client_id = auth.oidc_client.client_id
+    typer.echo(f"Signing in to Pipefy at {issuer_url} ...")
 
     def _print_url(url: str) -> None:
         typer.echo(f"\nAuthorization URL: {url}\n")
@@ -112,7 +105,7 @@ def auth_login(
 
     try:
         result = run_login(
-            issuer_url=auth_url,
+            issuer_url=issuer_url,
             client_id=client_id,
             callback_timeout_s=callback_timeout,
             open_browser=_open,

--- a/packages/cli/src/pipefy_cli/oauth/__init__.py
+++ b/packages/cli/src/pipefy_cli/oauth/__init__.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 from pipefy_cli.oauth.discovery import ProviderMetadata, fetch_provider_metadata
 from pipefy_cli.oauth.flow import LoginError, LoginResult, run_login
+from pipefy_cli.oauth.refresh import (
+    RefreshError,
+    ensure_fresh_session,
+    refresh_access_token,
+)
 from pipefy_cli.oauth.storage import (
     StoredSession,
     delete_session,
@@ -17,12 +22,15 @@ __all__ = [
     "LoginError",
     "LoginResult",
     "ProviderMetadata",
+    "RefreshError",
     "StoredSession",
     "delete_session",
+    "ensure_fresh_session",
     "fetch_provider_metadata",
     "keychain_backend_name",
     "keychain_key",
     "load_session",
+    "refresh_access_token",
     "run_login",
     "store_session",
 ]

--- a/packages/cli/src/pipefy_cli/oauth/_http.py
+++ b/packages/cli/src/pipefy_cli/oauth/_http.py
@@ -1,0 +1,24 @@
+"""Shared httpx.Client context-manager helper for the OAuth flow modules."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager, nullcontext
+from typing import Iterator
+
+import httpx
+
+
+@contextmanager
+def http_client(
+    provided: httpx.Client | None, *, timeout: float
+) -> Iterator[httpx.Client]:
+    """Yield ``provided`` (without closing it) or a fresh ``httpx.Client``."""
+    if provided is not None:
+        with nullcontext(provided) as client:
+            yield client
+        return
+    with httpx.Client(timeout=timeout) as client:
+        yield client
+
+
+__all__ = ["http_client"]

--- a/packages/cli/src/pipefy_cli/oauth/discovery.py
+++ b/packages/cli/src/pipefy_cli/oauth/discovery.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import httpx
 
-from pipefy_cli.oauth._http import http_client
+from pipefy_cli.oauth import _http
 
 DISCOVERY_PATH = "/.well-known/openid-configuration"
 _DEFAULT_TIMEOUT = 10.0
@@ -43,7 +43,7 @@ def fetch_provider_metadata(
             missing required endpoints. Message is user-facing.
     """
     url = discovery_url(issuer_url)
-    with http_client(client, timeout=timeout) as http:
+    with _http.http_client(client, timeout=timeout) as http:
         try:
             response = http.get(url)
         except httpx.HTTPError as exc:

--- a/packages/cli/src/pipefy_cli/oauth/discovery.py
+++ b/packages/cli/src/pipefy_cli/oauth/discovery.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 
 import httpx
 
+from pipefy_cli.oauth._http import http_client
+
 DISCOVERY_PATH = "/.well-known/openid-configuration"
 _DEFAULT_TIMEOUT = 10.0
 
@@ -41,15 +43,13 @@ def fetch_provider_metadata(
             missing required endpoints. Message is user-facing.
     """
     url = discovery_url(issuer_url)
-    owned = client is None
-    http = client or httpx.Client(timeout=timeout)
-    try:
-        response = http.get(url)
-    except httpx.HTTPError as exc:
-        raise ValueError(f"Could not reach Pipefy auth server at {url}: {exc}") from exc
-    finally:
-        if owned:
-            http.close()
+    with http_client(client, timeout=timeout) as http:
+        try:
+            response = http.get(url)
+        except httpx.HTTPError as exc:
+            raise ValueError(
+                f"Could not reach Pipefy auth server at {url}: {exc}"
+            ) from exc
 
     if response.status_code != 200:
         raise ValueError(

--- a/packages/cli/src/pipefy_cli/oauth/flow.py
+++ b/packages/cli/src/pipefy_cli/oauth/flow.py
@@ -124,7 +124,7 @@ def run_login(
             token exchange).
         TimeoutError: When no browser callback arrives in time.
     """
-    with _http_client(http_client, timeout=_TOKEN_EXCHANGE_TIMEOUT_S) as http:  # type: ignore[operator]
+    with _http_client(http_client, timeout=_TOKEN_EXCHANGE_TIMEOUT_S) as http:
         try:
             metadata = fetch_provider_metadata(issuer_url, client=http)
         except ValueError as exc:

--- a/packages/cli/src/pipefy_cli/oauth/flow.py
+++ b/packages/cli/src/pipefy_cli/oauth/flow.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import secrets
 import webbrowser
-from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
-from typing import Callable, Iterator
+from typing import Callable
 from urllib.parse import urlencode
 
 import httpx
 
+from pipefy_cli.oauth._http import http_client as _http_client
 from pipefy_cli.oauth.discovery import ProviderMetadata, fetch_provider_metadata
 from pipefy_cli.oauth.loopback import CallbackResult, LoopbackCapture
 from pipefy_cli.oauth.pkce import challenge_from_verifier, generate_verifier
@@ -90,18 +90,6 @@ def exchange_code(
     return payload
 
 
-@contextmanager
-def _http_client(
-    provided: httpx.Client | None, timeout: float
-) -> Iterator[httpx.Client]:
-    if provided is not None:
-        with nullcontext(provided) as client:
-            yield client
-        return
-    with httpx.Client(timeout=timeout) as client:
-        yield client
-
-
 def run_login(
     *,
     issuer_url: str,
@@ -136,7 +124,7 @@ def run_login(
             token exchange).
         TimeoutError: When no browser callback arrives in time.
     """
-    with _http_client(http_client, timeout=_TOKEN_EXCHANGE_TIMEOUT_S) as http:
+    with _http_client(http_client, timeout=_TOKEN_EXCHANGE_TIMEOUT_S) as http:  # type: ignore[operator]
         try:
             metadata = fetch_provider_metadata(issuer_url, client=http)
         except ValueError as exc:

--- a/packages/cli/src/pipefy_cli/oauth/flow.py
+++ b/packages/cli/src/pipefy_cli/oauth/flow.py
@@ -10,7 +10,7 @@ from urllib.parse import urlencode
 
 import httpx
 
-from pipefy_cli.oauth._http import http_client as _http_client
+from pipefy_cli.oauth import _http
 from pipefy_cli.oauth.discovery import ProviderMetadata, fetch_provider_metadata
 from pipefy_cli.oauth.loopback import CallbackResult, LoopbackCapture
 from pipefy_cli.oauth.pkce import challenge_from_verifier, generate_verifier
@@ -124,7 +124,7 @@ def run_login(
             token exchange).
         TimeoutError: When no browser callback arrives in time.
     """
-    with _http_client(http_client, timeout=_TOKEN_EXCHANGE_TIMEOUT_S) as http:
+    with _http.http_client(http_client, timeout=_TOKEN_EXCHANGE_TIMEOUT_S) as http:
         try:
             metadata = fetch_provider_metadata(issuer_url, client=http)
         except ValueError as exc:

--- a/packages/cli/src/pipefy_cli/oauth/refresh.py
+++ b/packages/cli/src/pipefy_cli/oauth/refresh.py
@@ -6,7 +6,7 @@ import time
 
 import httpx
 
-from pipefy_cli.oauth._http import http_client as _http_client
+from pipefy_cli.oauth import _http
 from pipefy_cli.oauth.discovery import fetch_provider_metadata
 from pipefy_cli.oauth.storage import StoredSession, load_session, store_session
 
@@ -36,7 +36,7 @@ def refresh_access_token(
         RefreshError: For any failure that prevents a fresh token response
             (discovery failure, network error, non-200, malformed body).
     """
-    with _http_client(http_client, timeout=_TIMEOUT_S) as http:
+    with _http.http_client(http_client, timeout=_TIMEOUT_S) as http:
         try:
             metadata = fetch_provider_metadata(issuer, client=http)
         except ValueError as exc:

--- a/packages/cli/src/pipefy_cli/oauth/refresh.py
+++ b/packages/cli/src/pipefy_cli/oauth/refresh.py
@@ -6,7 +6,7 @@ import time
 
 import httpx
 
-from pipefy_cli.oauth._http import http_client
+from pipefy_cli.oauth._http import http_client as _http_client
 from pipefy_cli.oauth.discovery import fetch_provider_metadata
 from pipefy_cli.oauth.storage import StoredSession, load_session, store_session
 
@@ -28,7 +28,7 @@ def refresh_access_token(
     issuer: str,
     client_id: str,
     refresh_token: str,
-    http_client_override: httpx.Client | None = None,
+    http_client: httpx.Client | None = None,
 ) -> dict[str, object]:
     """POST ``grant_type=refresh_token`` to the issuer's token endpoint.
 
@@ -36,7 +36,7 @@ def refresh_access_token(
         RefreshError: For any failure that prevents a fresh token response
             (discovery failure, network error, non-200, malformed body).
     """
-    with http_client(http_client_override, timeout=_TIMEOUT_S) as http:
+    with _http_client(http_client, timeout=_TIMEOUT_S) as http:
         try:
             metadata = fetch_provider_metadata(issuer, client=http)
         except ValueError as exc:
@@ -71,7 +71,7 @@ def ensure_fresh_session(
     issuer: str,
     client_id: str,
     leeway_s: int = _LEEWAY_S,
-    http_client_override: httpx.Client | None = None,
+    http_client: httpx.Client | None = None,
 ) -> StoredSession | None:
     """Load the stored session; refresh it if the access token is near expiry.
 
@@ -96,7 +96,7 @@ def ensure_fresh_session(
         issuer=issuer,
         client_id=client_id,
         refresh_token=session.refresh_token,
-        http_client_override=http_client_override,
+        http_client=http_client,
     )
     # Some IdPs don't rotate the refresh token on every refresh.
     token_response.setdefault("refresh_token", session.refresh_token)

--- a/packages/cli/src/pipefy_cli/oauth/refresh.py
+++ b/packages/cli/src/pipefy_cli/oauth/refresh.py
@@ -98,8 +98,19 @@ def ensure_fresh_session(
         refresh_token=session.refresh_token,
         http_client=http_client,
     )
-    # Some IdPs don't rotate the refresh token on every refresh.
+    # Carry forward fields the IdP may omit from a refresh response so the
+    # rotated session keeps its full shape — without ``expires_in`` the next
+    # freshness check treats the token as already expired and refreshes again
+    # on the very next call.
     token_response.setdefault("refresh_token", session.refresh_token)
+    if session.expires_in is not None:
+        token_response.setdefault("expires_in", session.expires_in)
+    if session.refresh_expires_in is not None:
+        token_response.setdefault("refresh_expires_in", session.refresh_expires_in)
+    if session.scope is not None:
+        token_response.setdefault("scope", session.scope)
+    if session.id_token is not None:
+        token_response.setdefault("id_token", session.id_token)
     return store_session(
         issuer=session.issuer,
         client_id=session.client_id,

--- a/packages/cli/src/pipefy_cli/oauth/refresh.py
+++ b/packages/cli/src/pipefy_cli/oauth/refresh.py
@@ -1,0 +1,114 @@
+"""Refresh-token grant + eager pre-use refresh for the stored OAuth user session."""
+
+from __future__ import annotations
+
+import time
+
+import httpx
+
+from pipefy_cli.oauth._http import http_client
+from pipefy_cli.oauth.discovery import fetch_provider_metadata
+from pipefy_cli.oauth.storage import StoredSession, load_session, store_session
+
+_LEEWAY_S = 60
+_TIMEOUT_S = 30.0
+
+
+class RefreshError(RuntimeError):
+    """A stored session exists but its refresh attempt failed.
+
+    Distinct from "no session" (which surfaces as ``None`` from
+    :func:`ensure_fresh_session`). The caller should surface a "run
+    ``pipefy auth login`` again" message and exit.
+    """
+
+
+def refresh_access_token(
+    *,
+    issuer: str,
+    client_id: str,
+    refresh_token: str,
+    http_client_override: httpx.Client | None = None,
+) -> dict[str, object]:
+    """POST ``grant_type=refresh_token`` to the issuer's token endpoint.
+
+    Raises:
+        RefreshError: For any failure that prevents a fresh token response
+            (discovery failure, network error, non-200, malformed body).
+    """
+    with http_client(http_client_override, timeout=_TIMEOUT_S) as http:
+        try:
+            metadata = fetch_provider_metadata(issuer, client=http)
+        except ValueError as exc:
+            raise RefreshError(f"OIDC discovery failed: {exc}") from exc
+        try:
+            response = http.post(
+                metadata.token_endpoint,
+                data={
+                    "grant_type": "refresh_token",
+                    "refresh_token": refresh_token,
+                    "client_id": client_id,
+                },
+            )
+        except httpx.HTTPError as exc:
+            raise RefreshError(f"Refresh request failed: {exc}") from exc
+
+    if response.status_code != 200:
+        raise RefreshError(
+            f"Refresh failed ({response.status_code}): {response.text[:300]}"
+        )
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise RefreshError(f"Token endpoint returned non-JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise RefreshError("Token endpoint returned a non-object JSON payload.")
+    return payload
+
+
+def ensure_fresh_session(
+    *,
+    issuer: str,
+    client_id: str,
+    leeway_s: int = _LEEWAY_S,
+    http_client_override: httpx.Client | None = None,
+) -> StoredSession | None:
+    """Load the stored session; refresh it if the access token is near expiry.
+
+    Returns ``None`` when no session is stored (or the keychain is unreachable
+    — ``load_session`` already collapses those cases). Returns the (possibly
+    refreshed) :class:`StoredSession` when one is usable.
+
+    Raises:
+        RefreshError: When a stored session exists but refresh failed.
+            Caller surfaces a "run ``pipefy auth login`` again" message.
+    """
+    session = load_session(issuer=issuer, client_id=client_id)
+    if session is None:
+        return None
+
+    expires_in = session.expires_in or 0
+    deadline = session.obtained_at + expires_in - leeway_s
+    if time.time() < deadline:
+        return session
+
+    token_response = refresh_access_token(
+        issuer=issuer,
+        client_id=client_id,
+        refresh_token=session.refresh_token,
+        http_client_override=http_client_override,
+    )
+    # Some IdPs don't rotate the refresh token on every refresh.
+    token_response.setdefault("refresh_token", session.refresh_token)
+    return store_session(
+        issuer=session.issuer,
+        client_id=session.client_id,
+        token_response=token_response,
+    )
+
+
+__all__ = [
+    "RefreshError",
+    "ensure_fresh_session",
+    "refresh_access_token",
+]

--- a/packages/cli/tests/conftest.py
+++ b/packages/cli/tests/conftest.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import keyring
+import keyring.backend
 import pytest
 from typer.testing import CliRunner
 
@@ -75,3 +77,39 @@ def _reset_cli_auth_cache() -> None:
     clear_authenticated_client_cache()
     yield
     clear_authenticated_client_cache()
+
+
+class InMemoryKeyring(keyring.backend.KeyringBackend):
+    """In-memory keyring backend that mirrors the real-world ``delete_password``
+    contract (raises ``PasswordDeleteError`` when the entry is missing)."""
+
+    priority = 1  # type: ignore[assignment]
+
+    def __init__(self) -> None:
+        self._store: dict[tuple[str, str], str] = {}
+
+    def get_password(self, service: str, username: str) -> str | None:
+        return self._store.get((service, username))
+
+    def set_password(self, service: str, username: str, password: str) -> None:
+        self._store[(service, username)] = password
+
+    def delete_password(self, service: str, username: str) -> None:
+        from keyring.errors import PasswordDeleteError
+
+        if (service, username) not in self._store:
+            raise PasswordDeleteError(f"no entry for {service}/{username}")
+        del self._store[(service, username)]
+
+
+@pytest.fixture
+def fake_keyring(monkeypatch: pytest.MonkeyPatch) -> InMemoryKeyring:
+    """Patch the ``keyring`` module surface our storage code uses."""
+
+    fake = InMemoryKeyring()
+    monkeypatch.setattr(keyring, "_keyring_backend", fake, raising=False)
+    monkeypatch.setattr(keyring, "get_keyring", lambda: fake)
+    monkeypatch.setattr(keyring, "set_password", fake.set_password)
+    monkeypatch.setattr(keyring, "get_password", fake.get_password)
+    monkeypatch.setattr(keyring, "delete_password", fake.delete_password)
+    return fake

--- a/packages/cli/tests/test_auth.py
+++ b/packages/cli/tests/test_auth.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+import typer
 from pipefy_sdk import PipefySettings
 
 from pipefy_cli.auth import get_authenticated_client
 from pipefy_cli.main import app
+from pipefy_cli.oauth import StoredSession
 
 
 def _minimal_oauth_settings() -> PipefySettings:
@@ -83,3 +87,131 @@ def test_cli_uses_pipefy_token_env_when_no_flag(
     assert result.exit_code == 0, result.stdout + (result.stderr or "")
     mock_gc.assert_called_once()
     assert mock_gc.call_args.kwargs.get("bearer_token") == "secret-from-env"
+
+
+# --------------------------------------------------------------------------- #
+# Priority 4: stored user session                                             #
+# --------------------------------------------------------------------------- #
+
+
+_FAR_FUTURE_EXPIRES_IN = 3600
+_ISSUER = "https://signin.example.com/realms/pipefy"
+
+
+def _fresh_stored_session(*, access_token: str = "SESSION_ACCESS") -> StoredSession:
+    return StoredSession(
+        issuer=_ISSUER,
+        client_id="pipefy-cli",
+        access_token=access_token,
+        refresh_token="REFRESH",
+        token_type="Bearer",
+        obtained_at=int(time.time()),
+        expires_in=_FAR_FUTURE_EXPIRES_IN,
+        refresh_expires_in=None,
+        scope="openid offline_access",
+        id_token=None,
+    )
+
+
+def _public_only_settings() -> PipefySettings:
+    """``PIPEFY_OAUTH_*`` triple absent → priority 3 unavailable, falls through to 4."""
+    return PipefySettings(graphql_url="https://unit.example.com/graphql")
+
+
+def test_bearer_token_wins_over_stored_session(clean_pipefy_env):
+    """Priority 1/2 (bearer) MUST short-circuit before the keychain is even consulted."""
+    settings = _minimal_oauth_settings()
+    with (
+        patch("pipefy_cli.auth.PipefyClient") as mock_pc,
+        patch("pipefy_cli.auth.ensure_fresh_session") as mock_ensure,
+    ):
+        mock_pc.return_value = MagicMock()
+        get_authenticated_client(
+            settings,
+            bearer_token="explicit-bearer",
+            auth_url=_ISSUER,
+            auth_client_id="pipefy-cli",
+        )
+        mock_pc.assert_called_once_with(settings, bearer_token="explicit-bearer")
+        mock_ensure.assert_not_called()
+
+
+def test_oauth_client_creds_wins_over_stored_session(clean_pipefy_env):
+    """Priority 3 (full OAuth triple) MUST short-circuit before the keychain is consulted."""
+    settings = _minimal_oauth_settings()
+    with (
+        patch("pipefy_cli.auth.PipefyClient") as mock_pc,
+        patch("pipefy_cli.auth.InternalApiClient"),
+        patch("pipefy_cli.auth.AiAutomationService"),
+        patch("pipefy_cli.auth.ensure_fresh_session") as mock_ensure,
+    ):
+        mock_pc.return_value = MagicMock()
+        get_authenticated_client(
+            settings,
+            auth_url=_ISSUER,
+            auth_client_id="pipefy-cli",
+        )
+        mock_pc.assert_called_once_with(settings)
+        mock_ensure.assert_not_called()
+
+
+def test_stored_session_used_when_no_other_source(clean_pipefy_env):
+    """Priority 4 activates when bearer absent AND OAuth triple incomplete."""
+    settings = _public_only_settings()
+    session = _fresh_stored_session()
+    with (
+        patch("pipefy_cli.auth.PipefyClient") as mock_pc,
+        patch("pipefy_cli.auth.ensure_fresh_session", return_value=session),
+    ):
+        mock_pc.return_value = MagicMock()
+        get_authenticated_client(
+            settings, auth_url=_ISSUER, auth_client_id="pipefy-cli"
+        )
+        mock_pc.assert_called_once_with(settings, bearer_token=session.access_token)
+
+
+def test_cache_invalidates_when_access_token_rotates(clean_pipefy_env):
+    """Two calls with different rotated access tokens → two PipefyClient builds."""
+    settings = _public_only_settings()
+    sessions = iter(
+        [
+            _fresh_stored_session(access_token="ROTATED_1"),
+            _fresh_stored_session(access_token="ROTATED_2"),
+        ]
+    )
+    with (
+        patch("pipefy_cli.auth.PipefyClient") as mock_pc,
+        patch(
+            "pipefy_cli.auth.ensure_fresh_session",
+            side_effect=lambda **_: next(sessions),
+        ),
+    ):
+        mock_pc.side_effect = [MagicMock(), MagicMock()]
+        get_authenticated_client(
+            settings, auth_url=_ISSUER, auth_client_id="pipefy-cli"
+        )
+        get_authenticated_client(
+            settings, auth_url=_ISSUER, auth_client_id="pipefy-cli"
+        )
+        assert mock_pc.call_count == 2
+        assert mock_pc.call_args_list[0].kwargs["bearer_token"] == "ROTATED_1"
+        assert mock_pc.call_args_list[1].kwargs["bearer_token"] == "ROTATED_2"
+
+
+def test_refresh_error_exits_2_with_relogin_hint(clean_pipefy_env, capsys):
+    """RefreshError from ensure_fresh_session surfaces as exit(2) + relogin message."""
+    from pipefy_cli.oauth import RefreshError
+
+    settings = _public_only_settings()
+    with patch(
+        "pipefy_cli.auth.ensure_fresh_session",
+        side_effect=RefreshError("invalid_grant"),
+    ):
+        with pytest.raises(typer.Exit) as excinfo:
+            get_authenticated_client(
+                settings, auth_url=_ISSUER, auth_client_id="pipefy-cli"
+            )
+        assert excinfo.value.exit_code == 2
+    err = capsys.readouterr().err
+    assert "Stored Pipefy session could not be refreshed" in err
+    assert "pipefy auth login" in err

--- a/packages/cli/tests/test_auth.py
+++ b/packages/cli/tests/test_auth.py
@@ -9,7 +9,7 @@ import pytest
 import typer
 from pipefy_sdk import PipefySettings
 
-from pipefy_cli.auth import get_authenticated_client
+from pipefy_cli.auth import AuthContext, OidcClient, get_authenticated_client
 from pipefy_cli.main import app
 from pipefy_cli.oauth import StoredSession
 
@@ -24,11 +24,26 @@ def _minimal_oauth_settings() -> PipefySettings:
     )
 
 
+def _auth(
+    *,
+    bearer_token: str | None = None,
+    issuer_url: str | None = None,
+    client_id: str | None = None,
+) -> AuthContext:
+    """Build an :class:`AuthContext` for tests; constructs :class:`OidcClient` iff both halves are provided."""
+    oidc_client = (
+        OidcClient(issuer_url=issuer_url, client_id=client_id)
+        if issuer_url and client_id
+        else None
+    )
+    return AuthContext(bearer_token=bearer_token, oidc_client=oidc_client)
+
+
 def test_get_authenticated_client_passes_bearer_to_pipefy_client(clean_pipefy_env):
     settings = _minimal_oauth_settings()
     with patch("pipefy_cli.auth.PipefyClient") as mock_pc:
         mock_pc.return_value = MagicMock()
-        client = get_authenticated_client(settings, bearer_token="tok")
+        client = get_authenticated_client(settings, _auth(bearer_token="tok"))
         mock_pc.assert_called_once_with(settings, bearer_token="tok")
         assert client is mock_pc.return_value
 
@@ -37,7 +52,7 @@ def test_get_authenticated_client_oauth_mode_no_bearer(clean_pipefy_env):
     settings = _minimal_oauth_settings()
     with patch("pipefy_cli.auth.PipefyClient") as mock_pc:
         mock_pc.return_value = MagicMock()
-        get_authenticated_client(settings)
+        get_authenticated_client(settings, _auth())
         mock_pc.assert_called_once_with(settings)
 
 
@@ -45,8 +60,8 @@ def test_cache_returns_same_instance_for_identical_oauth_settings(clean_pipefy_e
     settings = _minimal_oauth_settings()
     with patch("pipefy_cli.auth.PipefyClient") as mock_pc:
         mock_pc.return_value = MagicMock()
-        first = get_authenticated_client(settings)
-        second = get_authenticated_client(settings)
+        first = get_authenticated_client(settings, _auth())
+        second = get_authenticated_client(settings, _auth())
         assert first is second
         assert mock_pc.call_count == 1
 
@@ -86,7 +101,8 @@ def test_cli_uses_pipefy_token_env_when_no_flag(
         result = runner.invoke(app, ["card", "get", "77"])
     assert result.exit_code == 0, result.stdout + (result.stderr or "")
     mock_gc.assert_called_once()
-    assert mock_gc.call_args.kwargs.get("bearer_token") == "secret-from-env"
+    auth_arg = mock_gc.call_args.args[1]
+    assert auth_arg.bearer_token == "secret-from-env"
 
 
 # --------------------------------------------------------------------------- #
@@ -128,9 +144,11 @@ def test_bearer_token_wins_over_stored_session(clean_pipefy_env):
         mock_pc.return_value = MagicMock()
         get_authenticated_client(
             settings,
-            bearer_token="explicit-bearer",
-            auth_url=_ISSUER,
-            auth_client_id="pipefy-cli",
+            _auth(
+                bearer_token="explicit-bearer",
+                issuer_url=_ISSUER,
+                client_id="pipefy-cli",
+            ),
         )
         mock_pc.assert_called_once_with(settings, bearer_token="explicit-bearer")
         mock_ensure.assert_not_called()
@@ -148,8 +166,7 @@ def test_oauth_client_creds_wins_over_stored_session(clean_pipefy_env):
         mock_pc.return_value = MagicMock()
         get_authenticated_client(
             settings,
-            auth_url=_ISSUER,
-            auth_client_id="pipefy-cli",
+            _auth(issuer_url=_ISSUER, client_id="pipefy-cli"),
         )
         mock_pc.assert_called_once_with(settings)
         mock_ensure.assert_not_called()
@@ -165,7 +182,7 @@ def test_stored_session_used_when_no_other_source(clean_pipefy_env):
     ):
         mock_pc.return_value = MagicMock()
         get_authenticated_client(
-            settings, auth_url=_ISSUER, auth_client_id="pipefy-cli"
+            settings, _auth(issuer_url=_ISSUER, client_id="pipefy-cli")
         )
         mock_pc.assert_called_once_with(settings, bearer_token=session.access_token)
 
@@ -188,10 +205,10 @@ def test_cache_invalidates_when_access_token_rotates(clean_pipefy_env):
     ):
         mock_pc.side_effect = [MagicMock(), MagicMock()]
         get_authenticated_client(
-            settings, auth_url=_ISSUER, auth_client_id="pipefy-cli"
+            settings, _auth(issuer_url=_ISSUER, client_id="pipefy-cli")
         )
         get_authenticated_client(
-            settings, auth_url=_ISSUER, auth_client_id="pipefy-cli"
+            settings, _auth(issuer_url=_ISSUER, client_id="pipefy-cli")
         )
         assert mock_pc.call_count == 2
         assert mock_pc.call_args_list[0].kwargs["bearer_token"] == "ROTATED_1"
@@ -209,7 +226,7 @@ def test_refresh_error_exits_2_with_relogin_hint(clean_pipefy_env, capsys):
     ):
         with pytest.raises(typer.Exit) as excinfo:
             get_authenticated_client(
-                settings, auth_url=_ISSUER, auth_client_id="pipefy-cli"
+                settings, _auth(issuer_url=_ISSUER, client_id="pipefy-cli")
             )
         assert excinfo.value.exit_code == 2
     err = capsys.readouterr().err

--- a/packages/cli/tests/test_auth_login.py
+++ b/packages/cli/tests/test_auth_login.py
@@ -9,9 +9,8 @@ import threading
 import time
 
 import httpx
-import keyring
-import keyring.backend
 import pytest
+from conftest import InMemoryKeyring
 
 from pipefy_cli.main import app as cli_app
 from pipefy_cli.oauth import discovery, flow, loopback, pkce, storage
@@ -153,40 +152,6 @@ class TestLoopback:
 # --------------------------------------------------------------------------- #
 
 
-class _InMemoryKeyring(keyring.backend.KeyringBackend):
-    """In-memory keyring backend that mirrors the real-world ``delete_password``
-    contract (raises ``PasswordDeleteError`` when the entry is missing)."""
-
-    priority = 1  # type: ignore[assignment]
-
-    def __init__(self) -> None:
-        self._store: dict[tuple[str, str], str] = {}
-
-    def get_password(self, service: str, username: str) -> str | None:
-        return self._store.get((service, username))
-
-    def set_password(self, service: str, username: str, password: str) -> None:
-        self._store[(service, username)] = password
-
-    def delete_password(self, service: str, username: str) -> None:
-        from keyring.errors import PasswordDeleteError
-
-        if (service, username) not in self._store:
-            raise PasswordDeleteError(f"no entry for {service}/{username}")
-        del self._store[(service, username)]
-
-
-@pytest.fixture
-def fake_keyring(monkeypatch: pytest.MonkeyPatch) -> _InMemoryKeyring:
-    fake = _InMemoryKeyring()
-    monkeypatch.setattr(keyring, "_keyring_backend", fake, raising=False)
-    monkeypatch.setattr(keyring, "get_keyring", lambda: fake)
-    monkeypatch.setattr(keyring, "set_password", fake.set_password)
-    monkeypatch.setattr(keyring, "get_password", fake.get_password)
-    monkeypatch.setattr(keyring, "delete_password", fake.delete_password)
-    return fake
-
-
 class TestStorage:
     def test_keychain_key_uses_host_and_client(self) -> None:
         key = storage.keychain_key(
@@ -194,7 +159,7 @@ class TestStorage:
         )
         assert key == "signin.pipefy.com|pipefy-cli"
 
-    def test_store_then_load_roundtrip(self, fake_keyring: _InMemoryKeyring) -> None:
+    def test_store_then_load_roundtrip(self, fake_keyring: InMemoryKeyring) -> None:
         token = {
             "access_token": "AAA",
             "refresh_token": "RRR",
@@ -220,15 +185,13 @@ class TestStorage:
         assert loaded.refresh_token == "RRR"
         assert loaded.scope == "openid email"
 
-    def test_load_returns_none_when_absent(
-        self, fake_keyring: _InMemoryKeyring
-    ) -> None:
+    def test_load_returns_none_when_absent(self, fake_keyring: InMemoryKeyring) -> None:
         assert (
             storage.load_session(issuer="https://x.test/realms/foo", client_id="cid")
             is None
         )
 
-    def test_delete_reports_presence(self, fake_keyring: _InMemoryKeyring) -> None:
+    def test_delete_reports_presence(self, fake_keyring: InMemoryKeyring) -> None:
         storage.store_session(
             issuer="https://x.test/realms/foo",
             client_id="cid",
@@ -242,7 +205,7 @@ class TestStorage:
         )
 
     def test_store_rejects_missing_required_field(
-        self, fake_keyring: _InMemoryKeyring
+        self, fake_keyring: InMemoryKeyring
     ) -> None:
         with pytest.raises(ValueError, match="refresh_token"):
             storage.store_session(
@@ -399,7 +362,7 @@ class TestAuthLoginCommand:
         self,
         cli_runner,
         monkeypatch: pytest.MonkeyPatch,
-        fake_keyring: _InMemoryKeyring,
+        fake_keyring: InMemoryKeyring,
         clean_pipefy_env,
         saved_cwd,
     ) -> None:
@@ -437,7 +400,7 @@ class TestAuthLoginCommand:
         self,
         cli_runner,
         monkeypatch: pytest.MonkeyPatch,
-        fake_keyring: _InMemoryKeyring,
+        fake_keyring: InMemoryKeyring,
         clean_pipefy_env,
         saved_cwd,
     ) -> None:
@@ -464,7 +427,7 @@ class TestAuthLoginCommand:
         self,
         cli_runner,
         monkeypatch: pytest.MonkeyPatch,
-        fake_keyring: _InMemoryKeyring,
+        fake_keyring: InMemoryKeyring,
         clean_pipefy_env,
         saved_cwd,
     ) -> None:
@@ -512,7 +475,7 @@ class TestAuthLoginCommand:
         self,
         cli_runner,
         monkeypatch: pytest.MonkeyPatch,
-        fake_keyring: _InMemoryKeyring,
+        fake_keyring: InMemoryKeyring,
         clean_pipefy_env,
         saved_cwd,
     ) -> None:
@@ -551,7 +514,7 @@ class TestAuthLoginCommand:
         self,
         cli_runner,
         monkeypatch: pytest.MonkeyPatch,
-        fake_keyring: _InMemoryKeyring,
+        fake_keyring: InMemoryKeyring,
         clean_pipefy_env,
         saved_cwd,
     ) -> None:

--- a/packages/cli/tests/test_auth_refresh.py
+++ b/packages/cli/tests/test_auth_refresh.py
@@ -49,33 +49,31 @@ def _build_handler(
     return handler
 
 
-def _seed_session(*, obtained_at: int, expires_in: int = 300) -> None:
-    storage.store_session(
-        issuer=_ISSUER,
-        client_id=_CLIENT_ID,
-        token_response={
-            "access_token": "OLD",
-            "refresh_token": "OLD_R",
-            "token_type": "Bearer",
-            "expires_in": expires_in,
-            "scope": "openid offline_access",
-        },
-    )
-    # Overwrite obtained_at to put the token at the desired freshness.
-    loaded = storage.load_session(issuer=_ISSUER, client_id=_CLIENT_ID)
-    assert loaded is not None
-    import dataclasses
+def _seed_session(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    obtained_at: int,
+    expires_in: int = 300,
+) -> None:
+    """Persist a session whose ``obtained_at`` is pinned to ``obtained_at``.
 
-    rewritten = dataclasses.replace(loaded, obtained_at=obtained_at)
-    import json
-
-    import keyring
-
-    keyring.set_password(
-        "pipefy-cli",
-        storage.keychain_key(_ISSUER, _CLIENT_ID),
-        json.dumps(dataclasses.asdict(rewritten)),
-    )
+    ``store_session`` stamps ``obtained_at`` via ``time.time()`` at write time, so
+    we pin the clock for the single store call instead of writing-then-rewriting
+    the keychain entry.
+    """
+    with monkeypatch.context() as mp:
+        mp.setattr(time, "time", lambda: float(obtained_at))
+        storage.store_session(
+            issuer=_ISSUER,
+            client_id=_CLIENT_ID,
+            token_response={
+                "access_token": "OLD",
+                "refresh_token": "OLD_R",
+                "token_type": "Bearer",
+                "expires_in": expires_in,
+                "scope": "openid offline_access",
+            },
+        )
 
 
 # --------------------------------------------------------------------------- #
@@ -92,23 +90,29 @@ class TestEnsureFreshSession:
         )
 
     def test_returns_session_unchanged_when_fresh(
-        self, fake_keyring: InMemoryKeyring
+        self,
+        fake_keyring: InMemoryKeyring,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        _seed_session(obtained_at=int(time.time()))  # full 300s ahead
+        _seed_session(monkeypatch, obtained_at=int(time.time()))  # full 300s ahead
 
         client = httpx.Client(transport=httpx.MockTransport(_build_handler()))
         result = refresh.ensure_fresh_session(
             issuer=_ISSUER,
             client_id=_CLIENT_ID,
-            http_client_override=client,
+            http_client=client,
         )
         assert result is not None
         assert result.access_token == "OLD"
         assert result.refresh_token == "OLD_R"
 
-    def test_refreshes_when_within_leeway(self, fake_keyring: InMemoryKeyring) -> None:
+    def test_refreshes_when_within_leeway(
+        self,
+        fake_keyring: InMemoryKeyring,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         # 30s lifetime + 60s leeway → must refresh.
-        _seed_session(obtained_at=int(time.time()) - 1, expires_in=30)
+        _seed_session(monkeypatch, obtained_at=int(time.time()) - 1, expires_in=30)
 
         client = httpx.Client(
             transport=httpx.MockTransport(
@@ -125,14 +129,18 @@ class TestEnsureFreshSession:
         result = refresh.ensure_fresh_session(
             issuer=_ISSUER,
             client_id=_CLIENT_ID,
-            http_client_override=client,
+            http_client=client,
         )
         assert result is not None
         assert result.access_token == "NEW_A"
         assert result.refresh_token == "NEW_R"
 
-    def test_persists_rotated_session(self, fake_keyring: InMemoryKeyring) -> None:
-        _seed_session(obtained_at=int(time.time()) - 1, expires_in=30)
+    def test_persists_rotated_session(
+        self,
+        fake_keyring: InMemoryKeyring,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _seed_session(monkeypatch, obtained_at=int(time.time()) - 1, expires_in=30)
         client = httpx.Client(
             transport=httpx.MockTransport(
                 _build_handler(
@@ -146,7 +154,7 @@ class TestEnsureFreshSession:
         refresh.ensure_fresh_session(
             issuer=_ISSUER,
             client_id=_CLIENT_ID,
-            http_client_override=client,
+            http_client=client,
         )
 
         reloaded = storage.load_session(issuer=_ISSUER, client_id=_CLIENT_ID)
@@ -155,9 +163,11 @@ class TestEnsureFreshSession:
         assert reloaded.refresh_token == "NEW_R"
 
     def test_falls_back_to_old_refresh_token_when_idp_does_not_rotate(
-        self, fake_keyring: InMemoryKeyring
+        self,
+        fake_keyring: InMemoryKeyring,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        _seed_session(obtained_at=int(time.time()) - 1, expires_in=30)
+        _seed_session(monkeypatch, obtained_at=int(time.time()) - 1, expires_in=30)
         client = httpx.Client(
             transport=httpx.MockTransport(
                 _build_handler(
@@ -169,7 +179,7 @@ class TestEnsureFreshSession:
         result = refresh.ensure_fresh_session(
             issuer=_ISSUER,
             client_id=_CLIENT_ID,
-            http_client_override=client,
+            http_client=client,
         )
         assert result is not None
         assert result.refresh_token == "OLD_R"  # unchanged
@@ -181,7 +191,7 @@ class TestEnsureFreshSession:
     ) -> None:
         # Seed an expired session relative to the pinned "now" so the freshness
         # check decides to refresh and store_session re-stamps obtained_at.
-        _seed_session(obtained_at=1_700_000_000 - 1, expires_in=30)
+        _seed_session(monkeypatch, obtained_at=1_700_000_000 - 1, expires_in=30)
         client = httpx.Client(
             transport=httpx.MockTransport(
                 _build_handler(
@@ -196,16 +206,18 @@ class TestEnsureFreshSession:
         result = refresh.ensure_fresh_session(
             issuer=_ISSUER,
             client_id=_CLIENT_ID,
-            http_client_override=client,
+            http_client=client,
         )
         assert result is not None
         assert result.obtained_at == 1_700_000_000
 
     def test_custom_leeway_forces_earlier_refresh(
-        self, fake_keyring: InMemoryKeyring
+        self,
+        fake_keyring: InMemoryKeyring,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         # 100s lifetime, with 90s leeway → must refresh because deadline = 10s ahead.
-        _seed_session(obtained_at=int(time.time()), expires_in=100)
+        _seed_session(monkeypatch, obtained_at=int(time.time()), expires_in=100)
         client = httpx.Client(
             transport=httpx.MockTransport(
                 _build_handler(
@@ -221,15 +233,17 @@ class TestEnsureFreshSession:
             issuer=_ISSUER,
             client_id=_CLIENT_ID,
             leeway_s=200,
-            http_client_override=client,
+            http_client=client,
         )
         assert result is not None
         assert result.access_token == "REFRESHED_BECAUSE_LEEWAY"
 
     def test_refresh_failure_does_not_delete_stored_session(
-        self, fake_keyring: InMemoryKeyring
+        self,
+        fake_keyring: InMemoryKeyring,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        _seed_session(obtained_at=int(time.time()) - 1, expires_in=30)
+        _seed_session(monkeypatch, obtained_at=int(time.time()) - 1, expires_in=30)
         client = httpx.Client(
             transport=httpx.MockTransport(
                 _build_handler(
@@ -242,7 +256,7 @@ class TestEnsureFreshSession:
             refresh.ensure_fresh_session(
                 issuer=_ISSUER,
                 client_id=_CLIENT_ID,
-                http_client_override=client,
+                http_client=client,
             )
         # Session is still present (user can retry / re-login).
         assert storage.load_session(issuer=_ISSUER, client_id=_CLIENT_ID) is not None
@@ -268,7 +282,7 @@ class TestRefreshAccessTokenErrors:
                 issuer=_ISSUER,
                 client_id=_CLIENT_ID,
                 refresh_token="x",
-                http_client_override=client,
+                http_client=client,
             )
 
     def test_network_error_raises_refresh_error(self) -> None:
@@ -282,7 +296,7 @@ class TestRefreshAccessTokenErrors:
                 issuer=_ISSUER,
                 client_id=_CLIENT_ID,
                 refresh_token="x",
-                http_client_override=client,
+                http_client=client,
             )
 
     def test_discovery_failure_raises_refresh_error(self) -> None:
@@ -294,7 +308,7 @@ class TestRefreshAccessTokenErrors:
                 issuer=_ISSUER,
                 client_id=_CLIENT_ID,
                 refresh_token="x",
-                http_client_override=client,
+                http_client=client,
             )
 
     def test_non_object_json_raises_refresh_error(self) -> None:
@@ -309,5 +323,5 @@ class TestRefreshAccessTokenErrors:
                 issuer=_ISSUER,
                 client_id=_CLIENT_ID,
                 refresh_token="x",
-                http_client_override=client,
+                http_client=client,
             )

--- a/packages/cli/tests/test_auth_refresh.py
+++ b/packages/cli/tests/test_auth_refresh.py
@@ -162,6 +162,34 @@ class TestEnsureFreshSession:
         assert reloaded.access_token == "NEW_A"
         assert reloaded.refresh_token == "NEW_R"
 
+    def test_carries_forward_omitted_lifetime_fields(
+        self,
+        fake_keyring: InMemoryKeyring,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When the IdP omits ``expires_in`` from the refresh response, the
+        rotated session must inherit the previous value — otherwise the next
+        freshness check would treat the token as already expired and force a
+        refresh on the very next call."""
+        _seed_session(monkeypatch, obtained_at=int(time.time()) - 1, expires_in=300)
+        client = httpx.Client(
+            transport=httpx.MockTransport(
+                _build_handler(
+                    token_payload={
+                        "access_token": "NEW_A"
+                    }  # no expires_in / scope / id_token
+                )
+            )
+        )
+        result = refresh.ensure_fresh_session(
+            issuer=_ISSUER,
+            client_id=_CLIENT_ID,
+            http_client=client,
+        )
+        assert result is not None
+        assert result.expires_in == 300  # carried forward
+        assert result.scope == "openid offline_access"  # carried forward
+
     def test_falls_back_to_old_refresh_token_when_idp_does_not_rotate(
         self,
         fake_keyring: InMemoryKeyring,

--- a/packages/cli/tests/test_auth_refresh.py
+++ b/packages/cli/tests/test_auth_refresh.py
@@ -1,0 +1,313 @@
+"""Unit tests for ``oauth/refresh.py`` — ``ensure_fresh_session`` + refresh grant."""
+
+from __future__ import annotations
+
+import time
+
+import httpx
+import pytest
+from conftest import InMemoryKeyring
+
+from pipefy_cli.oauth import refresh, storage
+
+_ISSUER = "https://signin.example.com/realms/pipefy"
+_CLIENT_ID = "pipefy-cli"
+
+
+def _discovery_payload(issuer: str = _ISSUER) -> dict[str, str]:
+    return {
+        "issuer": issuer,
+        "authorization_endpoint": f"{issuer}/protocol/openid-connect/auth",
+        "token_endpoint": f"{issuer}/protocol/openid-connect/token",
+    }
+
+
+def _build_handler(
+    *,
+    discovery_status: int = 200,
+    discovery_payload: dict | None = None,
+    token_status: int = 200,
+    token_payload: dict | None = None,
+    raise_on_token: Exception | None = None,
+):
+    """Mock transport: returns canned responses for discovery + token endpoints."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/.well-known/openid-configuration"):
+            return httpx.Response(
+                discovery_status, json=discovery_payload or _discovery_payload()
+            )
+        if request.url.path.endswith("/protocol/openid-connect/token"):
+            if raise_on_token is not None:
+                raise raise_on_token
+            return httpx.Response(
+                token_status,
+                json=token_payload or {"access_token": "new", "refresh_token": "new_r"},
+            )
+        return httpx.Response(404)
+
+    return handler
+
+
+def _seed_session(*, obtained_at: int, expires_in: int = 300) -> None:
+    storage.store_session(
+        issuer=_ISSUER,
+        client_id=_CLIENT_ID,
+        token_response={
+            "access_token": "OLD",
+            "refresh_token": "OLD_R",
+            "token_type": "Bearer",
+            "expires_in": expires_in,
+            "scope": "openid offline_access",
+        },
+    )
+    # Overwrite obtained_at to put the token at the desired freshness.
+    loaded = storage.load_session(issuer=_ISSUER, client_id=_CLIENT_ID)
+    assert loaded is not None
+    import dataclasses
+
+    rewritten = dataclasses.replace(loaded, obtained_at=obtained_at)
+    import json
+
+    import keyring
+
+    keyring.set_password(
+        "pipefy-cli",
+        storage.keychain_key(_ISSUER, _CLIENT_ID),
+        json.dumps(dataclasses.asdict(rewritten)),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# ensure_fresh_session                                                        #
+# --------------------------------------------------------------------------- #
+
+
+class TestEnsureFreshSession:
+    def test_returns_none_when_no_keychain_entry(
+        self, fake_keyring: InMemoryKeyring
+    ) -> None:
+        assert (
+            refresh.ensure_fresh_session(issuer=_ISSUER, client_id=_CLIENT_ID) is None
+        )
+
+    def test_returns_session_unchanged_when_fresh(
+        self, fake_keyring: InMemoryKeyring
+    ) -> None:
+        _seed_session(obtained_at=int(time.time()))  # full 300s ahead
+
+        client = httpx.Client(transport=httpx.MockTransport(_build_handler()))
+        result = refresh.ensure_fresh_session(
+            issuer=_ISSUER,
+            client_id=_CLIENT_ID,
+            http_client_override=client,
+        )
+        assert result is not None
+        assert result.access_token == "OLD"
+        assert result.refresh_token == "OLD_R"
+
+    def test_refreshes_when_within_leeway(self, fake_keyring: InMemoryKeyring) -> None:
+        # 30s lifetime + 60s leeway → must refresh.
+        _seed_session(obtained_at=int(time.time()) - 1, expires_in=30)
+
+        client = httpx.Client(
+            transport=httpx.MockTransport(
+                _build_handler(
+                    token_payload={
+                        "access_token": "NEW_A",
+                        "refresh_token": "NEW_R",
+                        "token_type": "Bearer",
+                        "expires_in": 300,
+                    }
+                )
+            )
+        )
+        result = refresh.ensure_fresh_session(
+            issuer=_ISSUER,
+            client_id=_CLIENT_ID,
+            http_client_override=client,
+        )
+        assert result is not None
+        assert result.access_token == "NEW_A"
+        assert result.refresh_token == "NEW_R"
+
+    def test_persists_rotated_session(self, fake_keyring: InMemoryKeyring) -> None:
+        _seed_session(obtained_at=int(time.time()) - 1, expires_in=30)
+        client = httpx.Client(
+            transport=httpx.MockTransport(
+                _build_handler(
+                    token_payload={
+                        "access_token": "NEW_A",
+                        "refresh_token": "NEW_R",
+                    }
+                )
+            )
+        )
+        refresh.ensure_fresh_session(
+            issuer=_ISSUER,
+            client_id=_CLIENT_ID,
+            http_client_override=client,
+        )
+
+        reloaded = storage.load_session(issuer=_ISSUER, client_id=_CLIENT_ID)
+        assert reloaded is not None
+        assert reloaded.access_token == "NEW_A"
+        assert reloaded.refresh_token == "NEW_R"
+
+    def test_falls_back_to_old_refresh_token_when_idp_does_not_rotate(
+        self, fake_keyring: InMemoryKeyring
+    ) -> None:
+        _seed_session(obtained_at=int(time.time()) - 1, expires_in=30)
+        client = httpx.Client(
+            transport=httpx.MockTransport(
+                _build_handler(
+                    # No refresh_token in response.
+                    token_payload={"access_token": "NEW_A"}
+                )
+            )
+        )
+        result = refresh.ensure_fresh_session(
+            issuer=_ISSUER,
+            client_id=_CLIENT_ID,
+            http_client_override=client,
+        )
+        assert result is not None
+        assert result.refresh_token == "OLD_R"  # unchanged
+
+    def test_obtained_at_updated_after_refresh(
+        self,
+        fake_keyring: InMemoryKeyring,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Seed an expired session relative to the pinned "now" so the freshness
+        # check decides to refresh and store_session re-stamps obtained_at.
+        _seed_session(obtained_at=1_700_000_000 - 1, expires_in=30)
+        client = httpx.Client(
+            transport=httpx.MockTransport(
+                _build_handler(
+                    token_payload={
+                        "access_token": "NEW_A",
+                        "refresh_token": "NEW_R",
+                    }
+                )
+            )
+        )
+        monkeypatch.setattr(time, "time", lambda: 1_700_000_000.0)
+        result = refresh.ensure_fresh_session(
+            issuer=_ISSUER,
+            client_id=_CLIENT_ID,
+            http_client_override=client,
+        )
+        assert result is not None
+        assert result.obtained_at == 1_700_000_000
+
+    def test_custom_leeway_forces_earlier_refresh(
+        self, fake_keyring: InMemoryKeyring
+    ) -> None:
+        # 100s lifetime, with 90s leeway → must refresh because deadline = 10s ahead.
+        _seed_session(obtained_at=int(time.time()), expires_in=100)
+        client = httpx.Client(
+            transport=httpx.MockTransport(
+                _build_handler(
+                    token_payload={
+                        "access_token": "REFRESHED_BECAUSE_LEEWAY",
+                        "refresh_token": "NEW_R",
+                    }
+                )
+            )
+        )
+        # leeway_s=200 forces the deadline into the past → refresh.
+        result = refresh.ensure_fresh_session(
+            issuer=_ISSUER,
+            client_id=_CLIENT_ID,
+            leeway_s=200,
+            http_client_override=client,
+        )
+        assert result is not None
+        assert result.access_token == "REFRESHED_BECAUSE_LEEWAY"
+
+    def test_refresh_failure_does_not_delete_stored_session(
+        self, fake_keyring: InMemoryKeyring
+    ) -> None:
+        _seed_session(obtained_at=int(time.time()) - 1, expires_in=30)
+        client = httpx.Client(
+            transport=httpx.MockTransport(
+                _build_handler(
+                    token_status=400,
+                    token_payload={"error": "invalid_grant"},
+                )
+            )
+        )
+        with pytest.raises(refresh.RefreshError):
+            refresh.ensure_fresh_session(
+                issuer=_ISSUER,
+                client_id=_CLIENT_ID,
+                http_client_override=client,
+            )
+        # Session is still present (user can retry / re-login).
+        assert storage.load_session(issuer=_ISSUER, client_id=_CLIENT_ID) is not None
+
+
+# --------------------------------------------------------------------------- #
+# refresh_access_token (low-level)                                            #
+# --------------------------------------------------------------------------- #
+
+
+class TestRefreshAccessTokenErrors:
+    def test_invalid_grant_raises_refresh_error(self) -> None:
+        client = httpx.Client(
+            transport=httpx.MockTransport(
+                _build_handler(
+                    token_status=400,
+                    token_payload={"error": "invalid_grant"},
+                )
+            )
+        )
+        with pytest.raises(refresh.RefreshError, match="Refresh failed"):
+            refresh.refresh_access_token(
+                issuer=_ISSUER,
+                client_id=_CLIENT_ID,
+                refresh_token="x",
+                http_client_override=client,
+            )
+
+    def test_network_error_raises_refresh_error(self) -> None:
+        client = httpx.Client(
+            transport=httpx.MockTransport(
+                _build_handler(raise_on_token=httpx.ConnectError("boom"))
+            )
+        )
+        with pytest.raises(refresh.RefreshError, match="Refresh request failed"):
+            refresh.refresh_access_token(
+                issuer=_ISSUER,
+                client_id=_CLIENT_ID,
+                refresh_token="x",
+                http_client_override=client,
+            )
+
+    def test_discovery_failure_raises_refresh_error(self) -> None:
+        client = httpx.Client(
+            transport=httpx.MockTransport(_build_handler(discovery_status=404))
+        )
+        with pytest.raises(refresh.RefreshError, match="OIDC discovery failed"):
+            refresh.refresh_access_token(
+                issuer=_ISSUER,
+                client_id=_CLIENT_ID,
+                refresh_token="x",
+                http_client_override=client,
+            )
+
+    def test_non_object_json_raises_refresh_error(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/.well-known/openid-configuration"):
+                return httpx.Response(200, json=_discovery_payload())
+            return httpx.Response(200, json=["not", "an", "object"])
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with pytest.raises(refresh.RefreshError, match="non-object"):
+            refresh.refresh_access_token(
+                issuer=_ISSUER,
+                client_id=_CLIENT_ID,
+                refresh_token="x",
+                http_client_override=client,
+            )

--- a/packages/cli/tests/test_common_helpers.py
+++ b/packages/cli/tests/test_common_helpers.py
@@ -159,9 +159,9 @@ def test_run_pipefy_client_coroutine_runs_factory_and_returns(monkeypatch):
 
     captured: dict[str, Any] = {}
 
-    def fake_get_client(settings: object, *, bearer_token: object) -> object:
+    def fake_get_client(settings: object, **kwargs: object) -> object:
         captured["settings"] = settings
-        captured["bearer_token"] = bearer_token
+        captured["bearer_token"] = kwargs.get("bearer_token")
         return "client-instance"
 
     async def factory(client: object) -> str:
@@ -171,7 +171,14 @@ def test_run_pipefy_client_coroutine_runs_factory_and_returns(monkeypatch):
     sentinel_settings = object()
     monkeypatch.setattr(_common, "get_authenticated_client", fake_get_client)
     monkeypatch.setattr(
-        _common, "settings_and_token", lambda ctx: (sentinel_settings, "abc")
+        _common,
+        "auth_context_from_ctx",
+        lambda ctx: _common.AuthContext(
+            settings=sentinel_settings,
+            bearer_token="abc",
+            auth_url=None,
+            auth_client_id=None,
+        ),
     )
 
     result = run_pipefy_client_coroutine(MagicMock(), factory)
@@ -195,9 +202,15 @@ def test_run_pipefy_client_coroutine_maps_pipefy_error_to_exit_1(monkeypatch):
     from pipefy_cli.commands._common import run_pipefy_client_coroutine
 
     monkeypatch.setattr(
-        _common, "get_authenticated_client", lambda settings, *, bearer_token: object()
+        _common, "get_authenticated_client", lambda settings, **kwargs: object()
     )
-    monkeypatch.setattr(_common, "settings_and_token", lambda ctx: (object(), None))
+    monkeypatch.setattr(
+        _common,
+        "auth_context_from_ctx",
+        lambda ctx: _common.AuthContext(
+            settings=object(), bearer_token=None, auth_url=None, auth_client_id=None
+        ),
+    )
 
     async def factory(client: object) -> str:
         raise PipefyError("graphql denied")
@@ -214,9 +227,15 @@ def test_run_pipefy_client_coroutine_maps_value_error_when_configured(monkeypatc
     from pipefy_cli.commands._common import run_pipefy_client_coroutine
 
     monkeypatch.setattr(
-        _common, "get_authenticated_client", lambda settings, *, bearer_token: object()
+        _common, "get_authenticated_client", lambda settings, **kwargs: object()
     )
-    monkeypatch.setattr(_common, "settings_and_token", lambda ctx: (object(), None))
+    monkeypatch.setattr(
+        _common,
+        "auth_context_from_ctx",
+        lambda ctx: _common.AuthContext(
+            settings=object(), bearer_token=None, auth_url=None, auth_client_id=None
+        ),
+    )
 
     async def factory(client: object) -> None:
         raise ValueError("Export failed (state='failed').")
@@ -233,9 +252,15 @@ def test_run_pipefy_client_coroutine_broken_pipe_exits_0(monkeypatch):
     from pipefy_cli.commands._common import run_pipefy_client_coroutine
 
     monkeypatch.setattr(
-        _common, "get_authenticated_client", lambda settings, *, bearer_token: object()
+        _common, "get_authenticated_client", lambda settings, **kwargs: object()
     )
-    monkeypatch.setattr(_common, "settings_and_token", lambda ctx: (object(), None))
+    monkeypatch.setattr(
+        _common,
+        "auth_context_from_ctx",
+        lambda ctx: _common.AuthContext(
+            settings=object(), bearer_token=None, auth_url=None, auth_client_id=None
+        ),
+    )
 
     async def factory(client: object) -> None:
         raise BrokenPipeError()

--- a/packages/cli/tests/test_common_helpers.py
+++ b/packages/cli/tests/test_common_helpers.py
@@ -159,9 +159,9 @@ def test_run_pipefy_client_coroutine_runs_factory_and_returns(monkeypatch):
 
     captured: dict[str, Any] = {}
 
-    def fake_get_client(settings: object, **kwargs: object) -> object:
+    def fake_get_client(settings: object, auth: object) -> object:
         captured["settings"] = settings
-        captured["bearer_token"] = kwargs.get("bearer_token")
+        captured["bearer_token"] = auth.bearer_token  # type: ignore[attr-defined]
         return "client-instance"
 
     async def factory(client: object) -> str:
@@ -169,16 +169,12 @@ def test_run_pipefy_client_coroutine_runs_factory_and_returns(monkeypatch):
         return "done"
 
     sentinel_settings = object()
+    sentinel_auth = _common.AuthContext(bearer_token="abc", oidc_client=None)
     monkeypatch.setattr(_common, "get_authenticated_client", fake_get_client)
     monkeypatch.setattr(
         _common,
-        "auth_context_from_ctx",
-        lambda ctx: _common.AuthContext(
-            settings=sentinel_settings,
-            bearer_token="abc",
-            auth_url=None,
-            auth_client_id=None,
-        ),
+        "settings_and_auth_from_ctx",
+        lambda ctx: (sentinel_settings, sentinel_auth),
     )
 
     result = run_pipefy_client_coroutine(MagicMock(), factory)
@@ -202,13 +198,14 @@ def test_run_pipefy_client_coroutine_maps_pipefy_error_to_exit_1(monkeypatch):
     from pipefy_cli.commands._common import run_pipefy_client_coroutine
 
     monkeypatch.setattr(
-        _common, "get_authenticated_client", lambda settings, **kwargs: object()
+        _common, "get_authenticated_client", lambda settings, auth: object()
     )
     monkeypatch.setattr(
         _common,
-        "auth_context_from_ctx",
-        lambda ctx: _common.AuthContext(
-            settings=object(), bearer_token=None, auth_url=None, auth_client_id=None
+        "settings_and_auth_from_ctx",
+        lambda ctx: (
+            object(),
+            _common.AuthContext(bearer_token=None, oidc_client=None),
         ),
     )
 
@@ -227,13 +224,14 @@ def test_run_pipefy_client_coroutine_maps_value_error_when_configured(monkeypatc
     from pipefy_cli.commands._common import run_pipefy_client_coroutine
 
     monkeypatch.setattr(
-        _common, "get_authenticated_client", lambda settings, **kwargs: object()
+        _common, "get_authenticated_client", lambda settings, auth: object()
     )
     monkeypatch.setattr(
         _common,
-        "auth_context_from_ctx",
-        lambda ctx: _common.AuthContext(
-            settings=object(), bearer_token=None, auth_url=None, auth_client_id=None
+        "settings_and_auth_from_ctx",
+        lambda ctx: (
+            object(),
+            _common.AuthContext(bearer_token=None, oidc_client=None),
         ),
     )
 
@@ -252,13 +250,14 @@ def test_run_pipefy_client_coroutine_broken_pipe_exits_0(monkeypatch):
     from pipefy_cli.commands._common import run_pipefy_client_coroutine
 
     monkeypatch.setattr(
-        _common, "get_authenticated_client", lambda settings, **kwargs: object()
+        _common, "get_authenticated_client", lambda settings, auth: object()
     )
     monkeypatch.setattr(
         _common,
-        "auth_context_from_ctx",
-        lambda ctx: _common.AuthContext(
-            settings=object(), bearer_token=None, auth_url=None, auth_client_id=None
+        "settings_and_auth_from_ctx",
+        lambda ctx: (
+            object(),
+            _common.AuthContext(bearer_token=None, oidc_client=None),
         ),
     )
 


### PR DESCRIPTION
Closes the loop opened by #125: ``pipefy auth login`` writes a session to the keychain, but until this PR nothing downstream read it. After this lands, the four-tier credential precedence chain becomes fully operative:

| # | Source | Status before | Status after |
|---|---|---|---|
| 1 | ``--token`` flag | ✓ | unchanged |
| 2 | ``PIPEFY_TOKEN`` env | ✓ | unchanged |
| 3 | ``PIPEFY_OAUTH_*`` client-creds triple | ✓ | unchanged |
| 4 | Stored user session | ✗ dead | **operative** |

## Eager refresh

Before each ``pipefy <cmd>`` invocation, ``ensure_fresh_session`` checks the stored access token's age. If ≤ 60 s of leeway remains, the CLI POSTs ``grant_type=refresh_token`` to the issuer's token endpoint, persists rotated tokens back to the keychain, and builds the ``PipefyClient`` with the new access token. The existing cache key already includes ``bearer_token`` — refresh-induced rotation invalidates correctly with no key-shape change.

Reactive refresh-on-401 (via a custom httpx auth hook) is **deferred** to a separate slice. Eager refresh covers the common case (one-shot CLI invocations across the lifetime of a refresh token) and stays out of the SDK transport entirely.

## What's new

- ``oauth/refresh.py`` — ``RefreshError``, ``refresh_access_token``, ``ensure_fresh_session``.
- ``oauth/_http.py`` — shared httpx-client context manager extracted from ``flow.py`` so ``flow.py`` and ``refresh.py`` reuse the same borrow-or-create helper.
- ``oauth/__init__.py`` — re-exports for the new symbols.
- ``auth.py::get_authenticated_client`` — extended signature with ``auth_url`` / ``auth_client_id`` kwargs. New priority-4 branch runs ``ensure_fresh_session`` *before* the cache lookup so refresh-rotated tokens produce the right cache signature. Updated "no auth source" error mentions ``pipefy auth login``.
- ``commands/_common.py`` — new frozen dataclass ``AuthContext`` + helper ``auth_context_from_ctx(ctx)`` that threads the new ``auth_url`` / ``auth_client_id`` ctx values to the auth boundary. The 3 internal call sites (``run_pipefy_client_coroutine``, ``run_cli_command``, ``authenticated_client_from_ctx``) use it; ``settings_and_token`` stays unchanged for its 9 external command callers.
- ``tests/conftest.py`` — promoted ``InMemoryKeyring`` + ``fake_keyring`` from ``test_auth_login.py`` for cross-file reuse.

## Out of scope (tracked elsewhere or coming separately)

- Reactive refresh-on-401 (custom httpx auth hook).
- ``pipefy auth status`` / ``pipefy auth logout``.
- ``InternalApiClient`` over user-auth (AI-automation features remain unavailable on the bearer path — same limitation as ``PIPEFY_TOKEN`` today; lifting requires SDK changes).
- Distinguishing "keychain unreachable" from "no session" in the error message (both currently surface as ``None`` from ``load_session``).

## Test plan

- [x] ``test_auth_refresh.py`` — 12 new cases: ``ensure_fresh_session`` for no-session / fresh / refresh / rotation paths; ``RefreshError`` on ``invalid_grant`` / network error / discovery failure / non-object body; refresh failure preserves the stored session for retry.
- [x] ``test_auth.py`` — 5 new precedence cases: bearer wins over session, OAuth-triple wins over session, session used when no other source, cache invalidates when access token rotates, ``RefreshError`` → ``typer.Exit(2)`` with relogin hint.
- [x] ``test_common_helpers.py`` — 4 existing mocks updated to the new ``auth_context_from_ctx`` boundary.
- [x] ``uv run pytest -m "not integration"`` — **2222 passed**, 42 deselected.
- [x] ``uv run ruff check packages/cli`` — clean.
- [x] ``uv run ruff format --check packages/cli`` — clean.

### Manual E2E against piporacle (planned post-review)

```
unset PIPEFY_TOKEN PIPEFY_OAUTH_URL PIPEFY_OAUTH_CLIENT PIPEFY_OAUTH_SECRET
export PIPEFY_AUTH_URL=https://signin-piporacle.pipefy.com/realms/st-piporacle-pud1m
export PIPEFY_GRAPHQL_URL=https://piporacle.pipefy.com/graphql
uv run pipefy auth login         # browser flow → keychain
uv run pipefy pipe list           # should succeed via keychain session
PIPEFY_TOKEN=garbage uv run pipefy pipe list  # should 401 (proves --token wins)
```

## Size note

11 files / ~782 insertions / ~96 deletions. Above the AGENTS.md ≤300-line / ≤10-file guideline. Bulk is test scaffolding (~315 LOC in ``test_auth_refresh.py`` alone). Production code is ~295 LOC across 6 files. Happy to split into "refresh module + its tests" vs "auth.py wiring + its tests" if reviewers prefer.
