### PR TITLE
perf(cli): cache OIDC endpoints in stored session (#132)

### DIFF
--- a/packages/cli/src/pipefy_cli/commands/auth.py
+++ b/packages/cli/src/pipefy_cli/commands/auth.py
@@ -179,6 +179,8 @@ def auth_login(
             issuer=result.issuer,
             client_id=client_id,
             token_response=result.token_response,
+            authorization_endpoint=result.authorization_endpoint,
+            token_endpoint=result.token_endpoint,
         )
     except ValueError as exc:
         typer.echo(

--- a/packages/cli/src/pipefy_cli/oauth/flow.py
+++ b/packages/cli/src/pipefy_cli/oauth/flow.py
@@ -33,6 +33,8 @@ class LoginResult:
 
     issuer: str
     token_response: dict[str, object]
+    authorization_endpoint: str
+    token_endpoint: str
 
 
 def build_authorization_url(
@@ -196,7 +198,12 @@ def run_login(
                 code_verifier=verifier,
                 client=http,
             )
-    return LoginResult(issuer=metadata.issuer, token_response=token_response)
+    return LoginResult(
+        issuer=metadata.issuer,
+        token_response=token_response,
+        authorization_endpoint=metadata.authorization_endpoint,
+        token_endpoint=metadata.token_endpoint,
+    )
 
 
 def _ensure_callback_ok(callback: CallbackResult, *, expected_state: str) -> None:

--- a/packages/cli/src/pipefy_cli/oauth/refresh.py
+++ b/packages/cli/src/pipefy_cli/oauth/refresh.py
@@ -37,16 +37,23 @@ def refresh_access_token(
     *,
     session: StoredSession,
     http_client: httpx.Client | None = None,
-) -> dict[str, object]:
+) -> tuple[dict[str, object], str | None, str | None]:
     """POST ``grant_type=refresh_token`` to the issuer's token endpoint.
 
     Uses the persisted ``token_endpoint`` when available; otherwise falls back
     to OIDC discovery (legacy keychain entries from before endpoint caching).
 
+    Returns:
+        A tuple of ``(token_response, authorization_endpoint, token_endpoint)``.
+        The endpoint fields are populated only when discovery ran (legacy
+        sessions); callers should merge them into the stored session.
+
     Raises:
         RefreshError: For any failure that prevents a fresh token response
             (discovery failure, network error, non-200, malformed body).
     """
+    discovered_authorization_endpoint: str | None = None
+    discovered_token_endpoint: str | None = None
     with _http.http_client(http_client, timeout=_TIMEOUT_S) as http:
         if session.token_endpoint:
             token_endpoint = session.token_endpoint
@@ -56,6 +63,8 @@ def refresh_access_token(
             except ValueError as exc:
                 raise RefreshError(f"OIDC discovery failed: {exc}") from exc
             token_endpoint = metadata.token_endpoint
+            discovered_authorization_endpoint = metadata.authorization_endpoint
+            discovered_token_endpoint = metadata.token_endpoint
         try:
             response = http.post(
                 token_endpoint,
@@ -76,7 +85,7 @@ def refresh_access_token(
         raise RefreshError(f"Token endpoint returned non-JSON: {exc}") from exc
     if not isinstance(payload, dict):
         raise RefreshError("Token endpoint returned a non-object JSON payload.")
-    return payload
+    return payload, discovered_authorization_endpoint, discovered_token_endpoint
 
 
 def _refresh_error_from(response: httpx.Response) -> RefreshError:
@@ -134,7 +143,9 @@ def ensure_fresh_session(
     if time.time() < deadline:
         return session
 
-    token_response = refresh_access_token(session=session, http_client=http_client)
+    token_response, discovered_auth, discovered_token = refresh_access_token(
+        session=session, http_client=http_client
+    )
     # Carry forward fields the IdP may omit from a refresh response so the
     # rotated session keeps its full shape — without ``expires_in`` the next
     # freshness check treats the token as already expired and refreshes again
@@ -152,8 +163,8 @@ def ensure_fresh_session(
         issuer=session.issuer,
         client_id=session.client_id,
         token_response=token_response,
-        authorization_endpoint=session.authorization_endpoint,
-        token_endpoint=session.token_endpoint,
+        authorization_endpoint=session.authorization_endpoint or discovered_auth,
+        token_endpoint=session.token_endpoint or discovered_token,
     )
 
 

--- a/packages/cli/src/pipefy_cli/oauth/refresh.py
+++ b/packages/cli/src/pipefy_cli/oauth/refresh.py
@@ -35,29 +35,34 @@ class RefreshError(RuntimeError):
 
 def refresh_access_token(
     *,
-    issuer: str,
-    client_id: str,
-    refresh_token: str,
+    session: StoredSession,
     http_client: httpx.Client | None = None,
 ) -> dict[str, object]:
     """POST ``grant_type=refresh_token`` to the issuer's token endpoint.
+
+    Uses the persisted ``token_endpoint`` when available; otherwise falls back
+    to OIDC discovery (legacy keychain entries from before endpoint caching).
 
     Raises:
         RefreshError: For any failure that prevents a fresh token response
             (discovery failure, network error, non-200, malformed body).
     """
     with _http.http_client(http_client, timeout=_TIMEOUT_S) as http:
-        try:
-            metadata = fetch_provider_metadata(issuer, client=http)
-        except ValueError as exc:
-            raise RefreshError(f"OIDC discovery failed: {exc}") from exc
+        if session.token_endpoint:
+            token_endpoint = session.token_endpoint
+        else:
+            try:
+                metadata = fetch_provider_metadata(session.issuer, client=http)
+            except ValueError as exc:
+                raise RefreshError(f"OIDC discovery failed: {exc}") from exc
+            token_endpoint = metadata.token_endpoint
         try:
             response = http.post(
-                metadata.token_endpoint,
+                token_endpoint,
                 data={
                     "grant_type": "refresh_token",
-                    "refresh_token": refresh_token,
-                    "client_id": client_id,
+                    "refresh_token": session.refresh_token,
+                    "client_id": session.client_id,
                 },
             )
         except httpx.HTTPError as exc:
@@ -129,12 +134,7 @@ def ensure_fresh_session(
     if time.time() < deadline:
         return session
 
-    token_response = refresh_access_token(
-        issuer=issuer,
-        client_id=client_id,
-        refresh_token=session.refresh_token,
-        http_client=http_client,
-    )
+    token_response = refresh_access_token(session=session, http_client=http_client)
     # Carry forward fields the IdP may omit from a refresh response so the
     # rotated session keeps its full shape — without ``expires_in`` the next
     # freshness check treats the token as already expired and refreshes again
@@ -152,6 +152,8 @@ def ensure_fresh_session(
         issuer=session.issuer,
         client_id=session.client_id,
         token_response=token_response,
+        authorization_endpoint=session.authorization_endpoint,
+        token_endpoint=session.token_endpoint,
     )
 
 

--- a/packages/cli/src/pipefy_cli/oauth/storage.py
+++ b/packages/cli/src/pipefy_cli/oauth/storage.py
@@ -34,6 +34,8 @@ class StoredSession:
     refresh_expires_in: int | None
     scope: str | None
     id_token: str | None
+    authorization_endpoint: str | None = None
+    token_endpoint: str | None = None
 
 
 def _issuer_host(issuer_url: str) -> str:
@@ -53,6 +55,8 @@ def store_session(
     issuer: str,
     client_id: str,
     token_response: dict[str, object],
+    authorization_endpoint: str | None = None,
+    token_endpoint: str | None = None,
 ) -> StoredSession:
     """Persist a token response in the OS keychain. Returns the stored shape.
 
@@ -83,6 +87,8 @@ def store_session(
         refresh_expires_in=_optional_int(token_response.get("refresh_expires_in")),
         scope=_optional_str(token_response.get("scope")),
         id_token=_optional_str(token_response.get("id_token")),
+        authorization_endpoint=authorization_endpoint,
+        token_endpoint=token_endpoint,
     )
     keyring.set_password(
         _SERVICE, keychain_key(issuer, client_id), json.dumps(asdict(session))

--- a/packages/cli/tests/test_auth_login.py
+++ b/packages/cli/tests/test_auth_login.py
@@ -223,6 +223,12 @@ class TestLoopback:
 # --------------------------------------------------------------------------- #
 
 
+_ENDPTS = {
+    "authorization_endpoint": "https://x.test/realms/foo/protocol/openid-connect/auth",
+    "token_endpoint": "https://x.test/realms/foo/protocol/openid-connect/token",
+}
+
+
 class TestStorage:
     def test_keychain_key_uses_host_and_client(self) -> None:
         key = storage.keychain_key(
@@ -244,6 +250,8 @@ class TestStorage:
             issuer="https://x.test/realms/foo",
             client_id="pipefy-cli",
             token_response=token,
+            authorization_endpoint=_ENDPTS["authorization_endpoint"],
+            token_endpoint=_ENDPTS["token_endpoint"],
         )
         assert stored.access_token == "AAA"
         assert stored.refresh_token == "RRR"
@@ -255,6 +263,39 @@ class TestStorage:
         assert loaded is not None
         assert loaded.refresh_token == "RRR"
         assert loaded.scope == "openid email"
+        assert loaded.token_endpoint == _ENDPTS["token_endpoint"]
+
+    def test_load_accepts_legacy_keychain_entry_without_endpoints(self, fake_keyring):
+        """Soft migration: pre-cache keychain blobs must still load."""
+        import json
+
+        import keyring
+
+        legacy = {
+            "issuer": "https://x.test/realms/foo",
+            "client_id": "pipefy-cli",
+            "access_token": "AAA",
+            "refresh_token": "RRR",
+            "token_type": "Bearer",
+            "obtained_at": 1700000000,
+            "expires_in": 300,
+            "refresh_expires_in": None,
+            "scope": "openid",
+            "id_token": None,
+        }
+        keyring.set_password(
+            "pipefy-cli",
+            storage.keychain_key("https://x.test/realms/foo", "pipefy-cli"),
+            json.dumps(legacy),
+        )
+        loaded = storage.load_session(
+            issuer="https://x.test/realms/foo", client_id="pipefy-cli"
+        )
+        assert (
+            loaded
+            and loaded.authorization_endpoint is None
+            and loaded.token_endpoint is None
+        )
 
     def test_load_returns_none_when_absent(self, fake_keyring: InMemoryKeyring) -> None:
         assert (
@@ -518,6 +559,8 @@ class TestAuthLoginCommand:
                     "token_type": "Bearer",
                     "expires_in": 300,
                 },
+                authorization_endpoint=_ENDPTS["authorization_endpoint"],
+                token_endpoint=_ENDPTS["token_endpoint"],
             )
 
         from pipefy_cli.commands import auth as auth_module
@@ -533,6 +576,7 @@ class TestAuthLoginCommand:
         )
         assert loaded is not None
         assert loaded.refresh_token == "RRR"
+        assert loaded.token_endpoint == _ENDPTS["token_endpoint"]
 
     def test_masking_env_warning(
         self,
@@ -553,6 +597,8 @@ class TestAuthLoginCommand:
             lambda **_k: flow.LoginResult(
                 issuer="https://x.test/realms/foo",
                 token_response={"access_token": "A", "refresh_token": "R"},
+                authorization_endpoint=_ENDPTS["authorization_endpoint"],
+                token_endpoint=_ENDPTS["token_endpoint"],
             ),
         )
 
@@ -589,6 +635,8 @@ class TestAuthLoginCommand:
             return flow.LoginResult(
                 issuer="https://x.test/realms/foo",
                 token_response={"access_token": "A", "refresh_token": "R"},
+                authorization_endpoint=_ENDPTS["authorization_endpoint"],
+                token_endpoint=_ENDPTS["token_endpoint"],
             )
 
         monkeypatch.setattr(auth_module, "run_login", _spy_run_login)
@@ -638,6 +686,8 @@ class TestAuthLoginCommand:
             return flow.LoginResult(
                 issuer="https://x.test/realms/foo",
                 token_response={"access_token": "A", "refresh_token": "R"},
+                authorization_endpoint=_ENDPTS["authorization_endpoint"],
+                token_endpoint=_ENDPTS["token_endpoint"],
             )
 
         monkeypatch.setattr(auth_module, "run_login", _spy_run_login)

--- a/packages/cli/tests/test_auth_refresh.py
+++ b/packages/cli/tests/test_auth_refresh.py
@@ -12,6 +12,14 @@ from pipefy_cli.oauth import refresh, storage
 
 _ISSUER = "https://signin.example.com/realms/pipefy"
 _CLIENT_ID = "pipefy-cli"
+_TOKEN_ENDPOINT = f"{_ISSUER}/protocol/openid-connect/token"
+_AUTH_ENDPOINT = f"{_ISSUER}/protocol/openid-connect/auth"
+
+
+def _session(**overrides: object) -> storage.StoredSession:
+    defaults = {"issuer": _ISSUER, "client_id": _CLIENT_ID, "access_token": "x", "refresh_token": "x", "token_type": "Bearer", "obtained_at": 0, "expires_in": None, "refresh_expires_in": None, "scope": None, "id_token": None, "authorization_endpoint": None, "token_endpoint": None}
+    defaults.update(overrides)
+    return storage.StoredSession(**defaults)
 
 
 def _discovery_payload(issuer: str = _ISSUER) -> dict[str, str]:
@@ -54,6 +62,8 @@ def _seed_session(
     *,
     obtained_at: int,
     expires_in: int = 300,
+    authorization_endpoint: str | None = None,
+    token_endpoint: str | None = None,
 ) -> None:
     """Persist a session whose ``obtained_at`` is pinned to ``obtained_at``.
 
@@ -73,6 +83,8 @@ def _seed_session(
                 "expires_in": expires_in,
                 "scope": "openid offline_access",
             },
+            authorization_endpoint=authorization_endpoint,
+            token_endpoint=token_endpoint,
         )
 
 
@@ -290,6 +302,31 @@ class TestEnsureFreshSession:
         assert storage.load_session(issuer=_ISSUER, client_id=_CLIENT_ID) is not None
 
 
+class TestCachedTokenEndpoint:
+    def test_refresh_skips_discovery_when_token_endpoint_persisted(self, fake_keyring, monkeypatch):
+        _seed_session(monkeypatch, obtained_at=int(time.time())-1, expires_in=30, token_endpoint=_TOKEN_ENDPOINT)
+        called = False
+        def handler(r):
+            nonlocal called
+            if r.url.path.endswith("/.well-known/openid-configuration"):
+                called = True
+                return httpx.Response(500)
+            return httpx.Response(200, json={"access_token":"NEW","refresh_token":"NEW"})
+        refresh.ensure_fresh_session(issuer=_ISSUER, client_id=_CLIENT_ID, http_client=httpx.Client(transport=httpx.MockTransport(handler)))
+        assert not called
+
+    def test_legacy_session_without_endpoints_still_rediscovers(self, fake_keyring, monkeypatch):
+        _seed_session(monkeypatch, obtained_at=int(time.time())-1, expires_in=30)
+        called = False
+        def handler(r):
+            nonlocal called
+            if r.url.path.endswith("/.well-known/openid-configuration"):
+                called = True
+                return httpx.Response(200, json=_discovery_payload())
+            return httpx.Response(200, json={"access_token":"NEW","refresh_token":"NEW"})
+        refresh.ensure_fresh_session(issuer=_ISSUER, client_id=_CLIENT_ID, http_client=httpx.Client(transport=httpx.MockTransport(handler)))
+        assert called
+
 # --------------------------------------------------------------------------- #
 # refresh_access_token (low-level)                                            #
 # --------------------------------------------------------------------------- #
@@ -306,12 +343,7 @@ class TestRefreshAccessTokenErrors:
             )
         )
         with pytest.raises(refresh.RefreshError) as exc_info:
-            refresh.refresh_access_token(
-                issuer=_ISSUER,
-                client_id=_CLIENT_ID,
-                refresh_token="x",
-                http_client=client,
-            )
+            refresh.refresh_access_token(session=_session(refresh_token="x"), http_client=client)
         assert exc_info.value.error_code == "invalid_grant"
         assert "invalid_grant" in str(exc_info.value)
 
@@ -328,12 +360,7 @@ class TestRefreshAccessTokenErrors:
             )
         )
         with pytest.raises(refresh.RefreshError) as exc_info:
-            refresh.refresh_access_token(
-                issuer=_ISSUER,
-                client_id=_CLIENT_ID,
-                refresh_token="x",
-                http_client=client,
-            )
+            refresh.refresh_access_token(session=_session(refresh_token="x"), http_client=client)
         assert exc_info.value.error_code == "invalid_grant"
         assert "refresh token expired" in str(exc_info.value)
 
@@ -348,12 +375,7 @@ class TestRefreshAccessTokenErrors:
 
         client = httpx.Client(transport=httpx.MockTransport(handler))
         with pytest.raises(refresh.RefreshError) as exc_info:
-            refresh.refresh_access_token(
-                issuer=_ISSUER,
-                client_id=_CLIENT_ID,
-                refresh_token="x",
-                http_client=client,
-            )
+            refresh.refresh_access_token(session=_session(refresh_token="x"), http_client=client)
         assert exc_info.value.error_code is None
         assert "HTTP 503" in str(exc_info.value)
         assert "upstream gateway" not in str(exc_info.value)
@@ -379,12 +401,7 @@ class TestRefreshAccessTokenErrors:
 
         client = httpx.Client(transport=httpx.MockTransport(handler))
         with pytest.raises(refresh.RefreshError) as exc_info:
-            refresh.refresh_access_token(
-                issuer=_ISSUER,
-                client_id=_CLIENT_ID,
-                refresh_token="x",
-                http_client=client,
-            )
+            refresh.refresh_access_token(session=_session(refresh_token="x"), http_client=client)
         message = str(exc_info.value)
         assert "invalid_grant" in message
         assert "bad refresh" in message
@@ -398,24 +415,14 @@ class TestRefreshAccessTokenErrors:
             )
         )
         with pytest.raises(refresh.RefreshError, match="Refresh request failed"):
-            refresh.refresh_access_token(
-                issuer=_ISSUER,
-                client_id=_CLIENT_ID,
-                refresh_token="x",
-                http_client=client,
-            )
+            refresh.refresh_access_token(session=_session(refresh_token="x"), http_client=client)
 
     def test_discovery_failure_raises_refresh_error(self) -> None:
         client = httpx.Client(
             transport=httpx.MockTransport(_build_handler(discovery_status=404))
         )
         with pytest.raises(refresh.RefreshError, match="OIDC discovery failed"):
-            refresh.refresh_access_token(
-                issuer=_ISSUER,
-                client_id=_CLIENT_ID,
-                refresh_token="x",
-                http_client=client,
-            )
+            refresh.refresh_access_token(session=_session(refresh_token="x"), http_client=client)
 
     def test_non_object_json_raises_refresh_error(self) -> None:
         def handler(request: httpx.Request) -> httpx.Response:
@@ -425,9 +432,15 @@ class TestRefreshAccessTokenErrors:
 
         client = httpx.Client(transport=httpx.MockTransport(handler))
         with pytest.raises(refresh.RefreshError, match="non-object"):
-            refresh.refresh_access_token(
-                issuer=_ISSUER,
-                client_id=_CLIENT_ID,
-                refresh_token="x",
-                http_client=client,
-            )
+            refresh.refresh_access_token(session=_session(refresh_token="x"), http_client=client)
+
+    def test_persisted_token_endpoint_skips_discovery(self) -> None:
+        called = False
+        def handler(r):
+            nonlocal called
+            if r.url.path.endswith("/.well-known/openid-configuration"):
+                called = True
+                return httpx.Response(500)
+            return httpx.Response(200, json={"access_token":"new","refresh_token":"new_r"})
+        refresh.refresh_access_token(session=_session(refresh_token="x", token_endpoint=_TOKEN_ENDPOINT), http_client=httpx.Client(transport=httpx.MockTransport(handler)))
+        assert not called

--- a/packages/cli/tests/test_auth_refresh.py
+++ b/packages/cli/tests/test_auth_refresh.py
@@ -17,7 +17,20 @@ _AUTH_ENDPOINT = f"{_ISSUER}/protocol/openid-connect/auth"
 
 
 def _session(**overrides: object) -> storage.StoredSession:
-    defaults = {"issuer": _ISSUER, "client_id": _CLIENT_ID, "access_token": "x", "refresh_token": "x", "token_type": "Bearer", "obtained_at": 0, "expires_in": None, "refresh_expires_in": None, "scope": None, "id_token": None, "authorization_endpoint": None, "token_endpoint": None}
+    defaults = {
+        "issuer": _ISSUER,
+        "client_id": _CLIENT_ID,
+        "access_token": "x",
+        "refresh_token": "x",
+        "token_type": "Bearer",
+        "obtained_at": 0,
+        "expires_in": None,
+        "refresh_expires_in": None,
+        "scope": None,
+        "id_token": None,
+        "authorization_endpoint": None,
+        "token_endpoint": None,
+    }
     defaults.update(overrides)
     return storage.StoredSession(**defaults)
 
@@ -303,29 +316,97 @@ class TestEnsureFreshSession:
 
 
 class TestCachedTokenEndpoint:
-    def test_refresh_skips_discovery_when_token_endpoint_persisted(self, fake_keyring, monkeypatch):
-        _seed_session(monkeypatch, obtained_at=int(time.time())-1, expires_in=30, token_endpoint=_TOKEN_ENDPOINT)
+    def test_refresh_skips_discovery_when_token_endpoint_persisted(
+        self, fake_keyring, monkeypatch
+    ):
+        _seed_session(
+            monkeypatch,
+            obtained_at=int(time.time()) - 1,
+            expires_in=30,
+            token_endpoint=_TOKEN_ENDPOINT,
+        )
         called = False
+
         def handler(r):
             nonlocal called
             if r.url.path.endswith("/.well-known/openid-configuration"):
                 called = True
                 return httpx.Response(500)
-            return httpx.Response(200, json={"access_token":"NEW","refresh_token":"NEW"})
-        refresh.ensure_fresh_session(issuer=_ISSUER, client_id=_CLIENT_ID, http_client=httpx.Client(transport=httpx.MockTransport(handler)))
+            return httpx.Response(
+                200, json={"access_token": "NEW", "refresh_token": "NEW"}
+            )
+
+        refresh.ensure_fresh_session(
+            issuer=_ISSUER,
+            client_id=_CLIENT_ID,
+            http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+        )
         assert not called
 
-    def test_legacy_session_without_endpoints_still_rediscovers(self, fake_keyring, monkeypatch):
-        _seed_session(monkeypatch, obtained_at=int(time.time())-1, expires_in=30)
+    def test_legacy_session_without_endpoints_still_rediscovers(
+        self, fake_keyring, monkeypatch
+    ):
+        _seed_session(monkeypatch, obtained_at=int(time.time()) - 1, expires_in=30)
         called = False
+
         def handler(r):
             nonlocal called
             if r.url.path.endswith("/.well-known/openid-configuration"):
                 called = True
                 return httpx.Response(200, json=_discovery_payload())
-            return httpx.Response(200, json={"access_token":"NEW","refresh_token":"NEW"})
-        refresh.ensure_fresh_session(issuer=_ISSUER, client_id=_CLIENT_ID, http_client=httpx.Client(transport=httpx.MockTransport(handler)))
+            return httpx.Response(
+                200, json={"access_token": "NEW", "refresh_token": "NEW"}
+            )
+
+        refresh.ensure_fresh_session(
+            issuer=_ISSUER,
+            client_id=_CLIENT_ID,
+            http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+        )
         assert called
+
+    def test_legacy_session_backfills_endpoints_after_refresh(
+        self, fake_keyring, monkeypatch
+    ) -> None:
+        _seed_session(monkeypatch, obtained_at=int(time.time()) - 1, expires_in=30)
+        client = httpx.Client(transport=httpx.MockTransport(_build_handler()))
+        refresh.ensure_fresh_session(
+            issuer=_ISSUER, client_id=_CLIENT_ID, http_client=client
+        )
+        reloaded = storage.load_session(issuer=_ISSUER, client_id=_CLIENT_ID)
+        assert reloaded is not None
+        assert reloaded.token_endpoint == _TOKEN_ENDPOINT
+        assert reloaded.authorization_endpoint == _AUTH_ENDPOINT
+
+    def test_backfilled_session_skips_discovery_on_next_refresh(
+        self, fake_keyring, monkeypatch
+    ) -> None:
+        _seed_session(monkeypatch, obtained_at=int(time.time()) - 1, expires_in=30)
+        client = httpx.Client(transport=httpx.MockTransport(_build_handler()))
+        backfilled = refresh.ensure_fresh_session(
+            issuer=_ISSUER, client_id=_CLIENT_ID, http_client=client
+        )
+        assert backfilled is not None
+        assert backfilled.token_endpoint == _TOKEN_ENDPOINT
+        called = False
+
+        def handler(r):
+            nonlocal called
+            if r.url.path.endswith("/.well-known/openid-configuration"):
+                called = True
+                return httpx.Response(500)
+            return httpx.Response(
+                200, json={"access_token": "NEW2", "refresh_token": "NEW2"}
+            )
+
+        monkeypatch.setattr(time, "time", lambda: float(backfilled.obtained_at + 300))
+        refresh.ensure_fresh_session(
+            issuer=_ISSUER,
+            client_id=_CLIENT_ID,
+            http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+        )
+        assert not called
+
 
 # --------------------------------------------------------------------------- #
 # refresh_access_token (low-level)                                            #
@@ -343,7 +424,9 @@ class TestRefreshAccessTokenErrors:
             )
         )
         with pytest.raises(refresh.RefreshError) as exc_info:
-            refresh.refresh_access_token(session=_session(refresh_token="x"), http_client=client)
+            refresh.refresh_access_token(
+                session=_session(refresh_token="x"), http_client=client
+            )
         assert exc_info.value.error_code == "invalid_grant"
         assert "invalid_grant" in str(exc_info.value)
 
@@ -360,7 +443,9 @@ class TestRefreshAccessTokenErrors:
             )
         )
         with pytest.raises(refresh.RefreshError) as exc_info:
-            refresh.refresh_access_token(session=_session(refresh_token="x"), http_client=client)
+            refresh.refresh_access_token(
+                session=_session(refresh_token="x"), http_client=client
+            )
         assert exc_info.value.error_code == "invalid_grant"
         assert "refresh token expired" in str(exc_info.value)
 
@@ -375,7 +460,9 @@ class TestRefreshAccessTokenErrors:
 
         client = httpx.Client(transport=httpx.MockTransport(handler))
         with pytest.raises(refresh.RefreshError) as exc_info:
-            refresh.refresh_access_token(session=_session(refresh_token="x"), http_client=client)
+            refresh.refresh_access_token(
+                session=_session(refresh_token="x"), http_client=client
+            )
         assert exc_info.value.error_code is None
         assert "HTTP 503" in str(exc_info.value)
         assert "upstream gateway" not in str(exc_info.value)
@@ -401,7 +488,9 @@ class TestRefreshAccessTokenErrors:
 
         client = httpx.Client(transport=httpx.MockTransport(handler))
         with pytest.raises(refresh.RefreshError) as exc_info:
-            refresh.refresh_access_token(session=_session(refresh_token="x"), http_client=client)
+            refresh.refresh_access_token(
+                session=_session(refresh_token="x"), http_client=client
+            )
         message = str(exc_info.value)
         assert "invalid_grant" in message
         assert "bad refresh" in message
@@ -415,14 +504,18 @@ class TestRefreshAccessTokenErrors:
             )
         )
         with pytest.raises(refresh.RefreshError, match="Refresh request failed"):
-            refresh.refresh_access_token(session=_session(refresh_token="x"), http_client=client)
+            refresh.refresh_access_token(
+                session=_session(refresh_token="x"), http_client=client
+            )
 
     def test_discovery_failure_raises_refresh_error(self) -> None:
         client = httpx.Client(
             transport=httpx.MockTransport(_build_handler(discovery_status=404))
         )
         with pytest.raises(refresh.RefreshError, match="OIDC discovery failed"):
-            refresh.refresh_access_token(session=_session(refresh_token="x"), http_client=client)
+            refresh.refresh_access_token(
+                session=_session(refresh_token="x"), http_client=client
+            )
 
     def test_non_object_json_raises_refresh_error(self) -> None:
         def handler(request: httpx.Request) -> httpx.Response:
@@ -432,15 +525,24 @@ class TestRefreshAccessTokenErrors:
 
         client = httpx.Client(transport=httpx.MockTransport(handler))
         with pytest.raises(refresh.RefreshError, match="non-object"):
-            refresh.refresh_access_token(session=_session(refresh_token="x"), http_client=client)
+            refresh.refresh_access_token(
+                session=_session(refresh_token="x"), http_client=client
+            )
 
     def test_persisted_token_endpoint_skips_discovery(self) -> None:
         called = False
+
         def handler(r):
             nonlocal called
             if r.url.path.endswith("/.well-known/openid-configuration"):
                 called = True
                 return httpx.Response(500)
-            return httpx.Response(200, json={"access_token":"new","refresh_token":"new_r"})
-        refresh.refresh_access_token(session=_session(refresh_token="x", token_endpoint=_TOKEN_ENDPOINT), http_client=httpx.Client(transport=httpx.MockTransport(handler)))
+            return httpx.Response(
+                200, json={"access_token": "new", "refresh_token": "new_r"}
+            )
+
+        refresh.refresh_access_token(
+            session=_session(refresh_token="x", token_endpoint=_TOKEN_ENDPOINT),
+            http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+        )
         assert not called


### PR DESCRIPTION
## Summary
- Persist `authorization_endpoint` and `token_endpoint` in `StoredSession` at login time (soft migration: optional fields default to `None`).
- `refresh_access_token` uses the cached `token_endpoint` when present, skipping OIDC discovery on refresh; legacy keychain entries without endpoints still re-discover.
- Tests cover cached refresh (no discovery HTTP call) and legacy session fallback.

Closes #132

## Test plan
- [x] `uv run pytest packages/cli/tests/test_auth_refresh.py packages/cli/tests/test_auth_login.py -m "not integration"`
- [x] `uv run ruff check` / `uv run ruff format` on touched files