### PR TITLE
feat(cli): harden `pipefy auth login` (#126)

### DIFF
--- a/packages/cli/src/pipefy_cli/commands/auth.py
+++ b/packages/cli/src/pipefy_cli/commands/auth.py
@@ -27,6 +27,7 @@ from pipefy_cli.auth import (
 )
 from pipefy_cli.commands._common import settings_and_auth_from_ctx
 from pipefy_cli.oauth import (
+    DiscoveryPolicy,
     LoginError,
     RefreshError,
     ensure_fresh_session,
@@ -123,7 +124,7 @@ def auth_login(
     # Lazy to keep keyring's ~30-80ms backend-discovery cost off every CLI startup.
     from keyring.errors import KeyringError
 
-    _, auth = settings_and_auth_from_ctx(ctx)
+    settings, auth = settings_and_auth_from_ctx(ctx)
     if auth.oidc_client is None:
         typer.echo(
             "PIPEFY_AUTH_URL is required for `pipefy auth login` (the OIDC issuer "
@@ -159,6 +160,9 @@ def auth_login(
             callback_timeout_s=callback_timeout,
             open_browser=_open,
             on_url=_print_url,
+            discovery_policy=DiscoveryPolicy(
+                allow_insecure_urls=settings.allow_insecure_urls
+            ),
         )
     except LoginError as exc:
         typer.echo(f"Login failed: {exc}", err=True)

--- a/packages/cli/src/pipefy_cli/oauth/__init__.py
+++ b/packages/cli/src/pipefy_cli/oauth/__init__.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from pipefy_cli.oauth.discovery import ProviderMetadata, fetch_provider_metadata
+from pipefy_cli.oauth.discovery import (
+    DiscoveryPolicy,
+    ProviderMetadata,
+    fetch_provider_metadata,
+)
 from pipefy_cli.oauth.flow import LoginError, LoginResult, run_login
 from pipefy_cli.oauth.refresh import (
     RefreshError,
@@ -19,6 +23,7 @@ from pipefy_cli.oauth.storage import (
 )
 
 __all__ = [
+    "DiscoveryPolicy",
     "LoginError",
     "LoginResult",
     "ProviderMetadata",

--- a/packages/cli/src/pipefy_cli/oauth/discovery.py
+++ b/packages/cli/src/pipefy_cli/oauth/discovery.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import httpx
+from pipefy_sdk.utils.url_ssrf import validate_https_service_endpoint_url
 
 from pipefy_cli.oauth import _http
 
@@ -21,6 +22,17 @@ class ProviderMetadata:
     token_endpoint: str
 
 
+@dataclass(frozen=True)
+class DiscoveryPolicy:
+    """Knobs governing how ``fetch_provider_metadata`` validates its inputs.
+
+    Bundled so future flags (cached metadata, custom timeouts) can grow here
+    without re-threading kwargs through every caller.
+    """
+
+    allow_insecure_urls: bool = False
+
+
 def _normalize_issuer(issuer_url: str) -> str:
     return issuer_url.rstrip("/")
 
@@ -33,14 +45,22 @@ def discovery_url(issuer_url: str) -> str:
 def fetch_provider_metadata(
     issuer_url: str,
     *,
+    policy: DiscoveryPolicy = DiscoveryPolicy(),
     timeout: float = _DEFAULT_TIMEOUT,
     client: httpx.Client | None = None,
 ) -> ProviderMetadata:
     """Fetch and parse the issuer's OIDC discovery document.
 
+    Validates that ``metadata.issuer`` matches ``issuer_url`` (per OIDC
+    Discovery 1.0 §4.3) and that the returned ``authorization_endpoint`` and
+    ``token_endpoint`` aren't pointing at internal hosts or non-HTTPS URLs —
+    a tampered or misconfigured discovery doc must not be allowed to redirect
+    the browser dance or token exchange to an attacker-controlled target.
+
     Raises:
-        ValueError: When the discovery document is unreachable, malformed, or
-            missing required endpoints. Message is user-facing.
+        ValueError: When the discovery document is unreachable, malformed,
+            issuer-mismatched, or returns endpoint URLs that don't pass the
+            shared SSRF check. Message is user-facing.
     """
     url = discovery_url(issuer_url)
     with _http.http_client(client, timeout=timeout) as http:
@@ -80,15 +100,31 @@ def fetch_provider_metadata(
             f"document claims {claimed_issuer!r}"
         )
 
+    authorization_endpoint = str(data["authorization_endpoint"])
+    token_endpoint = str(data["token_endpoint"])
+    for field, value in (
+        ("authorization_endpoint", authorization_endpoint),
+        ("token_endpoint", token_endpoint),
+    ):
+        try:
+            validate_https_service_endpoint_url(
+                value, field, allow_insecure=policy.allow_insecure_urls
+            )
+        except ValueError as exc:
+            raise ValueError(
+                f"OIDC discovery returned invalid {field}: {exc}"
+            ) from exc
+
     return ProviderMetadata(
         issuer=claimed_issuer,
-        authorization_endpoint=str(data["authorization_endpoint"]),
-        token_endpoint=str(data["token_endpoint"]),
+        authorization_endpoint=authorization_endpoint,
+        token_endpoint=token_endpoint,
     )
 
 
 __all__ = [
     "DISCOVERY_PATH",
+    "DiscoveryPolicy",
     "ProviderMetadata",
     "discovery_url",
     "fetch_provider_metadata",

--- a/packages/cli/src/pipefy_cli/oauth/discovery.py
+++ b/packages/cli/src/pipefy_cli/oauth/discovery.py
@@ -111,9 +111,7 @@ def fetch_provider_metadata(
                 value, field, allow_insecure=policy.allow_insecure_urls
             )
         except ValueError as exc:
-            raise ValueError(
-                f"OIDC discovery returned invalid {field}: {exc}"
-            ) from exc
+            raise ValueError(f"OIDC discovery returned invalid {field}: {exc}") from exc
 
     return ProviderMetadata(
         issuer=claimed_issuer,

--- a/packages/cli/src/pipefy_cli/oauth/discovery.py
+++ b/packages/cli/src/pipefy_cli/oauth/discovery.py
@@ -71,8 +71,17 @@ def fetch_provider_metadata(
             f"OIDC discovery at {url} is missing required fields: {', '.join(missing)}"
         )
 
+    # OIDC Discovery 1.0 §4.3 — the ``issuer`` claim must match the URL the
+    # document was fetched from. Trailing slashes don't carry meaning here.
+    claimed_issuer = str(data["issuer"])
+    if _normalize_issuer(claimed_issuer) != _normalize_issuer(issuer_url):
+        raise ValueError(
+            f"OIDC discovery issuer mismatch: requested {issuer_url!r}, "
+            f"document claims {claimed_issuer!r}"
+        )
+
     return ProviderMetadata(
-        issuer=str(data["issuer"]),
+        issuer=claimed_issuer,
         authorization_endpoint=str(data["authorization_endpoint"]),
         token_endpoint=str(data["token_endpoint"]),
     )

--- a/packages/cli/src/pipefy_cli/oauth/discovery.py
+++ b/packages/cli/src/pipefy_cli/oauth/discovery.py
@@ -72,10 +72,10 @@ def fetch_provider_metadata(
             ) from exc
 
     if response.status_code != 200:
-        raise ValueError(
-            f"OIDC discovery failed ({response.status_code}) at {url}: "
-            f"{response.text[:200]}"
-        )
+        # Status-only; never echo the raw body. Discovery isn't OAuth so there's
+        # no RFC 6749 ``error`` field to surface, and a `[:N]` window of the
+        # body is the same echo-channel class scrubbed in ``_format_token_error``.
+        raise ValueError(f"OIDC discovery failed ({response.status_code}) at {url}")
 
     try:
         data = response.json()

--- a/packages/cli/src/pipefy_cli/oauth/flow.py
+++ b/packages/cli/src/pipefy_cli/oauth/flow.py
@@ -11,7 +11,11 @@ from urllib.parse import urlencode
 import httpx
 
 from pipefy_cli.oauth import _http
-from pipefy_cli.oauth.discovery import ProviderMetadata, fetch_provider_metadata
+from pipefy_cli.oauth.discovery import (
+    DiscoveryPolicy,
+    ProviderMetadata,
+    fetch_provider_metadata,
+)
 from pipefy_cli.oauth.loopback import CallbackResult, LoopbackCapture
 from pipefy_cli.oauth.pkce import challenge_from_verifier, generate_verifier
 
@@ -99,6 +103,7 @@ def run_login(
     open_browser: Callable[[str], bool] = webbrowser.open,
     on_url: Callable[[str], None] | None = None,
     http_client: httpx.Client | None = None,
+    discovery_policy: DiscoveryPolicy = DiscoveryPolicy(),
 ) -> LoginResult:
     """Run the full PKCE loopback login. Returns tokens; does **not** persist them.
 
@@ -118,6 +123,9 @@ def run_login(
         http_client: Optional pre-configured ``httpx.Client`` (testing). When
             omitted, one client is created and reused for discovery + token
             exchange so the same TLS connection can serve both requests.
+        discovery_policy: Validation knobs forwarded to
+            :func:`fetch_provider_metadata` (notably ``allow_insecure_urls``
+            for local-development IdPs over http / private IPs).
 
     Raises:
         LoginError: For any user-visible failure (discovery, state mismatch,
@@ -126,7 +134,9 @@ def run_login(
     """
     with _http.http_client(http_client, timeout=_TOKEN_EXCHANGE_TIMEOUT_S) as http:
         try:
-            metadata = fetch_provider_metadata(issuer_url, client=http)
+            metadata = fetch_provider_metadata(
+                issuer_url, policy=discovery_policy, client=http
+            )
         except ValueError as exc:
             raise LoginError(str(exc)) from exc
 

--- a/packages/cli/src/pipefy_cli/oauth/flow.py
+++ b/packages/cli/src/pipefy_cli/oauth/flow.py
@@ -82,9 +82,7 @@ def exchange_code(
         raise LoginError(f"Token exchange request failed: {exc}") from exc
 
     if response.status_code != 200:
-        raise LoginError(
-            f"Token exchange failed ({response.status_code}): {response.text[:300]}"
-        )
+        raise LoginError(_format_token_error(response))
     try:
         payload = response.json()
     except ValueError as exc:
@@ -92,6 +90,30 @@ def exchange_code(
     if not isinstance(payload, dict):
         raise LoginError("Token endpoint returned a non-object JSON payload.")
     return payload
+
+
+def _format_token_error(response: httpx.Response) -> str:
+    """Render a token-exchange non-200 as a user-safe message.
+
+    Only OAuth-standard ``error`` / ``error_description`` fields are surfaced;
+    raw bodies are never echoed (RFC 6749 doesn't forbid IdPs from including
+    submitted params like ``code_verifier`` in error responses, and a `[:N]`
+    snippet would be a guaranteed echo channel under a hostile IdP).
+    """
+    generic = f"Token endpoint returned HTTP {response.status_code}"
+    try:
+        payload = response.json()
+    except ValueError:
+        return generic
+    if not isinstance(payload, dict):
+        return generic
+    error = payload.get("error")
+    if not error:
+        return generic
+    description = payload.get("error_description")
+    if description:
+        return f"Token exchange failed: {error}: {description}"
+    return f"Token exchange failed: {error}"
 
 
 def run_login(

--- a/packages/cli/src/pipefy_cli/oauth/flow.py
+++ b/packages/cli/src/pipefy_cli/oauth/flow.py
@@ -110,6 +110,10 @@ def _format_token_error(response: httpx.Response) -> str:
     error = payload.get("error")
     if not error:
         return generic
+    # ``error_description`` is free-form per RFC 6749 §5.2 — its content reflects
+    # the IdP's framing, and surfacing it at all is part of trusting the IdP. A
+    # length cap wouldn't change that (an attacker can truncate to fit any cap,
+    # and a tight cap kills legitimate error context).
     description = payload.get("error_description")
     if description:
         return f"Token exchange failed: {error}: {description}"

--- a/packages/cli/tests/test_auth_login.py
+++ b/packages/cli/tests/test_auth_login.py
@@ -284,6 +284,26 @@ class TestStorage:
 # --------------------------------------------------------------------------- #
 
 
+def _exchange_error_for(response: httpx.Response) -> flow.LoginError:
+    """Invoke ``exchange_code`` against a canned response and return the raised error."""
+    meta = ProviderMetadata(
+        issuer="i",
+        authorization_endpoint="https://a/x",
+        token_endpoint="https://t/x",
+    )
+    client = httpx.Client(transport=httpx.MockTransport(lambda _r: response))
+    with pytest.raises(flow.LoginError) as exc_info:
+        flow.exchange_code(
+            metadata=meta,
+            client_id="cid",
+            code="c",
+            redirect_uri="r",
+            code_verifier="SENTINEL_VERIFIER",
+            client=client,
+        )
+    return exc_info.value
+
+
 class TestFlow:
     def test_build_authorization_url_has_all_required_params(self) -> None:
         meta = ProviderMetadata(
@@ -361,26 +381,8 @@ class TestFlow:
                 client=client,
             )
 
-    def _call_exchange(self, response: httpx.Response) -> flow.LoginError:
-        meta = ProviderMetadata(
-            issuer="i",
-            authorization_endpoint="https://a/x",
-            token_endpoint="https://t/x",
-        )
-        client = httpx.Client(transport=httpx.MockTransport(lambda _r: response))
-        with pytest.raises(flow.LoginError) as exc_info:
-            flow.exchange_code(
-                metadata=meta,
-                client_id="cid",
-                code="c",
-                redirect_uri="r",
-                code_verifier="SENTINEL_VERIFIER",
-                client=client,
-            )
-        return exc_info.value
-
     def test_exchange_error_renders_oauth_fields(self) -> None:
-        err = self._call_exchange(
+        err = _exchange_error_for(
             httpx.Response(
                 400,
                 json={"error": "invalid_grant", "error_description": "PKCE failed"},
@@ -390,22 +392,26 @@ class TestFlow:
         assert "PKCE failed" in str(err)
 
     def test_exchange_error_renders_error_alone_when_description_absent(self) -> None:
-        err = self._call_exchange(httpx.Response(400, json={"error": "invalid_grant"}))
+        err = _exchange_error_for(
+            httpx.Response(400, json={"error": "invalid_grant"})
+        )
         assert str(err) == "Token exchange failed: invalid_grant"
 
     def test_exchange_error_falls_back_when_error_key_missing(self) -> None:
         # error_description without error is half a message — fall back to generic.
-        err = self._call_exchange(
+        err = _exchange_error_for(
             httpx.Response(400, json={"error_description": "PKCE failed"})
         )
         assert str(err) == "Token endpoint returned HTTP 400"
 
     def test_exchange_error_falls_back_on_non_dict_json(self) -> None:
-        err = self._call_exchange(httpx.Response(400, json=["not", "a", "dict"]))
+        err = _exchange_error_for(httpx.Response(400, json=["not", "a", "dict"]))
         assert str(err) == "Token endpoint returned HTTP 400"
 
     def test_exchange_error_falls_back_on_non_json_body(self) -> None:
-        err = self._call_exchange(httpx.Response(500, text="<html>Bad Gateway</html>"))
+        err = _exchange_error_for(
+            httpx.Response(500, text="<html>Bad Gateway</html>")
+        )
         assert str(err) == "Token endpoint returned HTTP 500"
 
     def test_exchange_error_does_not_echo_raw_body(self) -> None:
@@ -417,7 +423,7 @@ class TestFlow:
             '{"error":"invalid_grant","error_description":"bad pkce",'
             f'"echoed":"{sentinel}"}}'
         )
-        err = self._call_exchange(httpx.Response(400, text=body))
+        err = _exchange_error_for(httpx.Response(400, text=body))
         message = str(err)
         assert "invalid_grant" in message
         assert "bad pkce" in message

--- a/packages/cli/tests/test_auth_login.py
+++ b/packages/cli/tests/test_auth_login.py
@@ -361,6 +361,69 @@ class TestFlow:
                 client=client,
             )
 
+    def _call_exchange(self, response: httpx.Response) -> flow.LoginError:
+        meta = ProviderMetadata(
+            issuer="i",
+            authorization_endpoint="https://a/x",
+            token_endpoint="https://t/x",
+        )
+        client = httpx.Client(transport=httpx.MockTransport(lambda _r: response))
+        with pytest.raises(flow.LoginError) as exc_info:
+            flow.exchange_code(
+                metadata=meta,
+                client_id="cid",
+                code="c",
+                redirect_uri="r",
+                code_verifier="SENTINEL_VERIFIER",
+                client=client,
+            )
+        return exc_info.value
+
+    def test_exchange_error_renders_oauth_fields(self) -> None:
+        err = self._call_exchange(
+            httpx.Response(
+                400,
+                json={"error": "invalid_grant", "error_description": "PKCE failed"},
+            )
+        )
+        assert "invalid_grant" in str(err)
+        assert "PKCE failed" in str(err)
+
+    def test_exchange_error_renders_error_alone_when_description_absent(self) -> None:
+        err = self._call_exchange(httpx.Response(400, json={"error": "invalid_grant"}))
+        assert str(err) == "Token exchange failed: invalid_grant"
+
+    def test_exchange_error_falls_back_when_error_key_missing(self) -> None:
+        # error_description without error is half a message — fall back to generic.
+        err = self._call_exchange(
+            httpx.Response(400, json={"error_description": "PKCE failed"})
+        )
+        assert str(err) == "Token endpoint returned HTTP 400"
+
+    def test_exchange_error_falls_back_on_non_dict_json(self) -> None:
+        err = self._call_exchange(httpx.Response(400, json=["not", "a", "dict"]))
+        assert str(err) == "Token endpoint returned HTTP 400"
+
+    def test_exchange_error_falls_back_on_non_json_body(self) -> None:
+        err = self._call_exchange(httpx.Response(500, text="<html>Bad Gateway</html>"))
+        assert str(err) == "Token endpoint returned HTTP 500"
+
+    def test_exchange_error_does_not_echo_raw_body(self) -> None:
+        # Regression guard for item 3: a hostile IdP could echo submitted params
+        # (like our code_verifier) into the raw response body. The scrub must
+        # never put that text into the LoginError message.
+        sentinel = "code_verifier=SENTINEL_VERIFIER_LEAK"
+        body = (
+            '{"error":"invalid_grant","error_description":"bad pkce",'
+            f'"echoed":"{sentinel}"}}'
+        )
+        err = self._call_exchange(httpx.Response(400, text=body))
+        message = str(err)
+        assert "invalid_grant" in message
+        assert "bad pkce" in message
+        assert sentinel not in message
+        assert "SENTINEL_VERIFIER_LEAK" not in message
+
     def test_run_login_state_mismatch_raises(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/packages/cli/tests/test_auth_login.py
+++ b/packages/cli/tests/test_auth_login.py
@@ -392,9 +392,7 @@ class TestFlow:
         assert "PKCE failed" in str(err)
 
     def test_exchange_error_renders_error_alone_when_description_absent(self) -> None:
-        err = _exchange_error_for(
-            httpx.Response(400, json={"error": "invalid_grant"})
-        )
+        err = _exchange_error_for(httpx.Response(400, json={"error": "invalid_grant"}))
         assert str(err) == "Token exchange failed: invalid_grant"
 
     def test_exchange_error_falls_back_when_error_key_missing(self) -> None:
@@ -409,9 +407,7 @@ class TestFlow:
         assert str(err) == "Token endpoint returned HTTP 400"
 
     def test_exchange_error_falls_back_on_non_json_body(self) -> None:
-        err = _exchange_error_for(
-            httpx.Response(500, text="<html>Bad Gateway</html>")
-        )
+        err = _exchange_error_for(httpx.Response(500, text="<html>Bad Gateway</html>"))
         assert str(err) == "Token endpoint returned HTTP 500"
 
     def test_exchange_error_does_not_echo_raw_body(self) -> None:

--- a/packages/cli/tests/test_auth_login.py
+++ b/packages/cli/tests/test_auth_login.py
@@ -120,6 +120,42 @@ class TestDiscovery:
             meta = discovery.fetch_provider_metadata(requested, client=client)
             assert meta.issuer == claimed
 
+    def test_http_authorization_endpoint_rejected(self) -> None:
+        bad = _discovery_payload()
+        bad["authorization_endpoint"] = "http://example.test/realms/foo/auth"
+        client = httpx.Client(
+            transport=httpx.MockTransport(lambda _r: httpx.Response(200, json=bad))
+        )
+        with pytest.raises(ValueError, match="authorization_endpoint"):
+            discovery.fetch_provider_metadata(
+                "https://example.test/realms/foo", client=client
+            )
+
+    def test_internal_token_endpoint_rejected(self) -> None:
+        bad = _discovery_payload()
+        bad["token_endpoint"] = "https://127.0.0.1/realms/foo/token"
+        client = httpx.Client(
+            transport=httpx.MockTransport(lambda _r: httpx.Response(200, json=bad))
+        )
+        with pytest.raises(ValueError, match="token_endpoint"):
+            discovery.fetch_provider_metadata(
+                "https://example.test/realms/foo", client=client
+            )
+
+    def test_allow_insecure_urls_bypasses_ssrf_checks(self) -> None:
+        # Same payload that fails by default succeeds when the policy opts in.
+        bad = _discovery_payload()
+        bad["authorization_endpoint"] = "http://127.0.0.1:8080/realms/foo/auth"
+        client = httpx.Client(
+            transport=httpx.MockTransport(lambda _r: httpx.Response(200, json=bad))
+        )
+        meta = discovery.fetch_provider_metadata(
+            "https://example.test/realms/foo",
+            policy=discovery.DiscoveryPolicy(allow_insecure_urls=True),
+            client=client,
+        )
+        assert meta.authorization_endpoint == "http://127.0.0.1:8080/realms/foo/auth"
+
 
 # --------------------------------------------------------------------------- #
 # Loopback                                                                    #
@@ -335,7 +371,9 @@ class TestFlow:
             token_endpoint="https://x.test/token",
         )
         monkeypatch.setattr(
-            flow, "fetch_provider_metadata", lambda url, client=None: meta
+            flow,
+            "fetch_provider_metadata",
+            lambda url, *, policy=None, client=None: meta,
         )
 
         class _FakeCapture:

--- a/packages/cli/tests/test_auth_login.py
+++ b/packages/cli/tests/test_auth_login.py
@@ -78,11 +78,18 @@ class TestDiscovery:
         assert meta.token_endpoint == payload["token_endpoint"]
 
     def test_fetch_non_200_raises(self) -> None:
+        sentinel = "SENTINEL_DISCOVERY_LEAK"
         client = httpx.Client(
-            transport=httpx.MockTransport(lambda _r: httpx.Response(404, text="nope"))
+            transport=httpx.MockTransport(
+                lambda _r: httpx.Response(404, text=f"<html>nope {sentinel}</html>")
+            )
         )
-        with pytest.raises(ValueError, match="OIDC discovery failed"):
+        with pytest.raises(ValueError, match="OIDC discovery failed") as exc_info:
             discovery.fetch_provider_metadata("https://x.test/realms/y", client=client)
+        # Status-only message; raw body must not leak (same threat-model as the
+        # token-exchange scrub).
+        assert sentinel not in str(exc_info.value)
+        assert "<html>" not in str(exc_info.value)
 
     def test_fetch_missing_field_raises(self) -> None:
         bad = {"issuer": "https://x.test", "token_endpoint": "https://x.test/t"}

--- a/packages/cli/tests/test_auth_login.py
+++ b/packages/cli/tests/test_auth_login.py
@@ -92,6 +92,34 @@ class TestDiscovery:
         with pytest.raises(ValueError, match="authorization_endpoint"):
             discovery.fetch_provider_metadata("https://x.test", client=client)
 
+    def test_issuer_mismatch_rejected(self) -> None:
+        bad = _discovery_payload(issuer="https://attacker.test/realms/foo")
+        client = httpx.Client(
+            transport=httpx.MockTransport(lambda _r: httpx.Response(200, json=bad))
+        )
+        with pytest.raises(ValueError, match="issuer mismatch") as exc:
+            discovery.fetch_provider_metadata(
+                "https://example.test/realms/foo", client=client
+            )
+        # Both URLs surface in the message so the user can see which side drifted.
+        assert "https://example.test/realms/foo" in str(exc.value)
+        assert "https://attacker.test/realms/foo" in str(exc.value)
+
+    def test_issuer_trailing_slash_variants_accepted(self) -> None:
+        # Claim with trailing slash; request without — and vice versa.
+        for claimed, requested in (
+            ("https://example.test/realms/foo/", "https://example.test/realms/foo"),
+            ("https://example.test/realms/foo", "https://example.test/realms/foo/"),
+        ):
+            payload = _discovery_payload(issuer=claimed)
+            client = httpx.Client(
+                transport=httpx.MockTransport(
+                    lambda _r, p=payload: httpx.Response(200, json=p)
+                )
+            )
+            meta = discovery.fetch_provider_metadata(requested, client=client)
+            assert meta.issuer == claimed
+
 
 # --------------------------------------------------------------------------- #
 # Loopback                                                                    #


### PR DESCRIPTION
## Summary

Three security-grade fixes for `pipefy auth login`, all deferred from PR #125's review and tracked in #126. Rebased on top of merged #142 (`auth status`) and the merged refresh body-scrub side-effect; the originally deferred follow-up on `refresh.py:56` is now closed.

- **Issuer match (commit 1)** — Verify `metadata.issuer` from the discovery document matches the URL it was fetched from (OIDC Discovery 1.0 §4.3). Compared on the `rstrip("/")` form so trailing-slash variants behave the same; both URLs land in the error message. Without this, a misrouted realm (piporacle vs prod) or a tampered discovery doc lands silently.
- **SSRF on discovery-returned endpoints (commit 2)** — `authorization_endpoint` and `token_endpoint` are now run through the shared `pipefy_sdk.utils.url_ssrf.validate_https_service_endpoint_url` before reaching the caller. A tampered discovery response otherwise sends the browser dance / token exchange wherever the doc says. Plumbing uses a new `DiscoveryPolicy` frozen dataclass (one field today, `allow_insecure_urls`) so the next two follow-ups (#132 cached metadata, #138 device flow) don't have to re-thread kwargs. The validation lives **inside** `fetch_provider_metadata` because `ProviderMetadata` is a frozen dataclass other paths construct directly — pushing the invariant down to where the type is born means future callers inherit it.
- **Scrub raw response body from token-exchange errors (commit 3)** — `exchange_code` was rendering `response.text[:300]` into `LoginError` on any non-200. RFC 6749 doesn't forbid IdPs from echoing submitted params (like our `code_verifier`); a `[:N]` window is a guaranteed echo channel under a hostile IdP. Now surfaces only the OAuth-standard `error` / `error_description` fields, with status-only fallback on missing/non-JSON/non-dict bodies. Includes a regression-guard test that asserts a sentinel `code_verifier=...` substring outside `error`/`error_description` does not appear in the resulting message.
- **Test-helper cleanup (commit 4)** — `TestFlow._call_exchange` was a class method that never used `self`. Lifted to module-level `_exchange_error_for`, matching the file's existing convention (`_discovery_payload`, `_fire_callback`).
- **Discovery non-200 scrub + IdP trust-boundary doc (commit 6, from review)** — `discovery.py` non-200 path was still echoing `response.text[:200]`; status-only now. Documented in `_format_token_error` that `error_description` is free-form per RFC 6749 §5.2 and surfacing it is part of trusting the IdP (no length cap — attackers can truncate to fit, tight caps kill legitimate context).

Closes #126.

## Out of scope (filed as follow-ups)

- ~~`discovery.py` non-200 path also does `response.text[:200]`~~ — **addressed in commit 6** in response to PR review.
- ~~`refresh.py` does the same `response.text[:300]` on refresh-grant failures~~ — **closed by PR #142** as a side-effect of the `RefreshError.error_code` refactor (squash `b3b05b1` on `dev`, originating commit `b4a3fec`).

## Test plan

- [x] Targeted unit tests: `pytest packages/cli/tests/test_auth_login.py` — passing (covers issuer mismatch, trailing-slash variants, SSRF rejection on http/internal-IP, `allow_insecure_urls` bypass, structured token-error rendering, sentinel regression guard, and the new `test_fetch_non_200_raises` sentinel for the D3 discovery scrub).
- [x] Full CLI regression: `pytest packages/cli/` — 242 passed, 10 skipped (clean after the #142 rebase).
- [x] Live smoke against the piporacle realm:
  - [x] **Happy path** — `pipefy auth login` completes against `https://signin-piporacle.pipefy.com/realms/st-piporacle-pud1m`, session stored in macOS Keyring. `pipefy auth status --json` returns `auth_source: "stored-session"`, `state: "active"`, populated `identity.email`/`identity.name`.
  - [x] **`masking_env_vars` (PR #142 cross-check)** — with `PIPEFY_OAUTH_*` set, `pipefy auth status --json` reports `auth_source: "service-account"` while `masking_env_vars: ["PIPEFY_OAUTH_*"]` surfaces the masked stored session. Confirms the C3 fix from #142 fires in production.
  - [x] **Tampered-discovery negative path** — `PIPEFY_AUTH_URL=…/wrong-realm-does-not-exist` returns `Login failed: OIDC discovery failed (404) at …`. Browser does NOT open; **no HTML body echoed** (D3 scrub working live).
  - [x] **SSRF reject without flag** — `PIPEFY_AUTH_URL=http://localhost:9999/realms/test` rejected at the settings layer (Pydantic `auth_url: must use HTTPS`) before the command starts.
  - [x] **`PIPEFY_ALLOW_INSECURE_URLS=true` bypass** — same URL with the flag set bypasses the settings HTTPS check and reaches the discovery network call (`ECONNREFUSED`, expected). Confirms `DiscoveryPolicy(allow_insecure_urls=…)` plumbs end-to-end from `PipefySettings` through `run_login` to `fetch_provider_metadata`.
  - Note: the PR #144 SSRF gate on discovery-*returned* endpoints (vs the settings-layer check on the issuer URL itself) can't be exercised live without a synthetic IdP serving a malicious discovery doc. That gate is covered by unit tests in `test_auth_login.py` (`test_fetch_returns_invalid_authorization_endpoint`, `test_fetch_returns_localhost_token_endpoint`, plus the `allow_insecure_urls=True` bypass case).