### PR TITLE
chore: auto-sync ruff pre-commit rev with uv.lock (#145)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "pre-commit": {
+    "enabled": true
+  },
+  "packageRules": [
+    {
+      "description": "Bump ruff in uv.lock and .pre-commit-config.yaml rev together",
+      "groupName": "ruff",
+      "matchManagers": ["pep621", "pre-commit"],
+      "matchPackageNames": ["ruff", "astral-sh/ruff-pre-commit"]
+    }
+  ]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "baseBranches": ["dev"],
   "pre-commit": {
     "enabled": true
   },

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,8 +10,6 @@
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Keep `rev` in sync with the ruff pin in `uv.lock`. CI uses `uv run ruff`
-    # (lockfile), so a drift here makes hook output disagree with CI.
     rev: v0.11.4
     hooks:
       - id: ruff


### PR DESCRIPTION
## Summary

- Add `.github/renovate.json` with Renovate enabled for pre-commit hooks and a `packageRules` entry that groups `ruff` (PEP 621 / `uv.lock`) and `astral-sh/ruff-pre-commit` (`.pre-commit-config.yaml` `rev:`) into a single PR.
- Remove the manual F1 sync-reminder comment from `.pre-commit-config.yaml` — sync is now bot-enforced.
- No Dependabot config existed; Renovate was chosen per issue #145.

Current pins (unchanged): ruff **0.11.4** in `uv.lock`, `rev: v0.11.4` in pre-commit.

## Test plan

- [x] `python3 -m json.tool .github/renovate.json` — valid JSON
- [x] Diff limited to `.github/renovate.json` and `.pre-commit-config.yaml` (comment removal only)
- [ ] After merge: enable Renovate app on the repo (if not already) and confirm the next ruff release opens one grouped PR touching both `uv.lock` and `.pre-commit-config.yaml`

Closes #145