### PR TITLE
docs(cli): document the CLI auth surface

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ This folder holds **human-facing** guides for the Pipefy Labs monorepo. Use the 
 | Doc | Role |
 |-----|------|
 | [`setup.md`](setup.md) | First-time install, `PIPEFY_*` variables, MCP client JSON samples |
+| [`cli/auth.md`](cli/auth.md) | CLI credential precedence, `pipefy auth login`, troubleshooting |
 | [`parity.md`](parity.md) | MCP tool ↔ CLI command matrix (source of truth for coverage and deferrals) |
 | [`MIGRATION.md`](MIGRATION.md) | Notes for existing MCP users across packaging changes |
 | [`dependencies.md`](dependencies.md) | Why each runtime dependency exists |

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -6,6 +6,7 @@ Material here describes **`pipefy-cli`** (Typer): terminal workflows, flags, and
 
 | Path | Description |
 |------|-------------|
+| [`auth.md`](auth.md) | Credential precedence, `pipefy auth login`, env vars, and troubleshooting for the four supported auth sources |
 | [`self-healing.md`](self-healing.md) | Discover GraphQL operations with `pipefy introspect`, then run `pipefy graphql exec` (mutations require `--yes`) |
 
 ## Quick conventions

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -1,0 +1,202 @@
+# CLI authentication
+
+See also the **[CLI docs index](README.md)** and **[`docs/setup.md`](../setup.md)** for the broader `PIPEFY_*` env-var story.
+
+The `pipefy` CLI accepts authentication from four sources. This page covers all of them, how the CLI picks one, and how to recover when something goes wrong.
+
+## Contents
+
+- [Credential precedence](#credential-precedence)
+- [Quick start](#quick-start)
+- [Reference](#reference)
+- [Headless / SSH](#headless--ssh)
+- [Troubleshooting](#troubleshooting)
+- [How it works](#how-it-works)
+
+---
+
+## Credential precedence
+
+Most-explicit wins. The CLI walks this list top-down and stops at the first source it can resolve:
+
+| # | Source | Identity | Notes |
+|---|--------|----------|-------|
+| 1 | `--token <bearer>` | Whoever owns the token | Skips OAuth entirely |
+| 2 | `PIPEFY_TOKEN` env var | Whoever owns the token | Same path as `--token` |
+| 3 | `PIPEFY_OAUTH_*` triple | Service account | Client-credentials grant (unlocks AI automations) |
+| 4 | Stored user session | You (the signed-in user) | Eager refresh inside a 60 s leeway window |
+
+Tiers 1, 2, and 4 ultimately become a **static bearer token** on the GraphQL client. Only tier 3 builds the `InternalApiClient` that some MCP/CLI features (AI automations, certain relation flows) rely on — see [Limitations on the bearer path](#limitations-on-the-bearer-path).
+
+If `pipefy auth login` succeeds but a higher-precedence source is set in your shell env, the CLI prints a one-line note so you know your stored session is being shadowed.
+
+---
+
+## Quick start
+
+### Interactive (you, in a browser)
+
+Use this when you want commands to run **as your Pipefy user** — useful for parity with the app's permission model and for AI-automation features that need a real user identity.
+
+```bash
+export PIPEFY_AUTH_URL=https://signin.pipefy.com/realms/pipefy
+export PIPEFY_GRAPHQL_URL=https://app.pipefy.com/graphql
+
+uv run pipefy auth login
+```
+
+This opens your browser, completes an OAuth 2.0 Authorization Code + PKCE flow against the Pipefy identity provider, and writes the resulting session (access token + refresh token + minimal metadata) into your OS keychain.
+
+After login, every other `pipefy <cmd>` invocation transparently reuses that session and refreshes the access token on demand.
+
+### Service account (non-interactive)
+
+Use this for CI, scripts, MCP servers, and any context where opening a browser isn't an option. Get the client id and secret from **Pipefy Admin → Service Accounts** and put them in `.env` at the repo root:
+
+```env
+PIPEFY_GRAPHQL_URL=https://app.pipefy.com/graphql
+PIPEFY_INTERNAL_API_URL=https://app.pipefy.com/internal_api
+PIPEFY_OAUTH_URL=https://app.pipefy.com/oauth/token
+PIPEFY_OAUTH_CLIENT=<SERVICE_ACCOUNT_CLIENT_ID>
+PIPEFY_OAUTH_SECRET=<SERVICE_ACCOUNT_CLIENT_SECRET>
+```
+
+The CLI loads `.env` from the current working directory; see [`docs/setup.md`](../setup.md) for the full Pydantic precedence rules.
+
+### Static bearer (one-off)
+
+For a single command — or to override the precedence chain on the fly:
+
+```bash
+uv run pipefy --token "$MY_BEARER" pipe list
+# or
+PIPEFY_TOKEN="$MY_BEARER" uv run pipefy pipe list
+```
+
+`--token` wins over every other source, including a stored session and `PIPEFY_OAUTH_*`.
+
+---
+
+## Reference
+
+### Environment variables
+
+| Key | Used by | Effect |
+|-----|---------|--------|
+| `PIPEFY_GRAPHQL_URL` | All commands | Public GraphQL endpoint. Required for any GraphQL call (default in `.env.example`). |
+| `PIPEFY_TOKEN` | Tier 2 | Direct bearer token. Overridden by `--token`. |
+| `PIPEFY_OAUTH_URL` | Tier 3 | Service-account token URL (e.g. `https://app.pipefy.com/oauth/token`). |
+| `PIPEFY_OAUTH_CLIENT` | Tier 3 | Service-account client id. |
+| `PIPEFY_OAUTH_SECRET` | Tier 3 | Service-account client secret. |
+| `PIPEFY_INTERNAL_API_URL` | Tier 3 | Internal GraphQL endpoint for AI automations / some relation flows. Required for those tools only. |
+| `PIPEFY_AUTH_URL` | Tier 4 | **OIDC issuer URL** for interactive login. The CLI appends `/.well-known/openid-configuration` to discover the authorization and token endpoints. Required for `pipefy auth login`. |
+| `PIPEFY_AUTH_CLIENT_ID` | Tier 4 | Public client id registered for the CLI. Defaults to `pipefy-cli`. |
+
+`PIPEFY_OAUTH_URL` and `PIPEFY_AUTH_URL` are **not** interchangeable: the first is a token URL for client-credentials, the second is an OIDC issuer URL for the user-login flow.
+
+### Global flags
+
+| Flag | Effect |
+|------|--------|
+| `--token <bearer>` | Tier 1 bearer. Overrides `PIPEFY_TOKEN` if both are set. |
+| `--graphql-url <url>` | Override `PIPEFY_GRAPHQL_URL` for this process. |
+| `--allow-insecure-urls` | Allow `http://` and private hosts for this process (dev only). |
+
+### Commands
+
+| Command | Status | Notes |
+|---------|--------|-------|
+| `pipefy auth login` | Available | Browser-based PKCE login; persists the session in the OS keychain. |
+| `pipefy auth status` | Forthcoming (#135) | Print which auth source is active, identity, and session expiry. |
+| `pipefy auth logout` | Forthcoming (#136) | Delete the stored session and revoke the refresh token. |
+
+#### `pipefy auth login` flags
+
+| Flag | Default | Effect |
+|------|---------|--------|
+| `--no-browser` | _off_ | Print the authorization URL to stdout instead of trying to launch a browser. |
+| `--callback-timeout <s>` | `180.0` | Seconds to wait for the browser callback (minimum 5). |
+
+### Pipefy issuer URLs
+
+| Environment | `PIPEFY_AUTH_URL` |
+|-------------|--------------------|
+| Production | `https://signin.pipefy.com/realms/pipefy` |
+| Validation (piporacle) | `https://signin-piporacle.pipefy.com/realms/st-piporacle-pud1m` |
+
+Pair each issuer with the matching `PIPEFY_GRAPHQL_URL` (`https://app.pipefy.com/graphql` for prod, `https://piporacle.pipefy.com/graphql` for piporacle).
+
+### Limitations on the bearer path
+
+Tiers 1, 2, and 4 all reach the SDK as a static bearer. Only tier 3 builds an `InternalApiClient` against `PIPEFY_INTERNAL_API_URL`. As a result, features that go through the internal API — AI agent automations, some relation flows — are **only available on the service-account path** today. This is the same limitation that already applies to `--token` / `PIPEFY_TOKEN`; lifting it for stored sessions is tracked separately.
+
+---
+
+## Headless / SSH
+
+The PKCE flow needs a loopback HTTP server on `127.0.0.1:<ephemeral>` and a browser that can reach it. SSH sessions and headless boxes break both assumptions.
+
+Options today:
+
+1. **Run `pipefy auth login` on your laptop**, then copy `.env` plus the relevant secrets over. The keychain entry itself doesn't transfer between machines.
+2. **Use a service account** (`PIPEFY_OAUTH_*`) on the headless box — this is the canonical answer for CI and servers.
+3. **Static bearer** via `PIPEFY_TOKEN` for short-lived debugging.
+
+Forthcoming: an OAuth 2.0 Device Authorization Grant (`pipefy auth login --device`) that swaps the loopback callback for a code you paste into a browser elsewhere. Tracked in issue #138.
+
+---
+
+## Troubleshooting
+
+### `Stored Pipefy session could not be refreshed: <reason>`
+
+The keychain has a session but its refresh token won't exchange. Most common causes: the refresh token's absolute lifetime expired, you signed out of the IdP, or the issuer URL changed (e.g. you switched between prod and piporacle without re-logging). Re-run `pipefy auth login`.
+
+### `PIPEFY_AUTH_URL is required for pipefy auth login`
+
+You haven't set the issuer URL. Use the value from [Pipefy issuer URLs](#pipefy-issuer-urls). The same env var also gates whether tier 4 can fire from any other command — without it, the CLI never consults the keychain.
+
+### `Login succeeded but the session could not be stored in your OS keychain (<backend>)`
+
+The login worked but `keyring` couldn't write the entry. On macOS / Windows this is rare. On headless Linux it usually means no Secret Service daemon is running — install `gnome-keyring` or `kwallet`, or fall back to a static `PIPEFY_TOKEN`.
+
+### `Missing authentication. Use --token, set PIPEFY_TOKEN, configure PIPEFY_OAUTH_*, or run pipefy auth login.`
+
+No source resolved. Pick one from [Credential precedence](#credential-precedence). The message also lists which `PIPEFY_OAUTH_*` keys are missing, in case you have a partial service-account setup.
+
+### `Note: PIPEFY_OAUTH_* is set in your environment; other pipefy commands will continue to use it ...`
+
+You ran `pipefy auth login` successfully, but a higher-precedence source is set in your shell. That source will keep being used until you unset it. Common when a `.env` file sets `PIPEFY_OAUTH_*` and the user expects the stored session to take over.
+
+### Identity mismatch (commands run as the wrong user)
+
+Run `whoami`-style queries (e.g. `pipefy graphql exec --query '{ me { email name } }'`) to confirm which identity the CLI is actually using. If you expected your own user but see a service account, check whether `--token`, `PIPEFY_TOKEN`, or a complete `PIPEFY_OAUTH_*` triple is set in your environment — any of them outranks the stored session.
+
+### `State mismatch on OAuth callback (possible CSRF)`
+
+The browser came back with a different `state` than the CLI sent. Re-run `pipefy auth login`. If it happens repeatedly, suspect a stale browser tab from a previous login attempt.
+
+---
+
+## How it works
+
+### Login (`pipefy auth login`)
+
+1. Read `PIPEFY_AUTH_URL` (issuer) and `PIPEFY_AUTH_CLIENT_ID` (default `pipefy-cli`).
+2. Fetch `<issuer>/.well-known/openid-configuration` to discover the authorization and token endpoints.
+3. Bind a loopback socket on `127.0.0.1:<ephemeral>` **before** opening the browser (so no other process can grab the port mid-flight).
+4. Open the browser at the authorization URL with `code_challenge_method=S256` and scopes `openid profile email offline_access` (the last one is what makes the IdP issue a refresh token).
+5. The IdP redirects back to the loopback callback with `?code=...&state=...`.
+6. The CLI verifies `state`, POSTs the code + PKCE verifier to the token endpoint, and persists the response in the OS keychain.
+
+The stored shape is keyed by `(issuer_host, client_id)` — one active session per (IdP, client) pair, per machine. Re-running `pipefy auth login` against the same issuer replaces the previous entry.
+
+### Eager refresh
+
+Each `pipefy <cmd>` invocation calls `ensure_fresh_session` before building the client. If the access token has less than **60 s** of life left, the CLI POSTs `grant_type=refresh_token` to the token endpoint, persists the rotated tokens back to the keychain, and uses the new access token. Failure surfaces as `Stored Pipefy session could not be refreshed: ...`, with no fallback to other tiers — the precedence chain is evaluated before refresh, so if the user explicitly chose tier 4 they get a hard "re-login" signal rather than a silent service-account swap.
+
+Reactive refresh-on-401 (for tokens revoked mid-session) is a separate slice, tracked in issue #137.
+
+### Keychain backends
+
+`keyring` selects an OS backend automatically: macOS Keychain on Darwin, Credential Manager on Windows, Secret Service (gnome-keyring / kwallet) on Linux. `pipefy auth login` prints the resolved backend name on success so you can confirm where the entry landed.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -78,6 +78,8 @@ Runtime settings come from **`pipefy_mcp.settings.Settings`** ([Pydantic Setting
 
 All other optional flags (insecure dev URLs, webhooks, introspection cache, etc.) are documented in **[`.env.example`](../.env.example)** only.
 
+> **CLI users:** the variables above feed the **service-account** path. The `pipefy` CLI also supports an interactive `pipefy auth login` flow (browser-based, per-user) and a direct `PIPEFY_TOKEN` bearer. The four-tier precedence between them is documented in **[`cli/auth.md`](cli/auth.md)**.
+
 ---
 
 ## MCP client setup

--- a/packages/cli/src/pipefy_cli/_docs.py
+++ b/packages/cli/src/pipefy_cli/_docs.py
@@ -1,3 +1,4 @@
 from __future__ import annotations
 
 DOCS_SETUP_REF = "docs/setup.md"
+DOCS_CLI_AUTH_REF = "docs/cli/auth.md"

--- a/packages/cli/src/pipefy_cli/auth.py
+++ b/packages/cli/src/pipefy_cli/auth.py
@@ -26,7 +26,7 @@ from pipefy_sdk import (
     PipefySettings,
 )
 
-from pipefy_cli._docs import DOCS_SETUP_REF
+from pipefy_cli._docs import DOCS_CLI_AUTH_REF
 from pipefy_cli.config import (
     describe_missing_oauth_vars,
     ensure_public_graphql_configured,
@@ -92,7 +92,7 @@ def _missing_auth_message(pipefy_settings: PipefySettings) -> str:
     return (
         "Missing authentication. Use --token, set PIPEFY_TOKEN, configure "
         f"PIPEFY_OAUTH_* ({missing}), or run `pipefy auth login`. "
-        f"See {DOCS_SETUP_REF}."
+        f"See {DOCS_CLI_AUTH_REF}."
     )
 
 

--- a/packages/cli/src/pipefy_cli/commands/auth.py
+++ b/packages/cli/src/pipefy_cli/commands/auth.py
@@ -7,7 +7,7 @@ import webbrowser
 
 import typer
 
-from pipefy_cli._docs import DOCS_SETUP_REF
+from pipefy_cli._docs import DOCS_CLI_AUTH_REF
 from pipefy_cli.commands._common import settings_and_auth_from_ctx
 from pipefy_cli.oauth import (
     LoginError,
@@ -80,7 +80,7 @@ def auth_login(
             "PIPEFY_AUTH_URL is required for `pipefy auth login` (the OIDC issuer "
             "URL for Pipefy authentication, e.g. "
             "https://signin.pipefy.com/realms/pipefy). "
-            f"See {DOCS_SETUP_REF}.",
+            f"See {DOCS_CLI_AUTH_REF}.",
             err=True,
         )
         raise typer.Exit(2)

--- a/packages/cli/tests/test_auth.py
+++ b/packages/cli/tests/test_auth.py
@@ -81,7 +81,7 @@ def test_missing_oauth_exits_2_cli(clean_pipefy_env, saved_cwd, monkeypatch, run
     result = runner.invoke(app, ["card", "get", "123"])
     assert result.exit_code == 2
     combined = (result.stderr or "") + (result.stdout or "")
-    assert "docs/setup.md" in combined
+    assert "docs/cli/auth.md" in combined
 
 
 def test_cli_uses_pipefy_token_env_when_no_flag(


### PR DESCRIPTION
Closes #139. **Stacked on #131** — targets `feat/cli-auth-refresh` because the doc-pointer edits in `auth.py::_missing_auth_message` only exist on that branch. After #131 merges, this PR's base auto-rebases against `dev`.

## Summary

Adds `docs/cli/auth.md` covering everything a user needs to reason about CLI authentication:

- **Credential precedence** — the four tiers (`--token`, `PIPEFY_TOKEN`, `PIPEFY_OAUTH_*`, stored user session) in one table, with an explicit callout that tiers 1/2/4 collapse to a static bearer and only tier 3 builds an `InternalApiClient` (so AI-automation features still need the service-account path today — same limitation as `PIPEFY_TOKEN`).
- **Quick start** for interactive (`pipefy auth login`), service-account (`PIPEFY_OAUTH_*`), and one-off bearer (`--token`).
- **Reference** tables for env vars, global flags, and commands. Forthcoming `auth status` (#135) and `auth logout` (#136) are listed with their issue numbers; production and piporacle issuer URLs are documented inline.
- **Headless / SSH** section pointing at service accounts today and forward-linking to the device-flow proposal in #138.
- **Troubleshooting** recipes for every user-facing auth error path (`Stored Pipefy session could not be refreshed`, `PIPEFY_AUTH_URL is required`, keychain-unreachable, missing-source, the masking-warning, identity-mismatch, state-mismatch).
- **How it works** — login orchestration, 60 s eager-refresh leeway, keychain backends per OS.

## Cross-links

Per the issue's acceptance criteria:

- Indexed from `docs/cli/README.md` and `docs/README.md`.
- Forward-linked from `docs/setup.md`'s env-vars section so first-time users discover the CLI-specific story.
- Auth-specific CLI errors now point at `docs/cli/auth.md` via a new `DOCS_CLI_AUTH_REF` constant (`_docs.py`):
  - `auth.py::_missing_auth_message` (the \"no auth source\" path)
  - `commands/auth.py::_auth_config_from_ctx` (the `PIPEFY_AUTH_URL` required path)
  - The unrelated `docs/setup.md` references in `config.py` (GraphQL URL / TOML format errors) stay as-is.
- `grep` confirmed no `packages/cli/src/pipefy_cli/skills/*.md` mentions auth env vars, so no skill-side link-outs were needed.

## Test plan

- [x] `uv run pytest packages/cli/tests -m \"not integration\"` — 208 passed.
- [x] `uv run ruff check packages/cli` — clean.
- [x] `uv run ruff format --check packages/cli` — clean.
- [x] Updated `test_missing_oauth_exits_2_cli` to assert on the new `docs/cli/auth.md` pointer.

## Out of scope

- Device-flow guidance (waiting on #138).
- Documenting `auth status` / `auth logout` beyond \"forthcoming\" (waiting on #135 / #136).