### PR TITLE
chore: add Renovate config on main for bot activation (#145)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "baseBranches": ["dev"],
+  "pre-commit": {
+    "enabled": true
+  },
+  "packageRules": [
+    {
+      "description": "Bump ruff in uv.lock and .pre-commit-config.yaml rev together",
+      "groupName": "ruff",
+      "matchManagers": ["pep621", "pre-commit"],
+      "matchPackageNames": ["ruff", "astral-sh/ruff-pre-commit"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Land `.github/renovate.json` on `main` so Renovate activates immediately (it only reads config from the default branch).
- Same config as #150: `baseBranches: ["dev"]`, grouped ruff bumps for `uv.lock` + `.pre-commit-config.yaml`.

## Test plan

- [x] `python3 -m json.tool .github/renovate.json` — valid JSON
- [ ] After merge: confirm Renovate app picks up config and opens grouped ruff PRs targeting `dev`

Related: #150