### PR TITLE
feat(cli): pipefy auth logout with token revocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - **CLI**: `pipefy auth status [--json|-j]` — reports auth source, identity, session expiry, and exit codes.
+- **CLI**: `pipefy auth logout` — revokes the refresh token at the IdP and clears the stored session.
 
 ### Changed
 

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -108,7 +108,7 @@ PIPEFY_TOKEN="$MY_BEARER" uv run pipefy pipe list
 |---------|--------|-------|
 | `pipefy auth login` | Available | Browser-based PKCE login; persists the session in the OS keychain. |
 | `pipefy auth status` | Available | Print which auth source is active, identity, and session expiry. |
-| `pipefy auth logout` | Forthcoming (#136) | Delete the stored session and revoke the refresh token. |
+| `pipefy auth logout` | Available | Revoke the refresh token at the IdP and clear the stored session. |
 
 #### `pipefy auth login` flags
 
@@ -153,6 +153,25 @@ The shape is stable across all sources (fields you don't have are `null` rather 
 | Stored session present but refresh grant rejected (`state` ∈ {`refresh-expired`, `needs-login`}) | **2** |
 | Signed in, but the identity `me` query returned 401 or transport-failed | **1** |
 | Signed in, identity fetched successfully | **0** |
+
+#### `pipefy auth logout`
+
+POSTs the stored refresh token to the IdP's `end_session_endpoint` (advertised in the OIDC discovery document) and removes the keychain entry. Without server-side revocation the refresh token would remain valid at the IdP until natural expiry — anyone who recovered it from a backup could still mint new access tokens.
+
+The command always clears the local keychain entry once it runs, even when the IdP round-trip fails. The two non-happy paths surface a stderr warning so the user knows whether server-side revocation succeeded:
+
+- **Revocation network / non-2xx failure** — stderr `Could not revoke refresh token at the IdP: <reason>. Clearing local session anyway; the refresh token may remain valid at the server until natural expiry.`
+- **IdP doesn't advertise `end_session_endpoint`** — stderr `Pipefy auth server does not advertise a logout endpoint; the refresh token could not be revoked server-side. Clearing local session only.` (OIDC Discovery 1.0 makes the field optional; Keycloak ships it.)
+
+When no session is stored, `pipefy auth logout` prints `Not signed in. Nothing to do.` and exits 0 — idempotent, matching `gh auth logout` and similar CLIs.
+
+##### Exit codes
+
+| Case | Exit |
+|------|------|
+| `PIPEFY_AUTH_URL` is unset | **2** — same gate as `pipefy auth login`. |
+| No session stored (no-op) | **0** |
+| Session cleared (revoke succeeded, failed, or unsupported) | **0** |
 
 ### Pipefy issuer URLs
 

--- a/packages/cli/src/pipefy_cli/commands/auth.py
+++ b/packages/cli/src/pipefy_cli/commands/auth.py
@@ -30,9 +30,13 @@ from pipefy_cli.oauth import (
     DiscoveryPolicy,
     LoginError,
     RefreshError,
+    RevocationError,
+    RevocationUnsupportedError,
+    delete_session,
     ensure_fresh_session,
     keychain_backend_name,
     load_session,
+    revoke_session,
     run_login,
     store_session,
 )
@@ -430,6 +434,59 @@ def auth_status(
         raise typer.Exit(exit_.exit_code) from exit_
 
     _render(report, json_out=json_out)
+
+
+@auth_app.command("logout")
+def auth_logout(ctx: typer.Context) -> None:
+    """Revoke the stored refresh token at the IdP and clear the local session."""
+    settings, auth = settings_and_auth_from_ctx(ctx)
+    if auth.oidc_client is None:
+        typer.echo(
+            "PIPEFY_AUTH_URL is required for `pipefy auth logout` (the OIDC "
+            "issuer URL used at login). "
+            f"See {DOCS_CLI_AUTH_REF}.",
+            err=True,
+        )
+        raise typer.Exit(2)
+
+    issuer = auth.oidc_client.issuer_url
+    client_id = auth.oidc_client.client_id
+
+    session = load_session(issuer=issuer, client_id=client_id)
+    if session is None:
+        typer.echo("Not signed in. Nothing to do.")
+        return
+
+    # Revoke at the IdP first — once we delete the keychain entry we no longer
+    # have the refresh_token to send. On any revoke failure still proceed to
+    # delete (warning makes the difference honest: server-side credential may
+    # remain valid until natural expiry).
+    revoke_warning: str | None = None
+    try:
+        revoke_session(
+            issuer=issuer,
+            client_id=client_id,
+            refresh_token=session.refresh_token,
+            policy=DiscoveryPolicy(allow_insecure_urls=settings.allow_insecure_urls),
+        )
+    except RevocationUnsupportedError:
+        revoke_warning = (
+            "Pipefy auth server does not advertise a logout endpoint; the "
+            "refresh token could not be revoked server-side. Clearing local "
+            "session only."
+        )
+    except RevocationError as exc:
+        revoke_warning = (
+            f"Could not revoke refresh token at the IdP: {exc}. Clearing "
+            "local session anyway; the refresh token may remain valid at the "
+            "server until natural expiry."
+        )
+
+    delete_session(issuer=issuer, client_id=client_id)
+
+    if revoke_warning:
+        typer.echo(revoke_warning, err=True)
+    typer.echo(f"Signed out of Pipefy ({issuer}).")
 
 
 __all__ = ["auth_app"]

--- a/packages/cli/src/pipefy_cli/commands/auth.py
+++ b/packages/cli/src/pipefy_cli/commands/auth.py
@@ -32,6 +32,7 @@ from pipefy_cli.oauth import (
     RefreshError,
     RevocationError,
     RevocationUnsupportedError,
+    SessionDeleteError,
     delete_session,
     ensure_fresh_session,
     keychain_backend_name,
@@ -482,7 +483,18 @@ def auth_logout(ctx: typer.Context) -> None:
             "server until natural expiry."
         )
 
-    delete_session(issuer=issuer, client_id=client_id)
+    try:
+        delete_session(issuer=issuer, client_id=client_id)
+    except SessionDeleteError as exc:
+        if revoke_warning:
+            typer.echo(revoke_warning, err=True)
+        typer.echo(
+            f"Could not delete local session from the keychain: {exc}. "
+            "The stored credential may still be present; remove it manually "
+            f"via your OS keychain (service: 'pipefy-cli'). See {DOCS_CLI_AUTH_REF}.",
+            err=True,
+        )
+        raise typer.Exit(1) from exc
 
     if revoke_warning:
         typer.echo(revoke_warning, err=True)

--- a/packages/cli/src/pipefy_cli/oauth/__init__.py
+++ b/packages/cli/src/pipefy_cli/oauth/__init__.py
@@ -13,6 +13,11 @@ from pipefy_cli.oauth.refresh import (
     ensure_fresh_session,
     refresh_access_token,
 )
+from pipefy_cli.oauth.revoke import (
+    RevocationError,
+    RevocationUnsupportedError,
+    revoke_session,
+)
 from pipefy_cli.oauth.storage import (
     StoredSession,
     delete_session,
@@ -28,6 +33,8 @@ __all__ = [
     "LoginResult",
     "ProviderMetadata",
     "RefreshError",
+    "RevocationError",
+    "RevocationUnsupportedError",
     "StoredSession",
     "delete_session",
     "ensure_fresh_session",
@@ -36,6 +43,7 @@ __all__ = [
     "keychain_key",
     "load_session",
     "refresh_access_token",
+    "revoke_session",
     "run_login",
     "store_session",
 ]

--- a/packages/cli/src/pipefy_cli/oauth/__init__.py
+++ b/packages/cli/src/pipefy_cli/oauth/__init__.py
@@ -19,6 +19,7 @@ from pipefy_cli.oauth.revoke import (
     revoke_session,
 )
 from pipefy_cli.oauth.storage import (
+    SessionDeleteError,
     StoredSession,
     delete_session,
     keychain_backend_name,
@@ -35,6 +36,7 @@ __all__ = [
     "RefreshError",
     "RevocationError",
     "RevocationUnsupportedError",
+    "SessionDeleteError",
     "StoredSession",
     "delete_session",
     "ensure_fresh_session",

--- a/packages/cli/src/pipefy_cli/oauth/discovery.py
+++ b/packages/cli/src/pipefy_cli/oauth/discovery.py
@@ -15,11 +15,17 @@ _DEFAULT_TIMEOUT = 10.0
 
 @dataclass(frozen=True)
 class ProviderMetadata:
-    """Subset of OIDC provider metadata the login flow needs."""
+    """Subset of OIDC provider metadata the login flow needs.
+
+    ``end_session_endpoint`` is optional per OIDC Discovery 1.0 — not every IdP
+    advertises it. ``auth logout`` soft-fails when it's absent (warns + clears
+    the local session only).
+    """
 
     issuer: str
     authorization_endpoint: str
     token_endpoint: str
+    end_session_endpoint: str | None = None
 
 
 @dataclass(frozen=True)
@@ -102,10 +108,16 @@ def fetch_provider_metadata(
 
     authorization_endpoint = str(data["authorization_endpoint"])
     token_endpoint = str(data["token_endpoint"])
-    for field, value in (
+    raw_end_session = data.get("end_session_endpoint")
+    end_session_endpoint = str(raw_end_session) if raw_end_session else None
+
+    endpoints: list[tuple[str, str]] = [
         ("authorization_endpoint", authorization_endpoint),
         ("token_endpoint", token_endpoint),
-    ):
+    ]
+    if end_session_endpoint is not None:
+        endpoints.append(("end_session_endpoint", end_session_endpoint))
+    for field, value in endpoints:
         try:
             validate_https_service_endpoint_url(
                 value, field, allow_insecure=policy.allow_insecure_urls
@@ -117,6 +129,7 @@ def fetch_provider_metadata(
         issuer=claimed_issuer,
         authorization_endpoint=authorization_endpoint,
         token_endpoint=token_endpoint,
+        end_session_endpoint=end_session_endpoint,
     )
 
 

--- a/packages/cli/src/pipefy_cli/oauth/revoke.py
+++ b/packages/cli/src/pipefy_cli/oauth/revoke.py
@@ -1,0 +1,68 @@
+"""OIDC end-session revocation: invalidate the refresh token at the IdP."""
+
+from __future__ import annotations
+
+import httpx
+
+from pipefy_cli.oauth import _http
+from pipefy_cli.oauth.discovery import DiscoveryPolicy, fetch_provider_metadata
+
+_TIMEOUT_S = 30.0
+
+
+class RevocationError(RuntimeError):
+    """A revocation POST failed (discovery, network, or non-2xx response)."""
+
+
+class RevocationUnsupportedError(RevocationError):
+    """The IdP's discovery doc doesn't advertise ``end_session_endpoint``.
+
+    Distinct from a transport failure so the CLI can phrase the warning honestly
+    ("provider doesn't support server-side logout" vs. "couldn't reach provider").
+    """
+
+
+def revoke_session(
+    *,
+    issuer: str,
+    client_id: str,
+    refresh_token: str,
+    policy: DiscoveryPolicy = DiscoveryPolicy(),
+    http_client: httpx.Client | None = None,
+) -> None:
+    """POST to the IdP's ``end_session_endpoint`` to revoke ``refresh_token``.
+
+    Raises:
+        RevocationUnsupportedError: When the discovery doc doesn't advertise an
+            ``end_session_endpoint``.
+        RevocationError: For any other revocation failure (discovery, network,
+            non-2xx response). Caller decides whether to fail or warn.
+    """
+    with _http.http_client(http_client, timeout=_TIMEOUT_S) as http:
+        try:
+            metadata = fetch_provider_metadata(issuer, policy=policy, client=http)
+        except ValueError as exc:
+            raise RevocationError(f"OIDC discovery failed: {exc}") from exc
+        if metadata.end_session_endpoint is None:
+            raise RevocationUnsupportedError(
+                "OIDC provider does not advertise an end_session_endpoint."
+            )
+        try:
+            response = http.post(
+                metadata.end_session_endpoint,
+                data={"client_id": client_id, "refresh_token": refresh_token},
+            )
+        except httpx.HTTPError as exc:
+            raise RevocationError(f"Revocation request failed: {exc}") from exc
+
+    # Keycloak returns 204; RFC treats any 2xx as success. No body echo on
+    # failure — we just sent ``refresh_token`` in the POST body, so a ``[:N]``
+    # window would be a guaranteed leak channel under a hostile IdP (same
+    # threat model as ``flow._format_token_error``).
+    if response.status_code // 100 != 2:
+        raise RevocationError(
+            f"Revocation endpoint returned HTTP {response.status_code}"
+        )
+
+
+__all__ = ["RevocationError", "RevocationUnsupportedError", "revoke_session"]

--- a/packages/cli/src/pipefy_cli/oauth/storage.py
+++ b/packages/cli/src/pipefy_cli/oauth/storage.py
@@ -20,6 +20,10 @@ from urllib.parse import urlparse
 _SERVICE = "pipefy-cli"
 
 
+class SessionDeleteError(RuntimeError):
+    """Keychain backend rejected the delete (distinct from "entry absent")."""
+
+
 @dataclass(frozen=True)
 class StoredSession:
     """Persisted session shape (JSON-serialised under one keychain key)."""
@@ -112,7 +116,14 @@ def load_session(*, issuer: str, client_id: str) -> StoredSession | None:
 
 
 def delete_session(*, issuer: str, client_id: str) -> bool:
-    """Remove the stored session. Returns True if an entry was present."""
+    """Remove the stored session. Returns True if an entry was present.
+
+    Raises:
+        SessionDeleteError: When the keychain backend rejects the operation
+            (distinct from "no entry to delete"). The local credential may
+            still exist; callers should surface a user-facing error rather
+            than claim a successful sign-out.
+    """
     import keyring
     from keyring.errors import KeyringError, PasswordDeleteError
 
@@ -120,8 +131,8 @@ def delete_session(*, issuer: str, client_id: str) -> bool:
         keyring.delete_password(_SERVICE, keychain_key(issuer, client_id))
     except PasswordDeleteError:
         return False
-    except KeyringError:
-        return False
+    except KeyringError as exc:
+        raise SessionDeleteError(str(exc)) from exc
     return True
 
 
@@ -154,6 +165,7 @@ def _optional_str(value: object) -> str | None:
 
 
 __all__ = [
+    "SessionDeleteError",
     "StoredSession",
     "delete_session",
     "keychain_backend_name",

--- a/packages/cli/tests/fixtures/cli_help_golden.txt
+++ b/packages/cli/tests/fixtures/cli_help_golden.txt
@@ -457,6 +457,8 @@ Usage: pipefy auth [OPTIONS] COMMAND [ARGS]...
 │          keychain.                                                           │
 │ status   Print which auth source is active, the authenticated identity, and  │
 │          session expiry.                                                     │
+│ logout   Revoke the stored refresh token at the IdP and clear the local      │
+│          session.                                                            │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 
 ### HELP auth/login
@@ -473,6 +475,15 @@ Usage: pipefy auth login [OPTIONS]
 │                                                 giving up.                   │
 │                                                 [default: 180.0]             │
 │ --help                                          Show this message and exit.  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP auth/logout
+Usage: pipefy auth logout [OPTIONS]
+
+ Revoke the stored refresh token at the IdP and clear the local session.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 
 ### HELP auth/status

--- a/packages/cli/tests/test_auth_login.py
+++ b/packages/cli/tests/test_auth_login.py
@@ -163,6 +163,55 @@ class TestDiscovery:
         )
         assert meta.authorization_endpoint == "http://127.0.0.1:8080/realms/foo/auth"
 
+    def test_end_session_endpoint_advertised(self) -> None:
+        payload = _discovery_payload()
+        payload["end_session_endpoint"] = (
+            "https://example.test/realms/foo/protocol/openid-connect/logout"
+        )
+        client = httpx.Client(
+            transport=httpx.MockTransport(lambda _r: httpx.Response(200, json=payload))
+        )
+        meta = discovery.fetch_provider_metadata(
+            "https://example.test/realms/foo", client=client
+        )
+        assert meta.end_session_endpoint == payload["end_session_endpoint"]
+
+    def test_end_session_endpoint_absent_is_none(self) -> None:
+        # Optional per OIDC Discovery 1.0; absence must not raise.
+        payload = _discovery_payload()
+        assert "end_session_endpoint" not in payload
+        client = httpx.Client(
+            transport=httpx.MockTransport(lambda _r: httpx.Response(200, json=payload))
+        )
+        meta = discovery.fetch_provider_metadata(
+            "https://example.test/realms/foo", client=client
+        )
+        assert meta.end_session_endpoint is None
+
+    def test_http_end_session_endpoint_rejected(self) -> None:
+        bad = _discovery_payload()
+        bad["end_session_endpoint"] = "http://example.test/realms/foo/logout"
+        client = httpx.Client(
+            transport=httpx.MockTransport(lambda _r: httpx.Response(200, json=bad))
+        )
+        with pytest.raises(ValueError, match="end_session_endpoint"):
+            discovery.fetch_provider_metadata(
+                "https://example.test/realms/foo", client=client
+            )
+
+    def test_allow_insecure_urls_bypasses_end_session_check(self) -> None:
+        bad = _discovery_payload()
+        bad["end_session_endpoint"] = "http://127.0.0.1:8080/realms/foo/logout"
+        client = httpx.Client(
+            transport=httpx.MockTransport(lambda _r: httpx.Response(200, json=bad))
+        )
+        meta = discovery.fetch_provider_metadata(
+            "https://example.test/realms/foo",
+            policy=discovery.DiscoveryPolicy(allow_insecure_urls=True),
+            client=client,
+        )
+        assert meta.end_session_endpoint == "http://127.0.0.1:8080/realms/foo/logout"
+
 
 # --------------------------------------------------------------------------- #
 # Loopback                                                                    #

--- a/packages/cli/tests/test_auth_login.py
+++ b/packages/cli/tests/test_auth_login.py
@@ -324,6 +324,22 @@ class TestStorage:
             issuer="https://x.test/realms/foo", client_id="cid"
         )
 
+    def test_delete_raises_on_backend_failure(
+        self,
+        fake_keyring: InMemoryKeyring,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Backend rejection is distinct from "entry absent": raise, don't return False."""
+        import keyring
+        from keyring.errors import KeyringError
+
+        def _boom(service: str, username: str) -> None:
+            raise KeyringError("backend locked")
+
+        monkeypatch.setattr(keyring, "delete_password", _boom)
+        with pytest.raises(storage.SessionDeleteError, match="backend locked"):
+            storage.delete_session(issuer="https://x.test/realms/foo", client_id="cid")
+
     def test_store_rejects_missing_required_field(
         self, fake_keyring: InMemoryKeyring
     ) -> None:

--- a/packages/cli/tests/test_auth_logout.py
+++ b/packages/cli/tests/test_auth_logout.py
@@ -6,6 +6,7 @@ import httpx
 import pytest
 from conftest import InMemoryKeyring
 
+from pipefy_cli.commands import auth as auth_module
 from pipefy_cli.main import app as cli_app
 from pipefy_cli.oauth import revoke, storage
 
@@ -191,8 +192,6 @@ class TestAuthLogoutCommand:
         ) -> None:
             revoke_calls.append((issuer, client_id, refresh_token))
 
-        from pipefy_cli.commands import auth as auth_module
-
         monkeypatch.setattr(auth_module, "revoke_session", _fake_revoke_session)
 
         result = runner.invoke(cli_app, ["auth", "logout"])
@@ -215,8 +214,6 @@ class TestAuthLogoutCommand:
 
         def _boom(**_kwargs: object) -> None:
             raise revoke.RevocationError("Revocation request failed: ConnectError")
-
-        from pipefy_cli.commands import auth as auth_module
 
         monkeypatch.setattr(auth_module, "revoke_session", _boom)
 
@@ -242,8 +239,6 @@ class TestAuthLogoutCommand:
             raise revoke.RevocationUnsupportedError(
                 "OIDC provider does not advertise an end_session_endpoint."
             )
-
-        from pipefy_cli.commands import auth as auth_module
 
         monkeypatch.setattr(auth_module, "revoke_session", _unsupported)
 

--- a/packages/cli/tests/test_auth_logout.py
+++ b/packages/cli/tests/test_auth_logout.py
@@ -1,11 +1,13 @@
-"""Unit tests for ``oauth/revoke.py`` (the ``pipefy auth logout`` command lands next)."""
+"""Unit tests for ``oauth/revoke.py`` and the ``pipefy auth logout`` command."""
 
 from __future__ import annotations
 
 import httpx
 import pytest
+from conftest import InMemoryKeyring
 
-from pipefy_cli.oauth import revoke
+from pipefy_cli.main import app as cli_app
+from pipefy_cli.oauth import revoke, storage
 
 # --------------------------------------------------------------------------- #
 # Helpers                                                                     #
@@ -120,3 +122,133 @@ class TestRevokeSession:
                 refresh_token="rt",
                 http_client=_make_client(handler),
             )
+
+
+# --------------------------------------------------------------------------- #
+# Command — pipefy auth logout                                                #
+# --------------------------------------------------------------------------- #
+
+
+def _store_test_session(issuer: str = _ISSUER, client_id: str = "pipefy-cli") -> None:
+    storage.store_session(
+        issuer=issuer,
+        client_id=client_id,
+        token_response={
+            "access_token": "AAA",
+            "refresh_token": "RRR",
+            "token_type": "Bearer",
+            "expires_in": 300,
+        },
+    )
+
+
+class TestAuthLogoutCommand:
+    def test_missing_auth_url_exits_2(
+        self,
+        runner,
+        clean_pipefy_env,
+        saved_cwd,
+    ) -> None:
+        result = runner.invoke(cli_app, ["auth", "logout"])
+        assert result.exit_code == 2
+        assert "PIPEFY_AUTH_URL is required" in result.stderr
+
+    def test_no_session_is_idempotent(
+        self,
+        runner,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_keyring: InMemoryKeyring,
+        clean_pipefy_env,
+        saved_cwd,
+    ) -> None:
+        monkeypatch.setenv("PIPEFY_AUTH_URL", _ISSUER)
+
+        result = runner.invoke(cli_app, ["auth", "logout"])
+        assert result.exit_code == 0, result.stderr
+        assert "Not signed in. Nothing to do." in result.stdout
+        assert result.stderr == ""
+
+    def test_happy_path_revokes_and_deletes(
+        self,
+        runner,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_keyring: InMemoryKeyring,
+        clean_pipefy_env,
+        saved_cwd,
+    ) -> None:
+        monkeypatch.setenv("PIPEFY_AUTH_URL", _ISSUER)
+        _store_test_session()
+
+        revoke_calls: list[tuple[str, str, str]] = []
+
+        def _fake_revoke_session(
+            *,
+            issuer: str,
+            client_id: str,
+            refresh_token: str,
+            policy=None,
+            http_client=None,
+        ) -> None:
+            revoke_calls.append((issuer, client_id, refresh_token))
+
+        from pipefy_cli.commands import auth as auth_module
+
+        monkeypatch.setattr(auth_module, "revoke_session", _fake_revoke_session)
+
+        result = runner.invoke(cli_app, ["auth", "logout"])
+        assert result.exit_code == 0, result.stderr
+        assert revoke_calls == [(_ISSUER, "pipefy-cli", "RRR")]
+        assert f"Signed out of Pipefy ({_ISSUER})." in result.stdout
+        assert result.stderr == ""
+        assert storage.load_session(issuer=_ISSUER, client_id="pipefy-cli") is None
+
+    def test_revoke_network_failure_still_deletes_keychain(
+        self,
+        runner,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_keyring: InMemoryKeyring,
+        clean_pipefy_env,
+        saved_cwd,
+    ) -> None:
+        monkeypatch.setenv("PIPEFY_AUTH_URL", _ISSUER)
+        _store_test_session()
+
+        def _boom(**_kwargs: object) -> None:
+            raise revoke.RevocationError("Revocation request failed: ConnectError")
+
+        from pipefy_cli.commands import auth as auth_module
+
+        monkeypatch.setattr(auth_module, "revoke_session", _boom)
+
+        result = runner.invoke(cli_app, ["auth", "logout"])
+        assert result.exit_code == 0, result.stderr
+        assert f"Signed out of Pipefy ({_ISSUER})." in result.stdout
+        assert "Could not revoke refresh token at the IdP" in result.stderr
+        assert "may remain valid at the server" in result.stderr
+        assert storage.load_session(issuer=_ISSUER, client_id="pipefy-cli") is None
+
+    def test_end_session_unsupported_warns_and_deletes(
+        self,
+        runner,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_keyring: InMemoryKeyring,
+        clean_pipefy_env,
+        saved_cwd,
+    ) -> None:
+        monkeypatch.setenv("PIPEFY_AUTH_URL", _ISSUER)
+        _store_test_session()
+
+        def _unsupported(**_kwargs: object) -> None:
+            raise revoke.RevocationUnsupportedError(
+                "OIDC provider does not advertise an end_session_endpoint."
+            )
+
+        from pipefy_cli.commands import auth as auth_module
+
+        monkeypatch.setattr(auth_module, "revoke_session", _unsupported)
+
+        result = runner.invoke(cli_app, ["auth", "logout"])
+        assert result.exit_code == 0, result.stderr
+        assert f"Signed out of Pipefy ({_ISSUER})." in result.stdout
+        assert "does not advertise a logout endpoint" in result.stderr
+        assert storage.load_session(issuer=_ISSUER, client_id="pipefy-cli") is None

--- a/packages/cli/tests/test_auth_logout.py
+++ b/packages/cli/tests/test_auth_logout.py
@@ -224,6 +224,33 @@ class TestAuthLogoutCommand:
         assert "may remain valid at the server" in result.stderr
         assert storage.load_session(issuer=_ISSUER, client_id="pipefy-cli") is None
 
+    def test_keychain_delete_failure_after_revoke_exits_1(
+        self,
+        runner,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_keyring: InMemoryKeyring,
+        clean_pipefy_env,
+        saved_cwd,
+    ) -> None:
+        """Revoke succeeds but keychain rejects delete: warn, don't claim sign-out, exit 1."""
+        monkeypatch.setenv("PIPEFY_AUTH_URL", _ISSUER)
+        _store_test_session()
+
+        def _ok_revoke(**_kwargs: object) -> None:
+            return None
+
+        def _delete_boom(*, issuer: str, client_id: str) -> bool:
+            raise storage.SessionDeleteError("Keychain is locked")
+
+        monkeypatch.setattr(auth_module, "revoke_session", _ok_revoke)
+        monkeypatch.setattr(auth_module, "delete_session", _delete_boom)
+
+        result = runner.invoke(cli_app, ["auth", "logout"])
+        assert result.exit_code == 1
+        assert "Signed out of Pipefy" not in result.stdout
+        assert "Could not delete local session from the keychain" in result.stderr
+        assert "Keychain is locked" in result.stderr
+
     def test_end_session_unsupported_warns_and_deletes(
         self,
         runner,

--- a/packages/cli/tests/test_auth_logout.py
+++ b/packages/cli/tests/test_auth_logout.py
@@ -1,0 +1,122 @@
+"""Unit tests for ``oauth/revoke.py`` (the ``pipefy auth logout`` command lands next)."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from pipefy_cli.oauth import revoke
+
+# --------------------------------------------------------------------------- #
+# Helpers                                                                     #
+# --------------------------------------------------------------------------- #
+
+_ISSUER = "https://example.test/realms/foo"
+_LOGOUT_URL = f"{_ISSUER}/protocol/openid-connect/logout"
+
+
+def _discovery_payload(*, include_end_session: bool = True) -> dict:
+    payload: dict = {
+        "issuer": _ISSUER,
+        "authorization_endpoint": f"{_ISSUER}/protocol/openid-connect/auth",
+        "token_endpoint": f"{_ISSUER}/protocol/openid-connect/token",
+    }
+    if include_end_session:
+        payload["end_session_endpoint"] = _LOGOUT_URL
+    return payload
+
+
+def _make_client(handler) -> httpx.Client:
+    return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+# --------------------------------------------------------------------------- #
+# revoke_session                                                              #
+# --------------------------------------------------------------------------- #
+
+
+class TestRevokeSession:
+    def test_happy_path_204(self) -> None:
+        seen: dict[str, object] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/.well-known/openid-configuration"):
+                return httpx.Response(200, json=_discovery_payload())
+            assert request.method == "POST"
+            assert str(request.url) == _LOGOUT_URL
+            seen["body"] = request.content
+            return httpx.Response(204)
+
+        revoke.revoke_session(
+            issuer=_ISSUER,
+            client_id="pipefy-cli",
+            refresh_token="rt_value",
+            http_client=_make_client(handler),
+        )
+        body = seen["body"]
+        assert isinstance(body, (bytes, bytearray))
+        assert b"client_id=pipefy-cli" in body
+        assert b"refresh_token=rt_value" in body
+
+    def test_end_session_endpoint_absent_raises_unsupported(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200, json=_discovery_payload(include_end_session=False)
+            )
+
+        with pytest.raises(revoke.RevocationUnsupportedError):
+            revoke.revoke_session(
+                issuer=_ISSUER,
+                client_id="pipefy-cli",
+                refresh_token="rt",
+                http_client=_make_client(handler),
+            )
+
+    def test_network_error_raises_revocation_error(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/.well-known/openid-configuration"):
+                return httpx.Response(200, json=_discovery_payload())
+            raise httpx.ConnectError("connection refused")
+
+        with pytest.raises(revoke.RevocationError, match="Revocation request failed"):
+            revoke.revoke_session(
+                issuer=_ISSUER,
+                client_id="pipefy-cli",
+                refresh_token="rt",
+                http_client=_make_client(handler),
+            )
+
+    def test_non_2xx_raises_with_status_only(self) -> None:
+        # Regression sentinel: body must not leak into the error message.
+        sentinel = "SENTINEL_REVOKE_LEAK"
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/.well-known/openid-configuration"):
+                return httpx.Response(200, json=_discovery_payload())
+            return httpx.Response(
+                400, text=f'{{"error":"invalid_token","echo":"{sentinel}"}}'
+            )
+
+        with pytest.raises(revoke.RevocationError) as exc_info:
+            revoke.revoke_session(
+                issuer=_ISSUER,
+                client_id="pipefy-cli",
+                refresh_token="rt",
+                http_client=_make_client(handler),
+            )
+        message = str(exc_info.value)
+        assert "400" in message
+        assert sentinel not in message
+        assert "invalid_token" not in message
+
+    def test_discovery_failure_raises_revocation_error(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, text="nope")
+
+        with pytest.raises(revoke.RevocationError, match="OIDC discovery failed"):
+            revoke.revoke_session(
+                issuer=_ISSUER,
+                client_id="pipefy-cli",
+                refresh_token="rt",
+                http_client=_make_client(handler),
+            )


### PR DESCRIPTION
## Summary

Adds `pipefy auth logout`. Closes #136.

The command revokes the refresh token at the IdP's `end_session_endpoint` and then clears the keychain entry. Without server-side revocation a "logout" today deletes the keychain entry locally but leaves the refresh token valid at Keycloak until natural expiry — recoverable from a backup, the `gh auth logout` / `aws sso logout` shape closes that gap.

### Behavior

| Path | stdout | stderr | exit |
|------|--------|--------|------|
| Happy: stored session + revoke 2xx | `Signed out of Pipefy (<issuer>).` | — | 0 |
| No session stored | `Not signed in. Nothing to do.` | — | 0 |
| Revoke network / non-2xx failure | `Signed out of Pipefy (<issuer>).` | `Could not revoke refresh token at the IdP: <reason>. Clearing local session anyway; …` | 0 |
| IdP doesn't advertise `end_session_endpoint` | `Signed out of Pipefy (<issuer>).` | `Pipefy auth server does not advertise a logout endpoint; …` | 0 |
| `PIPEFY_AUTH_URL` unset | — | `PIPEFY_AUTH_URL is required for \`pipefy auth logout\` …` | 2 |

Revoke runs before delete because once the keychain entry is cleared we no longer have the refresh_token to send. On revoke failure the local session is still cleared (a stranded keychain entry that no command can refresh is worse than an honest "we tried, may still be valid server-side" warning).

### Design choices

- `ProviderMetadata.end_session_endpoint: str | None = None` — optional per OIDC Discovery 1.0; not every IdP advertises it. The CLI soft-fails when it's absent.
- SSRF-validate `end_session_endpoint` through the same `validate_https_service_endpoint_url` gate as `authorization_endpoint` and `token_endpoint` (introduced in #144 / closes the same threat model — a tampered discovery doc shouldn't be able to redirect the revoke POST to an attacker-controlled host).
- New `oauth/revoke.py` module rather than a method on `refresh.py` — parallel shape (POST to OIDC endpoint, scrubbed error rendering), unrelated semantics, distinct error hierarchy (`RevocationError` / `RevocationUnsupportedError`).
- Body scrubbing matches the pattern in `flow._format_token_error` and `refresh._refresh_error_from`: status code only on non-2xx, never echo `response.text[:N]`. We just sent `refresh_token` in the POST body; a window into a hostile IdP's reply is a guaranteed leak channel. Regression-guarded with a sentinel-substring assertion (`test_non_2xx_raises_with_status_only`).

### Out of scope

- Multi-session logout (`--all`). Single-session contract from #125 still holds.
- RFC 7009 access-token `/revoke`. Access tokens expire in minutes; killing the refresh chain via `end_session_endpoint` is the meaningful step.
- DNS-resolution SSRF. Same posture as #126.
- `--local-only` flag. Could land later if users ask for it.

### Commit shape

- `feat(cli): expose end_session_endpoint in ProviderMetadata`
- `feat(cli): add oauth/revoke.py for OIDC end-session revocation`
- `feat(cli): add pipefy auth logout command (closes #136)`
- `docs: changelog + auth.md entry for pipefy auth logout`
- `test(cli): refresh --help golden fixture for auth logout`

## Test plan

- [x] Unit: `pytest packages/cli/tests/test_auth_logout.py` — 10 passed (5 `revoke_session`, 5 command).
- [x] Discovery field coverage: `pytest packages/cli/tests/test_auth_login.py::TestDiscovery` — 12 passed (4 new for `end_session_endpoint`).
- [x] Full CLI regression: `pytest packages/cli/` — 256 passed, 10 skipped.
- [x] `ruff check` + `ruff format --check` — green.
- [x] Live smoke against piporacle:
  - Happy path: stored session → `pipefy auth logout` → `Signed out of Pipefy (...)`, exit 0. `pipefy auth status` then reports "Not signed in."
  - Idempotent: re-run `pipefy auth logout` with no session → `Not signed in. Nothing to do.`, exit 0.
  - (Revoke-network-failure path is covered deterministically by `test_revoke_network_failure_still_deletes_keychain`; not retried live to avoid a second interactive re-login.)