### PR TITLE
feat(cli): pipefy auth status (#135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **CLI**: `pipefy auth status [--json|-j]` — reports auth source, identity, session expiry, and exit codes.
+
 ### Changed
 
 ### Fixed

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -107,7 +107,7 @@ PIPEFY_TOKEN="$MY_BEARER" uv run pipefy pipe list
 | Command | Status | Notes |
 |---------|--------|-------|
 | `pipefy auth login` | Available | Browser-based PKCE login; persists the session in the OS keychain. |
-| `pipefy auth status` | Forthcoming (#135) | Print which auth source is active, identity, and session expiry. |
+| `pipefy auth status` | Available | Print which auth source is active, identity, and session expiry. |
 | `pipefy auth logout` | Forthcoming (#136) | Delete the stored session and revoke the refresh token. |
 
 #### `pipefy auth login` flags
@@ -116,6 +116,43 @@ PIPEFY_TOKEN="$MY_BEARER" uv run pipefy pipe list
 |------|---------|--------|
 | `--no-browser` | _off_ | Print the authorization URL to stdout instead of trying to launch a browser. |
 | `--callback-timeout <s>` | `180.0` | Seconds to wait for the browser callback (minimum 5). |
+
+#### `pipefy auth status` flags
+
+| Flag | Default | Effect |
+|------|---------|--------|
+| `--json` / `-j` | _off_ | Emit a stable JSON schema instead of human-readable text. |
+
+The command answers four diagnostic questions: am I signed in, as whom, via which precedence tier, and (for stored sessions) when does the access/refresh token expire. It also reports which *other* credential sources are configured, so a CI failure where `PIPEFY_OAUTH_*` masks a stored login is one command away from being obvious.
+
+##### JSON schema
+
+```jsonc
+{
+  "signed_in": true,
+  "identity": {"email": "user@pipefy.com", "name": "Pipefy User"},
+  "auth_source": "stored-session",                // or "flag-token" | "env-token" | "service-account" | "none"
+  "detected_sources": ["stored-session"],         // every configured source (winner + masked)
+  "issuer": "https://signin.pipefy.com/realms/pipefy",
+  "state": "active",                              // or "refresh-expired" | "needs-login" | "n/a"
+  "access_expires_at": "2026-05-20T22:14:03Z",    // ISO 8601, null for static-bearer
+  "refresh_expires_at": "2026-06-19T18:02:00Z",   // ISO 8601, null when not stored-session
+  "token_rejected": false,                        // true only when the identity `me` query returned 401
+  "keychain_backend": "Keyring",                  // null for non-stored-session sources
+  "masking_env_vars": []                          // env vars masking a stored session, if any
+}
+```
+
+The shape is stable across all sources (fields you don't have are `null` rather than absent), so a script can `jq .auth_source` without branching on which tier is active.
+
+##### Exit codes
+
+| Case | Exit |
+|------|------|
+| `auth_source == "none"` | **2** — same code as a domain command that fails on missing credentials. |
+| Stored session present but refresh grant rejected (`state` ∈ {`refresh-expired`, `needs-login`}) | **2** |
+| Signed in, but the identity `me` query returned 401 or transport-failed | **1** |
+| Signed in, identity fetched successfully | **0** |
 
 ### Pipefy issuer URLs
 

--- a/packages/cli/src/pipefy_cli/auth.py
+++ b/packages/cli/src/pipefy_cli/auth.py
@@ -34,7 +34,6 @@ from pipefy_cli.config import (
 )
 from pipefy_cli.oauth import RefreshError, ensure_fresh_session, load_session
 
-
 AuthSource = Literal[
     "flag-token",
     "env-token",
@@ -126,10 +125,14 @@ def detect_all_sources(
         )
     if not describe_missing_oauth_vars(pipefy_settings):
         sources.append("service-account")
-    if auth.oidc_client is not None and load_session(
-        issuer=auth.oidc_client.issuer_url,
-        client_id=auth.oidc_client.client_id,
-    ) is not None:
+    if (
+        auth.oidc_client is not None
+        and load_session(
+            issuer=auth.oidc_client.issuer_url,
+            client_id=auth.oidc_client.client_id,
+        )
+        is not None
+    ):
         sources.append("stored-session")
     return sources
 

--- a/packages/cli/src/pipefy_cli/auth.py
+++ b/packages/cli/src/pipefy_cli/auth.py
@@ -17,6 +17,7 @@ SDK, so a refresh-rotated access token naturally invalidates the cached client.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Literal
 
 import typer
 from pipefy_sdk import (
@@ -31,7 +32,16 @@ from pipefy_cli.config import (
     describe_missing_oauth_vars,
     ensure_public_graphql_configured,
 )
-from pipefy_cli.oauth import RefreshError, ensure_fresh_session
+from pipefy_cli.oauth import RefreshError, ensure_fresh_session, load_session
+
+
+AuthSource = Literal[
+    "flag-token",
+    "env-token",
+    "service-account",
+    "stored-session",
+    "none",
+]
 
 
 @dataclass(frozen=True)
@@ -47,6 +57,18 @@ class OidcClient:
 
 
 @dataclass(frozen=True)
+class BearerToken:
+    """Static bearer token plus the surface that produced it (``--token`` or env).
+
+    Carrying the origin lets diagnostics (e.g. ``pipefy auth status``) report which
+    precedence tier won without having to re-inspect ``argv``/``os.environ``.
+    """
+
+    value: str
+    source: Literal["flag", "env"]
+
+
+@dataclass(frozen=True)
 class AuthContext:
     """User-auth identity for a single CLI invocation.
 
@@ -55,7 +77,7 @@ class AuthContext:
     passed alongside.
     """
 
-    bearer_token: str | None
+    bearer_token: BearerToken | None
     oidc_client: OidcClient | None
 
 
@@ -85,6 +107,40 @@ def _cache_key(
         bool(pipefy_settings.allow_insecure_urls),
         (bearer_token or "").strip(),
     )
+
+
+def detect_all_sources(
+    pipefy_settings: PipefySettings,
+    auth: AuthContext,
+) -> list[AuthSource]:
+    """Return every configured credential source, highest-precedence first.
+
+    Side-effect-free except for a single keychain read when an ``oidc_client`` is
+    set. Powers both :func:`detect_auth_source` (winner = first element) and
+    diagnostic display (full list surfaces masked sources).
+    """
+    sources: list[AuthSource] = []
+    if auth.bearer_token is not None:
+        sources.append(
+            "flag-token" if auth.bearer_token.source == "flag" else "env-token"
+        )
+    if not describe_missing_oauth_vars(pipefy_settings):
+        sources.append("service-account")
+    if auth.oidc_client is not None and load_session(
+        issuer=auth.oidc_client.issuer_url,
+        client_id=auth.oidc_client.client_id,
+    ) is not None:
+        sources.append("stored-session")
+    return sources
+
+
+def detect_auth_source(
+    pipefy_settings: PipefySettings,
+    auth: AuthContext,
+) -> AuthSource:
+    """Return the precedence winner among configured sources, or ``"none"``."""
+    sources = detect_all_sources(pipefy_settings, auth)
+    return sources[0] if sources else "none"
 
 
 def _missing_auth_message(pipefy_settings: PipefySettings) -> str:
@@ -126,12 +182,20 @@ def get_authenticated_client(
         typer.echo(str(exc), err=True)
         raise typer.Exit(2) from exc
 
-    missing_oauth = describe_missing_oauth_vars(pipefy_settings)
+    source = detect_auth_source(pipefy_settings, auth)
+
+    if source == "none":
+        typer.echo(_missing_auth_message(pipefy_settings), err=True)
+        raise typer.Exit(2)
 
     # Resolve the effective bearer BEFORE the cache lookup so a refresh-rotated
     # access token produces the right (new) cache signature.
-    effective_bearer = auth.bearer_token
-    if not effective_bearer and missing_oauth and auth.oidc_client is not None:
+    effective_bearer: str | None = None
+    if source in ("flag-token", "env-token"):
+        assert auth.bearer_token is not None  # narrowed by detect_auth_source
+        effective_bearer = auth.bearer_token.value
+    elif source == "stored-session":
+        assert auth.oidc_client is not None
         try:
             session = ensure_fresh_session(
                 issuer=auth.oidc_client.issuer_url,
@@ -144,8 +208,12 @@ def get_authenticated_client(
                 err=True,
             )
             raise typer.Exit(2) from exc
-        if session is not None:
-            effective_bearer = session.access_token
+        # ``detect_auth_source`` already confirmed a session is present; if it
+        # vanished between the two reads, fall through to the missing-auth path.
+        if session is None:
+            typer.echo(_missing_auth_message(pipefy_settings), err=True)
+            raise typer.Exit(2)
+        effective_bearer = session.access_token
 
     key = _cache_key(pipefy_settings, effective_bearer)
     if _cached_client is not None and _cached_signature == key:
@@ -162,11 +230,7 @@ def get_authenticated_client(
         _cached_client = client
         return client
 
-    if missing_oauth:
-        typer.echo(_missing_auth_message(pipefy_settings), err=True)
-        raise typer.Exit(2)
-
-    # Priority 3: client-credentials grant.
+    # source == "service-account": client-credentials grant.
     client = PipefyClient(pipefy_settings)
     internal_client = InternalApiClient(
         url=pipefy_settings.internal_api_url,
@@ -184,7 +248,11 @@ def get_authenticated_client(
 
 __all__ = [
     "AuthContext",
+    "AuthSource",
+    "BearerToken",
     "OidcClient",
     "clear_authenticated_client_cache",
+    "detect_all_sources",
+    "detect_auth_source",
     "get_authenticated_client",
 ]

--- a/packages/cli/src/pipefy_cli/auth.py
+++ b/packages/cli/src/pipefy_cli/auth.py
@@ -17,7 +17,7 @@ SDK, so a refresh-rotated access token naturally invalidates the cached client.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, NoReturn
 
 import typer
 from pipefy_sdk import (
@@ -155,6 +155,17 @@ def _missing_auth_message(pipefy_settings: PipefySettings) -> str:
     )
 
 
+def _raise_internal_error(detail: str) -> NoReturn:
+    """Exit(2) with an internal-error message.
+
+    Used for branches the auth-source classifier rules out but the type system
+    can't prove unreachable. ``assert`` would strip under ``python -O``; this
+    survives the optimization and gives the user a clean error.
+    """
+    typer.echo(f"Internal error: {detail} Please file an issue.", err=True)
+    raise typer.Exit(2)
+
+
 def get_authenticated_client(
     pipefy_settings: PipefySettings,
     auth: AuthContext,
@@ -196,24 +207,15 @@ def get_authenticated_client(
     effective_bearer: str | None = None
     if source in ("flag-token", "env-token"):
         if auth.bearer_token is None:
-            # Internal inconsistency: `detect_auth_source` returned a bearer
-            # source but the AuthContext doesn't carry one. Asserts get stripped
-            # under `python -O`, so guard explicitly.
-            typer.echo(
-                f"Internal error: auth source {source!r} detected but no bearer "
-                "token is configured. Please file an issue.",
-                err=True,
+            _raise_internal_error(
+                f"auth source {source!r} detected but no bearer token is configured."
             )
-            raise typer.Exit(2)
         effective_bearer = auth.bearer_token.value
     elif source == "stored-session":
         if auth.oidc_client is None:
-            typer.echo(
-                "Internal error: auth source 'stored-session' detected but no "
-                "OIDC client is configured. Please file an issue.",
-                err=True,
+            _raise_internal_error(
+                "auth source 'stored-session' detected but no OIDC client is configured."
             )
-            raise typer.Exit(2)
         try:
             session = ensure_fresh_session(
                 issuer=auth.oidc_client.issuer_url,

--- a/packages/cli/src/pipefy_cli/auth.py
+++ b/packages/cli/src/pipefy_cli/auth.py
@@ -195,10 +195,25 @@ def get_authenticated_client(
     # access token produces the right (new) cache signature.
     effective_bearer: str | None = None
     if source in ("flag-token", "env-token"):
-        assert auth.bearer_token is not None  # narrowed by detect_auth_source
+        if auth.bearer_token is None:
+            # Internal inconsistency: `detect_auth_source` returned a bearer
+            # source but the AuthContext doesn't carry one. Asserts get stripped
+            # under `python -O`, so guard explicitly.
+            typer.echo(
+                f"Internal error: auth source {source!r} detected but no bearer "
+                "token is configured. Please file an issue.",
+                err=True,
+            )
+            raise typer.Exit(2)
         effective_bearer = auth.bearer_token.value
     elif source == "stored-session":
-        assert auth.oidc_client is not None
+        if auth.oidc_client is None:
+            typer.echo(
+                "Internal error: auth source 'stored-session' detected but no "
+                "OIDC client is configured. Please file an issue.",
+                err=True,
+            )
+            raise typer.Exit(2)
         try:
             session = ensure_fresh_session(
                 issuer=auth.oidc_client.issuer_url,

--- a/packages/cli/src/pipefy_cli/commands/_common.py
+++ b/packages/cli/src/pipefy_cli/commands/_common.py
@@ -14,7 +14,12 @@ from gql.transport.exceptions import TransportError, TransportQueryError
 from pipefy_sdk import PipefyClient, PipefySettings, stream_bytes
 from pipefy_sdk.exceptions import PipefyError
 
-from pipefy_cli.auth import AuthContext, OidcClient, get_authenticated_client
+from pipefy_cli.auth import (
+    AuthContext,
+    BearerToken,
+    OidcClient,
+    get_authenticated_client,
+)
 from pipefy_cli.output import render_json, render_rich
 
 _T = TypeVar("_T")
@@ -193,7 +198,9 @@ def format_card_get_transport_query_error(exc: TransportQueryError) -> str:
     return base
 
 
-def settings_and_token(ctx: typer.Context) -> tuple[PipefySettings, str | None]:
+def settings_and_token(
+    ctx: typer.Context,
+) -> tuple[PipefySettings, BearerToken | None]:
     """Resolve root CLI context object into settings and optional bearer token."""
     root = ctx.find_root()
     obj = root.obj

--- a/packages/cli/src/pipefy_cli/commands/auth.py
+++ b/packages/cli/src/pipefy_cli/commands/auth.py
@@ -270,11 +270,8 @@ def _render_status_text(report: AuthStatusReport) -> None:
     if report.identity is not None:
         email = report.identity["email"]
         name = report.identity.get("name")
-        typer.echo(
-            f"  Identity:      {email} ({name})"
-            if name
-            else f"  Identity:      {email}"
-        )
+        identity_label = f"{email} ({name})" if name else email
+        typer.echo(f"  Identity:      {identity_label}")
     elif report.token_rejected:
         typer.echo("  Identity:      unknown (token rejected by upstream)")
     else:

--- a/packages/cli/src/pipefy_cli/commands/auth.py
+++ b/packages/cli/src/pipefy_cli/commands/auth.py
@@ -319,7 +319,6 @@ def _populate_stored_session(report: AuthStatusReport, oidc: OidcClient) -> None
     """Populate stored-session fields on ``report``; raise ``_StatusExit`` on failure."""
     report.issuer = oidc.issuer_url
     report.keychain_backend = keychain_backend_name()
-    report.masking_env_vars = _session_masking_env_vars()
     try:
         fresh_session = ensure_fresh_session(
             issuer=oidc.issuer_url, client_id=oidc.client_id
@@ -397,6 +396,13 @@ def auth_status(
     detected = detect_all_sources(settings, auth)
     source: AuthSource = detected[0] if detected else "none"
     report = AuthStatusReport(auth_source=source, detected_sources=detected)
+    # Whenever a stored session exists — even if a higher-precedence source
+    # ranks above it — surface the env vars masking it. That's the field's
+    # entire purpose: diagnose the "keychain login exists but CI vars override
+    # it" failure mode. Populated here (not inside `_populate_stored_session`)
+    # because that helper only runs when stored-session is the *winner*.
+    if "stored-session" in detected:
+        report.masking_env_vars = _session_masking_env_vars()
 
     try:
         if source == "none":

--- a/packages/cli/src/pipefy_cli/commands/auth.py
+++ b/packages/cli/src/pipefy_cli/commands/auth.py
@@ -324,8 +324,10 @@ def _populate_stored_session(report: AuthStatusReport, oidc: OidcClient) -> None
             issuer=oidc.issuer_url, client_id=oidc.client_id
         )
     except RefreshError as exc:
+        # Branch on the RFC 6749 ``error`` field, not on ``str(exc)``. The
+        # message text is for humans; ``error_code`` is the machine contract.
         report.state = (
-            "refresh-expired" if "invalid_grant" in str(exc) else "needs-login"
+            "refresh-expired" if exc.error_code == "invalid_grant" else "needs-login"
         )
         # Best-effort expiry from the pre-refresh blob so users see *why*.
         stale = load_session(issuer=oidc.issuer_url, client_id=oidc.client_id)

--- a/packages/cli/src/pipefy_cli/commands/auth.py
+++ b/packages/cli/src/pipefy_cli/commands/auth.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 import webbrowser
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Literal
 
@@ -14,6 +15,7 @@ from gql.transport.exceptions import (
     TransportQueryError,
     TransportServerError,
 )
+from pipefy_sdk import MePayload
 
 from pipefy_cli._docs import DOCS_CLI_AUTH_REF
 from pipefy_cli.auth import (
@@ -34,6 +36,32 @@ from pipefy_cli.oauth import (
 from pipefy_cli.output import render_json
 
 AuthSessionState = Literal["active", "refresh-expired", "needs-login", "n/a"]
+
+
+@dataclass
+class AuthStatusReport:
+    """Typed model for `auth status` rendering.
+
+    Distinct from the locked JSON wire schema (see :func:`_to_json_payload`):
+    renderers consume this typed value, not the wire dict, so the external
+    contract and the internal model can evolve independently.
+    """
+
+    auth_source: AuthSource
+    detected_sources: list[AuthSource]
+    issuer: str | None = None
+    state: AuthSessionState = "n/a"
+    access_expires_at: str | None = None
+    refresh_expires_at: str | None = None
+    identity: MePayload | None = None
+    token_rejected: bool = False
+    keychain_backend: str | None = None
+    masking_env_vars: list[str] = field(default_factory=list)
+
+    @property
+    def signed_in(self) -> bool:
+        return self.auth_source != "none"
+
 
 auth_app = typer.Typer(
     help="Authenticate the CLI as your Pipefy user (browser-based login).",
@@ -204,63 +232,81 @@ def _format_relative(iso_ts: str | None) -> str:
     return f"in {hours}h {minutes}m"
 
 
-def _render_status_text(payload: dict[str, Any]) -> None:
-    """Human-readable rendering of the status payload (stdout)."""
-    source: AuthSource = payload["auth_source"]
-    if not payload["signed_in"]:
+def _to_json_payload(report: AuthStatusReport) -> dict[str, Any]:
+    """Serialize the report to the locked JSON wire schema."""
+    return {
+        "signed_in": report.signed_in,
+        "identity": report.identity,
+        "auth_source": report.auth_source,
+        "detected_sources": report.detected_sources,
+        "issuer": report.issuer,
+        "state": report.state,
+        "access_expires_at": report.access_expires_at,
+        "refresh_expires_at": report.refresh_expires_at,
+        "token_rejected": report.token_rejected,
+        "keychain_backend": report.keychain_backend,
+        "masking_env_vars": report.masking_env_vars,
+    }
+
+
+def _render_status_text(report: AuthStatusReport) -> None:
+    """Human-readable rendering of the status report (stdout)."""
+    if not report.signed_in:
         typer.echo(
             "Not signed in. Run `pipefy auth login`, set PIPEFY_TOKEN, or "
             f"configure PIPEFY_OAUTH_*. See {DOCS_CLI_AUTH_REF}."
         )
         return
 
-    issuer = payload["issuer"]
-    header = f"Signed in to Pipefy ({issuer})" if issuer else "Signed in to Pipefy"
+    header = (
+        f"Signed in to Pipefy ({report.issuer})"
+        if report.issuer
+        else "Signed in to Pipefy"
+    )
     typer.echo(header)
 
-    identity = payload["identity"]
-    if identity is not None:
-        if identity.get("name"):
-            typer.echo(f"  Identity:      {identity['email']} ({identity['name']})")
-        else:
-            typer.echo(f"  Identity:      {identity['email']}")
-    elif payload["token_rejected"]:
+    if report.identity is not None:
+        email = report.identity["email"]
+        name = report.identity.get("name")
+        typer.echo(
+            f"  Identity:      {email} ({name})"
+            if name
+            else f"  Identity:      {email}"
+        )
+    elif report.token_rejected:
         typer.echo("  Identity:      unknown (token rejected by upstream)")
     else:
         typer.echo("  Identity:      unknown")
 
-    typer.echo(f"  Auth source:   {_AUTH_SOURCE_LABELS[source]}")
+    typer.echo(f"  Auth source:   {_AUTH_SOURCE_LABELS[report.auth_source]}")
 
-    if source == "stored-session":
-        typer.echo(f"  Expires:       {_format_relative(payload['access_expires_at'])}")
-        typer.echo(
-            f"  Refresh token: {_format_relative(payload['refresh_expires_at'])}"
-        )
-        if payload["keychain_backend"]:
-            typer.echo(f"  Keychain:      {payload['keychain_backend']}")
+    if report.auth_source == "stored-session":
+        typer.echo(f"  Expires:       {_format_relative(report.access_expires_at)}")
+        typer.echo(f"  Refresh token: {_format_relative(report.refresh_expires_at)}")
+        if report.keychain_backend:
+            typer.echo(f"  Keychain:      {report.keychain_backend}")
 
-    masking = payload["masking_env_vars"]
-    if masking:
+    if report.masking_env_vars:
         typer.echo("")
         typer.echo("Other auth sources detected in env:")
-        for name in masking:
+        for name in report.masking_env_vars:
             typer.echo(
                 f"  {name} (would mask the stored session if no --token is passed)"
             )
 
 
 def _emit_and_exit(
-    payload: dict[str, Any],
+    report: AuthStatusReport,
     *,
     json_out: bool,
     exit_code: int,
     stderr: str | None = None,
 ) -> typer.Exit:
-    """Render ``payload`` (JSON or text) and return the ``Exit`` for the caller to raise."""
+    """Render the report (JSON or text) and return the ``Exit`` for the caller to raise."""
     if json_out:
-        render_json(payload)
+        render_json(_to_json_payload(report))
     else:
-        _render_status_text(payload)
+        _render_status_text(report)
         if stderr:
             typer.echo(stderr, err=True)
     return typer.Exit(exit_code)
@@ -280,53 +326,39 @@ def auth_status(
     settings, auth = settings_and_auth_from_ctx(ctx)
     detected = detect_all_sources(settings, auth)
     source: AuthSource = detected[0] if detected else "none"
-
-    payload: dict[str, Any] = {
-        "signed_in": source != "none",
-        "identity": None,
-        "auth_source": source,
-        "detected_sources": detected,
-        "issuer": None,
-        "state": "n/a",
-        "access_expires_at": None,
-        "refresh_expires_at": None,
-        "token_rejected": False,
-        "keychain_backend": None,
-        "masking_env_vars": [],
-    }
+    report = AuthStatusReport(auth_source=source, detected_sources=detected)
 
     if source == "none":
-        raise _emit_and_exit(payload, json_out=json_out, exit_code=2)
+        raise _emit_and_exit(report, json_out=json_out, exit_code=2)
 
     if source == "stored-session":
         assert auth.oidc_client is not None
-        payload["issuer"] = auth.oidc_client.issuer_url
-        payload["keychain_backend"] = keychain_backend_name()
-        payload["masking_env_vars"] = _session_masking_env_vars()
+        report.issuer = auth.oidc_client.issuer_url
+        report.keychain_backend = keychain_backend_name()
+        report.masking_env_vars = _session_masking_env_vars()
         try:
             fresh_session = ensure_fresh_session(
                 issuer=auth.oidc_client.issuer_url,
                 client_id=auth.oidc_client.client_id,
             )
         except RefreshError as exc:
-            state: AuthSessionState = (
+            report.state = (
                 "refresh-expired" if "invalid_grant" in str(exc) else "needs-login"
             )
-            payload["state"] = state
             # Best-effort expiry from the pre-refresh blob so users see *why*.
             stale = load_session(
                 issuer=auth.oidc_client.issuer_url,
                 client_id=auth.oidc_client.client_id,
             )
             if stale is not None:
-                payload["access_expires_at"] = _iso_expiry(
+                report.access_expires_at = _iso_expiry(
                     stale.obtained_at, stale.expires_in
                 )
-                payload["refresh_expires_at"] = _iso_expiry(
+                report.refresh_expires_at = _iso_expiry(
                     stale.obtained_at, stale.refresh_expires_in
                 )
             raise _emit_and_exit(
-                payload,
+                report,
                 json_out=json_out,
                 exit_code=2,
                 stderr=(
@@ -335,45 +367,47 @@ def auth_status(
                 ),
             ) from exc
         if fresh_session is None:
-            # Vanished between detection and refresh.
-            payload["signed_in"] = False
-            payload["auth_source"] = "none"
-            raise _emit_and_exit(payload, json_out=json_out, exit_code=2)
-        payload["state"] = "active"
-        payload["access_expires_at"] = _iso_expiry(
+            # Session vanished between detection and refresh.
+            raise _emit_and_exit(
+                AuthStatusReport(auth_source="none", detected_sources=detected),
+                json_out=json_out,
+                exit_code=2,
+            )
+        report.state = "active"
+        report.access_expires_at = _iso_expiry(
             fresh_session.obtained_at, fresh_session.expires_in
         )
-        payload["refresh_expires_at"] = _iso_expiry(
+        report.refresh_expires_at = _iso_expiry(
             fresh_session.obtained_at, fresh_session.refresh_expires_in
         )
 
     client = get_authenticated_client(settings, auth)
     try:
-        payload["identity"] = asyncio.run(client.get_me())
+        report.identity = asyncio.run(client.get_me())
     except TransportServerError as exc:
         # Pipefy returns a literal HTTP 401 for invalid bearers (verified via
         # `curl -X POST <graphql>` with a bad token); other HTTP errors here
         # are upstream/transport problems, not credential rejections.
         if exc.code == 401:
-            payload["token_rejected"] = True
+            report.token_rejected = True
         raise _emit_and_exit(
-            payload,
+            report,
             json_out=json_out,
             exit_code=1,
             stderr=f"Identity fetch failed: {exc}",
         ) from exc
     except (TransportQueryError, TransportError) as exc:
         raise _emit_and_exit(
-            payload,
+            report,
             json_out=json_out,
             exit_code=1,
             stderr=f"Pipefy transport error: {exc}",
         ) from exc
 
     if json_out:
-        render_json(payload)
+        render_json(_to_json_payload(report))
     else:
-        _render_status_text(payload)
+        _render_status_text(report)
 
 
 __all__ = ["auth_app"]

--- a/packages/cli/src/pipefy_cli/commands/auth.py
+++ b/packages/cli/src/pipefy_cli/commands/auth.py
@@ -15,11 +15,13 @@ from gql.transport.exceptions import (
     TransportQueryError,
     TransportServerError,
 )
-from pipefy_sdk import MePayload
+from pipefy_sdk import MePayload, PipefySettings
 
 from pipefy_cli._docs import DOCS_CLI_AUTH_REF
 from pipefy_cli.auth import (
+    AuthContext,
     AuthSource,
+    OidcClient,
     detect_all_sources,
     get_authenticated_client,
 )
@@ -295,6 +297,14 @@ def _render_status_text(report: AuthStatusReport) -> None:
             )
 
 
+def _render(report: AuthStatusReport, *, json_out: bool) -> None:
+    """Render the report on stdout in the requested format."""
+    if json_out:
+        render_json(_to_json_payload(report))
+    else:
+        _render_status_text(report)
+
+
 def _emit_and_exit(
     report: AuthStatusReport,
     *,
@@ -302,85 +312,70 @@ def _emit_and_exit(
     exit_code: int,
     stderr: str | None = None,
 ) -> typer.Exit:
-    """Render the report (JSON or text) and return the ``Exit`` for the caller to raise."""
-    if json_out:
-        render_json(_to_json_payload(report))
-    else:
-        _render_status_text(report)
-        if stderr:
-            typer.echo(stderr, err=True)
+    """Render the report and return the ``Exit`` for the caller to raise."""
+    _render(report, json_out=json_out)
+    if stderr and not json_out:
+        typer.echo(stderr, err=True)
     return typer.Exit(exit_code)
 
 
-@auth_app.command("status")
-def auth_status(
-    ctx: typer.Context,
-    json_out: bool = typer.Option(  # noqa: B008 (Typer Option pattern)
-        False,
-        "--json",
-        "-j",
-        help="Emit a stable JSON schema instead of human-readable text.",
-    ),
+def _populate_stored_session(
+    report: AuthStatusReport, oidc: OidcClient, *, json_out: bool
 ) -> None:
-    """Print which auth source is active, the authenticated identity, and session expiry."""
-    settings, auth = settings_and_auth_from_ctx(ctx)
-    detected = detect_all_sources(settings, auth)
-    source: AuthSource = detected[0] if detected else "none"
-    report = AuthStatusReport(auth_source=source, detected_sources=detected)
-
-    if source == "none":
-        raise _emit_and_exit(report, json_out=json_out, exit_code=2)
-
-    if source == "stored-session":
-        assert auth.oidc_client is not None
-        report.issuer = auth.oidc_client.issuer_url
-        report.keychain_backend = keychain_backend_name()
-        report.masking_env_vars = _session_masking_env_vars()
-        try:
-            fresh_session = ensure_fresh_session(
-                issuer=auth.oidc_client.issuer_url,
-                client_id=auth.oidc_client.client_id,
-            )
-        except RefreshError as exc:
-            report.state = (
-                "refresh-expired" if "invalid_grant" in str(exc) else "needs-login"
-            )
-            # Best-effort expiry from the pre-refresh blob so users see *why*.
-            stale = load_session(
-                issuer=auth.oidc_client.issuer_url,
-                client_id=auth.oidc_client.client_id,
-            )
-            if stale is not None:
-                report.access_expires_at = _iso_expiry(
-                    stale.obtained_at, stale.expires_in
-                )
-                report.refresh_expires_at = _iso_expiry(
-                    stale.obtained_at, stale.refresh_expires_in
-                )
-            raise _emit_and_exit(
-                report,
-                json_out=json_out,
-                exit_code=2,
-                stderr=(
-                    f"Stored Pipefy session could not be refreshed: {exc}. "
-                    "Run `pipefy auth login` to sign in again."
-                ),
-            ) from exc
-        if fresh_session is None:
-            # Session vanished between detection and refresh.
-            raise _emit_and_exit(
-                AuthStatusReport(auth_source="none", detected_sources=detected),
-                json_out=json_out,
-                exit_code=2,
-            )
-        report.state = "active"
-        report.access_expires_at = _iso_expiry(
-            fresh_session.obtained_at, fresh_session.expires_in
+    """Populate stored-session fields on ``report``; ``raise _emit_and_exit`` on failure."""
+    report.issuer = oidc.issuer_url
+    report.keychain_backend = keychain_backend_name()
+    report.masking_env_vars = _session_masking_env_vars()
+    try:
+        fresh_session = ensure_fresh_session(
+            issuer=oidc.issuer_url, client_id=oidc.client_id
         )
-        report.refresh_expires_at = _iso_expiry(
-            fresh_session.obtained_at, fresh_session.refresh_expires_in
+    except RefreshError as exc:
+        report.state = (
+            "refresh-expired" if "invalid_grant" in str(exc) else "needs-login"
         )
+        # Best-effort expiry from the pre-refresh blob so users see *why*.
+        stale = load_session(issuer=oidc.issuer_url, client_id=oidc.client_id)
+        if stale is not None:
+            report.access_expires_at = _iso_expiry(stale.obtained_at, stale.expires_in)
+            report.refresh_expires_at = _iso_expiry(
+                stale.obtained_at, stale.refresh_expires_in
+            )
+        raise _emit_and_exit(
+            report,
+            json_out=json_out,
+            exit_code=2,
+            stderr=(
+                f"Stored Pipefy session could not be refreshed: {exc}. "
+                "Run `pipefy auth login` to sign in again."
+            ),
+        ) from exc
+    if fresh_session is None:
+        # Session vanished between detection and refresh.
+        raise _emit_and_exit(
+            AuthStatusReport(
+                auth_source="none", detected_sources=report.detected_sources
+            ),
+            json_out=json_out,
+            exit_code=2,
+        )
+    report.state = "active"
+    report.access_expires_at = _iso_expiry(
+        fresh_session.obtained_at, fresh_session.expires_in
+    )
+    report.refresh_expires_at = _iso_expiry(
+        fresh_session.obtained_at, fresh_session.refresh_expires_in
+    )
 
+
+def _fetch_identity(
+    report: AuthStatusReport,
+    settings: PipefySettings,
+    auth: AuthContext,
+    *,
+    json_out: bool,
+) -> None:
+    """Populate ``report.identity``; ``raise _emit_and_exit`` on transport / 401."""
     client = get_authenticated_client(settings, auth)
     try:
         report.identity = asyncio.run(client.get_me())
@@ -404,10 +399,31 @@ def auth_status(
             stderr=f"Pipefy transport error: {exc}",
         ) from exc
 
-    if json_out:
-        render_json(_to_json_payload(report))
-    else:
-        _render_status_text(report)
+
+@auth_app.command("status")
+def auth_status(
+    ctx: typer.Context,
+    json_out: bool = typer.Option(  # noqa: B008 (Typer Option pattern)
+        False,
+        "--json",
+        "-j",
+        help="Emit a stable JSON schema instead of human-readable text.",
+    ),
+) -> None:
+    """Print which auth source is active, the authenticated identity, and session expiry."""
+    settings, auth = settings_and_auth_from_ctx(ctx)
+    detected = detect_all_sources(settings, auth)
+    source: AuthSource = detected[0] if detected else "none"
+    report = AuthStatusReport(auth_source=source, detected_sources=detected)
+
+    if source == "none":
+        raise _emit_and_exit(report, json_out=json_out, exit_code=2)
+    if source == "stored-session":
+        assert auth.oidc_client is not None
+        _populate_stored_session(report, auth.oidc_client, json_out=json_out)
+
+    _fetch_identity(report, settings, auth, json_out=json_out)
+    _render(report, json_out=json_out)
 
 
 __all__ = ["auth_app"]

--- a/packages/cli/src/pipefy_cli/commands/auth.py
+++ b/packages/cli/src/pipefy_cli/commands/auth.py
@@ -398,11 +398,9 @@ def auth_status(
     detected = detect_all_sources(settings, auth)
     source: AuthSource = detected[0] if detected else "none"
     report = AuthStatusReport(auth_source=source, detected_sources=detected)
-    # Whenever a stored session exists — even if a higher-precedence source
-    # ranks above it — surface the env vars masking it. That's the field's
-    # entire purpose: diagnose the "keychain login exists but CI vars override
-    # it" failure mode. Populated here (not inside `_populate_stored_session`)
-    # because that helper only runs when stored-session is the *winner*.
+    # Surface masking env vars whenever a stored session exists — that's the
+    # CI-overrides-keychain failure mode the field is for, and the higher-
+    # precedence winner is the case where it matters.
     if "stored-session" in detected:
         report.masking_env_vars = _session_masking_env_vars()
 
@@ -411,10 +409,6 @@ def auth_status(
             raise _StatusExit(report=report, exit_code=2)
         if source == "stored-session":
             if auth.oidc_client is None:
-                # Internal inconsistency: `detect_all_sources` ranked
-                # 'stored-session' but no OIDC client is configured to refresh
-                # against. Asserts get stripped under `python -O`, so guard
-                # explicitly.
                 raise _StatusExit(
                     report=report,
                     exit_code=2,

--- a/packages/cli/src/pipefy_cli/commands/auth.py
+++ b/packages/cli/src/pipefy_cli/commands/auth.py
@@ -2,19 +2,38 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import webbrowser
+from datetime import datetime, timezone
+from typing import Any, Literal
 
 import typer
+from gql.transport.exceptions import (
+    TransportError,
+    TransportQueryError,
+    TransportServerError,
+)
 
 from pipefy_cli._docs import DOCS_CLI_AUTH_REF
+from pipefy_cli.auth import (
+    AuthSource,
+    detect_all_sources,
+    get_authenticated_client,
+)
 from pipefy_cli.commands._common import settings_and_auth_from_ctx
 from pipefy_cli.oauth import (
     LoginError,
+    RefreshError,
+    ensure_fresh_session,
     keychain_backend_name,
+    load_session,
     run_login,
     store_session,
 )
+from pipefy_cli.output import render_json
+
+AuthSessionState = Literal["active", "refresh-expired", "needs-login", "n/a"]
 
 auth_app = typer.Typer(
     help="Authenticate the CLI as your Pipefy user (browser-based login).",
@@ -146,6 +165,215 @@ def auth_login(
         f"Signed in to Pipefy ({result.issuer}). Session stored in {keychain_backend_name()}."
     )
     _warn_if_masked()
+
+
+_AUTH_SOURCE_LABELS: dict[AuthSource, str] = {
+    "flag-token": "--token flag",
+    "env-token": "PIPEFY_TOKEN environment variable",
+    "service-account": "PIPEFY_OAUTH_* (client credentials)",
+    "stored-session": "stored session (`pipefy auth login`)",
+    "none": "none",
+}
+
+
+def _iso_expiry(obtained_at: int, lifetime_s: int | None) -> str | None:
+    """Compute the ISO 8601 expiry timestamp; ``None`` when ``lifetime_s`` is missing."""
+    if lifetime_s is None:
+        return None
+    return (
+        datetime.fromtimestamp(obtained_at + lifetime_s, tz=timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _format_relative(iso_ts: str | None) -> str:
+    """Render an ISO timestamp as a human-friendly "in 4h 12m" / "expired" string."""
+    if iso_ts is None:
+        return "unknown"
+    target = datetime.fromisoformat(iso_ts.replace("Z", "+00:00"))
+    delta = target - datetime.now(tz=timezone.utc)
+    seconds = int(delta.total_seconds())
+    if seconds <= 0:
+        return "expired"
+    hours, remainder = divmod(seconds, 3600)
+    minutes = remainder // 60
+    if hours >= 24:
+        days, hours = divmod(hours, 24)
+        return f"in {days}d {hours}h"
+    return f"in {hours}h {minutes}m"
+
+
+def _render_status_text(payload: dict[str, Any]) -> None:
+    """Human-readable rendering of the status payload (stdout)."""
+    source: AuthSource = payload["auth_source"]
+    if not payload["signed_in"]:
+        typer.echo(
+            "Not signed in. Run `pipefy auth login`, set PIPEFY_TOKEN, or "
+            f"configure PIPEFY_OAUTH_*. See {DOCS_CLI_AUTH_REF}."
+        )
+        return
+
+    issuer = payload["issuer"]
+    header = f"Signed in to Pipefy ({issuer})" if issuer else "Signed in to Pipefy"
+    typer.echo(header)
+
+    identity = payload["identity"]
+    if identity is not None:
+        if identity.get("name"):
+            typer.echo(f"  Identity:      {identity['email']} ({identity['name']})")
+        else:
+            typer.echo(f"  Identity:      {identity['email']}")
+    elif payload["token_rejected"]:
+        typer.echo("  Identity:      unknown (token rejected by upstream)")
+    else:
+        typer.echo("  Identity:      unknown")
+
+    typer.echo(f"  Auth source:   {_AUTH_SOURCE_LABELS[source]}")
+
+    if source == "stored-session":
+        typer.echo(f"  Expires:       {_format_relative(payload['access_expires_at'])}")
+        typer.echo(
+            f"  Refresh token: {_format_relative(payload['refresh_expires_at'])}"
+        )
+        if payload["keychain_backend"]:
+            typer.echo(f"  Keychain:      {payload['keychain_backend']}")
+
+    masking = payload["masking_env_vars"]
+    if masking:
+        typer.echo("")
+        typer.echo("Other auth sources detected in env:")
+        for name in masking:
+            typer.echo(
+                f"  {name} (would mask the stored session if no --token is passed)"
+            )
+
+
+def _emit_and_exit(
+    payload: dict[str, Any],
+    *,
+    json_out: bool,
+    exit_code: int,
+    stderr: str | None = None,
+) -> typer.Exit:
+    """Render ``payload`` (JSON or text) and return the ``Exit`` for the caller to raise."""
+    if json_out:
+        render_json(payload)
+    else:
+        _render_status_text(payload)
+        if stderr:
+            typer.echo(stderr, err=True)
+    return typer.Exit(exit_code)
+
+
+@auth_app.command("status")
+def auth_status(
+    ctx: typer.Context,
+    json_out: bool = typer.Option(  # noqa: B008 (Typer Option pattern)
+        False,
+        "--json",
+        "-j",
+        help="Emit a stable JSON schema instead of human-readable text.",
+    ),
+) -> None:
+    """Print which auth source is active, the authenticated identity, and session expiry."""
+    settings, auth = settings_and_auth_from_ctx(ctx)
+    detected = detect_all_sources(settings, auth)
+    source: AuthSource = detected[0] if detected else "none"
+
+    payload: dict[str, Any] = {
+        "signed_in": source != "none",
+        "identity": None,
+        "auth_source": source,
+        "detected_sources": detected,
+        "issuer": None,
+        "state": "n/a",
+        "access_expires_at": None,
+        "refresh_expires_at": None,
+        "token_rejected": False,
+        "keychain_backend": None,
+        "masking_env_vars": [],
+    }
+
+    if source == "none":
+        raise _emit_and_exit(payload, json_out=json_out, exit_code=2)
+
+    if source == "stored-session":
+        assert auth.oidc_client is not None
+        payload["issuer"] = auth.oidc_client.issuer_url
+        payload["keychain_backend"] = keychain_backend_name()
+        payload["masking_env_vars"] = _session_masking_env_vars()
+        try:
+            fresh_session = ensure_fresh_session(
+                issuer=auth.oidc_client.issuer_url,
+                client_id=auth.oidc_client.client_id,
+            )
+        except RefreshError as exc:
+            state: AuthSessionState = (
+                "refresh-expired" if "invalid_grant" in str(exc) else "needs-login"
+            )
+            payload["state"] = state
+            # Best-effort expiry from the pre-refresh blob so users see *why*.
+            stale = load_session(
+                issuer=auth.oidc_client.issuer_url,
+                client_id=auth.oidc_client.client_id,
+            )
+            if stale is not None:
+                payload["access_expires_at"] = _iso_expiry(
+                    stale.obtained_at, stale.expires_in
+                )
+                payload["refresh_expires_at"] = _iso_expiry(
+                    stale.obtained_at, stale.refresh_expires_in
+                )
+            raise _emit_and_exit(
+                payload,
+                json_out=json_out,
+                exit_code=2,
+                stderr=(
+                    f"Stored Pipefy session could not be refreshed: {exc}. "
+                    "Run `pipefy auth login` to sign in again."
+                ),
+            ) from exc
+        if fresh_session is None:
+            # Vanished between detection and refresh.
+            payload["signed_in"] = False
+            payload["auth_source"] = "none"
+            raise _emit_and_exit(payload, json_out=json_out, exit_code=2)
+        payload["state"] = "active"
+        payload["access_expires_at"] = _iso_expiry(
+            fresh_session.obtained_at, fresh_session.expires_in
+        )
+        payload["refresh_expires_at"] = _iso_expiry(
+            fresh_session.obtained_at, fresh_session.refresh_expires_in
+        )
+
+    client = get_authenticated_client(settings, auth)
+    try:
+        payload["identity"] = asyncio.run(client.get_me())
+    except TransportServerError as exc:
+        # Pipefy returns a literal HTTP 401 for invalid bearers (verified via
+        # `curl -X POST <graphql>` with a bad token); other HTTP errors here
+        # are upstream/transport problems, not credential rejections.
+        if exc.code == 401:
+            payload["token_rejected"] = True
+        raise _emit_and_exit(
+            payload,
+            json_out=json_out,
+            exit_code=1,
+            stderr=f"Identity fetch failed: {exc}",
+        ) from exc
+    except (TransportQueryError, TransportError) as exc:
+        raise _emit_and_exit(
+            payload,
+            json_out=json_out,
+            exit_code=1,
+            stderr=f"Pipefy transport error: {exc}",
+        ) from exc
+
+    if json_out:
+        render_json(payload)
+    else:
+        _render_status_text(payload)
 
 
 __all__ = ["auth_app"]

--- a/packages/cli/src/pipefy_cli/commands/auth.py
+++ b/packages/cli/src/pipefy_cli/commands/auth.py
@@ -302,28 +302,21 @@ def _render(report: AuthStatusReport, *, json_out: bool) -> None:
         _render_status_text(report)
 
 
-def _fail(
-    report: AuthStatusReport,
-    *,
-    json_out: bool,
-    exit_code: int,
-    stderr: str | None = None,
-) -> typer.Exit:
-    """Render the report on the error path and return the ``Exit`` for the caller to raise.
+@dataclass
+class _StatusExit(Exception):
+    """Control-flow signal raised by phase helpers; translated to ``typer.Exit`` at the command boundary.
 
-    All call sites use a non-zero ``exit_code`` — this is the failure-path counterpart
-    to the final ``_render`` call on the success path.
+    Carries the report (which may differ from the in-progress one — see the vanished-session
+    branch) along with the exit code and optional stderr message.
     """
-    _render(report, json_out=json_out)
-    if stderr and not json_out:
-        typer.echo(stderr, err=True)
-    return typer.Exit(exit_code)
+
+    report: AuthStatusReport
+    exit_code: int
+    stderr: str | None = None
 
 
-def _populate_stored_session(
-    report: AuthStatusReport, oidc: OidcClient, *, json_out: bool
-) -> None:
-    """Populate stored-session fields on ``report``; ``raise _fail`` on failure."""
+def _populate_stored_session(report: AuthStatusReport, oidc: OidcClient) -> None:
+    """Populate stored-session fields on ``report``; raise ``_StatusExit`` on failure."""
     report.issuer = oidc.issuer_url
     report.keychain_backend = keychain_backend_name()
     report.masking_env_vars = _session_masking_env_vars()
@@ -342,9 +335,8 @@ def _populate_stored_session(
             report.refresh_expires_at = _iso_expiry(
                 stale.obtained_at, stale.refresh_expires_in
             )
-        raise _fail(
-            report,
-            json_out=json_out,
+        raise _StatusExit(
+            report=report,
             exit_code=2,
             stderr=(
                 f"Stored Pipefy session could not be refreshed: {exc}. "
@@ -353,11 +345,10 @@ def _populate_stored_session(
         ) from exc
     if fresh_session is None:
         # Session vanished between detection and refresh.
-        raise _fail(
-            AuthStatusReport(
+        raise _StatusExit(
+            report=AuthStatusReport(
                 auth_source="none", detected_sources=report.detected_sources
             ),
-            json_out=json_out,
             exit_code=2,
         )
     report.state = "active"
@@ -370,13 +361,9 @@ def _populate_stored_session(
 
 
 def _fetch_identity(
-    report: AuthStatusReport,
-    settings: PipefySettings,
-    auth: AuthContext,
-    *,
-    json_out: bool,
+    report: AuthStatusReport, settings: PipefySettings, auth: AuthContext
 ) -> None:
-    """Populate ``report.identity``; ``raise _fail`` on transport / 401."""
+    """Populate ``report.identity``; raise ``_StatusExit`` on transport / 401."""
     client = get_authenticated_client(settings, auth)
     try:
         report.identity = asyncio.run(client.get_me())
@@ -386,18 +373,12 @@ def _fetch_identity(
         # are upstream/transport problems, not credential rejections.
         if exc.code == 401:
             report.token_rejected = True
-        raise _fail(
-            report,
-            json_out=json_out,
-            exit_code=1,
-            stderr=f"Identity fetch failed: {exc}",
+        raise _StatusExit(
+            report=report, exit_code=1, stderr=f"Identity fetch failed: {exc}"
         ) from exc
     except (TransportQueryError, TransportError) as exc:
-        raise _fail(
-            report,
-            json_out=json_out,
-            exit_code=1,
-            stderr=f"Pipefy transport error: {exc}",
+        raise _StatusExit(
+            report=report, exit_code=1, stderr=f"Pipefy transport error: {exc}"
         ) from exc
 
 
@@ -417,13 +398,19 @@ def auth_status(
     source: AuthSource = detected[0] if detected else "none"
     report = AuthStatusReport(auth_source=source, detected_sources=detected)
 
-    if source == "none":
-        raise _fail(report, json_out=json_out, exit_code=2)
-    if source == "stored-session":
-        assert auth.oidc_client is not None
-        _populate_stored_session(report, auth.oidc_client, json_out=json_out)
+    try:
+        if source == "none":
+            raise _StatusExit(report=report, exit_code=2)
+        if source == "stored-session":
+            assert auth.oidc_client is not None
+            _populate_stored_session(report, auth.oidc_client)
+        _fetch_identity(report, settings, auth)
+    except _StatusExit as exit_:
+        _render(exit_.report, json_out=json_out)
+        if exit_.stderr and not json_out:
+            typer.echo(exit_.stderr, err=True)
+        raise typer.Exit(exit_.exit_code) from exit_
 
-    _fetch_identity(report, settings, auth, json_out=json_out)
     _render(report, json_out=json_out)
 
 

--- a/packages/cli/src/pipefy_cli/commands/auth.py
+++ b/packages/cli/src/pipefy_cli/commands/auth.py
@@ -402,7 +402,19 @@ def auth_status(
         if source == "none":
             raise _StatusExit(report=report, exit_code=2)
         if source == "stored-session":
-            assert auth.oidc_client is not None
+            if auth.oidc_client is None:
+                # Internal inconsistency: `detect_all_sources` ranked
+                # 'stored-session' but no OIDC client is configured to refresh
+                # against. Asserts get stripped under `python -O`, so guard
+                # explicitly.
+                raise _StatusExit(
+                    report=report,
+                    exit_code=2,
+                    stderr=(
+                        "Internal error: auth source 'stored-session' detected "
+                        "but no OIDC client is configured. Please file an issue."
+                    ),
+                )
             _populate_stored_session(report, auth.oidc_client)
         _fetch_identity(report, settings, auth)
     except _StatusExit as exit_:

--- a/packages/cli/src/pipefy_cli/commands/auth.py
+++ b/packages/cli/src/pipefy_cli/commands/auth.py
@@ -305,14 +305,18 @@ def _render(report: AuthStatusReport, *, json_out: bool) -> None:
         _render_status_text(report)
 
 
-def _emit_and_exit(
+def _fail(
     report: AuthStatusReport,
     *,
     json_out: bool,
     exit_code: int,
     stderr: str | None = None,
 ) -> typer.Exit:
-    """Render the report and return the ``Exit`` for the caller to raise."""
+    """Render the report on the error path and return the ``Exit`` for the caller to raise.
+
+    All call sites use a non-zero ``exit_code`` — this is the failure-path counterpart
+    to the final ``_render`` call on the success path.
+    """
     _render(report, json_out=json_out)
     if stderr and not json_out:
         typer.echo(stderr, err=True)
@@ -322,7 +326,7 @@ def _emit_and_exit(
 def _populate_stored_session(
     report: AuthStatusReport, oidc: OidcClient, *, json_out: bool
 ) -> None:
-    """Populate stored-session fields on ``report``; ``raise _emit_and_exit`` on failure."""
+    """Populate stored-session fields on ``report``; ``raise _fail`` on failure."""
     report.issuer = oidc.issuer_url
     report.keychain_backend = keychain_backend_name()
     report.masking_env_vars = _session_masking_env_vars()
@@ -341,7 +345,7 @@ def _populate_stored_session(
             report.refresh_expires_at = _iso_expiry(
                 stale.obtained_at, stale.refresh_expires_in
             )
-        raise _emit_and_exit(
+        raise _fail(
             report,
             json_out=json_out,
             exit_code=2,
@@ -352,7 +356,7 @@ def _populate_stored_session(
         ) from exc
     if fresh_session is None:
         # Session vanished between detection and refresh.
-        raise _emit_and_exit(
+        raise _fail(
             AuthStatusReport(
                 auth_source="none", detected_sources=report.detected_sources
             ),
@@ -375,7 +379,7 @@ def _fetch_identity(
     *,
     json_out: bool,
 ) -> None:
-    """Populate ``report.identity``; ``raise _emit_and_exit`` on transport / 401."""
+    """Populate ``report.identity``; ``raise _fail`` on transport / 401."""
     client = get_authenticated_client(settings, auth)
     try:
         report.identity = asyncio.run(client.get_me())
@@ -385,14 +389,14 @@ def _fetch_identity(
         # are upstream/transport problems, not credential rejections.
         if exc.code == 401:
             report.token_rejected = True
-        raise _emit_and_exit(
+        raise _fail(
             report,
             json_out=json_out,
             exit_code=1,
             stderr=f"Identity fetch failed: {exc}",
         ) from exc
     except (TransportQueryError, TransportError) as exc:
-        raise _emit_and_exit(
+        raise _fail(
             report,
             json_out=json_out,
             exit_code=1,
@@ -417,7 +421,7 @@ def auth_status(
     report = AuthStatusReport(auth_source=source, detected_sources=detected)
 
     if source == "none":
-        raise _emit_and_exit(report, json_out=json_out, exit_code=2)
+        raise _fail(report, json_out=json_out, exit_code=2)
     if source == "stored-session":
         assert auth.oidc_client is not None
         _populate_stored_session(report, auth.oidc_client, json_out=json_out)

--- a/packages/cli/src/pipefy_cli/main.py
+++ b/packages/cli/src/pipefy_cli/main.py
@@ -7,6 +7,7 @@ import os
 import typer
 
 from pipefy_cli import __version__ as _cli_version
+from pipefy_cli.auth import BearerToken
 from pipefy_cli.commands.agent import agent_app
 from pipefy_cli.commands.ai_automation import ai_automation_app
 from pipefy_cli.commands.attachment import attachment_app
@@ -92,7 +93,14 @@ def main(
     from_env = os.environ.get("PIPEFY_TOKEN")
     cli_token = token.strip() if token else None
     env_token = from_env.strip() if from_env else None
-    ctx.obj["token"] = cli_token or env_token
+    bearer: BearerToken | None
+    if cli_token:
+        bearer = BearerToken(value=cli_token, source="flag")
+    elif env_token:
+        bearer = BearerToken(value=env_token, source="env")
+    else:
+        bearer = None
+    ctx.obj["token"] = bearer
 
 
 app.add_typer(agent_app, name="agent")

--- a/packages/cli/src/pipefy_cli/oauth/refresh.py
+++ b/packages/cli/src/pipefy_cli/oauth/refresh.py
@@ -97,7 +97,9 @@ def _refresh_error_from(response: httpx.Response) -> RefreshError:
     if not error_code:
         return RefreshError(generic)
     if description:
-        return RefreshError(f"{generic}: {error_code}: {description}", error_code=error_code)
+        return RefreshError(
+            f"{generic}: {error_code}: {description}", error_code=error_code
+        )
     return RefreshError(f"{generic}: {error_code}", error_code=error_code)
 
 

--- a/packages/cli/src/pipefy_cli/oauth/refresh.py
+++ b/packages/cli/src/pipefy_cli/oauth/refresh.py
@@ -20,7 +20,17 @@ class RefreshError(RuntimeError):
     Distinct from "no session" (which surfaces as ``None`` from
     :func:`ensure_fresh_session`). The caller should surface a "run
     ``pipefy auth login`` again" message and exit.
+
+    ``error_code`` carries the RFC 6749 ``error`` value (e.g. ``invalid_grant``)
+    when the token endpoint returned a structured OAuth error response. Callers
+    that classify failures (e.g. CLI ``auth status`` deciding between
+    ``refresh-expired`` and ``needs-login``) should branch on this attribute,
+    not on substrings of ``str(exc)`` — message text isn't a stable contract.
     """
+
+    def __init__(self, message: str, *, error_code: str | None = None) -> None:
+        super().__init__(message)
+        self.error_code = error_code
 
 
 def refresh_access_token(
@@ -54,9 +64,7 @@ def refresh_access_token(
             raise RefreshError(f"Refresh request failed: {exc}") from exc
 
     if response.status_code != 200:
-        raise RefreshError(
-            f"Refresh failed ({response.status_code}): {response.text[:300]}"
-        )
+        raise _refresh_error_from(response)
     try:
         payload = response.json()
     except ValueError as exc:
@@ -64,6 +72,33 @@ def refresh_access_token(
     if not isinstance(payload, dict):
         raise RefreshError("Token endpoint returned a non-object JSON payload.")
     return payload
+
+
+def _refresh_error_from(response: httpx.Response) -> RefreshError:
+    """Render a non-200 refresh response as a structured ``RefreshError``.
+
+    Only OAuth-standard ``error`` / ``error_description`` fields are surfaced;
+    raw bodies are never echoed (same threat model as the token-exchange scrub
+    in ``flow._format_token_error`` — a hostile IdP could echo submitted params
+    like ``refresh_token`` in error responses, and a ``[:N]`` window would be a
+    guaranteed leak channel).
+    """
+    generic = f"Refresh failed (HTTP {response.status_code})"
+    try:
+        payload = response.json()
+    except ValueError:
+        return RefreshError(generic)
+    if not isinstance(payload, dict):
+        return RefreshError(generic)
+    error_value = payload.get("error")
+    error_code = error_value if isinstance(error_value, str) else None
+    description_value = payload.get("error_description")
+    description = description_value if isinstance(description_value, str) else None
+    if not error_code:
+        return RefreshError(generic)
+    if description:
+        return RefreshError(f"{generic}: {error_code}: {description}", error_code=error_code)
+    return RefreshError(f"{generic}: {error_code}", error_code=error_code)
 
 
 def ensure_fresh_session(

--- a/packages/cli/tests/fixtures/cli_help_golden.txt
+++ b/packages/cli/tests/fixtures/cli_help_golden.txt
@@ -453,8 +453,10 @@ Usage: pipefy auth [OPTIONS] COMMAND [ARGS]...
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ login   Sign in to Pipefy via your browser and store the session in the OS   │
-│         keychain.                                                            │
+│ login    Sign in to Pipefy via your browser and store the session in the OS  │
+│          keychain.                                                           │
+│ status   Print which auth source is active, the authenticated identity, and  │
+│          session expiry.                                                     │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 
 ### HELP auth/login
@@ -471,6 +473,17 @@ Usage: pipefy auth login [OPTIONS]
 │                                                 giving up.                   │
 │                                                 [default: 180.0]             │
 │ --help                                          Show this message and exit.  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP auth/status
+Usage: pipefy auth status [OPTIONS]
+
+ Print which auth source is active, the authenticated identity, and session
+ expiry.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --json  -j        Emit a stable JSON schema instead of human-readable text.  │
+│ --help            Show this message and exit.                                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 
 ### HELP automation

--- a/packages/cli/tests/test_auth.py
+++ b/packages/cli/tests/test_auth.py
@@ -9,7 +9,12 @@ import pytest
 import typer
 from pipefy_sdk import PipefySettings
 
-from pipefy_cli.auth import AuthContext, OidcClient, get_authenticated_client
+from pipefy_cli.auth import (
+    AuthContext,
+    BearerToken,
+    OidcClient,
+    get_authenticated_client,
+)
 from pipefy_cli.main import app
 from pipefy_cli.oauth import StoredSession
 
@@ -27,6 +32,7 @@ def _minimal_oauth_settings() -> PipefySettings:
 def _auth(
     *,
     bearer_token: str | None = None,
+    bearer_source: str = "flag",
     issuer_url: str | None = None,
     client_id: str | None = None,
 ) -> AuthContext:
@@ -36,7 +42,12 @@ def _auth(
         if issuer_url and client_id
         else None
     )
-    return AuthContext(bearer_token=bearer_token, oidc_client=oidc_client)
+    bearer = (
+        BearerToken(value=bearer_token, source=bearer_source)  # type: ignore[arg-type]
+        if bearer_token is not None
+        else None
+    )
+    return AuthContext(bearer_token=bearer, oidc_client=oidc_client)
 
 
 def test_get_authenticated_client_passes_bearer_to_pipefy_client(clean_pipefy_env):
@@ -102,7 +113,7 @@ def test_cli_uses_pipefy_token_env_when_no_flag(
     assert result.exit_code == 0, result.stdout + (result.stderr or "")
     mock_gc.assert_called_once()
     auth_arg = mock_gc.call_args.args[1]
-    assert auth_arg.bearer_token == "secret-from-env"
+    assert auth_arg.bearer_token == BearerToken(value="secret-from-env", source="env")
 
 
 # --------------------------------------------------------------------------- #
@@ -178,6 +189,7 @@ def test_stored_session_used_when_no_other_source(clean_pipefy_env):
     session = _fresh_stored_session()
     with (
         patch("pipefy_cli.auth.PipefyClient") as mock_pc,
+        patch("pipefy_cli.auth.load_session", return_value=session),
         patch("pipefy_cli.auth.ensure_fresh_session", return_value=session),
     ):
         mock_pc.return_value = MagicMock()
@@ -190,6 +202,7 @@ def test_stored_session_used_when_no_other_source(clean_pipefy_env):
 def test_cache_invalidates_when_access_token_rotates(clean_pipefy_env):
     """Two calls with different rotated access tokens → two PipefyClient builds."""
     settings = _public_only_settings()
+    stored = _fresh_stored_session()
     sessions = iter(
         [
             _fresh_stored_session(access_token="ROTATED_1"),
@@ -198,6 +211,7 @@ def test_cache_invalidates_when_access_token_rotates(clean_pipefy_env):
     )
     with (
         patch("pipefy_cli.auth.PipefyClient") as mock_pc,
+        patch("pipefy_cli.auth.load_session", return_value=stored),
         patch(
             "pipefy_cli.auth.ensure_fresh_session",
             side_effect=lambda **_: next(sessions),
@@ -220,9 +234,12 @@ def test_refresh_error_exits_2_with_relogin_hint(clean_pipefy_env, capsys):
     from pipefy_cli.oauth import RefreshError
 
     settings = _public_only_settings()
-    with patch(
-        "pipefy_cli.auth.ensure_fresh_session",
-        side_effect=RefreshError("invalid_grant"),
+    with (
+        patch("pipefy_cli.auth.load_session", return_value=_fresh_stored_session()),
+        patch(
+            "pipefy_cli.auth.ensure_fresh_session",
+            side_effect=RefreshError("invalid_grant"),
+        ),
     ):
         with pytest.raises(typer.Exit) as excinfo:
             get_authenticated_client(

--- a/packages/cli/tests/test_auth_integration.py
+++ b/packages/cli/tests/test_auth_integration.py
@@ -7,7 +7,7 @@ import asyncio
 import pytest
 from _shared.live_settings import live_pipefy_settings, require_live_creds
 
-from pipefy_cli.auth import get_authenticated_client
+from pipefy_cli.auth import AuthContext, get_authenticated_client
 
 
 @pytest.mark.integration
@@ -18,7 +18,9 @@ def test_live_oauth_round_trip_triggers_graphql_auth():
     settings = live_pipefy_settings()
 
     async def run():
-        client = get_authenticated_client(settings)
+        client = get_authenticated_client(
+            settings, AuthContext(bearer_token=None, oidc_client=None)
+        )
         return await client.search_schema("Card", kind="OBJECT")
 
     data = asyncio.run(run())

--- a/packages/cli/tests/test_auth_refresh.py
+++ b/packages/cli/tests/test_auth_refresh.py
@@ -296,7 +296,7 @@ class TestEnsureFreshSession:
 
 
 class TestRefreshAccessTokenErrors:
-    def test_invalid_grant_raises_refresh_error(self) -> None:
+    def test_invalid_grant_carries_oauth_error_code(self) -> None:
         client = httpx.Client(
             transport=httpx.MockTransport(
                 _build_handler(
@@ -305,13 +305,90 @@ class TestRefreshAccessTokenErrors:
                 )
             )
         )
-        with pytest.raises(refresh.RefreshError, match="Refresh failed"):
+        with pytest.raises(refresh.RefreshError) as exc_info:
             refresh.refresh_access_token(
                 issuer=_ISSUER,
                 client_id=_CLIENT_ID,
                 refresh_token="x",
                 http_client=client,
             )
+        assert exc_info.value.error_code == "invalid_grant"
+        assert "invalid_grant" in str(exc_info.value)
+
+    def test_oauth_error_description_included_in_message(self) -> None:
+        client = httpx.Client(
+            transport=httpx.MockTransport(
+                _build_handler(
+                    token_status=400,
+                    token_payload={
+                        "error": "invalid_grant",
+                        "error_description": "refresh token expired",
+                    },
+                )
+            )
+        )
+        with pytest.raises(refresh.RefreshError) as exc_info:
+            refresh.refresh_access_token(
+                issuer=_ISSUER,
+                client_id=_CLIENT_ID,
+                refresh_token="x",
+                http_client=client,
+            )
+        assert exc_info.value.error_code == "invalid_grant"
+        assert "refresh token expired" in str(exc_info.value)
+
+    def test_non_oauth_error_body_yields_generic_message_and_no_code(self) -> None:
+        """Non-200 with non-JSON body must not echo the body and must not invent
+        an ``error_code`` — callers branch on ``error_code``, not the message."""
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/.well-known/openid-configuration"):
+                return httpx.Response(200, json=_discovery_payload())
+            return httpx.Response(503, text="<html>upstream gateway timeout</html>")
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with pytest.raises(refresh.RefreshError) as exc_info:
+            refresh.refresh_access_token(
+                issuer=_ISSUER,
+                client_id=_CLIENT_ID,
+                refresh_token="x",
+                http_client=client,
+            )
+        assert exc_info.value.error_code is None
+        assert "HTTP 503" in str(exc_info.value)
+        assert "upstream gateway" not in str(exc_info.value)
+        assert "<html>" not in str(exc_info.value)
+
+    def test_error_response_does_not_echo_raw_body(self) -> None:
+        """Regression guard for the same threat-model as ``flow._format_token_error``.
+
+        A hostile or buggy IdP could include submitted params (e.g. the
+        ``refresh_token`` itself) in its error response body. The structured
+        scrub must never surface raw response text.
+        """
+        sentinel = "refresh_token=SENTINEL_REFRESH_LEAK"
+        body = (
+            '{"error":"invalid_grant","error_description":"bad refresh",'
+            f'"echoed":"{sentinel}"}}'
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/.well-known/openid-configuration"):
+                return httpx.Response(200, json=_discovery_payload())
+            return httpx.Response(400, text=body)
+
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        with pytest.raises(refresh.RefreshError) as exc_info:
+            refresh.refresh_access_token(
+                issuer=_ISSUER,
+                client_id=_CLIENT_ID,
+                refresh_token="x",
+                http_client=client,
+            )
+        message = str(exc_info.value)
+        assert "invalid_grant" in message
+        assert "bad refresh" in message
+        assert sentinel not in message
+        assert "SENTINEL_REFRESH_LEAK" not in message
 
     def test_network_error_raises_refresh_error(self) -> None:
         client = httpx.Client(

--- a/packages/cli/tests/test_auth_refresh.py
+++ b/packages/cli/tests/test_auth_refresh.py
@@ -340,6 +340,7 @@ class TestRefreshAccessTokenErrors:
     def test_non_oauth_error_body_yields_generic_message_and_no_code(self) -> None:
         """Non-200 with non-JSON body must not echo the body and must not invent
         an ``error_code`` — callers branch on ``error_code``, not the message."""
+
         def handler(request: httpx.Request) -> httpx.Response:
             if request.url.path.endswith("/.well-known/openid-configuration"):
                 return httpx.Response(200, json=_discovery_payload())

--- a/packages/cli/tests/test_auth_status.py
+++ b/packages/cli/tests/test_auth_status.py
@@ -163,7 +163,9 @@ def test_status_refresh_expired_exits_2(
     _seed_session(monkeypatch)
     with patch(
         "pipefy_cli.commands.auth.ensure_fresh_session",
-        side_effect=RefreshError("Refresh failed (400): invalid_grant"),
+        side_effect=RefreshError(
+            "Refresh failed (HTTP 400): invalid_grant", error_code="invalid_grant"
+        ),
     ):
         result = _invoke_status(runner, ["--json"])
 
@@ -182,12 +184,39 @@ def test_status_refresh_expired_text_includes_relogin_hint(
     _seed_session(monkeypatch)
     with patch(
         "pipefy_cli.commands.auth.ensure_fresh_session",
-        side_effect=RefreshError("Refresh failed (400): invalid_grant"),
+        side_effect=RefreshError(
+            "Refresh failed (HTTP 400): invalid_grant", error_code="invalid_grant"
+        ),
     ):
         result = _invoke_status(runner)
 
     assert result.exit_code == 2
     assert "pipefy auth login" in (result.stderr or "")
+
+
+def test_status_other_refresh_error_categorized_as_needs_login(
+    clean_pipefy_env, saved_cwd, monkeypatch, runner, fake_keyring
+):
+    """A non-``invalid_grant`` refresh failure must classify as ``needs-login``.
+
+    Proves the branch is driven by ``RefreshError.error_code``, not by a
+    substring match on the message — sentinel text containing ``invalid_grant``
+    in the human message must not flip ``state`` to ``refresh-expired``.
+    """
+    _set_auth_env(monkeypatch)
+    _seed_session(monkeypatch)
+    with patch(
+        "pipefy_cli.commands.auth.ensure_fresh_session",
+        side_effect=RefreshError(
+            "Refresh failed (HTTP 400): unauthorized_client (mentions invalid_grant in prose)",
+            error_code="unauthorized_client",
+        ),
+    ):
+        result = _invoke_status(runner, ["--json"])
+
+    assert result.exit_code == 2
+    payload = json.loads(result.stdout)
+    assert payload["state"] == "needs-login"
 
 
 # --------------------------------------------------------------------------- #

--- a/packages/cli/tests/test_auth_status.py
+++ b/packages/cli/tests/test_auth_status.py
@@ -326,8 +326,6 @@ def test_status_service_account_wins_over_stored_session(
     assert "stored-session" in payload["detected_sources"]
     assert payload["issuer"] is None
     assert payload["state"] == "n/a"
-    # `masking_env_vars` must surface the env vars hiding the keychain login,
-    # even when a higher-precedence source wins. That's the field's purpose.
     assert payload["masking_env_vars"] == ["PIPEFY_OAUTH_*"]
 
 

--- a/packages/cli/tests/test_auth_status.py
+++ b/packages/cli/tests/test_auth_status.py
@@ -1,0 +1,407 @@
+"""Unit tests for `pipefy auth status`."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import time
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pipefy_cli.main import app
+from pipefy_cli.oauth import RefreshError, StoredSession, storage
+
+_ISSUER = "https://signin.example.com/realms/pipefy"
+_CLIENT_ID = "pipefy-cli"
+_ME = {"email": "user@pipefy.com", "name": "Pipefy User"}
+
+
+def _seed_session(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    expires_in: int = 3600,
+    refresh_expires_in: int = 2592000,
+    obtained_at: int | None = None,
+) -> None:
+    """Plant a fresh stored session in the (faked) keyring."""
+    if obtained_at is None:
+        obtained_at = int(time.time())
+    with monkeypatch.context() as mp:
+        mp.setattr(time, "time", lambda: float(obtained_at))
+        storage.store_session(
+            issuer=_ISSUER,
+            client_id=_CLIENT_ID,
+            token_response={
+                "access_token": "AT",
+                "refresh_token": "RT",
+                "token_type": "Bearer",
+                "expires_in": expires_in,
+                "refresh_expires_in": refresh_expires_in,
+                "scope": "openid offline_access",
+            },
+        )
+
+
+def _set_auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PIPEFY_GRAPHQL_URL", "https://api.example.com/graphql")
+    monkeypatch.setenv("PIPEFY_AUTH_URL", _ISSUER)
+    monkeypatch.setenv("PIPEFY_AUTH_CLIENT_ID", _CLIENT_ID)
+
+
+def _mock_client_with_me(me_payload: dict | None = _ME) -> MagicMock:
+    client = MagicMock()
+    client.get_me = AsyncMock(return_value=me_payload)
+    return client
+
+
+def _patch_command_client(client: MagicMock) -> Any:
+    return patch(
+        "pipefy_cli.commands.auth.get_authenticated_client", return_value=client
+    )
+
+
+@contextlib.contextmanager
+def _patch_fresh_session(session: StoredSession | None) -> Iterator[None]:
+    """Patch ``ensure_fresh_session`` at both call sites (command + ``get_authenticated_client``)."""
+    with (
+        patch(
+            "pipefy_cli.commands.auth.ensure_fresh_session", return_value=session
+        ),
+        patch("pipefy_cli.auth.ensure_fresh_session", return_value=session),
+    ):
+        yield
+
+
+def _invoke_status(runner: Any, args: list[str] | None = None) -> Any:
+    return runner.invoke(app, ["auth", "status", *(args or [])])
+
+
+# --------------------------------------------------------------------------- #
+# Scenario 1: stored-session, fresh access token                              #
+# --------------------------------------------------------------------------- #
+def test_status_stored_session_active(
+    clean_pipefy_env, saved_cwd, monkeypatch, runner, fake_keyring
+):
+    _set_auth_env(monkeypatch)
+    _seed_session(monkeypatch)
+    session = storage.load_session(issuer=_ISSUER, client_id=_CLIENT_ID)
+    client = _mock_client_with_me()
+    with _patch_fresh_session(session), _patch_command_client(client):
+        result = _invoke_status(runner, ["--json"])
+
+    assert result.exit_code == 0, (result.stdout or "") + (result.stderr or "")
+    payload = json.loads(result.stdout)
+    assert payload["signed_in"] is True
+    assert payload["auth_source"] == "stored-session"
+    assert payload["identity"] == _ME
+    assert payload["state"] == "active"
+    assert payload["issuer"] == _ISSUER
+    assert payload["access_expires_at"] is not None
+    assert payload["refresh_expires_at"] is not None
+    assert payload["token_rejected"] is False
+    assert payload["keychain_backend"]
+    assert payload["masking_env_vars"] == []
+    client.get_me.assert_awaited_once()
+
+
+def test_status_stored_session_text_output(
+    clean_pipefy_env, saved_cwd, monkeypatch, runner, fake_keyring
+):
+    _set_auth_env(monkeypatch)
+    _seed_session(monkeypatch)
+    session = storage.load_session(issuer=_ISSUER, client_id=_CLIENT_ID)
+    client = _mock_client_with_me()
+    with _patch_fresh_session(session), _patch_command_client(client):
+        result = _invoke_status(runner)
+
+    assert result.exit_code == 0
+    assert "Signed in to Pipefy" in result.stdout
+    assert _ME["email"] in result.stdout
+    assert "stored session" in result.stdout
+    assert "Expires:" in result.stdout
+
+
+# --------------------------------------------------------------------------- #
+# Scenario 2: stored-session, eager refresh runs (we mock the result as fresh) #
+# --------------------------------------------------------------------------- #
+def test_status_stored_session_rotates_via_refresh(
+    clean_pipefy_env, saved_cwd, monkeypatch, runner, fake_keyring
+):
+    """If ensure_fresh_session returns a rotated session, status reports active."""
+    _set_auth_env(monkeypatch)
+    _seed_session(monkeypatch, expires_in=10)
+    rotated = storage.StoredSession(
+        issuer=_ISSUER,
+        client_id=_CLIENT_ID,
+        access_token="ROTATED",
+        refresh_token="RT",
+        token_type="Bearer",
+        obtained_at=int(time.time()),
+        expires_in=3600,
+        refresh_expires_in=2592000,
+        scope="openid offline_access",
+        id_token=None,
+    )
+    client = _mock_client_with_me()
+    with _patch_fresh_session(rotated), _patch_command_client(client):
+        result = _invoke_status(runner, ["--json"])
+
+    payload = json.loads(result.stdout)
+    assert result.exit_code == 0
+    assert payload["state"] == "active"
+    assert payload["identity"] == _ME
+
+
+# --------------------------------------------------------------------------- #
+# Scenario 3: refresh-token grant rejects (invalid_grant)                     #
+# --------------------------------------------------------------------------- #
+def test_status_refresh_expired_exits_2(
+    clean_pipefy_env, saved_cwd, monkeypatch, runner, fake_keyring
+):
+    _set_auth_env(monkeypatch)
+    _seed_session(monkeypatch)
+    with patch(
+        "pipefy_cli.commands.auth.ensure_fresh_session",
+        side_effect=RefreshError("Refresh failed (400): invalid_grant"),
+    ):
+        result = _invoke_status(runner, ["--json"])
+
+    assert result.exit_code == 2
+    payload = json.loads(result.stdout)
+    assert payload["auth_source"] == "stored-session"
+    assert payload["state"] == "refresh-expired"
+    # In --json mode the state field is the channel; no stderr commentary.
+    assert (result.stderr or "") == ""
+
+
+def test_status_refresh_expired_text_includes_relogin_hint(
+    clean_pipefy_env, saved_cwd, monkeypatch, runner, fake_keyring
+):
+    _set_auth_env(monkeypatch)
+    _seed_session(monkeypatch)
+    with patch(
+        "pipefy_cli.commands.auth.ensure_fresh_session",
+        side_effect=RefreshError("Refresh failed (400): invalid_grant"),
+    ):
+        result = _invoke_status(runner)
+
+    assert result.exit_code == 2
+    assert "pipefy auth login" in (result.stderr or "")
+
+
+# --------------------------------------------------------------------------- #
+# Scenario 4: me returns 401 → token_rejected                                 #
+# --------------------------------------------------------------------------- #
+def test_status_me_401_marks_token_rejected(
+    clean_pipefy_env, saved_cwd, monkeypatch, runner, fake_keyring
+):
+    from gql.transport.exceptions import TransportServerError
+
+    _set_auth_env(monkeypatch)
+    _seed_session(monkeypatch)
+    session = storage.load_session(issuer=_ISSUER, client_id=_CLIENT_ID)
+    client = MagicMock()
+    client.get_me = AsyncMock(
+        side_effect=TransportServerError("invalid_token", code=401)
+    )
+    with _patch_fresh_session(session), _patch_command_client(client):
+        result = _invoke_status(runner, ["--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["signed_in"] is True
+    assert payload["identity"] is None
+    assert payload["token_rejected"] is True
+
+
+def test_status_me_null_renders_identity_none(
+    clean_pipefy_env, saved_cwd, monkeypatch, runner, fake_keyring
+):
+    """`me` is schema-nullable; when null, identity is reported as null at exit 0."""
+    _set_auth_env(monkeypatch)
+    _seed_session(monkeypatch)
+    session = storage.load_session(issuer=_ISSUER, client_id=_CLIENT_ID)
+    client = MagicMock()
+    client.get_me = AsyncMock(return_value=None)
+    with _patch_fresh_session(session), _patch_command_client(client):
+        result = _invoke_status(runner, ["--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["signed_in"] is True
+    assert payload["identity"] is None
+    assert payload["token_rejected"] is False
+
+
+def test_status_me_null_name_renders_email_only(
+    clean_pipefy_env, saved_cwd, monkeypatch, runner, fake_keyring
+):
+    """`User.name` is nullable; text mode falls back to email-only."""
+    _set_auth_env(monkeypatch)
+    _seed_session(monkeypatch)
+    session = storage.load_session(issuer=_ISSUER, client_id=_CLIENT_ID)
+    client = MagicMock()
+    client.get_me = AsyncMock(return_value={"email": "anon@pipefy.com", "name": None})
+    with _patch_fresh_session(session), _patch_command_client(client):
+        result = _invoke_status(runner)
+
+    assert result.exit_code == 0
+    assert "anon@pipefy.com" in result.stdout
+    assert "(None)" not in result.stdout
+
+
+def test_status_me_500_is_transport_error_not_token_rejected(
+    clean_pipefy_env, saved_cwd, monkeypatch, runner, fake_keyring
+):
+    """A 5xx from upstream surfaces as transport error, NOT a credential rejection."""
+    from gql.transport.exceptions import TransportServerError
+
+    _set_auth_env(monkeypatch)
+    _seed_session(monkeypatch)
+    session = storage.load_session(issuer=_ISSUER, client_id=_CLIENT_ID)
+    client = MagicMock()
+    client.get_me = AsyncMock(
+        side_effect=TransportServerError("upstream down", code=503)
+    )
+    with _patch_fresh_session(session), _patch_command_client(client):
+        result = _invoke_status(runner, ["--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["token_rejected"] is False
+
+
+# --------------------------------------------------------------------------- #
+# Scenario 5: stored-session masked by PIPEFY_OAUTH_*                         #
+# --------------------------------------------------------------------------- #
+def test_status_service_account_wins_over_stored_session(
+    clean_pipefy_env, saved_cwd, monkeypatch, runner, fake_keyring
+):
+    _set_auth_env(monkeypatch)
+    _seed_session(monkeypatch)
+    monkeypatch.setenv("PIPEFY_INTERNAL_API_URL", "https://api.example.com/internal_api")
+    monkeypatch.setenv("PIPEFY_OAUTH_URL", "https://auth.example.com/oauth/token")
+    monkeypatch.setenv("PIPEFY_OAUTH_CLIENT", "cid")
+    monkeypatch.setenv("PIPEFY_OAUTH_SECRET", "csecret")
+    client = _mock_client_with_me()
+    with _patch_command_client(client):
+        result = _invoke_status(runner, ["--json"])
+
+    assert result.exit_code == 0, (result.stdout or "") + (result.stderr or "")
+    payload = json.loads(result.stdout)
+    assert payload["auth_source"] == "service-account"
+    assert "service-account" in payload["detected_sources"]
+    assert "stored-session" in payload["detected_sources"]
+    assert payload["issuer"] is None
+    assert payload["state"] == "n/a"
+
+
+# --------------------------------------------------------------------------- #
+# Scenario 6: stored-session masked by PIPEFY_TOKEN                           #
+# --------------------------------------------------------------------------- #
+def test_status_env_token_wins_over_stored_session(
+    clean_pipefy_env, saved_cwd, monkeypatch, runner, fake_keyring
+):
+    _set_auth_env(monkeypatch)
+    _seed_session(monkeypatch)
+    monkeypatch.setenv("PIPEFY_TOKEN", "env-bearer")
+    client = _mock_client_with_me()
+    with _patch_command_client(client):
+        result = _invoke_status(runner, ["--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["auth_source"] == "env-token"
+    assert "env-token" in payload["detected_sources"]
+    assert "stored-session" in payload["detected_sources"]
+
+
+# --------------------------------------------------------------------------- #
+# Scenario 7: --token flag                                                    #
+# --------------------------------------------------------------------------- #
+def test_status_flag_token(
+    clean_pipefy_env, saved_cwd, monkeypatch, runner, fake_keyring
+):
+    monkeypatch.setenv("PIPEFY_GRAPHQL_URL", "https://api.example.com/graphql")
+    client = _mock_client_with_me()
+    with _patch_command_client(client):
+        result = runner.invoke(
+            app, ["--token", "flag-bearer", "auth", "status", "--json"]
+        )
+
+    assert result.exit_code == 0, (result.stdout or "") + (result.stderr or "")
+    payload = json.loads(result.stdout)
+    assert payload["auth_source"] == "flag-token"
+    assert payload["identity"] == _ME
+    assert payload["issuer"] is None
+    assert payload["keychain_backend"] is None
+
+
+# --------------------------------------------------------------------------- #
+# Scenario 8: PIPEFY_TOKEN env var (no flag)                                  #
+# --------------------------------------------------------------------------- #
+def test_status_env_token_only(
+    clean_pipefy_env, saved_cwd, monkeypatch, runner, fake_keyring
+):
+    monkeypatch.setenv("PIPEFY_GRAPHQL_URL", "https://api.example.com/graphql")
+    monkeypatch.setenv("PIPEFY_TOKEN", "env-bearer")
+    client = _mock_client_with_me()
+    with _patch_command_client(client):
+        result = _invoke_status(runner, ["--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["auth_source"] == "env-token"
+
+
+# --------------------------------------------------------------------------- #
+# Scenario 9: service-account only                                            #
+# --------------------------------------------------------------------------- #
+def test_status_service_account_only(
+    clean_pipefy_env, saved_cwd, monkeypatch, runner, fake_keyring
+):
+    monkeypatch.setenv("PIPEFY_GRAPHQL_URL", "https://api.example.com/graphql")
+    monkeypatch.setenv("PIPEFY_INTERNAL_API_URL", "https://api.example.com/internal_api")
+    monkeypatch.setenv("PIPEFY_OAUTH_URL", "https://auth.example.com/oauth/token")
+    monkeypatch.setenv("PIPEFY_OAUTH_CLIENT", "cid")
+    monkeypatch.setenv("PIPEFY_OAUTH_SECRET", "csecret")
+    client = _mock_client_with_me()
+    with _patch_command_client(client):
+        result = _invoke_status(runner, ["--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["auth_source"] == "service-account"
+    assert payload["detected_sources"] == ["service-account"]
+
+
+# --------------------------------------------------------------------------- #
+# Scenario 10: no auth at all                                                 #
+# --------------------------------------------------------------------------- #
+def test_status_none_exits_2(
+    clean_pipefy_env, saved_cwd, monkeypatch, runner, fake_keyring
+):
+    monkeypatch.setenv("PIPEFY_GRAPHQL_URL", "https://api.example.com/graphql")
+    result = _invoke_status(runner, ["--json"])
+
+    assert result.exit_code == 2
+    payload = json.loads(result.stdout)
+    assert payload["signed_in"] is False
+    assert payload["auth_source"] == "none"
+    assert payload["detected_sources"] == []
+
+
+def test_status_none_text_mentions_onboarding(
+    clean_pipefy_env, saved_cwd, monkeypatch, runner, fake_keyring
+):
+    monkeypatch.setenv("PIPEFY_GRAPHQL_URL", "https://api.example.com/graphql")
+    result = _invoke_status(runner)
+
+    assert result.exit_code == 2
+    assert "Not signed in" in result.stdout
+    assert "pipefy auth login" in result.stdout
+    assert "PIPEFY_TOKEN" in result.stdout
+    assert "PIPEFY_OAUTH_*" in result.stdout

--- a/packages/cli/tests/test_auth_status.py
+++ b/packages/cli/tests/test_auth_status.py
@@ -67,9 +67,7 @@ def _patch_command_client(client: MagicMock) -> Any:
 def _patch_fresh_session(session: StoredSession | None) -> Iterator[None]:
     """Patch ``ensure_fresh_session`` at both call sites (command + ``get_authenticated_client``)."""
     with (
-        patch(
-            "pipefy_cli.commands.auth.ensure_fresh_session", return_value=session
-        ),
+        patch("pipefy_cli.commands.auth.ensure_fresh_session", return_value=session),
         patch("pipefy_cli.auth.ensure_fresh_session", return_value=session),
     ):
         yield
@@ -282,7 +280,9 @@ def test_status_service_account_wins_over_stored_session(
 ):
     _set_auth_env(monkeypatch)
     _seed_session(monkeypatch)
-    monkeypatch.setenv("PIPEFY_INTERNAL_API_URL", "https://api.example.com/internal_api")
+    monkeypatch.setenv(
+        "PIPEFY_INTERNAL_API_URL", "https://api.example.com/internal_api"
+    )
     monkeypatch.setenv("PIPEFY_OAUTH_URL", "https://auth.example.com/oauth/token")
     monkeypatch.setenv("PIPEFY_OAUTH_CLIENT", "cid")
     monkeypatch.setenv("PIPEFY_OAUTH_SECRET", "csecret")
@@ -364,7 +364,9 @@ def test_status_service_account_only(
     clean_pipefy_env, saved_cwd, monkeypatch, runner, fake_keyring
 ):
     monkeypatch.setenv("PIPEFY_GRAPHQL_URL", "https://api.example.com/graphql")
-    monkeypatch.setenv("PIPEFY_INTERNAL_API_URL", "https://api.example.com/internal_api")
+    monkeypatch.setenv(
+        "PIPEFY_INTERNAL_API_URL", "https://api.example.com/internal_api"
+    )
     monkeypatch.setenv("PIPEFY_OAUTH_URL", "https://auth.example.com/oauth/token")
     monkeypatch.setenv("PIPEFY_OAUTH_CLIENT", "cid")
     monkeypatch.setenv("PIPEFY_OAUTH_SECRET", "csecret")

--- a/packages/cli/tests/test_auth_status.py
+++ b/packages/cli/tests/test_auth_status.py
@@ -297,6 +297,9 @@ def test_status_service_account_wins_over_stored_session(
     assert "stored-session" in payload["detected_sources"]
     assert payload["issuer"] is None
     assert payload["state"] == "n/a"
+    # `masking_env_vars` must surface the env vars hiding the keychain login,
+    # even when a higher-precedence source wins. That's the field's purpose.
+    assert payload["masking_env_vars"] == ["PIPEFY_OAUTH_*"]
 
 
 # --------------------------------------------------------------------------- #
@@ -317,6 +320,7 @@ def test_status_env_token_wins_over_stored_session(
     assert payload["auth_source"] == "env-token"
     assert "env-token" in payload["detected_sources"]
     assert "stored-session" in payload["detected_sources"]
+    assert payload["masking_env_vars"] == ["PIPEFY_TOKEN"]
 
 
 # --------------------------------------------------------------------------- #

--- a/packages/cli/tests/test_common_helpers.py
+++ b/packages/cli/tests/test_common_helpers.py
@@ -161,7 +161,8 @@ def test_run_pipefy_client_coroutine_runs_factory_and_returns(monkeypatch):
 
     def fake_get_client(settings: object, auth: object) -> object:
         captured["settings"] = settings
-        captured["bearer_token"] = auth.bearer_token  # type: ignore[attr-defined]
+        bearer = auth.bearer_token  # type: ignore[attr-defined]
+        captured["bearer_token"] = bearer.value if bearer is not None else None
         return "client-instance"
 
     async def factory(client: object) -> str:
@@ -169,7 +170,10 @@ def test_run_pipefy_client_coroutine_runs_factory_and_returns(monkeypatch):
         return "done"
 
     sentinel_settings = object()
-    sentinel_auth = _common.AuthContext(bearer_token="abc", oidc_client=None)
+    sentinel_auth = _common.AuthContext(
+        bearer_token=_common.BearerToken(value="abc", source="flag"),
+        oidc_client=None,
+    )
     monkeypatch.setattr(_common, "get_authenticated_client", fake_get_client)
     monkeypatch.setattr(
         _common,

--- a/packages/sdk/src/pipefy_sdk/__init__.py
+++ b/packages/sdk/src/pipefy_sdk/__init__.py
@@ -43,7 +43,12 @@ from pipefy_sdk.services.table_service import (
     UPDATE_TABLE_RECORD_ALLOWED_FIELD_KEYS,
     UPDATE_TABLE_RECORD_FIELDS_ERROR_MESSAGE,
 )
-from pipefy_sdk.services.types import AiAgentGraphPayload, CardSearch, copy_card_search
+from pipefy_sdk.services.types import (
+    AiAgentGraphPayload,
+    CardSearch,
+    MePayload,
+    copy_card_search,
+)
 from pipefy_sdk.settings import PipefySettings
 
 __all__ = [
@@ -67,6 +72,7 @@ __all__ = [
     "DeleteCommentInput",
     "download_bytes",
     "InternalApiClient",
+    "MePayload",
     "MemberInvite",
     "NonBlankStr",
     "PipefyAPIError",

--- a/packages/sdk/src/pipefy_sdk/client.py
+++ b/packages/sdk/src/pipefy_sdk/client.py
@@ -67,8 +67,10 @@ from pipefy_sdk.services.types import (
     AiAgentGraphPayload,
     AutomationServiceResult,
     CardSearch,
+    MePayload,
     ToggleAgentStatusResult,
 )
+from pipefy_sdk.services.user_service import UserService
 from pipefy_sdk.services.webhook_service import WebhookService
 from pipefy_sdk.settings import PipefySettings
 
@@ -120,6 +122,7 @@ class PipefyClient:
         self._observability_service = ObservabilityService(settings=settings, auth=auth)
         self._report_service = ReportService(settings=settings, auth=auth)
         self._organization_service = OrganizationService(settings=settings, auth=auth)
+        self._user_service = UserService(settings=settings, auth=auth)
         self._attachment_service = AttachmentService(settings=settings, auth=auth)
         self._introspection_service = SchemaIntrospectionService(
             settings=settings, auth=auth
@@ -1174,6 +1177,10 @@ class PipefyClient:
             organization_id: Numeric organization ID.
         """
         return await self._organization_service.get_organization(organization_id)
+
+    async def get_me(self) -> MePayload | None:
+        """Return the authenticated user's identity, or ``None`` when ``me`` resolves null."""
+        return await self._user_service.get_me()
 
     async def create_presigned_url(
         self,

--- a/packages/sdk/src/pipefy_sdk/queries/me_queries.py
+++ b/packages/sdk/src/pipefy_sdk/queries/me_queries.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from gql import gql
+
+GET_ME_QUERY = gql(
+    """
+    query GetMe {
+        me {
+            email
+            name
+        }
+    }
+    """
+)
+
+__all__ = [
+    "GET_ME_QUERY",
+]

--- a/packages/sdk/src/pipefy_sdk/services/types.py
+++ b/packages/sdk/src/pipefy_sdk/services/types.py
@@ -50,3 +50,13 @@ class AutomationServiceResult(TypedDict):
 class ToggleAgentStatusResult(TypedDict):
     success: Literal[True]
     message: str
+
+
+class MePayload(TypedDict):
+    """Authenticated user identity returned by the GraphQL ``me`` query.
+
+    ``name`` is nullable in the Pipefy schema (verified via introspection).
+    """
+
+    email: str
+    name: str | None

--- a/packages/sdk/src/pipefy_sdk/services/user_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/user_service.py
@@ -1,0 +1,33 @@
+"""Service for fetching identity of the authenticated Pipefy user."""
+
+from __future__ import annotations
+
+from httpx import Auth
+
+from pipefy_sdk.base_client import BasePipefyClient
+from pipefy_sdk.queries.me_queries import GET_ME_QUERY
+from pipefy_sdk.services.types import MePayload
+from pipefy_sdk.settings import PipefySettings
+
+
+class UserService(BasePipefyClient):
+    """GraphQL operations scoped to the authenticated user (`me`)."""
+
+    def __init__(
+        self,
+        settings: PipefySettings,
+        auth: Auth | None = None,
+    ) -> None:
+        super().__init__(settings=settings, auth=auth)
+
+    async def get_me(self) -> MePayload | None:
+        """Return the authenticated user's identity, or ``None`` when the schema permits.
+
+        ``me`` is a nullable root field in Pipefy's schema (verified via introspection).
+        Callers should treat ``None`` as "no human identity available for this bearer".
+        """
+        data = await self.execute_query(GET_ME_QUERY, {})
+        me = data["me"]
+        if me is None:
+            return None
+        return {"email": me["email"], "name": me.get("name")}

--- a/packages/sdk/tests/services/pipefy/test_user_service.py
+++ b/packages/sdk/tests/services/pipefy/test_user_service.py
@@ -1,0 +1,63 @@
+"""Unit tests for UserService."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from pipefy_sdk.queries.me_queries import GET_ME_QUERY
+from pipefy_sdk.services.user_service import UserService
+from pipefy_sdk.settings import PipefySettings
+
+
+@pytest.fixture
+def mock_settings():
+    return PipefySettings(
+        graphql_url="https://api.pipefy.com/graphql",
+        oauth_url="https://auth.pipefy.com/oauth/token",
+        oauth_client="client_id",
+        oauth_secret="client_secret",
+    )
+
+
+def _make_service(mock_settings, return_value):
+    service = UserService(settings=mock_settings)
+    service.execute_query = AsyncMock(return_value=return_value)
+    return service
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_me_returns_identity(mock_settings):
+    """`me` payload is unwrapped into the `MePayload` shape."""
+    me_data = {"email": "user@pipefy.com", "name": "Pipefy User"}
+    service = _make_service(mock_settings, {"me": me_data})
+
+    result = await service.get_me()
+
+    service.execute_query.assert_called_once()
+    query_used, variables = service.execute_query.call_args[0]
+    assert query_used is GET_ME_QUERY
+    assert variables == {}
+    assert result == me_data
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_me_null_returns_none(mock_settings):
+    """`me` is nullable in the Pipefy schema (verified via introspection)."""
+    service = _make_service(mock_settings, {"me": None})
+
+    assert await service.get_me() is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_me_null_name_is_passed_through(mock_settings):
+    """`User.name` is nullable; the SDK preserves it rather than coercing."""
+    service = _make_service(
+        mock_settings, {"me": {"email": "user@pipefy.com", "name": None}}
+    )
+
+    result = await service.get_me()
+
+    assert result == {"email": "user@pipefy.com", "name": None}


### PR DESCRIPTION
## Summary

- New `pipefy auth status [--json|-j]` — reports which auth source is active, the authenticated identity, and (for stored sessions) access/refresh expiry. Locked JSON schema with `signed_in`, `identity`, `auth_source`, `detected_sources`, `issuer`, `state`, `access_expires_at`, `refresh_expires_at`, `token_rejected`, `keychain_backend`, `masking_env_vars`.
- Exit codes: **2** for no credentials / unrefreshable session, **1** for upstream rejection (401) or transport error, **0** for signed-in.
- SDK: typed `client.get_me() -> MePayload | None` mirroring `get_organization` (new `queries/me_queries.py`, `services/user_service.py`, `MePayload` TypedDict). `me` and `User.name` are both schema-nullable (verified via live introspection); types and renderers respect that.
- Refactor: `AuthContext.bearer_token` promoted to a `BearerToken(value, source)` dataclass so status can distinguish `--token` from `PIPEFY_TOKEN` without re-inspecting argv/env. New `detect_all_sources` / `detect_auth_source` helpers; `get_authenticated_client` now dispatches off the detection helper so runtime and status share one precedence definition.

Closes #135.

## Test plan

- [x] SDK unit tests (`packages/sdk/tests/services/pipefy/test_user_service.py`) — 3 cases (populated identity, `me: null`, `name: null`).
- [x] CLI command tests (`packages/cli/tests/test_auth_status.py`) — 16 cases covering all four sources, refresh-expired, 401, 5xx (distinct from 401), `me: null`, `name: null`, masked sources.
- [x] Golden CLI help refreshed (`tests/fixtures/cli_help_golden.txt`).
- [x] Full regression: SDK 729 passed; CLI 227 passed + 10 skipped (live-creds integration).
- [x] Live smoke: `pipefy auth status --json` against the service-account session returned the expected schema with the real synthetic identity.
- [x] Live smoke on a stored-session bearer (requires `pipefy auth login` first — reviewer's call whether to re-verify).