### PR TITLE
refactor: rename PIPEFY_OAUTH_* env vars to PIPEFY_SERVICE_ACCOUNT_*

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,9 +5,11 @@
 
 PIPEFY_GRAPHQL_URL=https://app.pipefy.com/graphql
 PIPEFY_INTERNAL_API_URL=https://app.pipefy.com/internal_api
-PIPEFY_OAUTH_URL=https://app.pipefy.com/oauth/token
-PIPEFY_OAUTH_CLIENT=<YOUR_SERVICE_ACCOUNT_CLIENT_ID>
-PIPEFY_OAUTH_SECRET=<YOUR_SERVICE_ACCOUNT_CLIENT_SECRET>
+PIPEFY_SERVICE_ACCOUNT_URL=https://app.pipefy.com/oauth/token
+PIPEFY_SERVICE_ACCOUNT_CLIENT_ID=<YOUR_SERVICE_ACCOUNT_CLIENT_ID>
+PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET=<YOUR_SERVICE_ACCOUNT_CLIENT_SECRET>
+# Legacy names PIPEFY_OAUTH_URL / _CLIENT / _SECRET still work but emit a one-shot
+# stderr deprecation warning; they will be removed in a future beta. See docs/MIGRATION.md.
 # Optional: default organization id for `pipefy org get` when you omit the positional id (numeric string).
 # PIPEFY_ORG_ID=
 # Optional (default false): allow http:// and internal hosts for GraphQL/OAuth/internal API/webhooks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **SDK / MCP / CLI**: renamed the three service-account credential env vars for clarity and to remove the one-letter footgun against `PIPEFY_AUTH_URL` (interactive user-login issuer): `PIPEFY_OAUTH_URL` → `PIPEFY_SERVICE_ACCOUNT_URL`, `PIPEFY_OAUTH_CLIENT` → `PIPEFY_SERVICE_ACCOUNT_CLIENT_ID`, `PIPEFY_OAUTH_SECRET` → `PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET`. Closes #127.
+
+### Deprecated
+
+- **SDK**: legacy `PIPEFY_OAUTH_*` env vars and `oauth_*` keys in `~/.config/pipefy/config.toml` still resolve to the new `service_account_*` fields via an alias shim, with a one-shot stderr deprecation warning per legacy key. The aliases will be removed in a later `0.2.0-beta.x` release (carrying an explicit breaking-change callout). See [`docs/MIGRATION.md`](docs/MIGRATION.md#service-account-env-var-rename).
+
 ### Fixed
 
 ### Removed
@@ -43,7 +49,7 @@ Monorepo **Pipefy Labs** public beta on the `v0.2.0-beta.*` line (GitHub Release
   files into `packages/cli/src/pipefy_cli/skills/`; use `--check` in CI or before release.
 - **CLI**: introduce `pipefy-cli` workspace package with `pipefy` entry point.
 - **CLI**: `pipefy card get <id>` (mirrors MCP `get_card`) with `--json` / Rich rendering.
-- **CLI**: OAuth client-credentials auth (`PIPEFY_OAUTH_*`) and `--token` / `PIPEFY_TOKEN` static bearer override; auth precedence flag > env > `~/.config/pipefy/config.toml`.
+- **CLI**: OAuth client-credentials auth (`PIPEFY_OAUTH_*`; renamed to `PIPEFY_SERVICE_ACCOUNT_*` in the Unreleased section) and `--token` / `PIPEFY_TOKEN` static bearer override; auth precedence flag > env > `~/.config/pipefy/config.toml`.
 - **CLI**: `--graphql-url` and `--allow-insecure-urls` global flags; same SSRF policy as MCP.
 - **CLI**: shell completion via `pipefy --install-completion bash|zsh`.
 - **SDK**: optional `bearer_token=` constructor on `PipefyClient` and `StaticBearerAuth` in `base_client` (transport auth path used by the CLI `--token` / `PIPEFY_TOKEN`).

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -14,5 +14,5 @@ if [[ -f .env ]]; then
   echo ".env already exists; not overwriting."
 else
   cp .env.example .env
-  echo "Created .env from .env.example — set PIPEFY_OAUTH_CLIENT, PIPEFY_OAUTH_SECRET, and any optional keys."
+  echo "Created .env from .env.example — set PIPEFY_SERVICE_ACCOUNT_CLIENT_ID, PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET, and any optional keys."
 fi

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -73,11 +73,34 @@ pipefy skills show pipes-and-cards | pbcopy   # paste into agent context
 
 ---
 
-## Environment variables — unchanged
+## Environment variables — mostly unchanged
 
-The same `PIPEFY_*` variables (`PIPEFY_OAUTH_CLIENT`, `PIPEFY_OAUTH_SECRET`, `PIPEFY_GRAPHQL_URL`, etc.) work for both MCP and CLI. A working `.env` for `pipefy-mcp-server` gives you `pipefy-cli` auth immediately.
+The same `PIPEFY_*` variables work for both MCP and CLI. A working `.env` for `pipefy-mcp-server` gives you `pipefy-cli` auth immediately. See [`docs/setup.md`](setup.md) for the full list.
 
-See [`docs/setup.md`](setup.md) for the full list.
+One rename in the upcoming `0.2.0-beta.x` line is covered below.
+
+---
+
+## Service-account env-var rename
+
+The three OAuth 2.0 client-credentials vars used by the service-account auth path are being renamed for clarity (and to remove the one-letter footgun against `PIPEFY_AUTH_URL`, the new OIDC user-login issuer):
+
+| Old | New |
+|---|---|
+| `PIPEFY_OAUTH_URL` | `PIPEFY_SERVICE_ACCOUNT_URL` |
+| `PIPEFY_OAUTH_CLIENT` | `PIPEFY_SERVICE_ACCOUNT_CLIENT_ID` |
+| `PIPEFY_OAUTH_SECRET` | `PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET` |
+
+**No immediate action required.** The legacy names are still honored — `PIPEFY_OAUTH_*` env vars and `oauth_*` keys in `~/.config/pipefy/config.toml` both flow through an alias shim and populate the renamed fields. The first command run with a legacy name set prints a one-shot stderr deprecation warning per legacy key still in use; the message names the replacement.
+
+When you're ready to update:
+
+1. Search-and-replace your shell, `.env`, MCP client JSON, CI secrets, and any `~/.config/pipefy/config.toml` per the table above.
+2. Optionally re-run any command (e.g. `pipefy org get --json`) to confirm the deprecation warning is gone.
+
+The legacy names will be removed in a later `0.2.0-beta.x` release; the change will carry an explicit breaking-change callout in the changelog at that time.
+
+`PIPEFY_TOKEN` (static bearer override) and `PIPEFY_AUTH_URL` / `PIPEFY_AUTH_CLIENT_ID` (interactive user-login flow) are **not** affected.
 
 ---
 

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -23,7 +23,7 @@ Most-explicit wins. The CLI walks this list top-down and stops at the first sour
 |---|--------|----------|-------|
 | 1 | `--token <bearer>` | Whoever owns the token | Skips OAuth entirely |
 | 2 | `PIPEFY_TOKEN` env var | Whoever owns the token | Same path as `--token` |
-| 3 | `PIPEFY_OAUTH_*` triple | Service account | Client-credentials grant (unlocks AI automations) |
+| 3 | `PIPEFY_SERVICE_ACCOUNT_*` triple | Service account | Client-credentials grant (unlocks AI automations) |
 | 4 | Stored user session | You (the signed-in user) | Eager refresh inside a 60 s leeway window |
 
 Tiers 1, 2, and 4 ultimately become a **static bearer token** on the GraphQL client. Only tier 3 builds the `InternalApiClient` that some MCP/CLI features (AI automations, certain relation flows) rely on — see [Limitations on the bearer path](#limitations-on-the-bearer-path).
@@ -56,12 +56,14 @@ Use this for CI, scripts, MCP servers, and any context where opening a browser i
 ```env
 PIPEFY_GRAPHQL_URL=https://app.pipefy.com/graphql
 PIPEFY_INTERNAL_API_URL=https://app.pipefy.com/internal_api
-PIPEFY_OAUTH_URL=https://app.pipefy.com/oauth/token
-PIPEFY_OAUTH_CLIENT=<SERVICE_ACCOUNT_CLIENT_ID>
-PIPEFY_OAUTH_SECRET=<SERVICE_ACCOUNT_CLIENT_SECRET>
+PIPEFY_SERVICE_ACCOUNT_URL=https://app.pipefy.com/oauth/token
+PIPEFY_SERVICE_ACCOUNT_CLIENT_ID=<SERVICE_ACCOUNT_CLIENT_ID>
+PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET=<SERVICE_ACCOUNT_CLIENT_SECRET>
 ```
 
 The CLI loads `.env` from the current working directory; see [`docs/setup.md`](../setup.md) for the full Pydantic precedence rules.
+
+> **Legacy names:** `PIPEFY_OAUTH_URL`, `PIPEFY_OAUTH_CLIENT`, and `PIPEFY_OAUTH_SECRET` are still honored (with a one-shot stderr deprecation warning) for back-compat. They will be removed in a future beta. See [`docs/MIGRATION.md`](../MIGRATION.md#service-account-env-var-rename).
 
 ### Static bearer (one-off)
 
@@ -73,7 +75,7 @@ uv run pipefy --token "$MY_BEARER" pipe list
 PIPEFY_TOKEN="$MY_BEARER" uv run pipefy pipe list
 ```
 
-`--token` wins over every other source, including a stored session and `PIPEFY_OAUTH_*`.
+`--token` wins over every other source, including a stored session and `PIPEFY_SERVICE_ACCOUNT_*`.
 
 ---
 
@@ -85,14 +87,14 @@ PIPEFY_TOKEN="$MY_BEARER" uv run pipefy pipe list
 |-----|---------|--------|
 | `PIPEFY_GRAPHQL_URL` | All commands | Public GraphQL endpoint. Required for any GraphQL call (default in `.env.example`). |
 | `PIPEFY_TOKEN` | Tier 2 | Direct bearer token. Overridden by `--token`. |
-| `PIPEFY_OAUTH_URL` | Tier 3 | Service-account token URL (e.g. `https://app.pipefy.com/oauth/token`). |
-| `PIPEFY_OAUTH_CLIENT` | Tier 3 | Service-account client id. |
-| `PIPEFY_OAUTH_SECRET` | Tier 3 | Service-account client secret. |
+| `PIPEFY_SERVICE_ACCOUNT_URL` | Tier 3 | Service-account token URL (e.g. `https://app.pipefy.com/oauth/token`). |
+| `PIPEFY_SERVICE_ACCOUNT_CLIENT_ID` | Tier 3 | Service-account client id. |
+| `PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET` | Tier 3 | Service-account client secret. |
 | `PIPEFY_INTERNAL_API_URL` | Tier 3 | Internal GraphQL endpoint for AI automations / some relation flows. Required for those tools only. |
 | `PIPEFY_AUTH_URL` | Tier 4 | **OIDC issuer URL** for interactive login. The CLI appends `/.well-known/openid-configuration` to discover the authorization and token endpoints. Required for `pipefy auth login`. |
 | `PIPEFY_AUTH_CLIENT_ID` | Tier 4 | Public client id registered for the CLI. Defaults to `pipefy-cli`. |
 
-`PIPEFY_OAUTH_URL` and `PIPEFY_AUTH_URL` are **not** interchangeable: the first is a token URL for client-credentials, the second is an OIDC issuer URL for the user-login flow.
+`PIPEFY_SERVICE_ACCOUNT_URL` and `PIPEFY_AUTH_URL` are **not** interchangeable: the first is a token URL for client-credentials, the second is an OIDC issuer URL for the user-login flow. (The previous name `PIPEFY_OAUTH_URL` was one letter from `PIPEFY_AUTH_URL` and is the reason for the rename — see the legacy-names note above.)
 
 ### Global flags
 
@@ -123,7 +125,7 @@ PIPEFY_TOKEN="$MY_BEARER" uv run pipefy pipe list
 |------|---------|--------|
 | `--json` / `-j` | _off_ | Emit a stable JSON schema instead of human-readable text. |
 
-The command answers four diagnostic questions: am I signed in, as whom, via which precedence tier, and (for stored sessions) when does the access/refresh token expire. It also reports which *other* credential sources are configured, so a CI failure where `PIPEFY_OAUTH_*` masks a stored login is one command away from being obvious.
+The command answers four diagnostic questions: am I signed in, as whom, via which precedence tier, and (for stored sessions) when does the access/refresh token expire. It also reports which *other* credential sources are configured, so a CI failure where `PIPEFY_SERVICE_ACCOUNT_*` masks a stored login is one command away from being obvious.
 
 ##### JSON schema
 
@@ -176,7 +178,7 @@ The PKCE flow needs a loopback HTTP server on `127.0.0.1:<ephemeral>` and a brow
 Options today:
 
 1. **Run `pipefy auth login` on your laptop**, then copy `.env` plus the relevant secrets over. The keychain entry itself doesn't transfer between machines.
-2. **Use a service account** (`PIPEFY_OAUTH_*`) on the headless box — this is the canonical answer for CI and servers.
+2. **Use a service account** (`PIPEFY_SERVICE_ACCOUNT_*`) on the headless box — this is the canonical answer for CI and servers.
 3. **Static bearer** via `PIPEFY_TOKEN` for short-lived debugging.
 
 Forthcoming: an OAuth 2.0 Device Authorization Grant (`pipefy auth login --device`) that swaps the loopback callback for a code you paste into a browser elsewhere. Tracked in issue #138.
@@ -197,17 +199,17 @@ You haven't set the issuer URL. Use the value from [Pipefy issuer URLs](#pipefy-
 
 The login worked but `keyring` couldn't write the entry. On macOS / Windows this is rare. On headless Linux it usually means no Secret Service daemon is running — install `gnome-keyring` or `kwallet`, or fall back to a static `PIPEFY_TOKEN`.
 
-### `Missing authentication. Use --token, set PIPEFY_TOKEN, configure PIPEFY_OAUTH_*, or run pipefy auth login.`
+### `Missing authentication. Use --token, set PIPEFY_TOKEN, configure PIPEFY_SERVICE_ACCOUNT_*, or run pipefy auth login.`
 
-No source resolved. Pick one from [Credential precedence](#credential-precedence). The message also lists which `PIPEFY_OAUTH_*` keys are missing, in case you have a partial service-account setup.
+No source resolved. Pick one from [Credential precedence](#credential-precedence). The message also lists which `PIPEFY_SERVICE_ACCOUNT_*` keys are missing, in case you have a partial service-account setup.
 
-### `Note: PIPEFY_OAUTH_* is set in your environment; other pipefy commands will continue to use it ...`
+### `Note: PIPEFY_SERVICE_ACCOUNT_* is set in your environment; other pipefy commands will continue to use it ...`
 
-You ran `pipefy auth login` successfully, but a higher-precedence source is set in your shell. That source will keep being used until you unset it. Common when a `.env` file sets `PIPEFY_OAUTH_*` and the user expects the stored session to take over.
+You ran `pipefy auth login` successfully, but a higher-precedence source is set in your shell. That source will keep being used until you unset it. Common when a `.env` file sets `PIPEFY_SERVICE_ACCOUNT_*` and the user expects the stored session to take over. During the deprecation window the warning fires identically for the legacy `PIPEFY_OAUTH_*` triple, naming whichever form is actually set.
 
 ### Identity mismatch (commands run as the wrong user)
 
-Run `whoami`-style queries (e.g. `pipefy graphql exec --query '{ me { email name } }'`) to confirm which identity the CLI is actually using. If you expected your own user but see a service account, check whether `--token`, `PIPEFY_TOKEN`, or a complete `PIPEFY_OAUTH_*` triple is set in your environment — any of them outranks the stored session.
+Run `whoami`-style queries (e.g. `pipefy graphql exec --query '{ me { email name } }'`) to confirm which identity the CLI is actually using. If you expected your own user but see a service account, check whether `--token`, `PIPEFY_TOKEN`, or a complete `PIPEFY_SERVICE_ACCOUNT_*` triple (or the legacy `PIPEFY_OAUTH_*` form) is set in your environment — any of them outranks the stored session.
 
 ### `State mismatch on OAuth callback (possible CSRF)`
 

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -94,7 +94,7 @@ PIPEFY_TOKEN="$MY_BEARER" uv run pipefy pipe list
 | `PIPEFY_AUTH_URL` | Tier 4 | **OIDC issuer URL** for interactive login. The CLI appends `/.well-known/openid-configuration` to discover the authorization and token endpoints. Required for `pipefy auth login`. |
 | `PIPEFY_AUTH_CLIENT_ID` | Tier 4 | Public client id registered for the CLI. Defaults to `pipefy-cli`. |
 
-`PIPEFY_SERVICE_ACCOUNT_URL` and `PIPEFY_AUTH_URL` are **not** interchangeable: the first is a token URL for client-credentials, the second is an OIDC issuer URL for the user-login flow. (The previous name `PIPEFY_OAUTH_URL` was one letter from `PIPEFY_AUTH_URL` and is the reason for the rename — see the legacy-names note above.)
+`PIPEFY_SERVICE_ACCOUNT_URL` and `PIPEFY_AUTH_URL` are **not** interchangeable: the first is a token URL for client-credentials, the second is an OIDC issuer URL for the user-login flow.
 
 ### Global flags
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -63,11 +63,13 @@ Runtime settings come from **`pipefy_mcp.settings.Settings`** ([Pydantic Setting
 |-----|------|
 | `PIPEFY_GRAPHQL_URL` | Public GraphQL endpoint (default in `.env.example`). |
 | `PIPEFY_INTERNAL_API_URL` | Internal GraphQL (AI automations, some relation flows). Use the value from [`.env.example`](../.env.example). |
-| `PIPEFY_OAUTH_URL` | OAuth token URL for the service account. |
-| `PIPEFY_OAUTH_CLIENT` | Service account client ID. |
-| `PIPEFY_OAUTH_SECRET` | Service account client secret. |
+| `PIPEFY_SERVICE_ACCOUNT_URL` | Service-account OAuth 2.0 token endpoint (client-credentials grant). |
+| `PIPEFY_SERVICE_ACCOUNT_CLIENT_ID` | Service-account client_id (OAuth 2.0 RFC 6749). |
+| `PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET` | Service-account client_secret. |
 
 `PIPEFY_INTERNAL_API_URL` points at Pipefy’s internal GraphQL; it is required for tools that use that path (e.g. AI automations, some relations). Values are **validated at startup** — public Pipefy hosts are the normal case; `localhost` / private hosts are rejected to avoid SSRF unless you use the insecure-dev flags in [`.env.example`](../.env.example).
+
+> **Legacy names:** `PIPEFY_OAUTH_URL`, `PIPEFY_OAUTH_CLIENT`, and `PIPEFY_OAUTH_SECRET` are still honored (with a one-shot stderr deprecation warning) for back-compat. They will be removed in a future beta. See [docs/MIGRATION.md](MIGRATION.md#service-account-env-var-rename).
 
 ### Optional
 
@@ -92,9 +94,9 @@ Use this **`env` shape** when you need to inline values (e.g. CI or machines wit
 "env": {
     "PIPEFY_GRAPHQL_URL": "https://app.pipefy.com/graphql",
     "PIPEFY_INTERNAL_API_URL": "https://app.pipefy.com/internal_api",
-    "PIPEFY_OAUTH_URL": "https://app.pipefy.com/oauth/token",
-    "PIPEFY_OAUTH_CLIENT": "<SERVICE_ACCOUNT_CLIENT_ID>",
-    "PIPEFY_OAUTH_SECRET": "<SERVICE_ACCOUNT_CLIENT_SECRET>"
+    "PIPEFY_SERVICE_ACCOUNT_URL": "https://app.pipefy.com/oauth/token",
+    "PIPEFY_SERVICE_ACCOUNT_CLIENT_ID": "<SERVICE_ACCOUNT_CLIENT_ID>",
+    "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET": "<SERVICE_ACCOUNT_CLIENT_SECRET>"
 }
 ```
 
@@ -119,9 +121,9 @@ Use this **`env` shape** when you need to inline values (e.g. CI or machines wit
             "env": {
                 "PIPEFY_GRAPHQL_URL": "https://app.pipefy.com/graphql",
                 "PIPEFY_INTERNAL_API_URL": "https://app.pipefy.com/internal_api",
-                "PIPEFY_OAUTH_URL": "https://app.pipefy.com/oauth/token",
-                "PIPEFY_OAUTH_CLIENT": "<SERVICE_ACCOUNT_CLIENT_ID>",
-                "PIPEFY_OAUTH_SECRET": "<SERVICE_ACCOUNT_CLIENT_SECRET>"
+                "PIPEFY_SERVICE_ACCOUNT_URL": "https://app.pipefy.com/oauth/token",
+                "PIPEFY_SERVICE_ACCOUNT_CLIENT_ID": "<SERVICE_ACCOUNT_CLIENT_ID>",
+                "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET": "<SERVICE_ACCOUNT_CLIENT_SECRET>"
             }
         }
     }
@@ -155,9 +157,9 @@ MCP servers load from a JSON config file. You can keep credentials in **`.env`**
             "env": {
                 "PIPEFY_GRAPHQL_URL": "https://app.pipefy.com/graphql",
                 "PIPEFY_INTERNAL_API_URL": "https://app.pipefy.com/internal_api",
-                "PIPEFY_OAUTH_URL": "https://app.pipefy.com/oauth/token",
-                "PIPEFY_OAUTH_CLIENT": "<SERVICE_ACCOUNT_CLIENT_ID>",
-                "PIPEFY_OAUTH_SECRET": "<SERVICE_ACCOUNT_CLIENT_SECRET>"
+                "PIPEFY_SERVICE_ACCOUNT_URL": "https://app.pipefy.com/oauth/token",
+                "PIPEFY_SERVICE_ACCOUNT_CLIENT_ID": "<SERVICE_ACCOUNT_CLIENT_ID>",
+                "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET": "<SERVICE_ACCOUNT_CLIENT_SECRET>"
             }
         }
     }
@@ -180,11 +182,11 @@ claude mcp add --scope project pipefy \
 Then (repeat for each key you need, matching [`.env.example`](../.env.example)):
 
 ```bash
-claude mcp add-env pipefy PIPEFY_OAUTH_CLIENT <YOUR_CLIENT_ID>
-claude mcp add-env pipefy PIPEFY_OAUTH_SECRET <YOUR_CLIENT_SECRET>
+claude mcp add-env pipefy PIPEFY_SERVICE_ACCOUNT_CLIENT_ID <YOUR_CLIENT_ID>
+claude mcp add-env pipefy PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET <YOUR_CLIENT_SECRET>
 claude mcp add-env pipefy PIPEFY_GRAPHQL_URL https://app.pipefy.com/graphql
 claude mcp add-env pipefy PIPEFY_INTERNAL_API_URL https://app.pipefy.com/internal_api
-claude mcp add-env pipefy PIPEFY_OAUTH_URL https://app.pipefy.com/oauth/token
+claude mcp add-env pipefy PIPEFY_SERVICE_ACCOUNT_URL https://app.pipefy.com/oauth/token
 ```
 
 **`.mcp.json` (project root)**
@@ -203,9 +205,9 @@ claude mcp add-env pipefy PIPEFY_OAUTH_URL https://app.pipefy.com/oauth/token
             "env": {
                 "PIPEFY_GRAPHQL_URL": "https://app.pipefy.com/graphql",
                 "PIPEFY_INTERNAL_API_URL": "https://app.pipefy.com/internal_api",
-                "PIPEFY_OAUTH_URL": "https://app.pipefy.com/oauth/token",
-                "PIPEFY_OAUTH_CLIENT": "<SERVICE_ACCOUNT_CLIENT_ID>",
-                "PIPEFY_OAUTH_SECRET": "<SERVICE_ACCOUNT_CLIENT_SECRET>"
+                "PIPEFY_SERVICE_ACCOUNT_URL": "https://app.pipefy.com/oauth/token",
+                "PIPEFY_SERVICE_ACCOUNT_CLIENT_ID": "<SERVICE_ACCOUNT_CLIENT_ID>",
+                "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET": "<SERVICE_ACCOUNT_CLIENT_SECRET>"
             }
         }
     }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -31,16 +31,16 @@ pipefy skills show pipes-and-cards | pbcopy
 Same `PIPEFY_*` environment variables as `pipefy-mcp-server` (`.env` in CWD is loaded automatically):
 
 ```env
-PIPEFY_OAUTH_CLIENT=your_client_id
-PIPEFY_OAUTH_SECRET=your_client_secret
+PIPEFY_SERVICE_ACCOUNT_CLIENT_ID=your_client_id
+PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET=your_client_secret
 PIPEFY_GRAPHQL_URL=https://app.pipefy.com/graphql
-PIPEFY_OAUTH_URL=https://app.pipefy.com/oauth/token
+PIPEFY_SERVICE_ACCOUNT_URL=https://app.pipefy.com/oauth/token
 PIPEFY_INTERNAL_API_URL=https://app.pipefy.com/internal_api
 ```
 
 Full guide: [`docs/setup.md`](../../docs/setup.md). CLI-focused docs: [`docs/cli/`](../../docs/cli/README.md).
 
-Use `PIPEFY_TOKEN` (or `--token`) for a direct bearer token instead of OAuth.
+Use `PIPEFY_TOKEN` (or `--token`) for a direct bearer token instead of service-account credentials.
 
 ## Output modes
 

--- a/packages/cli/src/pipefy_cli/auth.py
+++ b/packages/cli/src/pipefy_cli/auth.py
@@ -4,7 +4,7 @@ The credential precedence chain (most explicit wins) is:
 
 1. ``--token`` CLI flag
 2. ``PIPEFY_TOKEN`` env var
-3. ``PIPEFY_OAUTH_*`` triple → client-credentials grant (service account)
+3. ``PIPEFY_SERVICE_ACCOUNT_*`` triple → client-credentials grant (service account)
 4. Stored user session from ``pipefy auth login`` (keychain) — refreshed
    eagerly when the access token is within the leeway window
 
@@ -29,7 +29,7 @@ from pipefy_sdk import (
 
 from pipefy_cli._docs import DOCS_CLI_AUTH_REF
 from pipefy_cli.config import (
-    describe_missing_oauth_vars,
+    describe_missing_service_account_vars,
     ensure_public_graphql_configured,
 )
 from pipefy_cli.oauth import RefreshError, ensure_fresh_session, load_session
@@ -100,9 +100,9 @@ def _cache_key(
     return (
         (pipefy_settings.graphql_url or "").strip(),
         (pipefy_settings.internal_api_url or "").strip(),
-        (pipefy_settings.oauth_url or "").strip(),
-        (pipefy_settings.oauth_client or "").strip(),
-        (pipefy_settings.oauth_secret or "").strip(),
+        (pipefy_settings.service_account_url or "").strip(),
+        (pipefy_settings.service_account_client_id or "").strip(),
+        (pipefy_settings.service_account_client_secret or "").strip(),
         bool(pipefy_settings.allow_insecure_urls),
         (bearer_token or "").strip(),
     )
@@ -123,7 +123,7 @@ def detect_all_sources(
         sources.append(
             "flag-token" if auth.bearer_token.source == "flag" else "env-token"
         )
-    if not describe_missing_oauth_vars(pipefy_settings):
+    if not describe_missing_service_account_vars(pipefy_settings):
         sources.append("service-account")
     if (
         auth.oidc_client is not None
@@ -147,10 +147,10 @@ def detect_auth_source(
 
 
 def _missing_auth_message(pipefy_settings: PipefySettings) -> str:
-    missing = describe_missing_oauth_vars(pipefy_settings)
+    missing = describe_missing_service_account_vars(pipefy_settings)
     return (
         "Missing authentication. Use --token, set PIPEFY_TOKEN, configure "
-        f"PIPEFY_OAUTH_* ({missing}), or run `pipefy auth login`. "
+        f"PIPEFY_SERVICE_ACCOUNT_* ({missing}), or run `pipefy auth login`. "
         f"See {DOCS_CLI_AUTH_REF}."
     )
 
@@ -254,9 +254,9 @@ def get_authenticated_client(
     client = PipefyClient(pipefy_settings)
     internal_client = InternalApiClient(
         url=pipefy_settings.internal_api_url,
-        oauth_url=pipefy_settings.oauth_url,
-        oauth_client=pipefy_settings.oauth_client,
-        oauth_secret=pipefy_settings.oauth_secret,
+        service_account_url=pipefy_settings.service_account_url,
+        service_account_client_id=pipefy_settings.service_account_client_id,
+        service_account_client_secret=pipefy_settings.service_account_client_secret,
         allow_insecure_urls=pipefy_settings.allow_insecure_urls,
     )
     client.set_internal_api_client(internal_client)

--- a/packages/cli/src/pipefy_cli/commands/ai_automation.py
+++ b/packages/cli/src/pipefy_cli/commands/ai_automation.py
@@ -26,7 +26,7 @@ from pipefy_cli.commands._common import (
 )
 
 ai_automation_app = typer.Typer(
-    help="AI Automations (generate_with_ai; requires OAuth).",
+    help="AI Automations (generate_with_ai; requires service-account credentials).",
     no_args_is_help=True,
 )
 
@@ -34,8 +34,9 @@ ai_automation_app = typer.Typer(
 def _require_ai_automation(client: PipefyClient) -> None:
     if not client.ai_automation_available:
         typer.echo(
-            "AI Automation requires OAuth credentials "
-            "(PIPEFY_OAUTH_CLIENT, PIPEFY_OAUTH_SECRET, PIPEFY_OAUTH_URL). "
+            "AI Automation requires service-account credentials "
+            "(PIPEFY_SERVICE_ACCOUNT_URL, PIPEFY_SERVICE_ACCOUNT_CLIENT_ID, "
+            "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET). "
             "Bearer --token mode does not attach the internal API client.",
             err=True,
         )

--- a/packages/cli/src/pipefy_cli/commands/auth.py
+++ b/packages/cli/src/pipefy_cli/commands/auth.py
@@ -72,9 +72,9 @@ auth_app = typer.Typer(
 )
 
 _SERVICE_ACCOUNT_ENV_KEYS = (
-    "PIPEFY_OAUTH_URL",
-    "PIPEFY_OAUTH_CLIENT",
-    "PIPEFY_OAUTH_SECRET",
+    "PIPEFY_SERVICE_ACCOUNT_URL",
+    "PIPEFY_SERVICE_ACCOUNT_CLIENT_ID",
+    "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET",
 )
 
 
@@ -82,15 +82,15 @@ def _session_masking_env_vars() -> list[str]:
     """Env vars that outrank a stored session in the credential precedence chain.
 
     Only ``os.environ`` is consulted — by the precedence model, ``.env`` defaults
-    sit below the stored session. ``PIPEFY_OAUTH_*`` is listed only when the
-    *complete* triple is configured (otherwise the client-credentials path
+    sit below the stored session. ``PIPEFY_SERVICE_ACCOUNT_*`` is listed only when
+    the *complete* triple is configured (otherwise the client-credentials path
     wouldn't activate and the warning would be misleading).
     """
     env_vars: list[str] = []
     if os.environ.get("PIPEFY_TOKEN"):
         env_vars.append("PIPEFY_TOKEN")
     if all(os.environ.get(k) for k in _SERVICE_ACCOUNT_ENV_KEYS):
-        env_vars.append("PIPEFY_OAUTH_*")
+        env_vars.append("PIPEFY_SERVICE_ACCOUNT_*")
     return env_vars
 
 
@@ -204,7 +204,7 @@ def auth_login(
 _AUTH_SOURCE_LABELS: dict[AuthSource, str] = {
     "flag-token": "--token flag",
     "env-token": "PIPEFY_TOKEN environment variable",
-    "service-account": "PIPEFY_OAUTH_* (client credentials)",
+    "service-account": "PIPEFY_SERVICE_ACCOUNT_* (client credentials)",
     "stored-session": "stored session (`pipefy auth login`)",
     "none": "none",
 }
@@ -260,7 +260,7 @@ def _render_status_text(report: AuthStatusReport) -> None:
     if not report.signed_in:
         typer.echo(
             "Not signed in. Run `pipefy auth login`, set PIPEFY_TOKEN, or "
-            f"configure PIPEFY_OAUTH_*. See {DOCS_CLI_AUTH_REF}."
+            f"configure PIPEFY_SERVICE_ACCOUNT_*. See {DOCS_CLI_AUTH_REF}."
         )
         return
 

--- a/packages/cli/src/pipefy_cli/commands/auth.py
+++ b/packages/cli/src/pipefy_cli/commands/auth.py
@@ -16,6 +16,7 @@ from gql.transport.exceptions import (
     TransportServerError,
 )
 from pipefy_sdk import MePayload, PipefySettings
+from pipefy_sdk.settings import _LEGACY_ENV_KEYS_TO_NEW
 
 from pipefy_cli._docs import DOCS_CLI_AUTH_REF
 from pipefy_cli.auth import (
@@ -71,30 +72,18 @@ auth_app = typer.Typer(
     no_args_is_help=True,
 )
 
-_SERVICE_ACCOUNT_ENV_KEYS = (
-    "PIPEFY_SERVICE_ACCOUNT_URL",
-    "PIPEFY_SERVICE_ACCOUNT_CLIENT_ID",
-    "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET",
-)
-_LEGACY_SERVICE_ACCOUNT_ENV_KEYS = (
-    "PIPEFY_OAUTH_URL",
-    "PIPEFY_OAUTH_CLIENT",
-    "PIPEFY_OAUTH_SECRET",
-)
+_SERVICE_ACCOUNT_ENV_KEYS = tuple(_LEGACY_ENV_KEYS_TO_NEW.values())
+_LEGACY_SERVICE_ACCOUNT_ENV_KEYS = tuple(_LEGACY_ENV_KEYS_TO_NEW.keys())
 
 
 def _session_masking_env_vars() -> list[str]:
-    """Env vars that outrank a stored session in the credential precedence chain.
+    """Env vars in ``os.environ`` that outrank a stored session.
 
-    Only ``os.environ`` is consulted — by the precedence model, ``.env`` defaults
-    sit below the stored session. A service-account triple is listed only when
-    *complete* (otherwise the client-credentials path wouldn't activate and the
-    warning would be misleading). Both the canonical
-    ``PIPEFY_SERVICE_ACCOUNT_*`` and the legacy ``PIPEFY_OAUTH_*`` triples are
-    recognised during the deprecation window — ``PipefySettings.AliasChoices``
-    resolves either, so the masking diagnostic has to match or it would
-    silently regress on the legacy form. The label echoes the form the user
-    actually set so they know which keys to unset.
+    A service-account triple counts only when *complete* (otherwise the
+    client-credentials path wouldn't activate and the warning would mislead).
+    Both the canonical and legacy forms are accepted during the deprecation
+    window, and the label echoes whichever the user actually set so they know
+    which keys to unset.
     """
     env_vars: list[str] = []
     if os.environ.get("PIPEFY_TOKEN"):

--- a/packages/cli/src/pipefy_cli/commands/auth.py
+++ b/packages/cli/src/pipefy_cli/commands/auth.py
@@ -76,21 +76,33 @@ _SERVICE_ACCOUNT_ENV_KEYS = (
     "PIPEFY_SERVICE_ACCOUNT_CLIENT_ID",
     "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET",
 )
+_LEGACY_SERVICE_ACCOUNT_ENV_KEYS = (
+    "PIPEFY_OAUTH_URL",
+    "PIPEFY_OAUTH_CLIENT",
+    "PIPEFY_OAUTH_SECRET",
+)
 
 
 def _session_masking_env_vars() -> list[str]:
     """Env vars that outrank a stored session in the credential precedence chain.
 
     Only ``os.environ`` is consulted — by the precedence model, ``.env`` defaults
-    sit below the stored session. ``PIPEFY_SERVICE_ACCOUNT_*`` is listed only when
-    the *complete* triple is configured (otherwise the client-credentials path
-    wouldn't activate and the warning would be misleading).
+    sit below the stored session. A service-account triple is listed only when
+    *complete* (otherwise the client-credentials path wouldn't activate and the
+    warning would be misleading). Both the canonical
+    ``PIPEFY_SERVICE_ACCOUNT_*`` and the legacy ``PIPEFY_OAUTH_*`` triples are
+    recognised during the deprecation window — ``PipefySettings.AliasChoices``
+    resolves either, so the masking diagnostic has to match or it would
+    silently regress on the legacy form. The label echoes the form the user
+    actually set so they know which keys to unset.
     """
     env_vars: list[str] = []
     if os.environ.get("PIPEFY_TOKEN"):
         env_vars.append("PIPEFY_TOKEN")
     if all(os.environ.get(k) for k in _SERVICE_ACCOUNT_ENV_KEYS):
         env_vars.append("PIPEFY_SERVICE_ACCOUNT_*")
+    elif all(os.environ.get(k) for k in _LEGACY_SERVICE_ACCOUNT_ENV_KEYS):
+        env_vars.append("PIPEFY_OAUTH_*")
     return env_vars
 
 

--- a/packages/cli/src/pipefy_cli/commands/relation.py
+++ b/packages/cli/src/pipefy_cli/commands/relation.py
@@ -157,13 +157,14 @@ def relation_card_delete(
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
     json_out: bool = typer.Option(False, "--json", "-j"),
 ) -> None:
-    """Remove a card relation (requires OAuth; internal API)."""
+    """Remove a card relation (requires service-account credentials; internal API)."""
 
     client = authenticated_client_from_ctx(ctx)
     if not client.internal_api_available:
         typer.echo(
-            "delete_card_relation requires OAuth credentials "
-            "(PIPEFY_OAUTH_CLIENT, PIPEFY_OAUTH_SECRET, PIPEFY_OAUTH_URL). "
+            "delete_card_relation requires service-account credentials "
+            "(PIPEFY_SERVICE_ACCOUNT_URL, PIPEFY_SERVICE_ACCOUNT_CLIENT_ID, "
+            "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET). "
             "The deleteCardRelation mutation is only available on the internal API.",
             err=True,
         )

--- a/packages/cli/src/pipefy_cli/config.py
+++ b/packages/cli/src/pipefy_cli/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sys
 import tomllib
 from pathlib import Path
 from typing import Any, Self
@@ -17,6 +18,31 @@ from pipefy_cli._docs import DOCS_SETUP_REF
 _ALLOW_INSECURE_ENV_KEY = "PIPEFY_ALLOW_INSECURE_URLS"
 
 USER_CONFIG_PATH = Path.home() / ".config/pipefy/config.toml"
+
+# Legacy ``[pipefy]`` TOML keys mapped to their replacements (mirrors the
+# ``PIPEFY_OAUTH_*`` → ``PIPEFY_SERVICE_ACCOUNT_*`` env-var rename in #127).
+_LEGACY_TOML_KEYS_TO_NEW: dict[str, str] = {
+    "oauth_url": "service_account_url",
+    "oauth_client": "service_account_client_id",
+    "oauth_secret": "service_account_client_secret",
+}
+
+_warned_legacy_toml_keys: set[str] = set()
+
+
+def _warn_once_for_legacy_toml_key(legacy_key: str, new_key: str) -> None:
+    if legacy_key in _warned_legacy_toml_keys:
+        return
+    sys.stderr.write(
+        f"warning: '{legacy_key}' in {USER_CONFIG_PATH} is deprecated; "
+        f"rename to '{new_key}'. The legacy key will be removed in a future beta.\n"
+    )
+    _warned_legacy_toml_keys.add(legacy_key)
+
+
+def _reset_legacy_toml_warning_state() -> None:
+    """Test helper: clear the one-shot dedup so a fixture can re-trigger the warning."""
+    _warned_legacy_toml_keys.clear()
 
 
 DEFAULT_AUTH_CLIENT_ID = "pipefy-cli"
@@ -94,17 +120,41 @@ def _fill_if_missing_str(
         patch[field] = str(blob[key]).strip()
 
 
+def _normalize_legacy_toml_keys(blob: dict[str, Any]) -> dict[str, Any]:
+    """Translate legacy ``oauth_*`` TOML keys to ``service_account_*``; warn once per legacy key.
+
+    When both keys are present, the new key wins (mirrors ``AliasChoices`` precedence).
+    """
+    for legacy, new in _LEGACY_TOML_KEYS_TO_NEW.items():
+        if legacy in blob:
+            _warn_once_for_legacy_toml_key(legacy, new)
+            if new not in blob:
+                blob[new] = blob[legacy]
+    return blob
+
+
 def apply_toml_fallback(pipefy: PipefySettings) -> PipefySettings:
     """Fill only attributes still unset after env / ``.env`` (lowest precedence)."""
     blob = _read_toml_pipefy_dict()
     if not blob:
         return pipefy
+    blob = _normalize_legacy_toml_keys(blob)
     patch: dict[str, Any] = {}
     _fill_if_missing_str(pipefy, blob, "graphql_url", "graphql_url", patch)
     _fill_if_missing_str(pipefy, blob, "internal_api_url", "internal_api_url", patch)
-    _fill_if_missing_str(pipefy, blob, "oauth_url", "oauth_url", patch)
-    _fill_if_missing_str(pipefy, blob, "oauth_client", "oauth_client", patch)
-    _fill_if_missing_str(pipefy, blob, "oauth_secret", "oauth_secret", patch)
+    _fill_if_missing_str(
+        pipefy, blob, "service_account_url", "service_account_url", patch
+    )
+    _fill_if_missing_str(
+        pipefy, blob, "service_account_client_id", "service_account_client_id", patch
+    )
+    _fill_if_missing_str(
+        pipefy,
+        blob,
+        "service_account_client_secret",
+        "service_account_client_secret",
+        patch,
+    )
     if blob.get("service_account_ids") is not None and not pipefy.service_account_ids:
         patch["service_account_ids"] = blob["service_account_ids"]
     if blob.get("allow_insecure_urls") is not None and not pipefy.allow_insecure_urls:
@@ -168,15 +218,15 @@ def ensure_public_graphql_configured(pipefy: PipefySettings) -> None:
         raise ValueError(msg)
 
 
-def describe_missing_oauth_vars(pipefy: PipefySettings) -> str:
-    """Return a short message listing missing OAuth-related variables."""
+def describe_missing_service_account_vars(pipefy: PipefySettings) -> str:
+    """Return a short message listing missing service-account credential variables."""
     missing: list[str] = []
-    if _is_missing(pipefy.oauth_url):
-        missing.append("PIPEFY_OAUTH_URL")
-    if _is_missing(pipefy.oauth_client):
-        missing.append("PIPEFY_OAUTH_CLIENT")
-    if _is_missing(pipefy.oauth_secret):
-        missing.append("PIPEFY_OAUTH_SECRET")
+    if _is_missing(pipefy.service_account_url):
+        missing.append("PIPEFY_SERVICE_ACCOUNT_URL")
+    if _is_missing(pipefy.service_account_client_id):
+        missing.append("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID")
+    if _is_missing(pipefy.service_account_client_secret):
+        missing.append("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET")
     return ", ".join(missing)
 
 
@@ -185,7 +235,7 @@ __all__ = [
     "DEFAULT_AUTH_CLIENT_ID",
     "USER_CONFIG_PATH",
     "apply_toml_fallback",
-    "describe_missing_oauth_vars",
+    "describe_missing_service_account_vars",
     "ensure_public_graphql_configured",
     "resolve_cli_settings",
 ]

--- a/packages/cli/src/pipefy_cli/config.py
+++ b/packages/cli/src/pipefy_cli/config.py
@@ -19,8 +19,6 @@ _ALLOW_INSECURE_ENV_KEY = "PIPEFY_ALLOW_INSECURE_URLS"
 
 USER_CONFIG_PATH = Path.home() / ".config/pipefy/config.toml"
 
-# Legacy ``[pipefy]`` TOML keys mapped to their replacements (mirrors the
-# ``PIPEFY_OAUTH_*`` → ``PIPEFY_SERVICE_ACCOUNT_*`` env-var rename in #127).
 _LEGACY_TOML_KEYS_TO_NEW: dict[str, str] = {
     "oauth_url": "service_account_url",
     "oauth_client": "service_account_client_id",
@@ -125,6 +123,8 @@ def _normalize_legacy_toml_keys(blob: dict[str, Any]) -> dict[str, Any]:
 
     When both keys are present, the new key wins (mirrors ``AliasChoices`` precedence).
     """
+    if not any(legacy in blob for legacy in _LEGACY_TOML_KEYS_TO_NEW):
+        return blob
     for legacy, new in _LEGACY_TOML_KEYS_TO_NEW.items():
         if legacy in blob:
             _warn_once_for_legacy_toml_key(legacy, new)

--- a/packages/cli/tests/conftest.py
+++ b/packages/cli/tests/conftest.py
@@ -10,6 +10,12 @@ from typer.testing import CliRunner
 _PIPEFY_ENV_KEYS = (
     "PIPEFY_GRAPHQL_URL",
     "PIPEFY_INTERNAL_API_URL",
+    "PIPEFY_SERVICE_ACCOUNT_URL",
+    "PIPEFY_SERVICE_ACCOUNT_CLIENT_ID",
+    "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET",
+    # Legacy aliases — kept so tests that opt into back-compat coverage start
+    # from a clean slate even when the dropped names linger in the developer
+    # shell.
     "PIPEFY_OAUTH_URL",
     "PIPEFY_OAUTH_CLIENT",
     "PIPEFY_OAUTH_SECRET",
@@ -28,7 +34,7 @@ _PIPEFY_ENV_KEYS = (
 
 @pytest.fixture
 def oauth_env(monkeypatch: pytest.MonkeyPatch):
-    """Set minimal OAuth + GraphQL URLs for CLI commands that require OAuth mode."""
+    """Set minimal service-account + GraphQL URLs for CLI commands that require client-credentials mode."""
 
     def _set(host: str) -> None:
         monkeypatch.setenv("PIPEFY_GRAPHQL_URL", f"https://{host}.example.com/graphql")
@@ -37,10 +43,11 @@ def oauth_env(monkeypatch: pytest.MonkeyPatch):
             f"https://{host}.example.com/internal_api",
         )
         monkeypatch.setenv(
-            "PIPEFY_OAUTH_URL", f"https://{host}.example.com/oauth/token"
+            "PIPEFY_SERVICE_ACCOUNT_URL",
+            f"https://{host}.example.com/oauth/token",
         )
-        monkeypatch.setenv("PIPEFY_OAUTH_CLIENT", "cid")
-        monkeypatch.setenv("PIPEFY_OAUTH_SECRET", "sec")
+        monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", "cid")
+        monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET", "sec")
 
     return _set
 

--- a/packages/cli/tests/fixtures/cli_help_golden.txt
+++ b/packages/cli/tests/fixtures/cli_help_golden.txt
@@ -17,7 +17,8 @@ Usage: pipefy [OPTIONS] COMMAND [ARGS]...
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ───────────────────────────────────────────────────────────────────╮
 │ agent             AI Agents (repo-scoped).                                   │
-│ ai-automation     AI Automations (generate_with_ai; requires OAuth).         │
+│ ai-automation     AI Automations (generate_with_ai; requires service-account │
+│                   credentials).                                              │
 │ attachment        Attachment uploads (presigned URL + field update).         │
 │ audit             Pipe audit log exports.                                    │
 │ auth              Authenticate the CLI as your Pipefy user (browser-based    │
@@ -241,7 +242,7 @@ Usage: pipefy agent validate-behaviors [OPTIONS]
 ### HELP ai-automation
 Usage: pipefy ai-automation [OPTIONS] COMMAND [ARGS]...
 
- AI Automations (generate_with_ai; requires OAuth).
+ AI Automations (generate_with_ai; requires service-account credentials).
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
@@ -1921,7 +1922,8 @@ Usage: pipefy relation card [OPTIONS] COMMAND [ARGS]...
 │ list     List parent and child relations for a card (raw                     │
 │          ``get_card_relations`` payload).                                    │
 │ create   Link two cards via an existing pipe relation.                       │
-│ delete   Remove a card relation (requires OAuth; internal API).              │
+│ delete   Remove a card relation (requires service-account credentials;       │
+│          internal API).                                                      │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 
 ### HELP relation/card/create
@@ -1942,7 +1944,7 @@ Usage: pipefy relation card create [OPTIONS]
 ### HELP relation/card/delete
 Usage: pipefy relation card delete [OPTIONS]
 
- Remove a card relation (requires OAuth; internal API).
+ Remove a card relation (requires service-account credentials; internal API).
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ *  --child           TEXT  Child card id. [required]                         │

--- a/packages/cli/tests/test_auth.py
+++ b/packages/cli/tests/test_auth.py
@@ -1,4 +1,4 @@
-"""Tests for ``pipefy_cli.auth`` (OAuth / bearer factory and CLI exits)."""
+"""Tests for ``pipefy_cli.auth`` (service-account / bearer factory and CLI exits)."""
 
 from __future__ import annotations
 
@@ -19,13 +19,13 @@ from pipefy_cli.main import app
 from pipefy_cli.oauth import StoredSession
 
 
-def _minimal_oauth_settings() -> PipefySettings:
+def _minimal_service_account_settings() -> PipefySettings:
     return PipefySettings(
         graphql_url="https://unit.example.com/graphql",
         internal_api_url="https://unit.example.com/internal_api",
-        oauth_url="https://unit.example.com/oauth/token",
-        oauth_client="cid",
-        oauth_secret="csecret",
+        service_account_url="https://unit.example.com/oauth/token",
+        service_account_client_id="cid",
+        service_account_client_secret="csecret",
     )
 
 
@@ -51,7 +51,7 @@ def _auth(
 
 
 def test_get_authenticated_client_passes_bearer_to_pipefy_client(clean_pipefy_env):
-    settings = _minimal_oauth_settings()
+    settings = _minimal_service_account_settings()
     with patch("pipefy_cli.auth.PipefyClient") as mock_pc:
         mock_pc.return_value = MagicMock()
         client = get_authenticated_client(settings, _auth(bearer_token="tok"))
@@ -59,16 +59,18 @@ def test_get_authenticated_client_passes_bearer_to_pipefy_client(clean_pipefy_en
         assert client is mock_pc.return_value
 
 
-def test_get_authenticated_client_oauth_mode_no_bearer(clean_pipefy_env):
-    settings = _minimal_oauth_settings()
+def test_get_authenticated_client_service_account_mode_no_bearer(clean_pipefy_env):
+    settings = _minimal_service_account_settings()
     with patch("pipefy_cli.auth.PipefyClient") as mock_pc:
         mock_pc.return_value = MagicMock()
         get_authenticated_client(settings, _auth())
         mock_pc.assert_called_once_with(settings)
 
 
-def test_cache_returns_same_instance_for_identical_oauth_settings(clean_pipefy_env):
-    settings = _minimal_oauth_settings()
+def test_cache_returns_same_instance_for_identical_service_account_settings(
+    clean_pipefy_env,
+):
+    settings = _minimal_service_account_settings()
     with patch("pipefy_cli.auth.PipefyClient") as mock_pc:
         mock_pc.return_value = MagicMock()
         first = get_authenticated_client(settings, _auth())
@@ -141,13 +143,13 @@ def _fresh_stored_session(*, access_token: str = "SESSION_ACCESS") -> StoredSess
 
 
 def _public_only_settings() -> PipefySettings:
-    """``PIPEFY_OAUTH_*`` triple absent → priority 3 unavailable, falls through to 4."""
+    """``PIPEFY_SERVICE_ACCOUNT_*`` triple absent → priority 3 unavailable, falls through to 4."""
     return PipefySettings(graphql_url="https://unit.example.com/graphql")
 
 
 def test_bearer_token_wins_over_stored_session(clean_pipefy_env):
     """Priority 1/2 (bearer) MUST short-circuit before the keychain is even consulted."""
-    settings = _minimal_oauth_settings()
+    settings = _minimal_service_account_settings()
     with (
         patch("pipefy_cli.auth.PipefyClient") as mock_pc,
         patch("pipefy_cli.auth.ensure_fresh_session") as mock_ensure,
@@ -165,9 +167,9 @@ def test_bearer_token_wins_over_stored_session(clean_pipefy_env):
         mock_ensure.assert_not_called()
 
 
-def test_oauth_client_creds_wins_over_stored_session(clean_pipefy_env):
-    """Priority 3 (full OAuth triple) MUST short-circuit before the keychain is consulted."""
-    settings = _minimal_oauth_settings()
+def test_service_account_creds_win_over_stored_session(clean_pipefy_env):
+    """Priority 3 (full service-account triple) MUST short-circuit before the keychain is consulted."""
+    settings = _minimal_service_account_settings()
     with (
         patch("pipefy_cli.auth.PipefyClient") as mock_pc,
         patch("pipefy_cli.auth.InternalApiClient"),

--- a/packages/cli/tests/test_auth_status.py
+++ b/packages/cli/tests/test_auth_status.py
@@ -332,6 +332,33 @@ def test_status_service_account_wins_over_stored_session(
 
 
 # --------------------------------------------------------------------------- #
+# Scenario 5b: stored-session masked by legacy PIPEFY_OAUTH_* triple          #
+# --------------------------------------------------------------------------- #
+def test_status_legacy_service_account_triple_masks_stored_session(
+    clean_pipefy_env, saved_cwd, monkeypatch, runner, fake_keyring
+):
+    """During the alias window a legacy triple still masks — diagnostic must reflect it."""
+    _set_auth_env(monkeypatch)
+    _seed_session(monkeypatch)
+    monkeypatch.setenv(
+        "PIPEFY_INTERNAL_API_URL", "https://api.example.com/internal_api"
+    )
+    monkeypatch.setenv("PIPEFY_OAUTH_URL", "https://auth.example.com/oauth/token")
+    monkeypatch.setenv("PIPEFY_OAUTH_CLIENT", "cid")
+    monkeypatch.setenv("PIPEFY_OAUTH_SECRET", "csecret")
+    client = _mock_client_with_me()
+    with _patch_command_client(client):
+        result = _invoke_status(runner, ["--json"])
+
+    assert result.exit_code == 0, (result.stdout or "") + (result.stderr or "")
+    payload = json.loads(result.stdout)
+    assert payload["auth_source"] == "service-account"
+    assert "service-account" in payload["detected_sources"]
+    assert "stored-session" in payload["detected_sources"]
+    assert payload["masking_env_vars"] == ["PIPEFY_OAUTH_*"]
+
+
+# --------------------------------------------------------------------------- #
 # Scenario 6: stored-session masked by PIPEFY_TOKEN                           #
 # --------------------------------------------------------------------------- #
 def test_status_env_token_wins_over_stored_session(

--- a/packages/cli/tests/test_auth_status.py
+++ b/packages/cli/tests/test_auth_status.py
@@ -302,7 +302,7 @@ def test_status_me_500_is_transport_error_not_token_rejected(
 
 
 # --------------------------------------------------------------------------- #
-# Scenario 5: stored-session masked by PIPEFY_OAUTH_*                         #
+# Scenario 5: stored-session masked by PIPEFY_SERVICE_ACCOUNT_*               #
 # --------------------------------------------------------------------------- #
 def test_status_service_account_wins_over_stored_session(
     clean_pipefy_env, saved_cwd, monkeypatch, runner, fake_keyring
@@ -312,9 +312,11 @@ def test_status_service_account_wins_over_stored_session(
     monkeypatch.setenv(
         "PIPEFY_INTERNAL_API_URL", "https://api.example.com/internal_api"
     )
-    monkeypatch.setenv("PIPEFY_OAUTH_URL", "https://auth.example.com/oauth/token")
-    monkeypatch.setenv("PIPEFY_OAUTH_CLIENT", "cid")
-    monkeypatch.setenv("PIPEFY_OAUTH_SECRET", "csecret")
+    monkeypatch.setenv(
+        "PIPEFY_SERVICE_ACCOUNT_URL", "https://auth.example.com/oauth/token"
+    )
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", "cid")
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET", "csecret")
     client = _mock_client_with_me()
     with _patch_command_client(client):
         result = _invoke_status(runner, ["--json"])
@@ -326,7 +328,7 @@ def test_status_service_account_wins_over_stored_session(
     assert "stored-session" in payload["detected_sources"]
     assert payload["issuer"] is None
     assert payload["state"] == "n/a"
-    assert payload["masking_env_vars"] == ["PIPEFY_OAUTH_*"]
+    assert payload["masking_env_vars"] == ["PIPEFY_SERVICE_ACCOUNT_*"]
 
 
 # --------------------------------------------------------------------------- #
@@ -398,9 +400,11 @@ def test_status_service_account_only(
     monkeypatch.setenv(
         "PIPEFY_INTERNAL_API_URL", "https://api.example.com/internal_api"
     )
-    monkeypatch.setenv("PIPEFY_OAUTH_URL", "https://auth.example.com/oauth/token")
-    monkeypatch.setenv("PIPEFY_OAUTH_CLIENT", "cid")
-    monkeypatch.setenv("PIPEFY_OAUTH_SECRET", "csecret")
+    monkeypatch.setenv(
+        "PIPEFY_SERVICE_ACCOUNT_URL", "https://auth.example.com/oauth/token"
+    )
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", "cid")
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET", "csecret")
     client = _mock_client_with_me()
     with _patch_command_client(client):
         result = _invoke_status(runner, ["--json"])
@@ -437,4 +441,4 @@ def test_status_none_text_mentions_onboarding(
     assert "Not signed in" in result.stdout
     assert "pipefy auth login" in result.stdout
     assert "PIPEFY_TOKEN" in result.stdout
-    assert "PIPEFY_OAUTH_*" in result.stdout
+    assert "PIPEFY_SERVICE_ACCOUNT_*" in result.stdout

--- a/packages/cli/tests/test_card_get.py
+++ b/packages/cli/tests/test_card_get.py
@@ -37,11 +37,11 @@ def test_card_get_json_stdout(runner, clean_pipefy_env, saved_cwd, monkeypatch):
         "https://cli-card-json.example.com/internal_api",
     )
     monkeypatch.setenv(
-        "PIPEFY_OAUTH_URL",
+        "PIPEFY_SERVICE_ACCOUNT_URL",
         "https://cli-card-json.example.com/oauth/token",
     )
-    monkeypatch.setenv("PIPEFY_OAUTH_CLIENT", "cid")
-    monkeypatch.setenv("PIPEFY_OAUTH_SECRET", "sec")
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", "cid")
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET", "sec")
 
     payload = {"id": "501", "title": "Unit card"}
     patcher, mock_client = _patch_get_client(payload)
@@ -66,11 +66,11 @@ def test_card_get_rich_stdout(runner, clean_pipefy_env, saved_cwd, monkeypatch):
         "https://cli-card-rich.example.com/internal_api",
     )
     monkeypatch.setenv(
-        "PIPEFY_OAUTH_URL",
+        "PIPEFY_SERVICE_ACCOUNT_URL",
         "https://cli-card-rich.example.com/oauth/token",
     )
-    monkeypatch.setenv("PIPEFY_OAUTH_CLIENT", "cid")
-    monkeypatch.setenv("PIPEFY_OAUTH_SECRET", "sec")
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", "cid")
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET", "sec")
 
     payload = {"id": "502", "title": "Rich card"}
     patcher, _mock_client = _patch_get_client(payload)
@@ -93,11 +93,11 @@ def test_card_get_sdk_error_stderr_exit_1(
         "https://cli-card-err.example.com/internal_api",
     )
     monkeypatch.setenv(
-        "PIPEFY_OAUTH_URL",
+        "PIPEFY_SERVICE_ACCOUNT_URL",
         "https://cli-card-err.example.com/oauth/token",
     )
-    monkeypatch.setenv("PIPEFY_OAUTH_CLIENT", "cid")
-    monkeypatch.setenv("PIPEFY_OAUTH_SECRET", "sec")
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", "cid")
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET", "sec")
 
     mock_client = MagicMock()
     mock_client.get_card = AsyncMock(side_effect=PipefyAPIError("GraphQL failure"))
@@ -122,11 +122,11 @@ def test_card_get_permission_denied_hint_on_stderr(
         "https://cli-card-pd.example.com/internal_api",
     )
     monkeypatch.setenv(
-        "PIPEFY_OAUTH_URL",
+        "PIPEFY_SERVICE_ACCOUNT_URL",
         "https://cli-card-pd.example.com/oauth/token",
     )
-    monkeypatch.setenv("PIPEFY_OAUTH_CLIENT", "cid")
-    monkeypatch.setenv("PIPEFY_OAUTH_SECRET", "sec")
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", "cid")
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET", "sec")
 
     exc = TransportQueryError(
         "unused",
@@ -148,9 +148,14 @@ def test_card_get_permission_denied_hint_on_stderr(
 def _apply_settings_to_env(monkeypatch: pytest.MonkeyPatch, s: PipefySettings) -> None:
     monkeypatch.setenv("PIPEFY_GRAPHQL_URL", str(s.graphql_url))
     monkeypatch.setenv("PIPEFY_INTERNAL_API_URL", str(s.internal_api_url))
-    monkeypatch.setenv("PIPEFY_OAUTH_URL", str(s.oauth_url))
-    monkeypatch.setenv("PIPEFY_OAUTH_CLIENT", str(s.oauth_client))
-    monkeypatch.setenv("PIPEFY_OAUTH_SECRET", str(s.oauth_secret))
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_URL", str(s.service_account_url))
+    monkeypatch.setenv(
+        "PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", str(s.service_account_client_id)
+    )
+    monkeypatch.setenv(
+        "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET",
+        str(s.service_account_client_secret),
+    )
     if s.allow_insecure_urls:
         monkeypatch.setenv("PIPEFY_ALLOW_INSECURE_URLS", "true")
 

--- a/packages/cli/tests/test_cli_tasks_10_11.py
+++ b/packages/cli/tests/test_cli_tasks_10_11.py
@@ -493,11 +493,11 @@ def test_agent_toggle_inactive_yes_skips_confirm(
     )
 
 
-def test_ai_automation_create_requires_oauth(
+def test_ai_automation_create_requires_service_account(
     runner: CliRunner, clean_pipefy_env, saved_cwd, oauth_env
 ):
-    """``ai-automation create`` exits 2 with a clear message when OAuth is not configured."""
-    oauth_env("ai-no-oauth")
+    """``ai-automation create`` exits 2 with a clear message when service-account creds are not configured."""
+    oauth_env("ai-no-service-account")
     mock_client = MagicMock()
     mock_client.ai_automation_available = False
 
@@ -525,7 +525,7 @@ def test_ai_automation_create_requires_oauth(
         )
 
     assert r.exit_code == 2
-    assert "OAuth" in r.stderr
+    assert "service-account credentials" in r.stderr
     mock_client.create_ai_automation.assert_not_called()
 
 

--- a/packages/cli/tests/test_config.py
+++ b/packages/cli/tests/test_config.py
@@ -28,9 +28,11 @@ def test_env_only_resolution(
         "PIPEFY_INTERNAL_API_URL",
         "https://env-only.example.com/internal_api",
     )
-    monkeypatch.setenv("PIPEFY_OAUTH_URL", "https://env-only.example.com/oauth/token")
-    monkeypatch.setenv("PIPEFY_OAUTH_CLIENT", "env-client")
-    monkeypatch.setenv("PIPEFY_OAUTH_SECRET", "env-secret")
+    monkeypatch.setenv(
+        "PIPEFY_SERVICE_ACCOUNT_URL", "https://env-only.example.com/oauth/token"
+    )
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", "env-client")
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET", "env-secret")
 
     resolved = resolve_cli_settings(
         graphql_url_flag=None,
@@ -39,9 +41,9 @@ def test_env_only_resolution(
 
     assert resolved.graphql_url == "https://env-only.example.com/graphql"
     assert resolved.internal_api_url == "https://env-only.example.com/internal_api"
-    assert resolved.oauth_url == "https://env-only.example.com/oauth/token"
-    assert resolved.oauth_client == "env-client"
-    assert resolved.oauth_secret == "env-secret"
+    assert resolved.service_account_url == "https://env-only.example.com/oauth/token"
+    assert resolved.service_account_client_id == "env-client"
+    assert resolved.service_account_client_secret == "env-secret"
 
 
 def test_dotenv_only_resolution(
@@ -55,9 +57,9 @@ def test_dotenv_only_resolution(
             """\
             PIPEFY_GRAPHQL_URL=https://dotenv.example.com/graphql
             PIPEFY_INTERNAL_API_URL=https://dotenv.example.com/internal_api
-            PIPEFY_OAUTH_URL=https://dotenv.example.com/oauth/token
-            PIPEFY_OAUTH_CLIENT=dotenv-client
-            PIPEFY_OAUTH_SECRET=dotenv-secret
+            PIPEFY_SERVICE_ACCOUNT_URL=https://dotenv.example.com/oauth/token
+            PIPEFY_SERVICE_ACCOUNT_CLIENT_ID=dotenv-client
+            PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET=dotenv-secret
             """
         ),
         encoding="utf-8",
@@ -69,7 +71,7 @@ def test_dotenv_only_resolution(
     ).pipefy
 
     assert resolved.graphql_url == "https://dotenv.example.com/graphql"
-    assert resolved.oauth_client == "dotenv-client"
+    assert resolved.service_account_client_id == "dotenv-client"
 
 
 def test_process_env_overrides_dotenv(
@@ -166,8 +168,8 @@ def test_user_toml_fallback_lowest_precedence(
             """\
             [pipefy]
             graphql_url = "https://from-toml.example.com/graphql"
-            oauth_client = "toml-client"
-            oauth_secret = "toml-secret"
+            service_account_client_id = "toml-client"
+            service_account_client_secret = "toml-secret"
             """
         ),
         encoding="utf-8",
@@ -180,7 +182,7 @@ def test_user_toml_fallback_lowest_precedence(
     ).pipefy
 
     assert resolved.graphql_url == "https://from-toml.example.com/graphql"
-    assert resolved.oauth_client == "toml-client"
+    assert resolved.service_account_client_id == "toml-client"
 
 
 def test_env_overrides_user_toml(
@@ -194,8 +196,8 @@ def test_env_overrides_user_toml(
             """\
             [pipefy]
             graphql_url = "https://from-toml.example.com/graphql"
-            oauth_client = "toml-client"
-            oauth_secret = "toml-secret"
+            service_account_client_id = "toml-client"
+            service_account_client_secret = "toml-secret"
             """
         ),
         encoding="utf-8",
@@ -227,18 +229,18 @@ def test_apply_toml_fills_only_missing_fields(
             """\
             [pipefy]
             graphql_url = "https://toml-only.example.com/graphql"
-            oauth_client = "toml-client"
+            service_account_client_id = "toml-client"
             """
         ),
         encoding="utf-8",
     )
     monkeypatch.setattr(config_module, "USER_CONFIG_PATH", cfg_path)
 
-    base = PipefySettings(oauth_client="from-env")
+    base = PipefySettings(service_account_client_id="from-env")
     merged = apply_toml_fallback(base)
 
     assert merged.graphql_url == "https://toml-only.example.com/graphql"
-    assert merged.oauth_client == "from-env"
+    assert merged.service_account_client_id == "from-env"
 
 
 def test_graphql_url_flag_localhost_rejected_without_insecure(

--- a/packages/cli/tests/test_config_back_compat.py
+++ b/packages/cli/tests/test_config_back_compat.py
@@ -1,0 +1,202 @@
+"""Back-compat coverage for the env- and TOML-key rename in #127.
+
+End-to-end: `PIPEFY_OAUTH_*` shell/.env vars and ``oauth_*`` TOML keys still
+populate the new ``service_account_*`` fields, both emit one-shot stderr
+deprecation warnings, and new keys win when both names are present.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+from pipefy_sdk.settings import _reset_legacy_oauth_warning_state
+
+from pipefy_cli import config as config_module
+from pipefy_cli.config import (
+    _reset_legacy_toml_warning_state,
+    resolve_cli_settings,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_warning_dedup() -> None:
+    _reset_legacy_oauth_warning_state()
+    _reset_legacy_toml_warning_state()
+    yield
+    _reset_legacy_oauth_warning_state()
+    _reset_legacy_toml_warning_state()
+
+
+def test_legacy_env_vars_still_populate_new_fields(
+    clean_pipefy_env,
+    saved_cwd,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("PIPEFY_GRAPHQL_URL", "https://app.example.com/graphql")
+    monkeypatch.setenv("PIPEFY_OAUTH_URL", "https://legacy.example.com/oauth/token")
+    monkeypatch.setenv("PIPEFY_OAUTH_CLIENT", "legacy-client")
+    monkeypatch.setenv("PIPEFY_OAUTH_SECRET", "legacy-secret")
+
+    resolved = resolve_cli_settings(
+        graphql_url_flag=None,
+        allow_insecure_urls_flag=None,
+    ).pipefy
+
+    assert resolved.service_account_url == "https://legacy.example.com/oauth/token"
+    assert resolved.service_account_client_id == "legacy-client"
+    assert resolved.service_account_client_secret == "legacy-secret"
+
+
+def test_new_env_var_wins_when_both_legacy_and_new_set(
+    clean_pipefy_env,
+    saved_cwd,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("PIPEFY_GRAPHQL_URL", "https://app.example.com/graphql")
+    monkeypatch.setenv("PIPEFY_OAUTH_URL", "https://legacy.example.com/oauth/token")
+    monkeypatch.setenv(
+        "PIPEFY_SERVICE_ACCOUNT_URL", "https://new.example.com/oauth/token"
+    )
+
+    resolved = resolve_cli_settings(
+        graphql_url_flag=None,
+        allow_insecure_urls_flag=None,
+    ).pipefy
+
+    assert resolved.service_account_url == "https://new.example.com/oauth/token"
+
+
+def test_legacy_env_var_emits_stderr_warning_with_new_name(
+    clean_pipefy_env,
+    saved_cwd,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    monkeypatch.setenv("PIPEFY_GRAPHQL_URL", "https://app.example.com/graphql")
+    monkeypatch.setenv("PIPEFY_OAUTH_CLIENT", "legacy-client")
+
+    resolve_cli_settings(
+        graphql_url_flag=None,
+        allow_insecure_urls_flag=None,
+    )
+
+    err = capsys.readouterr().err
+    assert "PIPEFY_OAUTH_CLIENT is deprecated" in err
+    assert "rename to PIPEFY_SERVICE_ACCOUNT_CLIENT_ID" in err
+
+
+def test_legacy_toml_keys_still_populate_new_fields(
+    clean_pipefy_env,
+    saved_cwd,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    cfg_path = saved_cwd / "config.toml"
+    cfg_path.write_text(
+        textwrap.dedent(
+            """\
+            [pipefy]
+            graphql_url = "https://app.example.com/graphql"
+            oauth_url = "https://legacy-toml.example.com/oauth/token"
+            oauth_client = "legacy-toml-client"
+            oauth_secret = "legacy-toml-secret"
+            """
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(config_module, "USER_CONFIG_PATH", cfg_path)
+
+    resolved = resolve_cli_settings(
+        graphql_url_flag=None,
+        allow_insecure_urls_flag=None,
+    ).pipefy
+
+    assert resolved.service_account_url == "https://legacy-toml.example.com/oauth/token"
+    assert resolved.service_account_client_id == "legacy-toml-client"
+    assert resolved.service_account_client_secret == "legacy-toml-secret"
+
+
+def test_toml_new_key_wins_when_both_legacy_and_new_present(
+    clean_pipefy_env,
+    saved_cwd,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    cfg_path = saved_cwd / "config.toml"
+    cfg_path.write_text(
+        textwrap.dedent(
+            """\
+            [pipefy]
+            graphql_url = "https://app.example.com/graphql"
+            oauth_url = "https://legacy-toml.example.com/oauth/token"
+            service_account_url = "https://new-toml.example.com/oauth/token"
+            """
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(config_module, "USER_CONFIG_PATH", cfg_path)
+
+    resolved = resolve_cli_settings(
+        graphql_url_flag=None,
+        allow_insecure_urls_flag=None,
+    ).pipefy
+
+    assert resolved.service_account_url == "https://new-toml.example.com/oauth/token"
+
+
+def test_legacy_toml_key_emits_stderr_warning_with_new_name(
+    clean_pipefy_env,
+    saved_cwd,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    cfg_path = saved_cwd / "config.toml"
+    cfg_path.write_text(
+        textwrap.dedent(
+            """\
+            [pipefy]
+            graphql_url = "https://app.example.com/graphql"
+            oauth_secret = "legacy-toml-secret"
+            """
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(config_module, "USER_CONFIG_PATH", cfg_path)
+
+    resolve_cli_settings(
+        graphql_url_flag=None,
+        allow_insecure_urls_flag=None,
+    )
+
+    err = capsys.readouterr().err
+    assert "'oauth_secret'" in err
+    assert "is deprecated" in err
+    assert "'service_account_client_secret'" in err
+
+
+def test_toml_warning_dedups_across_repeated_loads(
+    clean_pipefy_env,
+    saved_cwd,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    cfg_path = saved_cwd / "config.toml"
+    cfg_path.write_text(
+        textwrap.dedent(
+            """\
+            [pipefy]
+            graphql_url = "https://app.example.com/graphql"
+            oauth_url = "https://legacy-toml.example.com/oauth/token"
+            """
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(config_module, "USER_CONFIG_PATH", cfg_path)
+
+    for _ in range(3):
+        resolve_cli_settings(
+            graphql_url_flag=None,
+            allow_insecure_urls_flag=None,
+        )
+
+    err = capsys.readouterr().err
+    assert err.count("'oauth_url' in") == 1

--- a/packages/cli/tests/test_org_commands.py
+++ b/packages/cli/tests/test_org_commands.py
@@ -20,11 +20,11 @@ def test_org_get_uses_pipefy_org_id_when_argument_omitted(
         "https://cli-org-env.example.com/internal_api",
     )
     monkeypatch.setenv(
-        "PIPEFY_OAUTH_URL",
+        "PIPEFY_SERVICE_ACCOUNT_URL",
         "https://cli-org-env.example.com/oauth/token",
     )
-    monkeypatch.setenv("PIPEFY_OAUTH_CLIENT", "cid")
-    monkeypatch.setenv("PIPEFY_OAUTH_SECRET", "sec")
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", "cid")
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET", "sec")
     monkeypatch.setenv("PIPEFY_ORG_ID", "302398434")
 
     payload = {"id": "302398434", "name": "Test Org"}
@@ -53,11 +53,11 @@ def test_org_get_positional_overrides_pipefy_org_id(
         "https://cli-org-pos.example.com/internal_api",
     )
     monkeypatch.setenv(
-        "PIPEFY_OAUTH_URL",
+        "PIPEFY_SERVICE_ACCOUNT_URL",
         "https://cli-org-pos.example.com/oauth/token",
     )
-    monkeypatch.setenv("PIPEFY_OAUTH_CLIENT", "cid")
-    monkeypatch.setenv("PIPEFY_OAUTH_SECRET", "sec")
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", "cid")
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET", "sec")
     monkeypatch.setenv("PIPEFY_ORG_ID", "111")
 
     payload = {"id": "222", "name": "Other Org"}
@@ -85,11 +85,11 @@ def test_org_get_missing_id_and_env_exits_2(
         "https://cli-org-miss.example.com/internal_api",
     )
     monkeypatch.setenv(
-        "PIPEFY_OAUTH_URL",
+        "PIPEFY_SERVICE_ACCOUNT_URL",
         "https://cli-org-miss.example.com/oauth/token",
     )
-    monkeypatch.setenv("PIPEFY_OAUTH_CLIENT", "cid")
-    monkeypatch.setenv("PIPEFY_OAUTH_SECRET", "sec")
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", "cid")
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET", "sec")
 
     result = runner.invoke(app, ["org", "get", "--json"])
     assert result.exit_code == 2

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -15,10 +15,10 @@ uvx --from git+https://github.com/<owner>/pipefy-labs --refresh pipefy-mcp-serve
 Set the following environment variables (or add to a `.env` file in your working directory):
 
 ```env
-PIPEFY_OAUTH_CLIENT=your_client_id
-PIPEFY_OAUTH_SECRET=your_client_secret
+PIPEFY_SERVICE_ACCOUNT_CLIENT_ID=your_client_id
+PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET=your_client_secret
 PIPEFY_GRAPHQL_URL=https://app.pipefy.com/graphql
-PIPEFY_OAUTH_URL=https://app.pipefy.com/oauth/token
+PIPEFY_SERVICE_ACCOUNT_URL=https://app.pipefy.com/oauth/token
 PIPEFY_INTERNAL_API_URL=https://app.pipefy.com/internal_api
 ```
 

--- a/packages/mcp/src/pipefy_mcp/core/container.py
+++ b/packages/mcp/src/pipefy_mcp/core/container.py
@@ -28,16 +28,20 @@ class ServicesContainer:
         """
         self.pipefy_client = PipefyClient(settings=settings.pipefy)
 
-        oauth_url = settings.pipefy.oauth_url
-        oauth_client = settings.pipefy.oauth_client
-        oauth_secret = settings.pipefy.oauth_secret
+        service_account_url = settings.pipefy.service_account_url
+        service_account_client_id = settings.pipefy.service_account_client_id
+        service_account_client_secret = settings.pipefy.service_account_client_secret
 
-        if oauth_url and oauth_client and oauth_secret:
+        if (
+            service_account_url
+            and service_account_client_id
+            and service_account_client_secret
+        ):
             internal_client = InternalApiClient(
                 url=settings.pipefy.internal_api_url,
-                oauth_url=oauth_url,
-                oauth_client=oauth_client,
-                oauth_secret=oauth_secret,
+                service_account_url=service_account_url,
+                service_account_client_id=service_account_client_id,
+                service_account_client_secret=service_account_client_secret,
                 allow_insecure_urls=settings.pipefy.allow_insecure_urls,
             )
             self.pipefy_client.set_internal_api_client(internal_client)

--- a/packages/mcp/src/pipefy_mcp/tools/ai_automation_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/ai_automation_tools.py
@@ -50,8 +50,9 @@ AI_AUTOMATION_UPDATE_FAILED = (
 )
 
 AI_AUTOMATION_NOT_CONFIGURED = (
-    "AI Automation requires OAuth credentials "
-    "(PIPEFY_OAUTH_CLIENT, PIPEFY_OAUTH_SECRET, PIPEFY_OAUTH_URL). "
+    "AI Automation requires service-account credentials "
+    "(PIPEFY_SERVICE_ACCOUNT_URL, PIPEFY_SERVICE_ACCOUNT_CLIENT_ID, "
+    "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET). "
     "Check .env.example for the required variables."
 )
 

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
@@ -420,15 +420,16 @@ class PipeTools:
             confirm: bool = False,
             debug: bool = False,
         ) -> dict:
-            """Remove a link between two related cards (requires OAuth credentials).
+            """Remove a link between two related cards (requires service-account credentials).
 
             ``source_id`` is the **pipe relation** id from ``get_pipe_relations`` (same as
             ``create_card_relation``). Two-step flow: preview with ``confirm=False`` (default),
             then execute with ``confirm=True`` after explicit approval.
 
-            Requires OAuth credentials (PIPEFY_OAUTH_CLIENT, PIPEFY_OAUTH_SECRET,
-            PIPEFY_OAUTH_URL) because the ``deleteCardRelation`` mutation is only available
-            on the internal API, not the public GraphQL schema.
+            Requires service-account credentials (PIPEFY_SERVICE_ACCOUNT_URL,
+            PIPEFY_SERVICE_ACCOUNT_CLIENT_ID, PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET) because the
+            ``deleteCardRelation`` mutation is only available on the internal API, not the
+            public GraphQL schema.
 
             Args:
                 child_id: Child card ID in the relation.
@@ -448,8 +449,9 @@ class PipeTools:
             if not client.internal_api_available:
                 return build_relation_error_payload(
                     message=(
-                        "delete_card_relation requires OAuth credentials "
-                        "(PIPEFY_OAUTH_CLIENT, PIPEFY_OAUTH_SECRET, PIPEFY_OAUTH_URL). "
+                        "delete_card_relation requires service-account credentials "
+                        "(PIPEFY_SERVICE_ACCOUNT_URL, PIPEFY_SERVICE_ACCOUNT_CLIENT_ID, "
+                        "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET). "
                         "The deleteCardRelation mutation is only available on the "
                         "internal API. Check .env.example for the required variables."
                     ),

--- a/packages/mcp/tests/core/test_container.py
+++ b/packages/mcp/tests/core/test_container.py
@@ -58,9 +58,9 @@ class TestServicesContainer:
         settings = Settings(
             pipefy=PipefySettings(
                 graphql_url="https://api.pipefy.com/graphql",
-                oauth_url="https://auth.pipefy.com/oauth/token",
-                oauth_client="client_id",
-                oauth_secret="client_secret",
+                service_account_url="https://auth.pipefy.com/oauth/token",
+                service_account_client_id="client_id",
+                service_account_client_secret="client_secret",
             )
         )
 
@@ -86,9 +86,9 @@ class TestServicesContainer:
         settings = Settings(
             pipefy=PipefySettings(
                 graphql_url="https://api.pipefy.com/graphql",
-                oauth_url="https://auth.pipefy.com/oauth/token",
-                oauth_client="client_id",
-                oauth_secret="client_secret",
+                service_account_url="https://auth.pipefy.com/oauth/token",
+                service_account_client_id="client_id",
+                service_account_client_secret="client_secret",
             )
         )
 

--- a/packages/mcp/tests/test_server.py
+++ b/packages/mcp/tests/test_server.py
@@ -26,9 +26,9 @@ def client_session():
 _MINIMAL_PIPEFY_SETTINGS = Settings(
     pipefy=PipefySettings(
         graphql_url="https://api.pipefy.com/graphql",
-        oauth_url="https://api.pipefy.com/oauth/token",
-        oauth_client="test-client",
-        oauth_secret="test-secret",
+        service_account_url="https://api.pipefy.com/oauth/token",
+        service_account_client_id="test-client",
+        service_account_client_secret="test-secret",
     )
 )
 

--- a/packages/mcp/tests/test_settings.py
+++ b/packages/mcp/tests/test_settings.py
@@ -52,7 +52,7 @@ def test_pipefy_settings_rejects_http_graphql_when_secure():
     with pytest.raises(ValueError, match="graphql_url.*HTTPS"):
         PipefySettings(
             graphql_url="http://app.pipefy.com/graphql",
-            oauth_url="https://auth.pipefy.com/oauth/token",
+            service_account_url="https://auth.pipefy.com/oauth/token",
             internal_api_url="https://app.pipefy.com/internal_api",
         )
 
@@ -62,7 +62,7 @@ def test_pipefy_settings_rejects_loopback_graphql():
     with pytest.raises(ValueError, match="graphql_url.*localhost|127"):
         PipefySettings(
             graphql_url="https://127.0.0.1/graphql",
-            oauth_url="https://auth.pipefy.com/oauth/token",
+            service_account_url="https://auth.pipefy.com/oauth/token",
             internal_api_url="https://app.pipefy.com/internal_api",
         )
 
@@ -72,7 +72,7 @@ def test_pipefy_settings_allow_insecure_urls_permits_http_localhost():
     s = PipefySettings(
         allow_insecure_urls=True,
         graphql_url="http://localhost/graphql",
-        oauth_url="http://localhost/oauth/token",
+        service_account_url="http://localhost/oauth/token",
         internal_api_url="http://localhost/internal_api",
     )
     assert s.graphql_url == "http://localhost/graphql"

--- a/packages/mcp/tests/tools/test_ai_automation_tools.py
+++ b/packages/mcp/tests/tools/test_ai_automation_tools.py
@@ -936,7 +936,7 @@ class TestAiAutomationNotConfigured:
         assert result.isError is False
         payload = extract_payload(result)
         assert payload["success"] is False
-        assert "OAuth" in tool_error_message(payload)
+        assert "service-account credentials" in tool_error_message(payload)
 
     async def test_update_returns_error_payload_when_not_configured(
         self,
@@ -951,7 +951,7 @@ class TestAiAutomationNotConfigured:
         assert result.isError is False
         payload = extract_payload(result)
         assert payload["success"] is False
-        assert "OAuth" in tool_error_message(payload)
+        assert "service-account credentials" in tool_error_message(payload)
 
     async def test_delete_works_without_oauth_config(
         self,

--- a/packages/mcp/tests/tools/test_pipe_tools.py
+++ b/packages/mcp/tests/tools/test_pipe_tools.py
@@ -2316,13 +2316,13 @@ class TestDeleteCardRelation:
         assert "did not succeed" in tool_error_message(payload).lower()
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
-    async def test_not_configured_returns_oauth_message(
+    async def test_not_configured_returns_service_account_message(
         self,
         client_session,
         mock_pipefy_client,
         extract_payload,
     ) -> None:
-        """delete_card_relation requires internal API (OAuth) credentials."""
+        """delete_card_relation requires internal API (service-account) credentials."""
         mock_pipefy_client.internal_api_available = False
         async with client_session as session:
             result = await session.call_tool(
@@ -2338,7 +2338,7 @@ class TestDeleteCardRelation:
         mock_pipefy_client.delete_card_relation.assert_not_called()
         payload = extract_payload(result)
         assert payload["success"] is False
-        assert "OAuth" in tool_error_message(payload)
+        assert "service-account credentials" in tool_error_message(payload)
 
 
 @pytest.mark.anyio

--- a/packages/sdk/src/pipefy_sdk/base_client.py
+++ b/packages/sdk/src/pipefy_sdk/base_client.py
@@ -68,17 +68,19 @@ class BasePipefyClient:
             self._fetched_gql_schema_lock = asyncio.Lock()
             return
 
-        if settings.oauth_url is None:
-            raise ValueError("OAuth URL must be provided in settings.")
-        if settings.oauth_client is None:
-            raise ValueError("OAuth client ID must be provided in settings.")
-        if settings.oauth_secret is None:
-            raise ValueError("OAuth client secret must be provided in settings.")
+        if settings.service_account_url is None:
+            raise ValueError("Service-account URL must be provided in settings.")
+        if settings.service_account_client_id is None:
+            raise ValueError("Service-account client ID must be provided in settings.")
+        if settings.service_account_client_secret is None:
+            raise ValueError(
+                "Service-account client secret must be provided in settings."
+            )
 
         self._auth = auth or OAuth2ClientCredentials(
-            token_url=settings.oauth_url,
-            client_id=settings.oauth_client,
-            client_secret=settings.oauth_secret,
+            token_url=settings.service_account_url,
+            client_id=settings.service_account_client_id,
+            client_secret=settings.service_account_client_secret,
         )
         # Populated when gql_reuse_fetched_graphql_schema is True; avoids repeating
         # introspection on every new Client (see Cons5 code review).

--- a/packages/sdk/src/pipefy_sdk/client.py
+++ b/packages/sdk/src/pipefy_sdk/client.py
@@ -96,9 +96,9 @@ class PipefyClient:
             auth: Auth = StaticBearerAuth(bearer_token)
         else:
             auth = OAuth2ClientCredentials(
-                token_url=settings.oauth_url,
-                client_id=settings.oauth_client,
-                client_secret=settings.oauth_secret,
+                token_url=settings.service_account_url,
+                client_id=settings.service_account_client_id,
+                client_secret=settings.service_account_client_secret,
             )
         self._pipe_service = PipeService(settings=settings, auth=auth)
         self._card_service = CardService(settings=settings, auth=auth)

--- a/packages/sdk/src/pipefy_sdk/services/internal_api_client.py
+++ b/packages/sdk/src/pipefy_sdk/services/internal_api_client.py
@@ -25,9 +25,9 @@ class InternalApiClient:
     def __init__(
         self,
         url: str,
-        oauth_url: str,
-        oauth_client: str,
-        oauth_secret: str,
+        service_account_url: str,
+        service_account_client_id: str,
+        service_account_client_secret: str,
         *,
         allow_insecure_urls: bool = False,
     ) -> None:
@@ -35,22 +35,24 @@ class InternalApiClient:
 
         Args:
             url: URL of the internal_api endpoint (e.g. https://app.pipefy.com/internal_api).
-            oauth_url: OAuth token URL.
-            oauth_client: OAuth client ID.
-            oauth_secret: OAuth client secret.
+            service_account_url: Service-account token endpoint URL.
+            service_account_client_id: Service-account OAuth client_id.
+            service_account_client_secret: Service-account OAuth client_secret.
             allow_insecure_urls: When True, allow http and internal hosts (must match settings).
         """
         validate_https_service_endpoint_url(
             url.strip(), "internal_api URL", allow_insecure=allow_insecure_urls
         )
         validate_https_service_endpoint_url(
-            oauth_url.strip(), "OAuth URL", allow_insecure=allow_insecure_urls
+            service_account_url.strip(),
+            "service-account URL",
+            allow_insecure=allow_insecure_urls,
         )
         self._url = url
         self._auth = OAuth2ClientCredentials(
-            token_url=oauth_url,
-            client_id=oauth_client,
-            client_secret=oauth_secret,
+            token_url=service_account_url,
+            client_id=service_account_client_id,
+            client_secret=service_account_client_secret,
         )
 
     async def execute_query(self, query: str, variables: dict[str, Any]) -> dict:

--- a/packages/sdk/src/pipefy_sdk/settings.py
+++ b/packages/sdk/src/pipefy_sdk/settings.py
@@ -1,9 +1,42 @@
 from __future__ import annotations
 
+import os
+import sys
 from typing import Annotated, Self
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import AliasChoices, BaseModel, Field, field_validator, model_validator
 from pydantic_settings import NoDecode
+
+_LEGACY_ENV_KEYS_TO_NEW: dict[str, str] = {
+    "PIPEFY_OAUTH_URL": "PIPEFY_SERVICE_ACCOUNT_URL",
+    "PIPEFY_OAUTH_CLIENT": "PIPEFY_SERVICE_ACCOUNT_CLIENT_ID",
+    "PIPEFY_OAUTH_SECRET": "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET",
+}
+
+_warned_legacy_env_keys: set[str] = set()
+
+
+def _warn_once_for_legacy_oauth_env_keys() -> None:
+    """Print a one-shot stderr deprecation warning for each ``PIPEFY_OAUTH_*`` env var still set.
+
+    Pydantic accepts the legacy names via ``AliasChoices`` so old configs keep working;
+    this nudge tells users to rename. Dedup state is process-global; tests reset via
+    :func:`_reset_legacy_oauth_warning_state`.
+    """
+    for legacy, new in _LEGACY_ENV_KEYS_TO_NEW.items():
+        if legacy in _warned_legacy_env_keys:
+            continue
+        if legacy in os.environ:
+            sys.stderr.write(
+                f"warning: {legacy} is deprecated; rename to {new}. "
+                "The legacy name will be removed in a future beta.\n"
+            )
+            _warned_legacy_env_keys.add(legacy)
+
+
+def _reset_legacy_oauth_warning_state() -> None:
+    """Test helper: clear the one-shot dedup so a fixture can re-trigger the warning."""
+    _warned_legacy_env_keys.clear()
 
 
 class PipefySettings(BaseModel):
@@ -27,19 +60,31 @@ class PipefySettings(BaseModel):
         description="Internal API URL for AI Automation endpoints",
     )
 
-    oauth_url: str | None = Field(
+    service_account_url: str | None = Field(
         default=None,
-        description="OAuth URL for Pipefy",
+        validation_alias=AliasChoices("service_account_url", "oauth_url"),
+        description=(
+            "Service-account token endpoint (OAuth 2.0 client-credentials grant) "
+            "(env: PIPEFY_SERVICE_ACCOUNT_URL; legacy PIPEFY_OAUTH_URL still honored)."
+        ),
     )
 
-    oauth_client: str | None = Field(
+    service_account_client_id: str | None = Field(
         default=None,
-        description="OAuth client ID for Pipefy",
+        validation_alias=AliasChoices("service_account_client_id", "oauth_client"),
+        description=(
+            "Service-account OAuth client_id "
+            "(env: PIPEFY_SERVICE_ACCOUNT_CLIENT_ID; legacy PIPEFY_OAUTH_CLIENT still honored)."
+        ),
     )
 
-    oauth_secret: str | None = Field(
+    service_account_client_secret: str | None = Field(
         default=None,
-        description="OAuth client secret for Pipefy",
+        validation_alias=AliasChoices("service_account_client_secret", "oauth_secret"),
+        description=(
+            "Service-account OAuth client_secret "
+            "(env: PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET; legacy PIPEFY_OAUTH_SECRET still honored)."
+        ),
     )
 
     org_id: str | None = Field(
@@ -113,6 +158,13 @@ class PipefySettings(BaseModel):
         msg = "service_account_ids must be a list or a comma-separated string"
         raise ValueError(msg)
 
+    @model_validator(mode="before")
+    @classmethod
+    def _emit_legacy_oauth_env_var_warning(cls, data: object) -> object:
+        # Runs before field validation so the nudge surfaces even if SSRF/URL checks fail.
+        _warn_once_for_legacy_oauth_env_keys()
+        return data
+
     @model_validator(mode="after")
     def _validate_pipefy_endpoint_urls(self) -> Self:
         # Deferred import: ``url_ssrf`` validates URLs that may reference settings types (cycle if top-level).
@@ -121,8 +173,12 @@ class PipefySettings(BaseModel):
         allow = self.allow_insecure_urls
         if self.graphql_url is not None and (u := self.graphql_url.strip()):
             validate_https_service_endpoint_url(u, "graphql_url", allow_insecure=allow)
-        if self.oauth_url is not None and (u := self.oauth_url.strip()):
-            validate_https_service_endpoint_url(u, "oauth_url", allow_insecure=allow)
+        if self.service_account_url is not None and (
+            u := self.service_account_url.strip()
+        ):
+            validate_https_service_endpoint_url(
+                u, "service_account_url", allow_insecure=allow
+            )
         if u := self.internal_api_url.strip():
             validate_https_service_endpoint_url(
                 u, "internal_api_url", allow_insecure=allow

--- a/packages/sdk/src/pipefy_sdk/settings.py
+++ b/packages/sdk/src/pipefy_sdk/settings.py
@@ -23,6 +23,8 @@ def _warn_once_for_legacy_oauth_env_keys() -> None:
     this nudge tells users to rename. Dedup state is process-global; tests reset via
     :func:`_reset_legacy_oauth_warning_state`.
     """
+    if len(_warned_legacy_env_keys) == len(_LEGACY_ENV_KEYS_TO_NEW):
+        return
     for legacy, new in _LEGACY_ENV_KEYS_TO_NEW.items():
         if legacy in _warned_legacy_env_keys:
             continue

--- a/packages/sdk/tests/_shared/live_settings.py
+++ b/packages/sdk/tests/_shared/live_settings.py
@@ -32,15 +32,15 @@ def live_pipefy_settings() -> PipefySettings:
 
 
 def pipefy_live_configured() -> bool:
-    """Return True when all OAuth + GraphQL credentials are present."""
+    """Return True when all service-account + GraphQL credentials are present."""
     p = _resolved_pipefy()
     return bool(
         p.graphql_url
         and str(p.graphql_url).startswith(("http://", "https://"))
-        and p.oauth_url
-        and str(p.oauth_url).startswith(("http://", "https://"))
-        and p.oauth_client
-        and p.oauth_secret
+        and p.service_account_url
+        and str(p.service_account_url).startswith(("http://", "https://"))
+        and p.service_account_client_id
+        and p.service_account_client_secret
     )
 
 
@@ -48,5 +48,6 @@ def require_live_creds() -> None:
     """Skip the current test if live credentials are not configured."""
     if not pipefy_live_configured():
         pytest.skip(
-            "Pipefy credentials not configured (PIPEFY_GRAPHQL_URL + OAuth in .env)"
+            "Pipefy credentials not configured "
+            "(PIPEFY_GRAPHQL_URL + PIPEFY_SERVICE_ACCOUNT_* in .env)"
         )

--- a/packages/sdk/tests/services/test_attachment_service.py
+++ b/packages/sdk/tests/services/test_attachment_service.py
@@ -17,9 +17,9 @@ from pipefy_sdk.settings import PipefySettings
 def mock_settings():
     return PipefySettings(
         graphql_url="https://api.pipefy.com/graphql",
-        oauth_url="https://auth.pipefy.com/oauth/token",
-        oauth_client="client_id",
-        oauth_secret="client_secret",
+        service_account_url="https://auth.pipefy.com/oauth/token",
+        service_account_client_id="client_id",
+        service_account_client_secret="client_secret",
     )
 
 

--- a/packages/sdk/tests/services/test_card_service.py
+++ b/packages/sdk/tests/services/test_card_service.py
@@ -20,9 +20,9 @@ from pipefy_sdk.settings import PipefySettings
 def mock_settings() -> PipefySettings:
     return PipefySettings(
         graphql_url="https://api.pipefy.com/graphql",
-        oauth_url="https://auth.pipefy.com/oauth/token",
-        oauth_client="client_id",
-        oauth_secret="client_secret",
+        service_account_url="https://auth.pipefy.com/oauth/token",
+        service_account_client_id="client_id",
+        service_account_client_secret="client_secret",
     )
 
 

--- a/packages/sdk/tests/services/test_internal_api_client.py
+++ b/packages/sdk/tests/services/test_internal_api_client.py
@@ -26,7 +26,7 @@ def test_pipefy_settings_internal_api_url_default():
     assert settings.internal_api_url == DEFAULT_INTERNAL_API_URL
 
 
-OAUTH_TOKEN_URL = "https://auth.pipefy.com/oauth/token"
+SERVICE_ACCOUNT_TOKEN_URL = "https://auth.pipefy.com/oauth/token"
 
 
 @pytest.mark.unit
@@ -38,7 +38,7 @@ async def test_execute_query_sends_post_with_correct_headers_and_body(respx_mock
     variables = {"key": "value"}
     expected_json = {"data": {"automation": {"id": "123"}}}
 
-    respx_mock.post(OAUTH_TOKEN_URL).mock(
+    respx_mock.post(SERVICE_ACCOUNT_TOKEN_URL).mock(
         return_value=httpx.Response(
             200,
             json={
@@ -54,9 +54,9 @@ async def test_execute_query_sends_post_with_correct_headers_and_body(respx_mock
 
     client = InternalApiClient(
         url=DEFAULT_INTERNAL_API_URL,
-        oauth_url=OAUTH_TOKEN_URL,
-        oauth_client="client_id",
-        oauth_secret="client_secret",
+        service_account_url=SERVICE_ACCOUNT_TOKEN_URL,
+        service_account_client_id="client_id",
+        service_account_client_secret="client_secret",
     )
     result = await client.execute_query(query_string, variables)
 
@@ -76,7 +76,7 @@ async def test_execute_query_sends_post_with_correct_headers_and_body(respx_mock
 async def test_execute_query_returns_parsed_json_response(respx_mock):
     """Test execute_query returns the parsed JSON response from the API."""
     api_response = {"data": {"automation": {"id": "456"}}}
-    respx_mock.post(OAUTH_TOKEN_URL).mock(
+    respx_mock.post(SERVICE_ACCOUNT_TOKEN_URL).mock(
         return_value=httpx.Response(
             200,
             json={"access_token": "tok", "token_type": "bearer", "expires_in": 3600},
@@ -88,9 +88,9 @@ async def test_execute_query_returns_parsed_json_response(respx_mock):
 
     client = InternalApiClient(
         url=DEFAULT_INTERNAL_API_URL,
-        oauth_url=OAUTH_TOKEN_URL,
-        oauth_client="client_id",
-        oauth_secret="client_secret",
+        service_account_url=SERVICE_ACCOUNT_TOKEN_URL,
+        service_account_client_id="client_id",
+        service_account_client_secret="client_secret",
     )
     result = await client.execute_query("query { x }", {})
 
@@ -102,7 +102,7 @@ async def test_execute_query_returns_parsed_json_response(respx_mock):
 @respx.mock(assert_all_mocked=False, assert_all_called=False)
 async def test_execute_query_raises_on_non_2xx_response(respx_mock):
     """Test execute_query raises when HTTP response is not 2xx."""
-    respx_mock.post(OAUTH_TOKEN_URL).mock(
+    respx_mock.post(SERVICE_ACCOUNT_TOKEN_URL).mock(
         return_value=httpx.Response(
             200,
             json={"access_token": "tok", "token_type": "bearer", "expires_in": 3600},
@@ -114,9 +114,9 @@ async def test_execute_query_raises_on_non_2xx_response(respx_mock):
 
     client = InternalApiClient(
         url=DEFAULT_INTERNAL_API_URL,
-        oauth_url=OAUTH_TOKEN_URL,
-        oauth_client="client_id",
-        oauth_secret="client_secret",
+        service_account_url=SERVICE_ACCOUNT_TOKEN_URL,
+        service_account_client_id="client_id",
+        service_account_client_secret="client_secret",
     )
 
     with pytest.raises(httpx.HTTPStatusError):
@@ -129,7 +129,7 @@ async def test_execute_query_raises_on_non_2xx_response(respx_mock):
 async def test_execute_query_raises_on_graphql_errors_in_body(respx_mock):
     """Test execute_query detects GraphQL errors (HTTP 200 but errors in JSON) and raises."""
     graphql_error_response = {"errors": [{"message": "Something went wrong"}]}
-    respx_mock.post(OAUTH_TOKEN_URL).mock(
+    respx_mock.post(SERVICE_ACCOUNT_TOKEN_URL).mock(
         return_value=httpx.Response(
             200,
             json={"access_token": "tok", "token_type": "bearer", "expires_in": 3600},
@@ -141,9 +141,9 @@ async def test_execute_query_raises_on_graphql_errors_in_body(respx_mock):
 
     client = InternalApiClient(
         url=DEFAULT_INTERNAL_API_URL,
-        oauth_url=OAUTH_TOKEN_URL,
-        oauth_client="client_id",
-        oauth_secret="client_secret",
+        service_account_url=SERVICE_ACCOUNT_TOKEN_URL,
+        service_account_client_id="client_id",
+        service_account_client_secret="client_secret",
     )
 
     with pytest.raises(ValueError, match=r"^Something went wrong$"):
@@ -168,7 +168,7 @@ async def test_execute_query_error_includes_extensions_code_and_correlation_id(
             }
         ]
     }
-    respx_mock.post(OAUTH_TOKEN_URL).mock(
+    respx_mock.post(SERVICE_ACCOUNT_TOKEN_URL).mock(
         return_value=httpx.Response(
             200,
             json={"access_token": "tok", "token_type": "bearer", "expires_in": 3600},
@@ -180,9 +180,9 @@ async def test_execute_query_error_includes_extensions_code_and_correlation_id(
 
     client = InternalApiClient(
         url=DEFAULT_INTERNAL_API_URL,
-        oauth_url=OAUTH_TOKEN_URL,
-        oauth_client="client_id",
-        oauth_secret="client_secret",
+        service_account_url=SERVICE_ACCOUNT_TOKEN_URL,
+        service_account_client_id="client_id",
+        service_account_client_secret="client_secret",
     )
 
     with pytest.raises(
@@ -207,7 +207,7 @@ async def test_execute_query_error_includes_correlation_id_when_code_absent(
             }
         ]
     }
-    respx_mock.post(OAUTH_TOKEN_URL).mock(
+    respx_mock.post(SERVICE_ACCOUNT_TOKEN_URL).mock(
         return_value=httpx.Response(
             200,
             json={"access_token": "tok", "token_type": "bearer", "expires_in": 3600},
@@ -219,9 +219,9 @@ async def test_execute_query_error_includes_correlation_id_when_code_absent(
 
     client = InternalApiClient(
         url=DEFAULT_INTERNAL_API_URL,
-        oauth_url=OAUTH_TOKEN_URL,
-        oauth_client="client_id",
-        oauth_secret="client_secret",
+        service_account_url=SERVICE_ACCOUNT_TOKEN_URL,
+        service_account_client_id="client_id",
+        service_account_client_secret="client_secret",
     )
 
     with pytest.raises(
@@ -242,7 +242,7 @@ async def test_execute_query_error_concatenates_multiple_errors(respx_mock):
             {"message": "Error two", "extensions": {"code": "BAD_INPUT"}},
         ]
     }
-    respx_mock.post(OAUTH_TOKEN_URL).mock(
+    respx_mock.post(SERVICE_ACCOUNT_TOKEN_URL).mock(
         return_value=httpx.Response(
             200,
             json={"access_token": "tok", "token_type": "bearer", "expires_in": 3600},
@@ -254,9 +254,9 @@ async def test_execute_query_error_concatenates_multiple_errors(respx_mock):
 
     client = InternalApiClient(
         url=DEFAULT_INTERNAL_API_URL,
-        oauth_url=OAUTH_TOKEN_URL,
-        oauth_client="client_id",
-        oauth_secret="client_secret",
+        service_account_url=SERVICE_ACCOUNT_TOKEN_URL,
+        service_account_client_id="client_id",
+        service_account_client_secret="client_secret",
     )
 
     with pytest.raises(
@@ -274,7 +274,7 @@ async def test_execute_query_error_without_message_uses_fallback(respx_mock):
     graphql_error_response = {
         "errors": [{"extensions": {"code": "UNKNOWN"}}],
     }
-    respx_mock.post(OAUTH_TOKEN_URL).mock(
+    respx_mock.post(SERVICE_ACCOUNT_TOKEN_URL).mock(
         return_value=httpx.Response(
             200,
             json={"access_token": "tok", "token_type": "bearer", "expires_in": 3600},
@@ -286,9 +286,9 @@ async def test_execute_query_error_without_message_uses_fallback(respx_mock):
 
     client = InternalApiClient(
         url=DEFAULT_INTERNAL_API_URL,
-        oauth_url=OAUTH_TOKEN_URL,
-        oauth_client="client_id",
-        oauth_secret="client_secret",
+        service_account_url=SERVICE_ACCOUNT_TOKEN_URL,
+        service_account_client_id="client_id",
+        service_account_client_secret="client_secret",
     )
 
     with pytest.raises(
@@ -315,9 +315,9 @@ async def test_execute_query_raises_on_timeout():
     ):
         client = InternalApiClient(
             url=DEFAULT_INTERNAL_API_URL,
-            oauth_url=OAUTH_TOKEN_URL,
-            oauth_client="client_id",
-            oauth_secret="client_secret",
+            service_account_url=SERVICE_ACCOUNT_TOKEN_URL,
+            service_account_client_id="client_id",
+            service_account_client_secret="client_secret",
         )
 
         with pytest.raises(httpx.TimeoutException):
@@ -329,20 +329,20 @@ def test_internal_api_client_rejects_http_url():
     with pytest.raises(ValueError, match="HTTPS"):
         InternalApiClient(
             url="http://app.pipefy.com/internal_api",
-            oauth_url="https://auth.pipefy.com/oauth/token",
-            oauth_client="id",
-            oauth_secret="secret",
+            service_account_url="https://auth.pipefy.com/oauth/token",
+            service_account_client_id="id",
+            service_account_client_secret="secret",
         )
 
 
 @pytest.mark.unit
-def test_internal_api_client_rejects_http_oauth_url():
+def test_internal_api_client_rejects_http_service_account_url():
     with pytest.raises(ValueError, match="HTTPS"):
         InternalApiClient(
             url="https://app.pipefy.com/internal_api",
-            oauth_url="http://auth.pipefy.com/oauth/token",
-            oauth_client="id",
-            oauth_secret="secret",
+            service_account_url="http://auth.pipefy.com/oauth/token",
+            service_account_client_id="id",
+            service_account_client_secret="secret",
         )
 
 
@@ -351,9 +351,9 @@ def test_internal_api_client_rejects_empty_hostname():
     with pytest.raises(ValueError, match="hostname"):
         InternalApiClient(
             url="https://",
-            oauth_url="https://auth.pipefy.com/oauth/token",
-            oauth_client="id",
-            oauth_secret="secret",
+            service_account_url="https://auth.pipefy.com/oauth/token",
+            service_account_client_id="id",
+            service_account_client_secret="secret",
         )
 
 
@@ -362,9 +362,9 @@ def test_internal_api_client_rejects_localhost():
     with pytest.raises(ValueError, match="localhost"):
         InternalApiClient(
             url="https://localhost/internal_api",
-            oauth_url="https://auth.pipefy.com/oauth/token",
-            oauth_client="id",
-            oauth_secret="secret",
+            service_account_url="https://auth.pipefy.com/oauth/token",
+            service_account_client_id="id",
+            service_account_client_secret="secret",
         )
 
 
@@ -373,9 +373,9 @@ def test_internal_api_client_rejects_private_literal_ip():
     with pytest.raises(ValueError, match="private|loopback|link-local"):
         InternalApiClient(
             url="https://10.0.0.1/internal_api",
-            oauth_url="https://auth.pipefy.com/oauth/token",
-            oauth_client="id",
-            oauth_secret="secret",
+            service_account_url="https://auth.pipefy.com/oauth/token",
+            service_account_client_id="id",
+            service_account_client_secret="secret",
         )
 
 
@@ -383,8 +383,8 @@ def test_internal_api_client_rejects_private_literal_ip():
 def test_internal_api_client_allow_insecure_accepts_http():
     InternalApiClient(
         url="http://127.0.0.1/internal_api",
-        oauth_url="http://127.0.0.1/oauth/token",
-        oauth_client="id",
-        oauth_secret="secret",
+        service_account_url="http://127.0.0.1/oauth/token",
+        service_account_client_id="id",
+        service_account_client_secret="secret",
         allow_insecure_urls=True,
     )

--- a/packages/sdk/tests/services/test_pipefy_base_client.py
+++ b/packages/sdk/tests/services/test_pipefy_base_client.py
@@ -10,9 +10,9 @@ from pipefy_sdk.settings import PipefySettings
 def valid_settings() -> PipefySettings:
     return PipefySettings(
         graphql_url="https://api.pipefy.com/graphql",
-        oauth_url="https://auth.pipefy.com/oauth/token",
-        oauth_client="client_id",
-        oauth_secret="client_secret",
+        service_account_url="https://auth.pipefy.com/oauth/token",
+        service_account_client_id="client_id",
+        service_account_client_secret="client_secret",
     )
 
 
@@ -108,9 +108,9 @@ def test_init_raises_when_graphql_url_is_none():
     """Test that __init__ raises ValueError when graphql_url is None."""
     settings = PipefySettings(
         graphql_url=None,
-        oauth_url="https://auth.pipefy.com/oauth/token",
-        oauth_client="client_id",
-        oauth_secret="client_secret",
+        service_account_url="https://auth.pipefy.com/oauth/token",
+        service_account_client_id="client_id",
+        service_account_client_secret="client_secret",
     )
 
     with pytest.raises(ValueError) as exc:
@@ -120,48 +120,50 @@ def test_init_raises_when_graphql_url_is_none():
 
 
 @pytest.mark.unit
-def test_init_raises_when_oauth_url_is_none():
-    """Test that __init__ raises ValueError when oauth_url is None."""
+def test_init_raises_when_service_account_url_is_none():
+    """Test that __init__ raises ValueError when service_account_url is None."""
     settings = PipefySettings(
         graphql_url="https://api.pipefy.com/graphql",
-        oauth_url=None,
-        oauth_client="client_id",
-        oauth_secret="client_secret",
+        service_account_url=None,
+        service_account_client_id="client_id",
+        service_account_client_secret="client_secret",
     )
 
     with pytest.raises(ValueError) as exc:
         BasePipefyClient(settings=settings)
 
-    assert "OAuth URL must be provided in settings" in str(exc.value)
+    assert "Service-account URL must be provided in settings" in str(exc.value)
 
 
 @pytest.mark.unit
-def test_init_raises_when_oauth_client_is_none():
-    """Test that __init__ raises ValueError when oauth_client is None."""
+def test_init_raises_when_service_account_client_id_is_none():
+    """Test that __init__ raises ValueError when service_account_client_id is None."""
     settings = PipefySettings(
         graphql_url="https://api.pipefy.com/graphql",
-        oauth_url="https://auth.pipefy.com/oauth/token",
-        oauth_client=None,
-        oauth_secret="client_secret",
+        service_account_url="https://auth.pipefy.com/oauth/token",
+        service_account_client_id=None,
+        service_account_client_secret="client_secret",
     )
 
     with pytest.raises(ValueError) as exc:
         BasePipefyClient(settings=settings)
 
-    assert "OAuth client ID must be provided in settings" in str(exc.value)
+    assert "Service-account client ID must be provided in settings" in str(exc.value)
 
 
 @pytest.mark.unit
-def test_init_raises_when_oauth_secret_is_none():
-    """Test that __init__ raises ValueError when oauth_secret is None."""
+def test_init_raises_when_service_account_client_secret_is_none():
+    """Test that __init__ raises ValueError when service_account_client_secret is None."""
     settings = PipefySettings(
         graphql_url="https://api.pipefy.com/graphql",
-        oauth_url="https://auth.pipefy.com/oauth/token",
-        oauth_client="client_id",
-        oauth_secret=None,
+        service_account_url="https://auth.pipefy.com/oauth/token",
+        service_account_client_id="client_id",
+        service_account_client_secret=None,
     )
 
     with pytest.raises(ValueError) as exc:
         BasePipefyClient(settings=settings)
 
-    assert "OAuth client secret must be provided in settings" in str(exc.value)
+    assert "Service-account client secret must be provided in settings" in str(
+        exc.value
+    )

--- a/packages/sdk/tests/services/test_pipefy_facade.py
+++ b/packages/sdk/tests/services/test_pipefy_facade.py
@@ -25,9 +25,9 @@ from pipefy_sdk.settings import PipefySettings
 def mock_settings():
     return PipefySettings(
         graphql_url="https://api.pipefy.com/graphql",
-        oauth_url="https://auth.pipefy.com/oauth/token",
-        oauth_client="client_id",
-        oauth_secret="client_secret",
+        service_account_url="https://auth.pipefy.com/oauth/token",
+        service_account_client_id="client_id",
+        service_account_client_secret="client_secret",
     )
 
 
@@ -550,9 +550,9 @@ def test_pipefy_client_creates_services_with_shared_auth():
 
     settings = PipefySettings(
         graphql_url="https://api.pipefy.com/graphql",
-        oauth_url="https://auth.pipefy.com/oauth/token",
-        oauth_client="client_id",
-        oauth_secret="client_secret",
+        service_account_url="https://auth.pipefy.com/oauth/token",
+        service_account_client_id="client_id",
+        service_account_client_secret="client_secret",
     )
     client = PipefyClient(settings=settings)
 

--- a/packages/sdk/tests/services/test_table_service_search_tables.py
+++ b/packages/sdk/tests/services/test_table_service_search_tables.py
@@ -29,9 +29,9 @@ def _table_connection(
 def mock_settings() -> PipefySettings:
     return PipefySettings(
         graphql_url="https://api.pipefy.com/graphql",
-        oauth_url="https://auth.pipefy.com/oauth/token",
-        oauth_client="client_id",
-        oauth_secret="client_secret",
+        service_account_url="https://auth.pipefy.com/oauth/token",
+        service_account_client_id="client_id",
+        service_account_client_secret="client_secret",
     )
 
 

--- a/packages/sdk/tests/test_settings_back_compat.py
+++ b/packages/sdk/tests/test_settings_back_compat.py
@@ -1,0 +1,132 @@
+"""Back-compat coverage for the ``PIPEFY_OAUTH_*`` → ``PIPEFY_SERVICE_ACCOUNT_*`` rename.
+
+The rename ships an ``AliasChoices`` shim on ``PipefySettings`` plus a one-shot
+stderr deprecation warning. These tests pin both behaviors so the eventual
+PR that drops the aliases (and the warning) has a clear regression surface.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pipefy_sdk.settings import (
+    PipefySettings,
+    _reset_legacy_oauth_warning_state,
+    _warn_once_for_legacy_oauth_env_keys,
+)
+
+_LEGACY_TO_NEW_KEY = {
+    "PIPEFY_OAUTH_URL": "PIPEFY_SERVICE_ACCOUNT_URL",
+    "PIPEFY_OAUTH_CLIENT": "PIPEFY_SERVICE_ACCOUNT_CLIENT_ID",
+    "PIPEFY_OAUTH_SECRET": "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET",
+}
+
+
+@pytest.fixture(autouse=True)
+def _reset_warning_dedup(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each test sees a fresh warning dedup set and a clean process env."""
+    for key in _LEGACY_TO_NEW_KEY:
+        monkeypatch.delenv(key, raising=False)
+    for key in _LEGACY_TO_NEW_KEY.values():
+        monkeypatch.delenv(key, raising=False)
+    _reset_legacy_oauth_warning_state()
+    yield
+    _reset_legacy_oauth_warning_state()
+
+
+@pytest.mark.unit
+def test_legacy_kwargs_populate_new_fields():
+    """``PipefySettings(oauth_url=...)`` still validates and binds to ``service_account_url``."""
+    s = PipefySettings(
+        graphql_url="https://app.pipefy.com/graphql",
+        oauth_url="https://legacy.example.com/oauth/token",
+        oauth_client="legacy-client",
+        oauth_secret="legacy-secret",
+    )
+    assert s.service_account_url == "https://legacy.example.com/oauth/token"
+    assert s.service_account_client_id == "legacy-client"
+    assert s.service_account_client_secret == "legacy-secret"
+
+
+@pytest.mark.unit
+def test_new_kwargs_populate_new_fields():
+    s = PipefySettings(
+        graphql_url="https://app.pipefy.com/graphql",
+        service_account_url="https://new.example.com/oauth/token",
+        service_account_client_id="new-client",
+        service_account_client_secret="new-secret",
+    )
+    assert s.service_account_url == "https://new.example.com/oauth/token"
+    assert s.service_account_client_id == "new-client"
+    assert s.service_account_client_secret == "new-secret"
+
+
+@pytest.mark.unit
+def test_legacy_env_var_emits_deprecation_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    monkeypatch.setenv("PIPEFY_OAUTH_URL", "https://shell.example.com/oauth/token")
+
+    # Trigger via direct emitter call — model construction below would also trigger,
+    # but the emitter is the unit under test here.
+    _warn_once_for_legacy_oauth_env_keys()
+
+    err = capsys.readouterr().err
+    assert "PIPEFY_OAUTH_URL is deprecated" in err
+    assert "rename to PIPEFY_SERVICE_ACCOUNT_URL" in err
+    # Only the legacy key that is set should warn.
+    assert "PIPEFY_OAUTH_CLIENT" not in err
+    assert "PIPEFY_OAUTH_SECRET" not in err
+
+
+@pytest.mark.unit
+def test_deprecation_warning_dedups_within_process(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    monkeypatch.setenv("PIPEFY_OAUTH_URL", "https://shell.example.com/oauth/token")
+
+    _warn_once_for_legacy_oauth_env_keys()
+    _warn_once_for_legacy_oauth_env_keys()
+    _warn_once_for_legacy_oauth_env_keys()
+
+    err = capsys.readouterr().err
+    assert err.count("PIPEFY_OAUTH_URL is deprecated") == 1
+
+
+@pytest.mark.unit
+def test_no_deprecation_warning_when_only_new_env_keys_set(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    monkeypatch.setenv(
+        "PIPEFY_SERVICE_ACCOUNT_URL", "https://new.example.com/oauth/token"
+    )
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", "new-client")
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET", "new-secret")
+
+    PipefySettings(
+        graphql_url="https://app.pipefy.com/graphql",
+        service_account_url="https://new.example.com/oauth/token",
+        service_account_client_id="new-client",
+        service_account_client_secret="new-secret",
+    )
+
+    err = capsys.readouterr().err
+    assert "deprecated" not in err
+
+
+@pytest.mark.unit
+def test_pipefy_settings_construction_triggers_warning_via_model_validator(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    """The ``mode="before"`` model_validator wires the warning into PipefySettings init."""
+    monkeypatch.setenv("PIPEFY_OAUTH_SECRET", "legacy-secret-in-shell")
+
+    PipefySettings(graphql_url="https://app.pipefy.com/graphql")
+
+    err = capsys.readouterr().err
+    assert "PIPEFY_OAUTH_SECRET is deprecated" in err
+    assert "rename to PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET" in err

--- a/packages/sdk/tests/test_settings_back_compat.py
+++ b/packages/sdk/tests/test_settings_back_compat.py
@@ -10,24 +10,19 @@ from __future__ import annotations
 import pytest
 
 from pipefy_sdk.settings import (
+    _LEGACY_ENV_KEYS_TO_NEW,
     PipefySettings,
     _reset_legacy_oauth_warning_state,
     _warn_once_for_legacy_oauth_env_keys,
 )
 
-_LEGACY_TO_NEW_KEY = {
-    "PIPEFY_OAUTH_URL": "PIPEFY_SERVICE_ACCOUNT_URL",
-    "PIPEFY_OAUTH_CLIENT": "PIPEFY_SERVICE_ACCOUNT_CLIENT_ID",
-    "PIPEFY_OAUTH_SECRET": "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET",
-}
-
 
 @pytest.fixture(autouse=True)
 def _reset_warning_dedup(monkeypatch: pytest.MonkeyPatch) -> None:
     """Each test sees a fresh warning dedup set and a clean process env."""
-    for key in _LEGACY_TO_NEW_KEY:
+    for key in _LEGACY_ENV_KEYS_TO_NEW:
         monkeypatch.delenv(key, raising=False)
-    for key in _LEGACY_TO_NEW_KEY.values():
+    for key in _LEGACY_ENV_KEYS_TO_NEW.values():
         monkeypatch.delenv(key, raising=False)
     _reset_legacy_oauth_warning_state()
     yield

--- a/skills/api-troubleshoot/pipefy-api-fallback/SKILL.md
+++ b/skills/api-troubleshoot/pipefy-api-fallback/SKILL.md
@@ -37,7 +37,7 @@ Two options (use whichever is available in the environment). Prefer the Service 
 ```bash
 TOKEN=$(curl -s -X POST https://app.pipefy.com/oauth/token \
   -H "Content-Type: application/json" \
-  -d "{\"grant_type\":\"client_credentials\",\"client_id\":\"$PIPEFY_OAUTH_CLIENT\",\"client_secret\":\"$PIPEFY_OAUTH_SECRET\"}" \
+  -d "{\"grant_type\":\"client_credentials\",\"client_id\":\"$PIPEFY_SERVICE_ACCOUNT_CLIENT_ID\",\"client_secret\":\"$PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET\"}" \
   | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
 ```
 
@@ -52,7 +52,7 @@ PATs are deprecated for new integrations but may still exist in the environment.
 ### Token rules
 
 - The `Bearer ` prefix is **mandatory** — Pipefy rejects requests without it.
-- Never expose `PIPEFY_OAUTH_CLIENT`, `PIPEFY_OAUTH_SECRET`, `PIPEFY_PAT`, or `PIPEFY_TOKEN` in responses to the user or in logs.
+- Never expose `PIPEFY_SERVICE_ACCOUNT_CLIENT_ID`, `PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET`, `PIPEFY_PAT`, or `PIPEFY_TOKEN` in responses to the user or in logs.
 - Service Account tokens are reused while valid; only re-fetch on expiry (401).
 
 ---
@@ -206,7 +206,7 @@ Only after all 3 tiers and external resources have failed:
 
 - Never log or print tokens in plain text.
 - Prefer environment variables over inline credentials.
-- Use `PIPEFY_TOKEN` / `PIPEFY_PAT` only for personal/development use; use OAuth (`PIPEFY_OAUTH_CLIENT` + `PIPEFY_OAUTH_SECRET`) for service accounts.
+- Use `PIPEFY_TOKEN` / `PIPEFY_PAT` only for personal/development use; use service-account credentials (`PIPEFY_SERVICE_ACCOUNT_CLIENT_ID` + `PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET`) for service accounts.
 
 ## See also
 


### PR DESCRIPTION
## Summary

Renames the three service-account credential env vars across SDK / CLI / MCP. Closes #127.

| Old | New |
|---|---|
| `PIPEFY_OAUTH_URL` | `PIPEFY_SERVICE_ACCOUNT_URL` |
| `PIPEFY_OAUTH_CLIENT` | `PIPEFY_SERVICE_ACCOUNT_CLIENT_ID` |
| `PIPEFY_OAUTH_SECRET` | `PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET` |

`PIPEFY_OAUTH_URL` sat one letter from `PIPEFY_AUTH_URL` (the OIDC issuer for the interactive user-login flow in #125 / #142 / #149) — a real ergonomic footgun, and `PIPEFY_OAUTH_*` was imprecise on its own (both flows are OAuth). The rest of the codebase already uses the domain term **service account** (`PIPEFY_SERVICE_ACCOUNT_IDS`, `_SERVICE_ACCOUNT_ENV_KEYS`).

## Naming choices

- **`SERVICE_ACCOUNT`** prefix matches existing `PIPEFY_SERVICE_ACCOUNT_IDS` precedent.
- **`_CLIENT_ID` / `_CLIENT_SECRET`** match OAuth 2.0 RFC 6749 (`client_id` / `client_secret`) and the existing internal `PIPEFY_AUTH_CLIENT_ID` from the user-login flow. `_CLIENT` / `_SECRET` would diverge from both.
- **`_URL`** (not `_TOKEN_URL`) mirrors `PIPEFY_AUTH_URL`. The prefix change alone fully resolves the footgun; the service-account endpoint is a Doorkeeper token URL with no issuer or `.well-known` discovery (confirmed against `pipefy-core`), so a forward-looking `_TOKEN_URL` would carry no future benefit.

`PIPEFY_TOKEN` (static bearer) and `PIPEFY_AUTH_URL` / `PIPEFY_AUTH_CLIENT_ID` (user-login) are **not** renamed — already correctly scoped.

## Back-compat mechanics

- **`AliasChoices(new, old)`** on each `PipefySettings` field accepts both forms; new wins when both are set. Honors `PIPEFY_OAUTH_*` env vars and `.env` keys without code changes on the user side.
- **TOML key alias**: `apply_toml_fallback` normalizes legacy `oauth_*` keys in `~/.config/pipefy/config.toml` to the new names; new key wins when both present.
- **One-shot stderr deprecation warning** per legacy key still in use, fired via a `model_validator(mode="before")` so it surfaces even when downstream validation fails. Process-global dedup; short-circuits once all legacy keys have warned.

The shim ships in the Unreleased section without a breaking-change callout. A follow-up PR drops the aliases and carries the breaking flag.

## Out of scope

- `PIPEFY_TOKEN` — static bearer, not a service-account credential.
- `PIPEFY_AUTH_URL` / `PIPEFY_AUTH_CLIENT_ID` — user-login flow, already correctly scoped.
- Dropping the `AliasChoices` shim — separate PR after one beta release cycle.

## Commit shape

- ` refactor: rename PIPEFY_OAUTH_* to PIPEFY_SERVICE_ACCOUNT_* (#127)` — source-file rename across SDK/CLI/MCP + AliasChoices + stderr warning + TOML alias + `InternalApiClient` kwargs + golden fixture regen.
- ` test: cover AliasChoices, env+TOML deprecation warnings for #127` — 13 new back-compat tests pinning the legacy paths and the new-wins precedence.
- ` docs: rename PIPEFY_OAUTH_* env vars to PIPEFY_SERVICE_ACCOUNT_* (#127)` — `.env.example`, `bootstrap.sh`, `docs/setup.md`, `docs/MIGRATION.md` (new section), READMEs, `SKILL.md`, `CHANGELOG.md` Unreleased entry.
- ` refactor: polish per /simplify review of the #127 rename` — early-out guards in the warning emitter and TOML normalizer, dedup the legacy-key map between settings and test files.

## Test plan

- [x] `uv run pytest packages/` — 2048 passed, 42 skipped.
- [x] `uv run ruff check packages/` + `uv run ruff format --check packages/` — clean.
- [x] Live smoke with legacy env vars set: all three stderr warnings fire naming the correct replacements; values populate the new fields.
- [x] Live smoke with new env vars only: clean stderr; values populate the new fields.
- [x] Source-file grep audit: only intentional legacy refs remain (`AliasChoices` shim, `_LEGACY_TOML_KEYS_TO_NEW` map, deprecation-warning message strings, docstrings naming both forms).