### PR TITLE
chore: enable ruff S101 workspace-wide (#147)

### DIFF
--- a/packages/cli/pyproject.toml
+++ b/packages/cli/pyproject.toml
@@ -46,7 +46,8 @@ markers = [
 ]
 
 [tool.ruff]
-lint.extend-select = ["I", "TID251"]
+extend = "../../pyproject.toml"
+lint.extend-select = ["TID251"]
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "pipefy_mcp".msg = "pipefy_cli must not import the MCP package; use pipefy_sdk instead."

--- a/packages/cli/src/pipefy_cli/oauth/flow.py
+++ b/packages/cli/src/pipefy_cli/oauth/flow.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import secrets
 import webbrowser
 from dataclasses import dataclass
-from typing import Callable
+from typing import Callable, cast
 from urllib.parse import urlencode
 
 import httpx
@@ -186,12 +186,12 @@ def run_login(
 
             callback = capture.await_callback(timeout=callback_timeout_s)
             _ensure_callback_ok(callback, expected_state=state)
-            assert callback.code is not None
+            code = cast(str, callback.code)
 
             token_response = exchange_code(
                 metadata=metadata,
                 client_id=client_id,
-                code=callback.code,
+                code=code,
                 redirect_uri=capture.redirect_uri,
                 code_verifier=verifier,
                 client=http,

--- a/packages/mcp/pyproject.toml
+++ b/packages/mcp/pyproject.toml
@@ -56,7 +56,8 @@ markers = [
 ]
 
 [tool.ruff]
-lint.extend-select = ["I", "TID251"]
+extend = "../../pyproject.toml"
+lint.extend-select = ["TID251"]
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "pipefy_cli".msg = "pipefy_mcp must not import the CLI package; keep MCP independent of pipefy-cli."

--- a/packages/sdk/pyproject.toml
+++ b/packages/sdk/pyproject.toml
@@ -44,7 +44,8 @@ markers = [
 ]
 
 [tool.ruff]
-lint.extend-select = ["I", "TID251"]
+extend = "../../pyproject.toml"
+lint.extend-select = ["TID251"]
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "pipefy_mcp".msg = "pipefy_sdk must not import the MCP package."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ dev = [
 ]
 
 [tool.ruff]
-lint.extend-select = ["I"]
+lint.extend-select = ["I", "S101"]
+lint.per-file-ignores = { "**/tests/**" = ["S101"] }
 
 [tool.pytest.ini_options]
 testpaths = ["tests", "packages/sdk/tests", "packages/mcp/tests", "packages/cli/tests"]


### PR DESCRIPTION
## Summary

- Enable ruff rule **S101** (`assert` banned in production code) at the workspace root, with `**/tests/**` exempt via `per-file-ignores`.
- Point each package `pyproject.toml` at the root config via `extend = "../../pyproject.toml"`, keeping local `TID251` and banned-api rules.
- Replace the lone production `assert` in OAuth flow with `typing.cast` after `_ensure_callback_ok` validates the callback code.

Closes #147

## Test plan

- [x] `uv run ruff check packages/` — all checks passed
- [x] `uv run pytest -m "not integration"` — 2257 passed
- [x] `uv run ruff format .` — no changes needed