### PR TITLE
chore: add pre-commit config running ruff lint + format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+# Pre-commit hooks. Install once per clone with:
+#
+#     uvx pre-commit install
+#
+# Then ruff lint + format run on every `git commit` (only on staged Python
+# files). Bypass for a one-off WIP commit with `git commit --no-verify`.
+# Run against the whole tree on demand with `uvx pre-commit run --all-files`.
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.4
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,11 +3,15 @@
 #     uvx pre-commit install
 #
 # Then ruff lint + format run on every `git commit` (only on staged Python
-# files). Bypass for a one-off WIP commit with `git commit --no-verify`.
-# Run against the whole tree on demand with `uvx pre-commit run --all-files`.
+# files). If a hook rewrites a file, the commit is aborted — re-stage with
+# `git add` and commit again. Bypass for a one-off WIP commit with
+# `git commit --no-verify`. Run against the whole tree on demand with
+# `uvx pre-commit run --all-files`.
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Keep `rev` in sync with the ruff pin in `uv.lock`. CI uses `uv run ruff`
+    # (lockfile), so a drift here makes hook output disagree with CI.
     rev: v0.11.4
     hooks:
       - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,4 +16,5 @@ repos:
     hooks:
       - id: ruff
         args: [--fix]
+      # `ruff --fix` must run before `ruff-format` (ruff-pre-commit docs).
       - id: ruff-format

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ skills/         → agent skills catalog (Markdown; no Python package)
 - `uv run pipefy --help` — run CLI locally.
 - `uv run pytest` — full test suite.
 - `uv run ruff check .` / `uv run ruff format .` — lint and format.
+- `uvx pre-commit install` — opt in to the ruff lint + format git hook (one-time, per clone). Run against the whole tree with `uvx pre-commit run --all-files`; bypass for a WIP commit with `git commit --no-verify`. The hook's ruff `rev` in `.pre-commit-config.yaml` must move with `uv.lock` to keep hook and CI aligned.
 - Coverage: `uv run pytest --cov=packages/sdk/src/pipefy_sdk --cov-report=term-missing`.
 
 ### Manual E2E


### PR DESCRIPTION
## Summary

Adds `.pre-commit-config.yaml` so `ruff --fix` and `ruff-format` run automatically on every `git commit`, catching lint/format drift before it reaches CI. Pinned to ruff `v0.11.4` to match the version already installed in the dev environment.

## Setup (per clone)

```bash
uvx pre-commit install
```

That's it — the hook runs from then on. Bypass for an explicit WIP commit with `git commit --no-verify`. Run against the entire tree on demand with `uvx pre-commit run --all-files`.

## Test plan

- [x] `uvx pre-commit run --all-files` — both hooks pass against the entire `dev` tree.
- [x] Config matches the ruff version (`0.11.4`) reported by `uv run ruff --version` inside `packages/cli` and `packages/sdk`, so hook and `uv run ruff` won't disagree.
- [ ] Reviewer: run `uvx pre-commit install` after merge and confirm a staged-file commit triggers the hook.