### PR TITLE
refactor: consolidate auth precedence chain in pipefy_auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,11 +82,13 @@ jobs:
             raise SystemExit(f"version mismatch across packages: {found}")
         PY
     - name: Lint (full tree)
-      run: uv run ruff check packages/sdk/src packages/mcp/src packages/cli/src
+      run: uv run ruff check packages/sdk/src packages/mcp/src packages/cli/src packages/auth/src
     - name: Check formatting
-      run: uv run ruff format --check packages/sdk/src packages/mcp/src packages/cli/src
+      run: uv run ruff format --check packages/sdk/src packages/mcp/src packages/cli/src packages/auth/src
     - name: Lint SDK (banned upward imports)
       run: cd packages/sdk && uv run ruff check src
+    - name: Lint auth (banned upward imports)
+      run: cd packages/auth && uv run ruff check src
     - name: Build MCP wheel (packaging smoke)
       run: uv build packages/mcp -o packages/mcp/dist
     - name: Run tests

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -23,10 +23,10 @@ Most-explicit wins. The CLI walks this list top-down and stops at the first sour
 |---|--------|----------|-------|
 | 1 | `--token <bearer>` | Whoever owns the token | Skips OAuth entirely |
 | 2 | `PIPEFY_TOKEN` env var | Whoever owns the token | Same path as `--token` |
-| 3 | `PIPEFY_SERVICE_ACCOUNT_*` triple | Service account | Client-credentials grant (unlocks AI automations) |
+| 3 | `PIPEFY_SERVICE_ACCOUNT_*` triple | Service account | OAuth2 client-credentials grant |
 | 4 | Stored user session | You (the signed-in user) | Eager refresh inside a 60 s leeway window |
 
-Tiers 1, 2, and 4 ultimately become a **static bearer token** on the GraphQL client. Only tier 3 builds the `InternalApiClient` that some MCP/CLI features (AI automations, certain relation flows) rely on — see [Limitations on the bearer path](#limitations-on-the-bearer-path).
+Every tier wires the `InternalApiClient` against `PIPEFY_INTERNAL_API_URL` when that variable is set, so features that go through the internal API (AI agent automations, some relation flows) work from any path — not just the service-account one.
 
 If `pipefy auth login` succeeds but a higher-precedence source is set in your shell env, the CLI prints a one-line note so you know your stored session is being shadowed.
 
@@ -184,10 +184,6 @@ When no session is stored, `pipefy auth logout` prints `Not signed in. Nothing t
 
 Pair each issuer with the matching `PIPEFY_GRAPHQL_URL` (`https://app.pipefy.com/graphql` for prod, `https://piporacle.pipefy.com/graphql` for piporacle).
 
-### Limitations on the bearer path
-
-Tiers 1, 2, and 4 all reach the SDK as a static bearer. Only tier 3 builds an `InternalApiClient` against `PIPEFY_INTERNAL_API_URL`. As a result, features that go through the internal API — AI agent automations, some relation flows — are **only available on the service-account path** today. This is the same limitation that already applies to `--token` / `PIPEFY_TOKEN`; lifting it for stored sessions is tracked separately.
-
 ---
 
 ## Headless / SSH
@@ -218,9 +214,9 @@ You haven't set the issuer URL. Use the value from [Pipefy issuer URLs](#pipefy-
 
 The login worked but `keyring` couldn't write the entry. On macOS / Windows this is rare. On headless Linux it usually means no Secret Service daemon is running — install `gnome-keyring` or `kwallet`, or fall back to a static `PIPEFY_TOKEN`.
 
-### `Missing authentication. Use --token, set PIPEFY_TOKEN, configure PIPEFY_SERVICE_ACCOUNT_*, or run pipefy auth login.`
+### `Missing Pipefy authentication. Set PIPEFY_TOKEN, configure PIPEFY_SERVICE_ACCOUNT_*, or run \`pipefy auth login\`.`
 
-No source resolved. Pick one from [Credential precedence](#credential-precedence). The message also lists which `PIPEFY_SERVICE_ACCOUNT_*` keys are missing, in case you have a partial service-account setup.
+No source resolved. Pick one from [Credential precedence](#credential-precedence). You can also pass `--token <bearer>` for a one-off override.
 
 ### `Note: PIPEFY_SERVICE_ACCOUNT_* is set in your environment; other pipefy commands will continue to use it ...`
 

--- a/packages/auth/pyproject.toml
+++ b/packages/auth/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "httpx>=0.28",
+    "httpx-auth>=0.23.1",
     "keyring>=24",
 ]
 

--- a/packages/auth/src/pipefy_auth/__init__.py
+++ b/packages/auth/src/pipefy_auth/__init__.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 __version__ = "0.2.0-beta.1"
 
+from pipefy_auth.bearer import CallableBearerAuth, StaticBearerAuth
 from pipefy_auth.discovery import (
     DiscoveryPolicy,
     ProviderMetadata,
@@ -22,6 +23,16 @@ from pipefy_auth.refresh import (
     RefreshError,
     ensure_fresh_session,
     refresh_access_token,
+)
+from pipefy_auth.resolver import (
+    SERVICE_ACCOUNT_TIER,
+    STATIC_TOKEN_TIER,
+    STORED_SESSION_TIER,
+    ServiceAccount,
+    detect_pipefy_tiers,
+    missing_auth_message,
+    resolve_pipefy_auth,
+    tier_for,
 )
 from pipefy_auth.revoke import (
     RevocationError,
@@ -39,6 +50,7 @@ from pipefy_auth.storage import (
 )
 
 __all__ = [
+    "CallableBearerAuth",
     "DEFAULT_AUTH_CLIENT_ID",
     "DiscoveryPolicy",
     "LoginError",
@@ -48,17 +60,26 @@ __all__ = [
     "RefreshError",
     "RevocationError",
     "RevocationUnsupportedError",
+    "SERVICE_ACCOUNT_TIER",
+    "STATIC_TOKEN_TIER",
+    "STORED_SESSION_TIER",
+    "ServiceAccount",
     "SessionDeleteError",
+    "StaticBearerAuth",
     "StoredSession",
     "__version__",
     "delete_session",
+    "detect_pipefy_tiers",
     "ensure_fresh_session",
     "fetch_provider_metadata",
     "keychain_backend_name",
     "keychain_key",
     "load_session",
+    "missing_auth_message",
     "refresh_access_token",
+    "resolve_pipefy_auth",
     "revoke_session",
     "run_login",
     "store_session",
+    "tier_for",
 ]

--- a/packages/auth/src/pipefy_auth/bearer.py
+++ b/packages/auth/src/pipefy_auth/bearer.py
@@ -1,0 +1,52 @@
+"""``httpx.Auth`` adapters that attach ``Authorization: Bearer …`` headers."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Generator
+from typing import AsyncGenerator
+
+from httpx import Auth, Request, Response
+
+
+class StaticBearerAuth(Auth):
+    """Attach a fixed ``Authorization: Bearer …`` header."""
+
+    def __init__(self, token: str) -> None:
+        self._token = token
+
+    def auth_flow(self, request: Request) -> Generator[Request, Response, None]:
+        request.headers["Authorization"] = f"Bearer {self._token}"
+        yield request
+
+
+class CallableBearerAuth(Auth):
+    """Attach ``Authorization: Bearer …`` from a token provider invoked per request.
+
+    The provider is re-called on every request so transparent rotation (e.g. a
+    keychain-backed refresh in :func:`ensure_fresh_session`) is observed without
+    rebuilding the SDK client. The async path serializes concurrent calls so a
+    single request triggers at most one refresh under async fan-out.
+    """
+
+    def __init__(self, token_provider: Callable[[], str]) -> None:
+        self._token_provider = token_provider
+        self._async_lock = asyncio.Lock()
+
+    def auth_flow(self, request: Request) -> Generator[Request, Response, None]:
+        request.headers["Authorization"] = f"Bearer {self._token_provider()}"
+        yield request
+
+    async def async_auth_flow(
+        self, request: Request
+    ) -> AsyncGenerator[Request, Response]:
+        async with self._async_lock:
+            token = await asyncio.to_thread(self._token_provider)
+        request.headers["Authorization"] = f"Bearer {token}"
+        yield request
+
+
+__all__ = [
+    "CallableBearerAuth",
+    "StaticBearerAuth",
+]

--- a/packages/auth/src/pipefy_auth/resolver.py
+++ b/packages/auth/src/pipefy_auth/resolver.py
@@ -1,0 +1,165 @@
+"""Single source of truth for the Pipefy credential precedence chain.
+
+The chain is a fixed three-slot tuple — consumers do not extend it:
+
+1. ``static-token`` — a pre-resolved bearer (consumers collapse their own
+   surfaces — CLI ``--token`` flag, ``PIPEFY_TOKEN`` env var — into one value).
+2. ``service-account`` — OAuth2 client-credentials grant.
+3. ``stored-session`` — keychain session populated by ``pipefy auth login``.
+
+The flag-vs-env distinction the CLI surfaces in ``pipefy auth status`` is a
+display concern handled in CLI code, not a tier here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from httpx import Auth
+from httpx_auth import OAuth2ClientCredentials
+
+from pipefy_auth.bearer import CallableBearerAuth, StaticBearerAuth
+from pipefy_auth.identity import OidcClient
+from pipefy_auth.refresh import ensure_fresh_session
+from pipefy_auth.storage import load_session
+
+STATIC_TOKEN_TIER = "static-token"
+SERVICE_ACCOUNT_TIER = "service-account"
+STORED_SESSION_TIER = "stored-session"
+
+
+@dataclass(frozen=True)
+class ServiceAccount:
+    """OAuth2 client-credentials inputs for the service-account tier."""
+
+    token_url: str
+    client_id: str
+    client_secret: str
+
+
+# Maps each ``httpx.Auth`` implementation back to the resolver-tier name that
+# produced it. ``tier_for`` is the public lookup; the mapping itself is the
+# single source of truth so the wire-schema strings (e.g. ``"stored-session"``)
+# stay in one place.
+_TIER_BY_AUTH_TYPE: dict[type[Auth], str] = {
+    StaticBearerAuth: STATIC_TOKEN_TIER,
+    OAuth2ClientCredentials: SERVICE_ACCOUNT_TIER,
+    CallableBearerAuth: STORED_SESSION_TIER,
+}
+
+
+def tier_for(auth: Auth) -> str:
+    """Return the resolver-tier name that produced ``auth``.
+
+    Raises:
+        ValueError: When ``auth`` is not an instance produced by
+            :func:`resolve_pipefy_auth` (e.g. a consumer-provided
+            ``httpx.Auth`` for tests or a custom integration).
+    """
+    for cls, source in _TIER_BY_AUTH_TYPE.items():
+        if isinstance(auth, cls):
+            return source
+    raise ValueError(
+        f"No resolver-tier name for httpx.Auth of type {type(auth).__name__}"
+    )
+
+
+def _stored_session_provider(oidc_client: OidcClient) -> CallableBearerAuth:
+    def _provider() -> str:
+        session = ensure_fresh_session(
+            issuer=oidc_client.issuer_url, client_id=oidc_client.client_id
+        )
+        if session is None:
+            raise RuntimeError(
+                "Stored Pipefy session was removed; run `pipefy auth login` again."
+            )
+        return session.access_token
+
+    return CallableBearerAuth(_provider)
+
+
+def _has_stored_session(oidc_client: OidcClient) -> bool:
+    return (
+        load_session(issuer=oidc_client.issuer_url, client_id=oidc_client.client_id)
+        is not None
+    )
+
+
+def resolve_pipefy_auth(
+    *,
+    static_token: str | None = None,
+    service_account: ServiceAccount | None = None,
+    oidc_client: OidcClient | None = None,
+) -> Auth | None:
+    """Resolve the highest-precedence tier with credentials available.
+
+    Short-circuits at the first tier that resolves — lower tiers are never
+    inspected. The returned ``httpx.Auth`` carries the tier identity in its
+    concrete type; use :func:`tier_for` to recover the resolver-tier name
+    (e.g. for the ``pipefy auth status`` wire schema).
+
+    For an enumeration of every detected tier (e.g. for diagnostics), call
+    :func:`detect_pipefy_tiers` instead.
+
+    Args:
+        static_token: Pre-resolved bearer for the static-token tier. Consumers
+            collapse their own per-source precedence (e.g. CLI ``--token`` flag
+            vs ``PIPEFY_TOKEN`` env var) into one value before calling.
+        service_account: Service-account client-credentials inputs.
+        oidc_client: OIDC client identity for the stored-session tier; the
+            session is loaded from the keychain at detection time, and a fresh
+            access token is fetched per request via :class:`CallableBearerAuth`.
+    """
+    if static_token and static_token.strip():
+        return StaticBearerAuth(static_token.strip())
+    if service_account is not None:
+        return OAuth2ClientCredentials(
+            token_url=service_account.token_url,
+            client_id=service_account.client_id,
+            client_secret=service_account.client_secret,
+        )
+    if oidc_client is not None and _has_stored_session(oidc_client):
+        return _stored_session_provider(oidc_client)
+    return None
+
+
+def detect_pipefy_tiers(
+    *,
+    static_token: str | None = None,
+    service_account: ServiceAccount | None = None,
+    oidc_client: OidcClient | None = None,
+) -> list[str]:
+    """Return every tier with credentials available, highest-precedence first.
+
+    Used by ``pipefy auth status`` to surface masked sources alongside the
+    winner. Does not short-circuit — every tier's detection runs (including
+    the keychain read for the stored-session tier).
+    """
+    detected: list[str] = []
+    if static_token and static_token.strip():
+        detected.append(STATIC_TOKEN_TIER)
+    if service_account is not None:
+        detected.append(SERVICE_ACCOUNT_TIER)
+    if oidc_client is not None and _has_stored_session(oidc_client):
+        detected.append(STORED_SESSION_TIER)
+    return detected
+
+
+def missing_auth_message(*, login_command: str = "pipefy auth login") -> str:
+    """Canonical "no auth configured" message; consumers append their own context."""
+    return (
+        "Missing Pipefy authentication. Set PIPEFY_TOKEN, configure "
+        f"PIPEFY_SERVICE_ACCOUNT_*, or run `{login_command}`."
+    )
+
+
+__all__ = [
+    "SERVICE_ACCOUNT_TIER",
+    "STATIC_TOKEN_TIER",
+    "STORED_SESSION_TIER",
+    "ServiceAccount",
+    "detect_pipefy_tiers",
+    "missing_auth_message",
+    "resolve_pipefy_auth",
+    "tier_for",
+]

--- a/packages/auth/tests/test_bearer.py
+++ b/packages/auth/tests/test_bearer.py
@@ -1,0 +1,56 @@
+"""Unit tests for ``pipefy_auth.bearer`` (Static + Callable bearer adapters)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from pipefy_auth.bearer import CallableBearerAuth, StaticBearerAuth
+
+
+@pytest.mark.unit
+def test_static_bearer_sets_authorization_header():
+    auth = StaticBearerAuth("ABC")
+    request = httpx.Request("GET", "https://example.test/")
+    flow = auth.auth_flow(request)
+    sent = next(flow)
+    assert sent.headers["Authorization"] == "Bearer ABC"
+
+
+@pytest.mark.unit
+def test_callable_bearer_invokes_provider_per_request_sync():
+    tokens = iter(["T1", "T2", "T3"])
+    auth = CallableBearerAuth(lambda: next(tokens))
+    seen = []
+    for _ in range(3):
+        request = httpx.Request("GET", "https://example.test/")
+        next(auth.auth_flow(request))
+        seen.append(request.headers["Authorization"])
+    assert seen == ["Bearer T1", "Bearer T2", "Bearer T3"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_callable_bearer_async_serializes_provider_calls():
+    """The async lock means two concurrent ``async_auth_flow`` calls do not
+    interleave the provider invocations."""
+    call_order: list[str] = []
+
+    def provider() -> str:
+        call_order.append("call")
+        return "TOK"
+
+    auth = CallableBearerAuth(provider)
+
+    async def one_call() -> str:
+        request = httpx.Request("GET", "https://example.test/")
+        gen = auth.async_auth_flow(request)
+        await gen.__anext__()
+        await gen.aclose()
+        return request.headers["Authorization"]
+
+    headers = await asyncio.gather(one_call(), one_call(), one_call())
+    assert headers == ["Bearer TOK"] * 3
+    assert len(call_order) == 3

--- a/packages/auth/tests/test_resolver.py
+++ b/packages/auth/tests/test_resolver.py
@@ -1,0 +1,177 @@
+"""Unit tests for ``pipefy_auth.resolver`` (fixed three-tier precedence chain)."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from httpx_auth import OAuth2ClientCredentials
+
+from pipefy_auth.bearer import CallableBearerAuth, StaticBearerAuth
+from pipefy_auth.identity import OidcClient
+from pipefy_auth.resolver import (
+    SERVICE_ACCOUNT_TIER,
+    STATIC_TOKEN_TIER,
+    STORED_SESSION_TIER,
+    ServiceAccount,
+    detect_pipefy_tiers,
+    missing_auth_message,
+    resolve_pipefy_auth,
+    tier_for,
+)
+from pipefy_auth.storage import StoredSession
+
+
+def _stored_session() -> StoredSession:
+    return StoredSession(
+        issuer="https://issuer.test/realms/pipefy",
+        client_id="pipefy-cli",
+        access_token="ACCESS",
+        refresh_token="REFRESH",
+        token_type="Bearer",
+        obtained_at=int(time.time()),
+        expires_in=3600,
+        refresh_expires_in=None,
+        scope=None,
+        id_token=None,
+    )
+
+
+def _service_account() -> ServiceAccount:
+    return ServiceAccount(token_url="https://t/", client_id="c", client_secret="s")
+
+
+def _oidc() -> OidcClient:
+    return OidcClient(issuer_url="https://issuer.test/", client_id="pipefy-cli")
+
+
+@pytest.mark.unit
+def test_resolve_with_no_inputs_returns_none():
+    assert resolve_pipefy_auth() is None
+
+
+@pytest.mark.unit
+def test_static_token_wins_and_short_circuits_lower_tiers(monkeypatch):
+    """Once the static-token tier resolves, lower tiers' inputs are never inspected."""
+    mock_load = MockCounter()
+    monkeypatch.setattr("pipefy_auth.resolver.load_session", mock_load)
+    resolved = resolve_pipefy_auth(
+        static_token="TOKEN",
+        service_account=_service_account(),
+        oidc_client=_oidc(),
+    )
+    assert isinstance(resolved, StaticBearerAuth)
+    assert tier_for(resolved) == STATIC_TOKEN_TIER
+    assert mock_load.calls == 0
+
+
+@pytest.mark.unit
+def test_static_token_trimmed_and_blank_treated_as_absent():
+    assert resolve_pipefy_auth(static_token="   ") is None
+    resolved = resolve_pipefy_auth(static_token="  ABC  ")
+    assert isinstance(resolved, StaticBearerAuth)
+
+
+@pytest.mark.unit
+def test_service_account_wins_when_no_static_token_and_short_circuits_stored(
+    monkeypatch,
+):
+    mock_load = MockCounter()
+    monkeypatch.setattr("pipefy_auth.resolver.load_session", mock_load)
+    resolved = resolve_pipefy_auth(
+        service_account=_service_account(), oidc_client=_oidc()
+    )
+    assert isinstance(resolved, OAuth2ClientCredentials)
+    assert tier_for(resolved) == SERVICE_ACCOUNT_TIER
+    assert mock_load.calls == 0
+
+
+@pytest.mark.unit
+def test_stored_session_wins_when_nothing_else_configured(monkeypatch):
+    monkeypatch.setattr(
+        "pipefy_auth.resolver.load_session", lambda **_: _stored_session()
+    )
+    resolved = resolve_pipefy_auth(oidc_client=_oidc())
+    assert isinstance(resolved, CallableBearerAuth)
+    assert tier_for(resolved) == STORED_SESSION_TIER
+
+
+@pytest.mark.unit
+def test_stored_session_tier_requires_keychain_entry(monkeypatch):
+    monkeypatch.setattr("pipefy_auth.resolver.load_session", lambda **_: None)
+    assert resolve_pipefy_auth(oidc_client=_oidc()) is None
+
+
+@pytest.mark.unit
+def test_detect_lists_every_configured_tier_in_precedence_order(monkeypatch):
+    monkeypatch.setattr(
+        "pipefy_auth.resolver.load_session", lambda **_: _stored_session()
+    )
+    tiers = detect_pipefy_tiers(
+        static_token="T",
+        service_account=_service_account(),
+        oidc_client=_oidc(),
+    )
+    assert tiers == [
+        STATIC_TOKEN_TIER,
+        SERVICE_ACCOUNT_TIER,
+        STORED_SESSION_TIER,
+    ]
+
+
+@pytest.mark.unit
+def test_detect_skips_tiers_without_credentials(monkeypatch):
+    monkeypatch.setattr("pipefy_auth.resolver.load_session", lambda **_: None)
+    tiers = detect_pipefy_tiers(static_token="T", service_account=_service_account())
+    assert tiers == [STATIC_TOKEN_TIER, SERVICE_ACCOUNT_TIER]
+
+
+@pytest.mark.unit
+def test_missing_auth_message_mentions_all_tiers():
+    msg = missing_auth_message()
+    assert "PIPEFY_TOKEN" in msg
+    assert "PIPEFY_SERVICE_ACCOUNT_*" in msg
+    assert "pipefy auth login" in msg
+
+
+@pytest.mark.unit
+def test_missing_auth_message_custom_login_command():
+    msg = missing_auth_message(login_command="my-cli login")
+    assert "my-cli login" in msg
+    assert "pipefy auth login" not in msg
+
+
+@pytest.mark.unit
+def test_tier_for_raises_on_foreign_auth_class():
+    """``tier_for`` only recognises auth produced by ``resolve_pipefy_auth``."""
+
+    class CustomAuth:
+        pass
+
+    with pytest.raises(ValueError, match="No resolver-tier name"):
+        tier_for(CustomAuth())  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_stored_session_provider_raises_when_session_vanishes(monkeypatch):
+    """The callable provider raises if the keychain entry disappears after detect."""
+    monkeypatch.setattr(
+        "pipefy_auth.resolver.load_session", lambda **_: _stored_session()
+    )
+    monkeypatch.setattr("pipefy_auth.resolver.ensure_fresh_session", lambda **_: None)
+    resolved = resolve_pipefy_auth(oidc_client=_oidc())
+    assert isinstance(resolved, CallableBearerAuth)
+    provider = resolved._token_provider  # type: ignore[attr-defined]
+    with pytest.raises(RuntimeError, match="session was removed"):
+        provider()
+
+
+class MockCounter:
+    """Counts invocations so tests can assert short-circuit behavior."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self, **_: object) -> None:
+        self.calls += 1
+        return None

--- a/packages/cli/src/pipefy_cli/auth.py
+++ b/packages/cli/src/pipefy_cli/auth.py
@@ -1,26 +1,33 @@
 """Build an authenticated :class:`PipefyClient` from CLI configuration.
 
-The credential precedence chain (most explicit wins) is:
-
-1. ``--token`` CLI flag
-2. ``PIPEFY_TOKEN`` env var
-3. ``PIPEFY_SERVICE_ACCOUNT_*`` triple → client-credentials grant (service account)
-4. Stored user session from ``pipefy auth login`` (keychain) — refreshed
-   eagerly when the access token is within the leeway window
-
-Tiers 1 and 2 reach this function collapsed into ``AuthContext.bearer_token``
-(resolved by the root Typer callback in ``main.py``); tier 4 resolves into
-the same slot. The cache key includes whichever bearer ultimately reaches the
-SDK, so a refresh-rotated access token naturally invalidates the cached client.
+The precedence chain lives in :func:`pipefy_auth.resolve_pipefy_auth`; this
+module collapses the CLI's two static-token surfaces (``--token`` flag and
+``PIPEFY_TOKEN`` env var) into a single value before calling the resolver, and
+translates resolver failures into Typer exits. The flag-vs-env distinction
+survives only as a diagnostic label for ``pipefy auth status``.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Literal, NoReturn
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from typing import Literal
 
 import typer
-from pipefy_auth import OidcClient, RefreshError, ensure_fresh_session, load_session
+from httpx import Auth
+from pipefy_auth import (
+    STATIC_TOKEN_TIER,
+    STORED_SESSION_TIER,
+    OidcClient,
+    RefreshError,
+    ServiceAccount,
+    detect_pipefy_tiers,
+    ensure_fresh_session,
+    missing_auth_message,
+    resolve_pipefy_auth,
+    tier_for,
+)
 from pipefy_sdk import (
     AiAutomationService,
     InternalApiClient,
@@ -29,27 +36,17 @@ from pipefy_sdk import (
 )
 
 from pipefy_cli._docs import DOCS_CLI_AUTH_REF
-from pipefy_cli.config import (
-    describe_missing_service_account_vars,
-    ensure_public_graphql_configured,
-)
+from pipefy_cli.config import ensure_public_graphql_configured
 
-AuthSource = Literal[
-    "flag-token",
-    "env-token",
-    "service-account",
-    "stored-session",
-    "none",
-]
+# Display labels for ``pipefy auth status``. The resolver knows the
+# static-token tier; the CLI restores the flag-vs-env distinction here.
+FLAG_TOKEN_SOURCE = "flag-token"
+ENV_TOKEN_SOURCE = "env-token"
 
 
 @dataclass(frozen=True)
 class BearerToken:
-    """Static bearer token plus the surface that produced it (``--token`` or env).
-
-    Carrying the origin lets diagnostics (e.g. ``pipefy auth status``) report which
-    precedence tier won without having to re-inspect ``argv``/``os.environ``.
-    """
+    """Static bearer token plus the surface that produced it (``--token`` or env)."""
 
     value: str
     source: Literal["flag", "env"]
@@ -68,7 +65,7 @@ class AuthContext:
     oidc_client: OidcClient | None
 
 
-_cached_signature: tuple[object, ...] | None = None
+_cached_signature: str | None = None
 # One-shot CLIs reuse this; long-lived programmatic use should call
 # ``clear_authenticated_client_cache`` between logical sessions (tests reset via fixture).
 _cached_client: PipefyClient | None = None
@@ -81,77 +78,72 @@ def clear_authenticated_client_cache() -> None:
     _cached_client = None
 
 
+def _service_account(pipefy_settings: PipefySettings) -> ServiceAccount | None:
+    if (
+        pipefy_settings.service_account_url
+        and pipefy_settings.service_account_client_id
+        and pipefy_settings.service_account_client_secret
+    ):
+        return ServiceAccount(
+            token_url=pipefy_settings.service_account_url,
+            client_id=pipefy_settings.service_account_client_id,
+            client_secret=pipefy_settings.service_account_client_secret,
+        )
+    return None
+
+
+def _resolve(pipefy_settings: PipefySettings, auth: AuthContext) -> Auth | None:
+    return resolve_pipefy_auth(
+        static_token=auth.bearer_token.value if auth.bearer_token else None,
+        service_account=_service_account(pipefy_settings),
+        oidc_client=auth.oidc_client,
+    )
+
+
+def _to_display_source(tier: str, bearer: BearerToken | None) -> str:
+    """Map a resolver tier name to the locked JSON wire schema for ``auth status``."""
+    if tier == STATIC_TOKEN_TIER:
+        return (
+            FLAG_TOKEN_SOURCE
+            if bearer and bearer.source == "flag"
+            else ENV_TOKEN_SOURCE
+        )
+    return tier
+
+
+def detect_cli_sources(pipefy_settings: PipefySettings, auth: AuthContext) -> list[str]:
+    """Return detected sources mapped to CLI display labels."""
+    detected = detect_pipefy_tiers(
+        static_token=auth.bearer_token.value if auth.bearer_token else None,
+        service_account=_service_account(pipefy_settings),
+        oidc_client=auth.oidc_client,
+    )
+    return [_to_display_source(tier, auth.bearer_token) for tier in detected]
+
+
 def _cache_key(
     pipefy_settings: PipefySettings,
-    bearer_token: str | None,
-) -> tuple[object, ...]:
-    return (
-        (pipefy_settings.graphql_url or "").strip(),
-        (pipefy_settings.internal_api_url or "").strip(),
-        (pipefy_settings.service_account_url or "").strip(),
-        (pipefy_settings.service_account_client_id or "").strip(),
-        (pipefy_settings.service_account_client_secret or "").strip(),
-        bool(pipefy_settings.allow_insecure_urls),
-        (bearer_token or "").strip(),
-    )
-
-
-def detect_all_sources(
-    pipefy_settings: PipefySettings,
     auth: AuthContext,
-) -> list[AuthSource]:
-    """Return every configured credential source, highest-precedence first.
+    tier: str,
+) -> str:
+    """SHA-256 digest of every input that could change the cached client.
 
-    Side-effect-free except for a single keychain read when an ``oidc_client`` is
-    set. Powers both :func:`detect_auth_source` (winner = first element) and
-    diagnostic display (full list surfaces masked sources).
+    Hashed (not stored as plaintext) so the dump's secrets — the bearer
+    token, the service-account ``client_secret`` — don't linger in module
+    state for the process lifetime. Adding a new field to
+    :class:`PipefySettings` or :class:`AuthContext` automatically participates
+    in the key without touching this function.
     """
-    sources: list[AuthSource] = []
-    if auth.bearer_token is not None:
-        sources.append(
-            "flag-token" if auth.bearer_token.source == "flag" else "env-token"
-        )
-    if not describe_missing_service_account_vars(pipefy_settings):
-        sources.append("service-account")
-    if (
-        auth.oidc_client is not None
-        and load_session(
-            issuer=auth.oidc_client.issuer_url,
-            client_id=auth.oidc_client.client_id,
-        )
-        is not None
-    ):
-        sources.append("stored-session")
-    return sources
-
-
-def detect_auth_source(
-    pipefy_settings: PipefySettings,
-    auth: AuthContext,
-) -> AuthSource:
-    """Return the precedence winner among configured sources, or ``"none"``."""
-    sources = detect_all_sources(pipefy_settings, auth)
-    return sources[0] if sources else "none"
-
-
-def _missing_auth_message(pipefy_settings: PipefySettings) -> str:
-    missing = describe_missing_service_account_vars(pipefy_settings)
-    return (
-        "Missing authentication. Use --token, set PIPEFY_TOKEN, configure "
-        f"PIPEFY_SERVICE_ACCOUNT_* ({missing}), or run `pipefy auth login`. "
-        f"See {DOCS_CLI_AUTH_REF}."
+    payload = json.dumps(
+        {
+            "settings": pipefy_settings.model_dump(mode="json"),
+            "auth": asdict(auth),
+            "tier": tier,
+        },
+        sort_keys=True,
+        default=str,
     )
-
-
-def _raise_internal_error(detail: str) -> NoReturn:
-    """Exit(2) with an internal-error message.
-
-    Used for branches the auth-source classifier rules out but the type system
-    can't prove unreachable. ``assert`` would strip under ``python -O``; this
-    survives the optimization and gives the user a clean error.
-    """
-    typer.echo(f"Internal error: {detail} Please file an issue.", err=True)
-    raise typer.Exit(2)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
 def get_authenticated_client(
@@ -160,21 +152,9 @@ def get_authenticated_client(
 ) -> PipefyClient:
     """Return a facade client using the highest-precedence available auth source.
 
-    Args:
-        pipefy_settings: Validated Pipefy endpoint settings (``PIPEFY_*``).
-        auth: User-auth identity for this invocation. ``bearer_token`` covers
-            tiers 1 and 2 (``--token`` / ``PIPEFY_TOKEN``); ``oidc_client`` covers
-            tier 4 (stored user session keyed by issuer + client id). Tier 3
-            (service-account client credentials) is resolved from
-            ``pipefy_settings`` alone.
-
-    Returns:
-        Shared in-process instance when settings match a prior call; otherwise
-        a new client.
-
     Raises:
-        typer.Exit: Code 2 when no auth source resolves, or when a stored
-            session exists but refresh failed.
+        typer.Exit: Code 2 when no auth source resolves, or when refreshing a
+            stored session fails.
     """
     global _cached_signature, _cached_client
 
@@ -184,28 +164,23 @@ def get_authenticated_client(
         typer.echo(str(exc), err=True)
         raise typer.Exit(2) from exc
 
-    source = detect_auth_source(pipefy_settings, auth)
-
-    if source == "none":
-        typer.echo(_missing_auth_message(pipefy_settings), err=True)
+    resolved = _resolve(pipefy_settings, auth)
+    if resolved is None:
+        typer.echo(f"{missing_auth_message()} See {DOCS_CLI_AUTH_REF}.", err=True)
         raise typer.Exit(2)
+    tier = tier_for(resolved)
 
-    # Resolve the effective bearer BEFORE the cache lookup so a refresh-rotated
-    # access token produces the right (new) cache signature.
-    effective_bearer: str | None = None
-    if source in ("flag-token", "env-token"):
-        if auth.bearer_token is None:
-            _raise_internal_error(
-                f"auth source {source!r} detected but no bearer token is configured."
-            )
-        effective_bearer = auth.bearer_token.value
-    elif source == "stored-session":
+    # Stored-session: warm up eagerly so refresh failures surface as a clean
+    # exit(2) with a "run `pipefy auth login` again" hint instead of leaking
+    # out as a transport error on the first GraphQL call. ``CallableBearerAuth``
+    # observes the rotated token on subsequent requests.
+    if tier == STORED_SESSION_TIER:
         if auth.oidc_client is None:
-            _raise_internal_error(
-                "auth source 'stored-session' detected but no OIDC client is configured."
-            )
+            # Unreachable per the resolver contract; guard kept so the
+            # invariant holds under ``python -O``.
+            raise typer.Exit(2)
         try:
-            session = ensure_fresh_session(
+            ensure_fresh_session(
                 issuer=auth.oidc_client.issuer_url,
                 client_id=auth.oidc_client.client_id,
             )
@@ -216,39 +191,20 @@ def get_authenticated_client(
                 err=True,
             )
             raise typer.Exit(2) from exc
-        # ``detect_auth_source`` already confirmed a session is present; if it
-        # vanished between the two reads, fall through to the missing-auth path.
-        if session is None:
-            typer.echo(_missing_auth_message(pipefy_settings), err=True)
-            raise typer.Exit(2)
-        effective_bearer = session.access_token
 
-    key = _cache_key(pipefy_settings, effective_bearer)
+    key = _cache_key(pipefy_settings, auth, tier)
     if _cached_client is not None and _cached_signature == key:
         return _cached_client
 
-    if effective_bearer:
-        # Priorities 1, 2, and 4 collapse to "use a static bearer".
-        # The bearer slot does not build an InternalApiClient — same
-        # limitation as ``--token``/``PIPEFY_TOKEN`` today.
-        client: PipefyClient = PipefyClient(
-            pipefy_settings, bearer_token=effective_bearer.strip()
+    client = PipefyClient(pipefy_settings, auth=resolved)
+    if pipefy_settings.internal_api_url:
+        internal_client = InternalApiClient(
+            url=pipefy_settings.internal_api_url,
+            auth=resolved,
+            allow_insecure_urls=pipefy_settings.allow_insecure_urls,
         )
-        _cached_signature = key
-        _cached_client = client
-        return client
-
-    # source == "service-account": client-credentials grant.
-    client = PipefyClient(pipefy_settings)
-    internal_client = InternalApiClient(
-        url=pipefy_settings.internal_api_url,
-        service_account_url=pipefy_settings.service_account_url,
-        service_account_client_id=pipefy_settings.service_account_client_id,
-        service_account_client_secret=pipefy_settings.service_account_client_secret,
-        allow_insecure_urls=pipefy_settings.allow_insecure_urls,
-    )
-    client.set_internal_api_client(internal_client)
-    client.set_ai_automation_service(AiAutomationService(client=internal_client))
+        client.set_internal_api_client(internal_client)
+        client.set_ai_automation_service(AiAutomationService(client=internal_client))
     _cached_signature = key
     _cached_client = client
     return client
@@ -256,10 +212,10 @@ def get_authenticated_client(
 
 __all__ = [
     "AuthContext",
-    "AuthSource",
     "BearerToken",
+    "ENV_TOKEN_SOURCE",
+    "FLAG_TOKEN_SOURCE",
     "clear_authenticated_client_cache",
-    "detect_all_sources",
-    "detect_auth_source",
+    "detect_cli_sources",
     "get_authenticated_client",
 ]

--- a/packages/cli/src/pipefy_cli/commands/auth.py
+++ b/packages/cli/src/pipefy_cli/commands/auth.py
@@ -37,12 +37,23 @@ from pipefy_sdk.settings import _LEGACY_ENV_KEYS_TO_NEW
 from pipefy_cli._docs import DOCS_CLI_AUTH_REF
 from pipefy_cli.auth import (
     AuthContext,
-    AuthSource,
-    detect_all_sources,
+    detect_cli_sources,
     get_authenticated_client,
 )
 from pipefy_cli.commands._common import settings_and_auth_from_ctx
 from pipefy_cli.output import render_json
+
+# Locked JSON wire schema. Matches the policy ``name`` field produced by
+# :func:`pipefy_cli.auth.build_policies` (so the resolver's identifiers reach
+# the wire unchanged), plus an explicit ``"none"`` sentinel for the case where
+# no policy resolved.
+DisplaySource = Literal[
+    "flag-token",
+    "env-token",
+    "service-account",
+    "stored-session",
+    "none",
+]
 
 AuthSessionState = Literal["active", "refresh-expired", "needs-login", "n/a"]
 
@@ -56,8 +67,8 @@ class AuthStatusReport:
     contract and the internal model can evolve independently.
     """
 
-    auth_source: AuthSource
-    detected_sources: list[AuthSource]
+    auth_source: DisplaySource
+    detected_sources: list[DisplaySource]
     issuer: str | None = None
     state: AuthSessionState = "n/a"
     access_expires_at: str | None = None
@@ -207,7 +218,7 @@ def auth_login(
     _warn_if_masked()
 
 
-_AUTH_SOURCE_LABELS: dict[AuthSource, str] = {
+_AUTH_SOURCE_LABELS: dict[DisplaySource, str] = {
     "flag-token": "--token flag",
     "env-token": "PIPEFY_TOKEN environment variable",
     "service-account": "PIPEFY_SERVICE_ACCOUNT_* (client credentials)",
@@ -405,8 +416,14 @@ def auth_status(
 ) -> None:
     """Print which auth source is active, the authenticated identity, and session expiry."""
     settings, auth = settings_and_auth_from_ctx(ctx)
-    detected = detect_all_sources(settings, auth)
-    source: AuthSource = detected[0] if detected else "none"
+    detected_names = detect_cli_sources(settings, auth)
+    # The locked JSON wire schema matches the policy names exactly; cast for
+    # typing only — values are already constrained by ``build_policies``.
+    detected: list[DisplaySource] = [
+        name  # type: ignore[misc]
+        for name in detected_names
+    ]
+    source: DisplaySource = detected[0] if detected else "none"
     report = AuthStatusReport(auth_source=source, detected_sources=detected)
     # Surface masking env vars whenever a stored session exists — that's the
     # CI-overrides-keychain failure mode the field is for, and the higher-

--- a/packages/cli/tests/test_auth.py
+++ b/packages/cli/tests/test_auth.py
@@ -1,4 +1,4 @@
-"""Tests for ``pipefy_cli.auth`` (service-account / bearer factory and CLI exits)."""
+"""Tests for ``pipefy_cli.auth`` (resolver wiring, eager warmup, CLI exits)."""
 
 from __future__ import annotations
 
@@ -7,12 +7,18 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import typer
-from pipefy_auth import OidcClient, StoredSession
+from pipefy_auth import (
+    CallableBearerAuth,
+    OidcClient,
+    StaticBearerAuth,
+    StoredSession,
+)
 from pipefy_sdk import PipefySettings
 
 from pipefy_cli.auth import (
     AuthContext,
     BearerToken,
+    detect_cli_sources,
     get_authenticated_client,
 )
 from pipefy_cli.main import app
@@ -49,28 +55,39 @@ def _auth(
     return AuthContext(bearer_token=bearer, oidc_client=oidc_client)
 
 
-def test_get_authenticated_client_passes_bearer_to_pipefy_client(clean_pipefy_env):
+def test_get_authenticated_client_passes_auth_to_pipefy_client(clean_pipefy_env):
     settings = _minimal_service_account_settings()
     with patch("pipefy_cli.auth.PipefyClient") as mock_pc:
         mock_pc.return_value = MagicMock()
         client = get_authenticated_client(settings, _auth(bearer_token="tok"))
-        mock_pc.assert_called_once_with(settings, bearer_token="tok")
+        kwargs = mock_pc.call_args.kwargs
+        assert mock_pc.call_args.args == (settings,)
+        assert isinstance(kwargs["auth"], StaticBearerAuth)
         assert client is mock_pc.return_value
 
 
-def test_get_authenticated_client_service_account_mode_no_bearer(clean_pipefy_env):
+def test_get_authenticated_client_service_account_wires_internal_api(clean_pipefy_env):
     settings = _minimal_service_account_settings()
-    with patch("pipefy_cli.auth.PipefyClient") as mock_pc:
+    with (
+        patch("pipefy_cli.auth.PipefyClient") as mock_pc,
+        patch("pipefy_cli.auth.InternalApiClient") as mock_internal,
+        patch("pipefy_cli.auth.AiAutomationService"),
+    ):
         mock_pc.return_value = MagicMock()
         get_authenticated_client(settings, _auth())
-        mock_pc.assert_called_once_with(settings)
+        mock_pc.assert_called_once()
+        mock_internal.assert_called_once()
 
 
 def test_cache_returns_same_instance_for_identical_service_account_settings(
     clean_pipefy_env,
 ):
     settings = _minimal_service_account_settings()
-    with patch("pipefy_cli.auth.PipefyClient") as mock_pc:
+    with (
+        patch("pipefy_cli.auth.PipefyClient") as mock_pc,
+        patch("pipefy_cli.auth.InternalApiClient"),
+        patch("pipefy_cli.auth.AiAutomationService"),
+    ):
         mock_pc.return_value = MagicMock()
         first = get_authenticated_client(settings, _auth())
         second = get_authenticated_client(settings, _auth())
@@ -118,7 +135,28 @@ def test_cli_uses_pipefy_token_env_when_no_flag(
 
 
 # --------------------------------------------------------------------------- #
-# Priority 4: stored user session                                             #
+# Display source mapping                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def test_detect_cli_sources_maps_static_token_to_flag_label(clean_pipefy_env):
+    """``--token`` source surfaces as the locked ``flag-token`` wire value."""
+    settings = _minimal_service_account_settings()
+    sources = detect_cli_sources(
+        settings, _auth(bearer_token="t", bearer_source="flag")
+    )
+    assert sources[0] == "flag-token"
+
+
+def test_detect_cli_sources_maps_env_token_to_env_label(clean_pipefy_env):
+    """``PIPEFY_TOKEN`` source surfaces as the locked ``env-token`` wire value."""
+    settings = _minimal_service_account_settings()
+    sources = detect_cli_sources(settings, _auth(bearer_token="t", bearer_source="env"))
+    assert sources[0] == "env-token"
+
+
+# --------------------------------------------------------------------------- #
+# Stored user session                                                         #
 # --------------------------------------------------------------------------- #
 
 
@@ -142,15 +180,18 @@ def _fresh_stored_session(*, access_token: str = "SESSION_ACCESS") -> StoredSess
 
 
 def _public_only_settings() -> PipefySettings:
-    """``PIPEFY_SERVICE_ACCOUNT_*`` triple absent → priority 3 unavailable, falls through to 4."""
+    """``PIPEFY_SERVICE_ACCOUNT_*`` triple absent → service-account tier unavailable, stored session wins."""
     return PipefySettings(graphql_url="https://unit.example.com/graphql")
 
 
 def test_bearer_token_wins_over_stored_session(clean_pipefy_env):
-    """Priority 1/2 (bearer) MUST short-circuit before the keychain is even consulted."""
+    """The static-token tier MUST short-circuit before the keychain is even consulted."""
     settings = _minimal_service_account_settings()
     with (
         patch("pipefy_cli.auth.PipefyClient") as mock_pc,
+        patch("pipefy_cli.auth.InternalApiClient"),
+        patch("pipefy_cli.auth.AiAutomationService"),
+        patch("pipefy_auth.resolver.load_session") as mock_load,
         patch("pipefy_cli.auth.ensure_fresh_session") as mock_ensure,
     ):
         mock_pc.return_value = MagicMock()
@@ -162,17 +203,19 @@ def test_bearer_token_wins_over_stored_session(clean_pipefy_env):
                 client_id="pipefy-cli",
             ),
         )
-        mock_pc.assert_called_once_with(settings, bearer_token="explicit-bearer")
+        assert isinstance(mock_pc.call_args.kwargs["auth"], StaticBearerAuth)
         mock_ensure.assert_not_called()
+        mock_load.assert_not_called()
 
 
 def test_service_account_creds_win_over_stored_session(clean_pipefy_env):
-    """Priority 3 (full service-account triple) MUST short-circuit before the keychain is consulted."""
+    """The service-account tier MUST short-circuit before the keychain is consulted."""
     settings = _minimal_service_account_settings()
     with (
         patch("pipefy_cli.auth.PipefyClient") as mock_pc,
         patch("pipefy_cli.auth.InternalApiClient"),
         patch("pipefy_cli.auth.AiAutomationService"),
+        patch("pipefy_auth.resolver.load_session") as mock_load,
         patch("pipefy_cli.auth.ensure_fresh_session") as mock_ensure,
     ):
         mock_pc.return_value = MagicMock()
@@ -180,68 +223,67 @@ def test_service_account_creds_win_over_stored_session(clean_pipefy_env):
             settings,
             _auth(issuer_url=_ISSUER, client_id="pipefy-cli"),
         )
-        mock_pc.assert_called_once_with(settings)
+        mock_pc.assert_called_once()
         mock_ensure.assert_not_called()
+        mock_load.assert_not_called()
 
 
 def test_stored_session_used_when_no_other_source(clean_pipefy_env):
-    """Priority 4 activates when bearer absent AND OAuth triple incomplete."""
+    """Stored-session tier activates when bearer absent and service-account triple incomplete."""
     settings = _public_only_settings()
     session = _fresh_stored_session()
     with (
         patch("pipefy_cli.auth.PipefyClient") as mock_pc,
-        patch("pipefy_cli.auth.load_session", return_value=session),
+        patch("pipefy_auth.resolver.load_session", return_value=session),
         patch("pipefy_cli.auth.ensure_fresh_session", return_value=session),
     ):
         mock_pc.return_value = MagicMock()
         get_authenticated_client(
             settings, _auth(issuer_url=_ISSUER, client_id="pipefy-cli")
         )
-        mock_pc.assert_called_once_with(settings, bearer_token=session.access_token)
+        mock_pc.assert_called_once()
+        assert isinstance(mock_pc.call_args.kwargs["auth"], CallableBearerAuth)
 
 
-def test_cache_invalidates_when_access_token_rotates(clean_pipefy_env):
-    """Two calls with different rotated access tokens → two PipefyClient builds."""
+def test_cache_reuses_resolved_auth_for_stored_session(clean_pipefy_env):
+    """Two stored-session calls with identical OIDC inputs reuse the cached client."""
     settings = _public_only_settings()
     stored = _fresh_stored_session()
-    sessions = iter(
-        [
-            _fresh_stored_session(access_token="ROTATED_1"),
-            _fresh_stored_session(access_token="ROTATED_2"),
-        ]
-    )
     with (
         patch("pipefy_cli.auth.PipefyClient") as mock_pc,
-        patch("pipefy_cli.auth.load_session", return_value=stored),
-        patch(
-            "pipefy_cli.auth.ensure_fresh_session",
-            side_effect=lambda **_: next(sessions),
-        ),
+        patch("pipefy_auth.resolver.load_session", return_value=stored),
+        patch("pipefy_cli.auth.ensure_fresh_session", return_value=stored),
     ):
-        mock_pc.side_effect = [MagicMock(), MagicMock()]
-        get_authenticated_client(
+        mock_pc.return_value = MagicMock()
+        first = get_authenticated_client(
             settings, _auth(issuer_url=_ISSUER, client_id="pipefy-cli")
         )
-        get_authenticated_client(
+        second = get_authenticated_client(
             settings, _auth(issuer_url=_ISSUER, client_id="pipefy-cli")
         )
-        assert mock_pc.call_count == 2
-        assert mock_pc.call_args_list[0].kwargs["bearer_token"] == "ROTATED_1"
-        assert mock_pc.call_args_list[1].kwargs["bearer_token"] == "ROTATED_2"
+        assert first is second
+        assert mock_pc.call_count == 1
 
 
 def test_refresh_error_exits_2_with_relogin_hint(clean_pipefy_env, capsys):
-    """RefreshError from ensure_fresh_session surfaces as exit(2) + relogin message."""
+    """RefreshError from the eager warmup surfaces as exit(2) + relogin message."""
     from pipefy_auth import RefreshError
 
     settings = _public_only_settings()
     with (
-        patch("pipefy_cli.auth.load_session", return_value=_fresh_stored_session()),
+        patch(
+            "pipefy_auth.resolver.load_session", return_value=_fresh_stored_session()
+        ),
+        patch("pipefy_cli.auth.resolve_pipefy_auth") as mock_resolve,
         patch(
             "pipefy_cli.auth.ensure_fresh_session",
             side_effect=RefreshError("invalid_grant"),
         ),
     ):
+        # ``resolve_pipefy_auth`` now returns the ``httpx.Auth`` directly;
+        # use a real ``CallableBearerAuth`` so ``tier_for`` recognises it as
+        # the stored-session tier and triggers the eager warmup.
+        mock_resolve.return_value = CallableBearerAuth(lambda: "ACCESS")
         with pytest.raises(typer.Exit) as excinfo:
             get_authenticated_client(
                 settings, _auth(issuer_url=_ISSUER, client_id="pipefy-cli")

--- a/packages/cli/tests/test_auth.py
+++ b/packages/cli/tests/test_auth.py
@@ -79,6 +79,24 @@ def test_get_authenticated_client_service_account_wires_internal_api(clean_pipef
         mock_internal.assert_called_once()
 
 
+def test_get_authenticated_client_bearer_path_shares_auth_with_internal_api(
+    clean_pipefy_env,
+):
+    """Both clients receive the SAME ``auth`` instance on the bearer path."""
+    settings = _minimal_service_account_settings()
+    with (
+        patch("pipefy_cli.auth.PipefyClient") as mock_pc,
+        patch("pipefy_cli.auth.InternalApiClient") as mock_internal,
+        patch("pipefy_cli.auth.AiAutomationService"),
+    ):
+        mock_pc.return_value = MagicMock()
+        get_authenticated_client(settings, _auth(bearer_token="tok"))
+        pc_auth = mock_pc.call_args.kwargs["auth"]
+        internal_auth = mock_internal.call_args.kwargs["auth"]
+        assert isinstance(pc_auth, StaticBearerAuth)
+        assert internal_auth is pc_auth
+
+
 def test_cache_returns_same_instance_for_identical_service_account_settings(
     clean_pipefy_env,
 ):

--- a/packages/mcp/pyproject.toml
+++ b/packages/mcp/pyproject.toml
@@ -7,13 +7,15 @@ requires-python = ">=3.11"
 dependencies = [
     "httpx>=0.27.0",
     "mcp[cli]>=1.25.0",
-    # Workspace resolves version in dev; PyPI releases stage this wheel alongside CLI/MCP (see release workflow).
+    # Workspace resolves versions in dev; PyPI releases stage these wheels alongside CLI/MCP (see release workflow).
+    "pipefy-auth",
     "pipefy-sdk",
     "pydantic>=2.11.3",
     "pydantic-settings>=2.8.1",
 ]
 
 [tool.uv.sources]
+pipefy-auth = { workspace = true }
 pipefy-sdk = { workspace = true }
 
 [project.scripts]

--- a/packages/mcp/src/pipefy_mcp/core/container.py
+++ b/packages/mcp/src/pipefy_mcp/core/container.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
+import os
 from typing import Self
 
+from pipefy_auth import (
+    ServiceAccount,
+    missing_auth_message,
+    resolve_pipefy_auth,
+)
 from pipefy_sdk import AiAutomationService, InternalApiClient, PipefyClient
 
 from pipefy_mcp.settings import Settings
@@ -26,23 +32,31 @@ class ServicesContainer:
         Args:
             settings: Application settings with Pipefy credentials.
         """
-        self.pipefy_client = PipefyClient(settings=settings.pipefy)
-
-        service_account_url = settings.pipefy.service_account_url
-        service_account_client_id = settings.pipefy.service_account_client_id
-        service_account_client_secret = settings.pipefy.service_account_client_secret
-
+        pipefy = settings.pipefy
+        service_account: ServiceAccount | None = None
         if (
-            service_account_url
-            and service_account_client_id
-            and service_account_client_secret
+            pipefy.service_account_url
+            and pipefy.service_account_client_id
+            and pipefy.service_account_client_secret
         ):
+            service_account = ServiceAccount(
+                token_url=pipefy.service_account_url,
+                client_id=pipefy.service_account_client_id,
+                client_secret=pipefy.service_account_client_secret,
+            )
+        # The stored-session tier is wired in a follow-up against #213.
+        resolved = resolve_pipefy_auth(
+            static_token=os.environ.get("PIPEFY_TOKEN"),
+            service_account=service_account,
+        )
+        if resolved is None:
+            raise RuntimeError(missing_auth_message())
+        self.pipefy_client = PipefyClient(settings=pipefy, auth=resolved)
+        if pipefy.internal_api_url:
             internal_client = InternalApiClient(
-                url=settings.pipefy.internal_api_url,
-                service_account_url=service_account_url,
-                service_account_client_id=service_account_client_id,
-                service_account_client_secret=service_account_client_secret,
-                allow_insecure_urls=settings.pipefy.allow_insecure_urls,
+                url=pipefy.internal_api_url,
+                auth=resolved,
+                allow_insecure_urls=pipefy.allow_insecure_urls,
             )
             self.pipefy_client.set_internal_api_client(internal_client)
             self.pipefy_client.set_ai_automation_service(

--- a/packages/mcp/tests/core/test_container.py
+++ b/packages/mcp/tests/core/test_container.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock, patch
 
 import pytest
+from pipefy_auth import StaticBearerAuth
 from pipefy_sdk import PipefyClient, PipefySettings
 
 from pipefy_mcp.core.container import ServicesContainer
@@ -67,7 +68,10 @@ class TestServicesContainer:
         container = ServicesContainer()
         container.initialize_services(settings)
 
-        mock_pipefy_client_class.assert_called_once_with(settings=settings.pipefy)
+        mock_pipefy_client_class.assert_called_once()
+        kwargs = mock_pipefy_client_class.call_args.kwargs
+        assert kwargs["settings"] is settings.pipefy
+        assert "auth" in kwargs
         assert container.pipefy_client is mock_client
 
     @patch("pipefy_mcp.core.container.InternalApiClient")
@@ -100,3 +104,48 @@ class TestServicesContainer:
         mock_client.set_ai_automation_service.assert_called_once_with(
             mock_ai_automation_service_class.return_value
         )
+
+    @patch("pipefy_mcp.core.container.AiAutomationService")
+    @patch("pipefy_mcp.core.container.InternalApiClient")
+    @patch("pipefy_mcp.core.container.PipefyClient")
+    def test_initialize_services_picks_up_pipefy_token_over_service_account(
+        self,
+        mock_pipefy_client_class,
+        mock_internal_api_client_class,
+        mock_ai_automation_service_class,
+        monkeypatch,
+    ):
+        """``PIPEFY_TOKEN`` outranks ``PIPEFY_SERVICE_ACCOUNT_*`` (same precedence as the CLI)."""
+        mock_pipefy_client_class.return_value = Mock(spec=PipefyClient)
+        monkeypatch.setenv("PIPEFY_TOKEN", "env-bearer")
+        settings = Settings(
+            pipefy=PipefySettings(
+                graphql_url="https://api.pipefy.com/graphql",
+                service_account_url="https://auth.pipefy.com/oauth/token",
+                service_account_client_id="client_id",
+                service_account_client_secret="client_secret",
+            )
+        )
+        ServicesContainer().initialize_services(settings)
+        auth = mock_pipefy_client_class.call_args.kwargs["auth"]
+        assert isinstance(auth, StaticBearerAuth)
+
+    @patch("pipefy_mcp.core.container.AiAutomationService")
+    @patch("pipefy_mcp.core.container.InternalApiClient")
+    @patch("pipefy_mcp.core.container.PipefyClient")
+    def test_initialize_services_raises_when_no_auth_source_configured(
+        self,
+        mock_pipefy_client_class,
+        mock_internal_api_client_class,
+        mock_ai_automation_service_class,
+        monkeypatch,
+    ):
+        """No PIPEFY_TOKEN and no service-account triple → runtime error with policy chain."""
+        monkeypatch.delenv("PIPEFY_TOKEN", raising=False)
+        settings = Settings(
+            pipefy=PipefySettings(
+                graphql_url="https://api.pipefy.com/graphql",
+            )
+        )
+        with pytest.raises(RuntimeError, match="Missing Pipefy authentication"):
+            ServicesContainer().initialize_services(settings)

--- a/packages/mcp/tests/core/test_container.py
+++ b/packages/mcp/tests/core/test_container.py
@@ -115,8 +115,15 @@ class TestServicesContainer:
         mock_ai_automation_service_class,
         monkeypatch,
     ):
-        """``PIPEFY_TOKEN`` outranks ``PIPEFY_SERVICE_ACCOUNT_*`` (same precedence as the CLI)."""
-        mock_pipefy_client_class.return_value = Mock(spec=PipefyClient)
+        """``PIPEFY_TOKEN`` outranks ``PIPEFY_SERVICE_ACCOUNT_*`` (same precedence as the CLI).
+
+        Also asserts that the bearer path wires ``InternalApiClient`` +
+        ``AiAutomationService`` with the SAME ``auth`` instance
+        ``PipefyClient`` got, so GraphQL auth and AI automation can't drift.
+        """
+        mock_client = Mock(spec=PipefyClient)
+        mock_client.client = Mock()
+        mock_pipefy_client_class.return_value = mock_client
         monkeypatch.setenv("PIPEFY_TOKEN", "env-bearer")
         settings = Settings(
             pipefy=PipefySettings(
@@ -127,8 +134,14 @@ class TestServicesContainer:
             )
         )
         ServicesContainer().initialize_services(settings)
-        auth = mock_pipefy_client_class.call_args.kwargs["auth"]
-        assert isinstance(auth, StaticBearerAuth)
+        pc_auth = mock_pipefy_client_class.call_args.kwargs["auth"]
+        assert isinstance(pc_auth, StaticBearerAuth)
+        mock_internal_api_client_class.assert_called_once()
+        assert mock_internal_api_client_class.call_args.kwargs["auth"] is pc_auth
+        mock_ai_automation_service_class.assert_called_once()
+        mock_client.set_ai_automation_service.assert_called_once_with(
+            mock_ai_automation_service_class.return_value
+        )
 
     @patch("pipefy_mcp.core.container.AiAutomationService")
     @patch("pipefy_mcp.core.container.InternalApiClient")

--- a/packages/sdk/pyproject.toml
+++ b/packages/sdk/pyproject.toml
@@ -8,7 +8,6 @@ dependencies = [
     "email-validator>=2.2.0",
     "gql[httpx]>=3.5.2",
     "httpx>=0.27.0",
-    "httpx-auth>=0.23.1",
     "openpyxl>=3.1.5",
     "pydantic>=2.11.3",
     "pydantic-settings>=2.8.1",

--- a/packages/sdk/src/pipefy_sdk/base_client.py
+++ b/packages/sdk/src/pipefy_sdk/base_client.py
@@ -6,21 +6,9 @@ from typing import Any, ClassVar
 from gql import Client
 from gql.transport.httpx import HTTPXAsyncTransport
 from graphql import GraphQLSchema
-from httpx import Auth, Request, Timeout
-from httpx_auth import OAuth2ClientCredentials
+from httpx import Auth, Timeout
 
 from pipefy_sdk.settings import PipefySettings
-
-
-class StaticBearerAuth(Auth):
-    """Attach a fixed ``Authorization: Bearer …`` header (CLI ``--token``, tests)."""
-
-    def __init__(self, token: str) -> None:
-        self._token = token
-
-    def auth_flow(self, request: Request):
-        request.headers["Authorization"] = f"Bearer {self._token}"
-        yield request
 
 
 def unwrap_relay_connection_nodes(connection: Any) -> list[dict[str, Any]]:
@@ -45,9 +33,9 @@ class BasePipefyClient:
 
     Creates a fresh transport per execute_query() call so parallel requests
     never share mutable transport state (avoids TransportAlreadyConnected).
-    The OAuth2 auth instance is shared across calls to reuse the token cache.
-    Pass a pre-built auth instance to share it across multiple service instances
-    (e.g. from PipefyClient) so only one token cache exists for the whole client.
+    The ``auth`` instance is shared across calls to reuse the token cache.
+    Pass the same instance to multiple services (e.g. from PipefyClient) so
+    only one token cache exists for the whole client.
     """
 
     GRAPHQL_REQUEST_TIMEOUT_SECONDS: ClassVar[int] = 30
@@ -55,33 +43,14 @@ class BasePipefyClient:
     def __init__(
         self,
         settings: PipefySettings,
-        auth: OAuth2ClientCredentials | Auth | None = None,
+        *,
+        auth: Auth,
     ) -> None:
         if settings.graphql_url is None:
             raise ValueError("GraphQL URL must be provided in settings.")
 
         self.settings = settings
-
-        if auth is not None and not isinstance(auth, OAuth2ClientCredentials):
-            self._auth = auth
-            self._fetched_gql_schema = None
-            self._fetched_gql_schema_lock = asyncio.Lock()
-            return
-
-        if settings.service_account_url is None:
-            raise ValueError("Service-account URL must be provided in settings.")
-        if settings.service_account_client_id is None:
-            raise ValueError("Service-account client ID must be provided in settings.")
-        if settings.service_account_client_secret is None:
-            raise ValueError(
-                "Service-account client secret must be provided in settings."
-            )
-
-        self._auth = auth or OAuth2ClientCredentials(
-            token_url=settings.service_account_url,
-            client_id=settings.service_account_client_id,
-            client_secret=settings.service_account_client_secret,
-        )
+        self._auth = auth
         # Populated when gql_reuse_fetched_graphql_schema is True; avoids repeating
         # introspection on every new Client (see Cons5 code review).
         self._fetched_gql_schema: GraphQLSchema | None = None

--- a/packages/sdk/src/pipefy_sdk/client.py
+++ b/packages/sdk/src/pipefy_sdk/client.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import Any
 
 from httpx import Auth
-from httpx_auth import OAuth2ClientCredentials
 
 from pipefy_sdk.ai_pipe_validation import resolve_and_populate_field_refs
 from pipefy_sdk.attachment_upload import (
@@ -16,7 +15,6 @@ from pipefy_sdk.attachment_upload import (
 from pipefy_sdk.automation_preflight import (
     validate_traditional_automation_move_transition,
 )
-from pipefy_sdk.base_client import StaticBearerAuth
 from pipefy_sdk.models.ai_agent import (
     BehaviorInput,
     CreateAiAgentInput,
@@ -83,24 +81,16 @@ class PipefyClient:
         self,
         settings: PipefySettings,
         *,
-        bearer_token: str | None = None,
+        auth: Auth,
     ) -> None:
-        """Build a facade wired for OAuth client-credentials or a static bearer token.
+        """Build a facade wired with a pre-constructed ``httpx.Auth``.
 
         Args:
-            settings: Pipefy endpoints and credentials (OAuth fields may be omitted when
-                ``bearer_token`` is set).
-            bearer_token: When set, GraphQL requests use this bearer and OAuth credentials
-                from ``settings`` are not required for the public GraphQL transport.
+            settings: Pipefy endpoint configuration.
+            auth: ``httpx.Auth`` that supplies the credentials for every GraphQL
+                call (construct via ``pipefy_auth.resolve`` or one of the bearer
+                adapters from ``pipefy_auth``).
         """
-        if bearer_token is not None:
-            auth: Auth = StaticBearerAuth(bearer_token)
-        else:
-            auth = OAuth2ClientCredentials(
-                token_url=settings.service_account_url,
-                client_id=settings.service_account_client_id,
-                client_secret=settings.service_account_client_secret,
-            )
         self._pipe_service = PipeService(settings=settings, auth=auth)
         self._card_service = CardService(settings=settings, auth=auth)
         self._pipe_config_service = PipeConfigService(

--- a/packages/sdk/src/pipefy_sdk/services/internal_api_client.py
+++ b/packages/sdk/src/pipefy_sdk/services/internal_api_client.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 import httpx
-from httpx import Timeout
-from httpx_auth import OAuth2ClientCredentials
+from httpx import Auth, Timeout
 
 from pipefy_sdk.utils.url_ssrf import (
     validate_https_service_endpoint_url,
@@ -18,42 +17,29 @@ REQUEST_TIMEOUT_SECONDS = 30
 class InternalApiClient:
     """HTTP client for Pipefy internal API (AI Automation mutations).
 
-    Uses OAuth2 client credentials for token authentication. Sends GraphQL
-    requests as JSON POST to the configured internal_api URL.
+    Sends GraphQL requests as JSON POST to the configured internal_api URL,
+    using the ``httpx.Auth`` supplied at construction time.
     """
 
     def __init__(
         self,
         url: str,
-        service_account_url: str,
-        service_account_client_id: str,
-        service_account_client_secret: str,
         *,
+        auth: Auth,
         allow_insecure_urls: bool = False,
     ) -> None:
         """Create an internal API client.
 
         Args:
             url: URL of the internal_api endpoint (e.g. https://app.pipefy.com/internal_api).
-            service_account_url: Service-account token endpoint URL.
-            service_account_client_id: Service-account OAuth client_id.
-            service_account_client_secret: Service-account OAuth client_secret.
+            auth: Pre-constructed ``httpx.Auth`` (e.g. from ``pipefy_auth.resolve``).
             allow_insecure_urls: When True, allow http and internal hosts (must match settings).
         """
         validate_https_service_endpoint_url(
             url.strip(), "internal_api URL", allow_insecure=allow_insecure_urls
         )
-        validate_https_service_endpoint_url(
-            service_account_url.strip(),
-            "service-account URL",
-            allow_insecure=allow_insecure_urls,
-        )
         self._url = url
-        self._auth = OAuth2ClientCredentials(
-            token_url=service_account_url,
-            client_id=service_account_client_id,
-            client_secret=service_account_client_secret,
-        )
+        self._auth = auth
 
     async def execute_query(self, query: str, variables: dict[str, Any]) -> dict:
         """Execute a GraphQL query/mutation via POST.

--- a/packages/sdk/tests/services/pipefy/test_automation_service.py
+++ b/packages/sdk/tests/services/pipefy/test_automation_service.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 from gql.transport.exceptions import TransportQueryError
+from pipefy_auth import StaticBearerAuth
 
 from pipefy_sdk.queries.automation_queries import (
     AUTOMATION_SIMULATION_QUERY,
@@ -23,6 +24,9 @@ from pipefy_sdk.services.automation_service import (
     _format_automation_error_details,
 )
 from pipefy_sdk.settings import PipefySettings
+
+_TEST_AUTH = StaticBearerAuth("test-bearer-token")
+
 
 ## ---------------------------------------------------------------------------
 ## _format_automation_error_details edge cases
@@ -112,7 +116,7 @@ def mock_settings():
 
 
 def _make_service(mock_settings, return_value: dict):
-    service = AutomationService(settings=mock_settings)
+    service = AutomationService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(return_value=return_value)
     return service
 
@@ -175,7 +179,7 @@ async def test_get_automation_when_api_returns_null(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_get_automation_transport_error(mock_settings):
-    service = AutomationService(settings=mock_settings)
+    service = AutomationService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "not found"}])
     )
@@ -204,7 +208,7 @@ async def test_get_automations_success(mock_settings):
 @pytest.mark.asyncio
 async def test_get_automations_success_resolves_org_from_pipe(mock_settings):
     rows = [{"id": "a1", "name": "Rule 1", "active": True}]
-    service = AutomationService(settings=mock_settings)
+    service = AutomationService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=[
             {"pipe": {"organizationId": "300"}},
@@ -240,7 +244,7 @@ async def test_get_automations_organization_only_omits_repo_id(mock_settings):
 @pytest.mark.asyncio
 async def test_get_automations_pipe_only_org_not_found_returns_empty(mock_settings):
     """When pipe_id is given but org lookup returns no organizationId, return empty."""
-    service = AutomationService(settings=mock_settings)
+    service = AutomationService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(return_value={"pipe": {"organizationId": None}})
     result = await service.get_automations(pipe_id="100")
     assert result == []
@@ -250,7 +254,7 @@ async def test_get_automations_pipe_only_org_not_found_returns_empty(mock_settin
 @pytest.mark.asyncio
 async def test_get_automations_pipe_only_pipe_missing_returns_empty(mock_settings):
     """When pipe lookup returns no pipe key at all, return empty."""
-    service = AutomationService(settings=mock_settings)
+    service = AutomationService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(return_value={"pipe": None})
     result = await service.get_automations(pipe_id="100")
     assert result == []
@@ -291,7 +295,7 @@ async def test_get_automation_events_null_returns_empty(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_get_automations_both_none_returns_empty(mock_settings):
-    service = AutomationService(settings=mock_settings)
+    service = AutomationService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock()
     result = await service.get_automations()
     service.execute_query.assert_not_called()
@@ -301,7 +305,7 @@ async def test_get_automations_both_none_returns_empty(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_get_automations_transport_error(mock_settings):
-    service = AutomationService(settings=mock_settings)
+    service = AutomationService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "denied"}])
     )
@@ -338,7 +342,7 @@ async def test_get_automation_actions_success(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_get_automation_actions_transport_error(mock_settings):
-    service = AutomationService(settings=mock_settings)
+    service = AutomationService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "bad pipe"}])
     )
@@ -370,7 +374,7 @@ async def test_get_automation_events_success(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_get_automation_events_transport_error(mock_settings):
-    service = AutomationService(settings=mock_settings)
+    service = AutomationService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "nope"}])
     )
@@ -510,7 +514,7 @@ async def test_create_send_task_automation_includes_event_params_and_condition(
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_create_automation_transport_error(mock_settings):
-    service = AutomationService(settings=mock_settings)
+    service = AutomationService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "reject"}])
     )
@@ -571,7 +575,7 @@ async def test_update_automation_success(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_update_automation_transport_error(mock_settings):
-    service = AutomationService(settings=mock_settings)
+    service = AutomationService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "gone"}])
     )
@@ -595,7 +599,7 @@ async def test_delete_automation_success(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_delete_automation_transport_error(mock_settings):
-    service = AutomationService(settings=mock_settings)
+    service = AutomationService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "no access"}])
     )
@@ -619,7 +623,7 @@ async def test_simulate_automation_success(mock_settings):
             "simulationResult": {"preview": True},
         },
     }
-    service = AutomationService(settings=mock_settings)
+    service = AutomationService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(side_effect=[mutation_payload, query_payload])
     result = await service.simulate_automation(
         pipe_id="pipe-77",
@@ -667,7 +671,7 @@ async def test_simulate_automation_extra_input_overrides_repo_ids(mock_settings)
             "simulationResult": None,
         },
     }
-    service = AutomationService(settings=mock_settings)
+    service = AutomationService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(side_effect=[mutation_payload, query_payload])
     await service.simulate_automation(
         pipe_id="default-pipe",
@@ -683,7 +687,7 @@ async def test_simulate_automation_extra_input_overrides_repo_ids(mock_settings)
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_simulate_automation_raises_when_no_simulation_id(mock_settings):
-    service = AutomationService(settings=mock_settings)
+    service = AutomationService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         return_value={"createAutomationSimulation": {"simulationId": None}},
     )
@@ -698,7 +702,7 @@ async def test_simulate_automation_raises_when_no_simulation_id(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_simulate_automation_transport_error(mock_settings):
-    service = AutomationService(settings=mock_settings)
+    service = AutomationService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "denied"}])
     )

--- a/packages/sdk/tests/services/pipefy/test_member_service.py
+++ b/packages/sdk/tests/services/pipefy/test_member_service.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 from gql.transport.exceptions import TransportQueryError
+from pipefy_auth import StaticBearerAuth
 
 from pipefy_sdk.queries.member_queries import (
     INVITE_MEMBERS_MUTATION,
@@ -13,6 +14,8 @@ from pipefy_sdk.queries.member_queries import (
 from pipefy_sdk.services.member_service import MemberService
 from pipefy_sdk.services.pipe_service import PipeService
 from pipefy_sdk.settings import PipefySettings
+
+_TEST_AUTH = StaticBearerAuth("test-bearer-token")
 
 
 @pytest.fixture
@@ -26,7 +29,7 @@ def mock_settings():
 
 
 def _make_service(mock_settings, return_value: dict):
-    service = MemberService(settings=mock_settings)
+    service = MemberService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(return_value=return_value)
     return service
 
@@ -56,7 +59,7 @@ async def test_invite_members_success(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_invite_members_transport_error(mock_settings):
-    service = MemberService(settings=mock_settings)
+    service = MemberService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "denied"}])
     )
@@ -69,7 +72,7 @@ async def test_invite_members_transport_error(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_invite_members_rejects_invalid_email(mock_settings):
-    service = MemberService(settings=mock_settings)
+    service = MemberService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock()
     with pytest.raises(ValueError) as excinfo:
         await service.invite_members(
@@ -86,7 +89,7 @@ async def test_invite_members_rejects_invalid_email(mock_settings):
 @pytest.mark.asyncio
 async def test_invite_members_rejects_unknown_keys(mock_settings):
     """``MemberInvite.model_config`` forbids extras; surfaced as one-line ``ValueError``."""
-    service = MemberService(settings=mock_settings)
+    service = MemberService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock()
     with pytest.raises(ValueError) as excinfo:
         await service.invite_members(
@@ -109,7 +112,7 @@ async def test_invite_members_rejects_unknown_keys(mock_settings):
 @pytest.mark.asyncio
 async def test_invite_members_rejects_blank_role_name(mock_settings):
     """Blank ``role_name`` surfaces a single-line error pointing at the right field."""
-    service = MemberService(settings=mock_settings)
+    service = MemberService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock()
     with pytest.raises(ValueError) as excinfo:
         await service.invite_members(
@@ -190,7 +193,7 @@ async def test_remove_members_from_pipe_transport_error(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_remove_members_from_pipe_invalid_pipe_id_raises(mock_settings):
-    service = MemberService(settings=mock_settings)
+    service = MemberService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock()
     with pytest.raises(ValueError, match="pipe_id must be a numeric"):
         await service.remove_members_from_pipe("not-a-pipe-id", ["u1"])
@@ -251,7 +254,7 @@ async def test_set_role_success(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_set_role_transport_error(mock_settings):
-    service = MemberService(settings=mock_settings)
+    service = MemberService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "invalid"}])
     )
@@ -262,7 +265,7 @@ async def test_set_role_transport_error(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_remove_members_rejects_uuid_pipe_id(mock_settings):
-    service = MemberService(settings=mock_settings)
+    service = MemberService(settings=mock_settings, auth=_TEST_AUTH)
     with pytest.raises(ValueError, match="numeric pipe ID"):
         await service.remove_members_from_pipe(
             "a1b2c3d4-e5f6-7890-abcd-ef1234567890", ["u1"]

--- a/packages/sdk/tests/services/pipefy/test_observability_service.py
+++ b/packages/sdk/tests/services/pipefy/test_observability_service.py
@@ -7,6 +7,7 @@ import httpx
 import pytest
 from gql.transport.exceptions import TransportQueryError
 from openpyxl import Workbook
+from pipefy_auth import StaticBearerAuth
 
 from pipefy_sdk.queries.observability_queries import (
     CREATE_AUTOMATION_JOBS_EXPORT_MUTATION,
@@ -23,6 +24,9 @@ from pipefy_sdk.queries.observability_queries import (
 from pipefy_sdk.services.observability_service import ObservabilityService
 from pipefy_sdk.settings import PipefySettings
 
+_TEST_AUTH = StaticBearerAuth("test-bearer-token")
+
+
 _ORG_UUID_FOR_TESTS = "341c1327-261c-4766-bb96-7953e4c3970d"
 
 
@@ -37,7 +41,7 @@ def mock_settings():
 
 
 def _make_service(mock_settings, return_value):
-    service = ObservabilityService(settings=mock_settings)
+    service = ObservabilityService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(return_value=return_value)
     return service
 
@@ -199,7 +203,7 @@ async def test_get_automation_logs_by_repo_success(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_get_ai_agent_logs_transport_error(mock_settings):
-    service = ObservabilityService(settings=mock_settings)
+    service = ObservabilityService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "denied"}])
     )
@@ -316,7 +320,7 @@ async def test_get_ai_credit_usage_resolves_numeric_organization_id(mock_setting
             },
         }
     }
-    service = ObservabilityService(settings=mock_settings)
+    service = ObservabilityService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(side_effect=[resolve_payload, credit_payload])
     result = await service.get_ai_credit_usage("300514213", "current_month")
 
@@ -337,7 +341,7 @@ async def test_get_ai_credit_usage_resolves_numeric_organization_id(mock_setting
 async def test_get_ai_credit_usage_resolve_fails_when_organization_missing(
     mock_settings,
 ):
-    service = ObservabilityService(settings=mock_settings)
+    service = ObservabilityService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(return_value={"organization": None})
     with pytest.raises(ValueError, match="Organization not found"):
         await service.get_ai_credit_usage("999999999", "current_month")
@@ -397,7 +401,7 @@ def _tiny_xlsx_bytes() -> bytes:
 @pytest.mark.asyncio
 async def test_get_automation_jobs_export_csv_success(mock_settings):
     xlsx = _tiny_xlsx_bytes()
-    service = ObservabilityService(settings=mock_settings)
+    service = ObservabilityService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         return_value={
             "automationJobsExport": {
@@ -424,7 +428,7 @@ async def test_get_automation_jobs_export_csv_success(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_get_automation_jobs_export_csv_not_finished(mock_settings):
-    service = ObservabilityService(settings=mock_settings)
+    service = ObservabilityService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         return_value={
             "automationJobsExport": {
@@ -441,7 +445,7 @@ async def test_get_automation_jobs_export_csv_not_finished(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_get_automation_jobs_export_csv_download_error(mock_settings):
-    service = ObservabilityService(settings=mock_settings)
+    service = ObservabilityService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         return_value={
             "automationJobsExport": {
@@ -464,7 +468,7 @@ async def test_get_automation_jobs_export_csv_download_error(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_get_agents_usage_transport_error(mock_settings):
-    service = ObservabilityService(settings=mock_settings)
+    service = ObservabilityService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "forbidden"}])
     )
@@ -476,7 +480,7 @@ async def test_get_agents_usage_transport_error(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_get_automation_logs_transport_error(mock_settings):
-    service = ObservabilityService(settings=mock_settings)
+    service = ObservabilityService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "denied"}])
     )
@@ -494,7 +498,7 @@ async def test_get_agents_usage_resolves_numeric_organization_id(mock_settings):
             "totalCredits": 5.0,
         }
     }
-    service = ObservabilityService(settings=mock_settings)
+    service = ObservabilityService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(side_effect=[resolve_payload, usage_payload])
     filter_date = {"from": "2026-03-01T00:00:00Z", "to": "2026-03-31T23:59:59Z"}
     result = await service.get_agents_usage("300514213", filter_date)
@@ -518,7 +522,7 @@ async def test_get_automations_usage_resolves_numeric_organization_id(mock_setti
             "totalExecutions": 42,
         }
     }
-    service = ObservabilityService(settings=mock_settings)
+    service = ObservabilityService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(side_effect=[resolve_payload, usage_payload])
     filter_date = {"from": "2026-03-01T00:00:00Z", "to": "2026-03-31T23:59:59Z"}
     result = await service.get_automations_usage("300514213", filter_date)

--- a/packages/sdk/tests/services/pipefy/test_organization_service.py
+++ b/packages/sdk/tests/services/pipefy/test_organization_service.py
@@ -3,12 +3,15 @@
 from unittest.mock import AsyncMock
 
 import pytest
+from pipefy_auth import StaticBearerAuth
 
 from pipefy_sdk.queries.organization_queries import (
     GET_ORGANIZATION_QUERY,
 )
 from pipefy_sdk.services.organization_service import OrganizationService
 from pipefy_sdk.settings import PipefySettings
+
+_TEST_AUTH = StaticBearerAuth("test-bearer-token")
 
 
 @pytest.fixture
@@ -22,7 +25,7 @@ def mock_settings():
 
 
 def _make_service(mock_settings, return_value):
-    service = OrganizationService(settings=mock_settings)
+    service = OrganizationService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(return_value=return_value)
     return service
 

--- a/packages/sdk/tests/services/pipefy/test_pipe_config_service.py
+++ b/packages/sdk/tests/services/pipefy/test_pipe_config_service.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 from gql.transport.exceptions import TransportQueryError
+from pipefy_auth import StaticBearerAuth
 
 from pipefy_sdk.queries.pipe_config_queries import (
     CLONE_PIPE_MUTATION,
@@ -28,6 +29,8 @@ from pipefy_sdk.queries.pipe_config_queries import (
 from pipefy_sdk.services.pipe_config_service import PipeConfigService
 from pipefy_sdk.settings import PipefySettings
 
+_TEST_AUTH = StaticBearerAuth("test-bearer-token")
+
 
 @pytest.fixture
 def mock_settings():
@@ -40,7 +43,7 @@ def mock_settings():
 
 
 def _make_service(mock_settings, return_value: dict):
-    service = PipeConfigService(settings=mock_settings)
+    service = PipeConfigService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(return_value=return_value)
     return service
 
@@ -682,7 +685,7 @@ async def test_delete_label_sends_delete_input(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_create_pipe_propagates_execute_query_errors(mock_settings):
-    service = PipeConfigService(settings=mock_settings)
+    service = PipeConfigService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(side_effect=RuntimeError("upstream"))
 
     with pytest.raises(RuntimeError, match="upstream"):
@@ -798,7 +801,7 @@ async def test_create_field_condition_rejects_reserved_phaseId_attr(mock_setting
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_create_field_condition_transport_error(mock_settings):
-    service = PipeConfigService(settings=mock_settings)
+    service = PipeConfigService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "invalid"}])
     )
@@ -873,7 +876,7 @@ async def test_update_field_condition_rejects_reserved_id_attr(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_update_field_condition_transport_error(mock_settings):
-    service = PipeConfigService(settings=mock_settings)
+    service = PipeConfigService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "not found"}])
     )
@@ -896,7 +899,7 @@ async def test_delete_field_condition_success(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_delete_field_condition_transport_error(mock_settings):
-    service = PipeConfigService(settings=mock_settings)
+    service = PipeConfigService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "forbidden"}])
     )
@@ -962,7 +965,7 @@ async def test_get_field_condition_success(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_get_field_condition_transport_error(mock_settings):
-    service = PipeConfigService(settings=mock_settings)
+    service = PipeConfigService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "not found"}])
     )

--- a/packages/sdk/tests/services/pipefy/test_relation_service.py
+++ b/packages/sdk/tests/services/pipefy/test_relation_service.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 from gql.transport.exceptions import TransportQueryError
+from pipefy_auth import StaticBearerAuth
 
 from pipefy_sdk.queries.relation_queries import (
     CREATE_CARD_RELATION_MUTATION,
@@ -15,6 +16,8 @@ from pipefy_sdk.queries.relation_queries import (
 )
 from pipefy_sdk.services.relation_service import RelationService
 from pipefy_sdk.settings import PipefySettings
+
+_TEST_AUTH = StaticBearerAuth("test-bearer-token")
 
 
 @pytest.fixture
@@ -28,7 +31,7 @@ def mock_settings():
 
 
 def _make_service(mock_settings, return_value: dict):
-    service = RelationService(settings=mock_settings)
+    service = RelationService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(return_value=return_value)
     return service
 
@@ -56,7 +59,7 @@ async def test_get_pipe_relations_sends_pipe_id(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_get_pipe_relations_transport_error(mock_settings):
-    service = RelationService(settings=mock_settings)
+    service = RelationService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "denied"}])
     )
@@ -80,7 +83,7 @@ async def test_get_table_relations_sends_ids_list(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_get_table_relations_transport_error(mock_settings):
-    service = RelationService(settings=mock_settings)
+    service = RelationService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "missing"}])
     )
@@ -124,7 +127,7 @@ async def test_create_pipe_relation_merges_attrs(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_create_pipe_relation_transport_error(mock_settings):
-    service = RelationService(settings=mock_settings)
+    service = RelationService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "bad"}])
     )
@@ -163,7 +166,7 @@ async def test_update_pipe_relation_merges_attrs(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_update_pipe_relation_transport_error(mock_settings):
-    service = RelationService(settings=mock_settings)
+    service = RelationService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "nope"}])
     )
@@ -187,7 +190,7 @@ async def test_delete_pipe_relation_sends_id(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_delete_pipe_relation_transport_error(mock_settings):
-    service = RelationService(settings=mock_settings)
+    service = RelationService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "gone"}])
     )
@@ -226,7 +229,7 @@ async def test_create_card_relation_allows_source_type_override(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_create_card_relation_transport_error(mock_settings):
-    service = RelationService(settings=mock_settings)
+    service = RelationService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "nope"}])
     )

--- a/packages/sdk/tests/services/pipefy/test_report_service.py
+++ b/packages/sdk/tests/services/pipefy/test_report_service.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 from gql.transport.exceptions import TransportQueryError
+from pipefy_auth import StaticBearerAuth
 
 from pipefy_sdk.queries.report_queries import (
     CREATE_ORGANIZATION_REPORT_MUTATION,
@@ -26,6 +27,8 @@ from pipefy_sdk.queries.report_queries import (
 from pipefy_sdk.services.report_service import ReportService
 from pipefy_sdk.settings import PipefySettings
 
+_TEST_AUTH = StaticBearerAuth("test-bearer-token")
+
 
 @pytest.fixture
 def mock_settings():
@@ -38,7 +41,7 @@ def mock_settings():
 
 
 def _make_service(mock_settings, return_value):
-    service = ReportService(settings=mock_settings)
+    service = ReportService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(return_value=return_value)
     return service
 
@@ -106,7 +109,7 @@ async def test_get_pipe_reports_with_optional_params(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_get_pipe_reports_transport_error(mock_settings):
-    service = ReportService(settings=mock_settings)
+    service = ReportService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "denied"}])
     )
@@ -322,7 +325,7 @@ async def test_create_pipe_report_minimal(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_create_pipe_report_transport_error(mock_settings):
-    service = ReportService(settings=mock_settings)
+    service = ReportService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "denied"}])
     )
@@ -449,7 +452,7 @@ async def test_export_pipe_report_success(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_export_pipe_report_transport_error(mock_settings):
-    service = ReportService(settings=mock_settings)
+    service = ReportService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "denied"}])
     )
@@ -499,7 +502,7 @@ async def test_export_pipe_audit_logs_success(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_get_pipe_report_columns_transport_error(mock_settings):
-    service = ReportService(settings=mock_settings)
+    service = ReportService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "denied"}])
     )
@@ -510,7 +513,7 @@ async def test_get_pipe_report_columns_transport_error(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_update_pipe_report_transport_error(mock_settings):
-    service = ReportService(settings=mock_settings)
+    service = ReportService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "gone"}])
     )

--- a/packages/sdk/tests/services/pipefy/test_schema_introspection_service.py
+++ b/packages/sdk/tests/services/pipefy/test_schema_introspection_service.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock
 import pytest
 from gql.transport.exceptions import TransportQueryError
 from graphql import GraphQLError
+from pipefy_auth import StaticBearerAuth
 
 from pipefy_sdk.queries.introspection_queries import (
     INTROSPECT_MUTATION_QUERY,
@@ -16,6 +17,8 @@ from pipefy_sdk.services.schema_introspection_service import (
     SchemaIntrospectionService,
 )
 from pipefy_sdk.settings import PipefySettings
+
+_TEST_AUTH = StaticBearerAuth("test-bearer-token")
 
 
 @pytest.fixture
@@ -29,7 +32,7 @@ def mock_settings():
 
 
 def _make_service(mock_settings, return_value):
-    service = SchemaIntrospectionService(settings=mock_settings)
+    service = SchemaIntrospectionService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(return_value=return_value)
     return service
 
@@ -353,7 +356,7 @@ async def test_introspect_type_depth_2_resolves_deeply_wrapped_types(mock_settin
         "enumValues": None,
     }
 
-    service = SchemaIntrospectionService(settings=mock_settings)
+    service = SchemaIntrospectionService(settings=mock_settings, auth=_TEST_AUTH)
 
     async def mock_execute_query(query, variables):
         type_name = variables.get("typeName", "")
@@ -407,7 +410,7 @@ async def test_introspect_type_depth_2_resolves_field_types(mock_settings):
         "enumValues": None,
     }
 
-    service = SchemaIntrospectionService(settings=mock_settings)
+    service = SchemaIntrospectionService(settings=mock_settings, auth=_TEST_AUTH)
     call_count = 0
 
     async def mock_execute_query(query, variables):
@@ -493,7 +496,7 @@ async def test_introspect_mutation_depth_2_resolves_arg_types(mock_settings):
         "enumValues": None,
     }
 
-    service = SchemaIntrospectionService(settings=mock_settings)
+    service = SchemaIntrospectionService(settings=mock_settings, auth=_TEST_AUTH)
 
     async def mock_execute_query(query, variables):
         type_name = variables.get("typeName", "")
@@ -728,7 +731,7 @@ async def test_execute_graphql_surfaces_graphql_errors_from_transport(mock_setti
             ],
         )
 
-    service = SchemaIntrospectionService(settings=mock_settings)
+    service = SchemaIntrospectionService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(side_effect=raise_transport_error)
     result = await service.execute_graphql("query Q { __typename }", {})
 
@@ -744,7 +747,7 @@ async def test_execute_graphql_surfaces_graphql_errors_from_transport(mock_setti
 @pytest.mark.asyncio
 async def test_execute_graphql_surfaces_gql_client_graphql_error(mock_settings):
     """Schema validation errors from gql (before or during execute) map to an errors payload."""
-    service = SchemaIntrospectionService(settings=mock_settings)
+    service = SchemaIntrospectionService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=GraphQLError("Cannot query field `nope` on type `Query`.")
     )
@@ -780,7 +783,7 @@ async def test_execute_graphql_query_field_not_found_hints_mutation(mock_setting
             }
         }
 
-    service = SchemaIntrospectionService(settings=mock_settings)
+    service = SchemaIntrospectionService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(side_effect=mock_execute)
     result = await service.execute_graphql("query Q { createCard { id } }", None)
 
@@ -812,7 +815,7 @@ async def test_execute_graphql_mutation_field_not_found_hints_query(mock_setting
             }
         }
 
-    service = SchemaIntrospectionService(settings=mock_settings)
+    service = SchemaIntrospectionService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(side_effect=mock_execute)
     result = await service.execute_graphql("mutation M { pipe(id: 1) { name } }", None)
 
@@ -840,7 +843,7 @@ async def test_execute_graphql_no_hint_when_field_absent_from_both(mock_settings
             )
         return {"__type": {"fields": [{"name": "pipe"}]}}
 
-    service = SchemaIntrospectionService(settings=mock_settings)
+    service = SchemaIntrospectionService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(side_effect=mock_execute)
     result = await service.execute_graphql("query Q { nonexistent }", None)
 
@@ -870,7 +873,7 @@ async def test_execute_graphql_hint_works_with_backtick_error_format(mock_settin
             }
         }
 
-    service = SchemaIntrospectionService(settings=mock_settings)
+    service = SchemaIntrospectionService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(side_effect=mock_execute)
     result = await service.execute_graphql("query Q { createCard { id } }", None)
 
@@ -891,7 +894,7 @@ async def test_execute_graphql_no_hint_on_unrelated_error(mock_settings):
             errors=[{"message": "Permission denied"}],
         )
 
-    service = SchemaIntrospectionService(settings=mock_settings)
+    service = SchemaIntrospectionService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(side_effect=raise_transport_error)
     result = await service.execute_graphql("query Q { __typename }", None)
 
@@ -918,7 +921,7 @@ async def test_execute_graphql_hint_lookup_failure_does_not_mask_error(mock_sett
         # Hint lookup also fails
         raise TransportQueryError("hint lookup failed", errors=[])
 
-    service = SchemaIntrospectionService(settings=mock_settings)
+    service = SchemaIntrospectionService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(side_effect=mock_execute)
     result = await service.execute_graphql("query Q { createCard { id } }", None)
 
@@ -950,7 +953,7 @@ async def test_execute_graphql_hint_lookup_unexpected_error_propagates(
             )
         raise RuntimeError("simulated bug during hint introspection")
 
-    service = SchemaIntrospectionService(settings=mock_settings)
+    service = SchemaIntrospectionService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(side_effect=mock_execute)
 
     with caplog.at_level("ERROR"):

--- a/packages/sdk/tests/services/pipefy/test_table_service.py
+++ b/packages/sdk/tests/services/pipefy/test_table_service.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock
 import pytest
 from _shared.pagination_test_defaults import DEFAULT_FIRST
 from gql.transport.exceptions import TransportQueryError
+from pipefy_auth import StaticBearerAuth
 
 from pipefy_sdk.queries.table_queries import (
     CREATE_TABLE_FIELD_MUTATION,
@@ -26,6 +27,8 @@ from pipefy_sdk.queries.table_queries import (
 from pipefy_sdk.services.table_service import TableService
 from pipefy_sdk.settings import PipefySettings
 
+_TEST_AUTH = StaticBearerAuth("test-bearer-token")
+
 
 @pytest.fixture
 def mock_settings():
@@ -38,7 +41,7 @@ def mock_settings():
 
 
 def _make_service(mock_settings, return_value: dict):
-    service = TableService(settings=mock_settings)
+    service = TableService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(return_value=return_value)
     return service
 
@@ -192,7 +195,7 @@ async def test_create_table_sends_create_table_input(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_create_table_raises_transport_query_error(mock_settings):
-    service = TableService(settings=mock_settings)
+    service = TableService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("x", errors=[{"message": "denied"}])
     )
@@ -217,7 +220,7 @@ async def test_update_table_merges_id_and_attrs(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_update_table_raises_transport_query_error(mock_settings):
-    service = TableService(settings=mock_settings)
+    service = TableService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("x", errors=[{"message": "bad"}])
     )
@@ -240,7 +243,7 @@ async def test_delete_table_sends_delete_input(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_delete_table_raises_transport_query_error(mock_settings):
-    service = TableService(settings=mock_settings)
+    service = TableService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("x", errors=[{"message": "nope"}])
     )
@@ -270,7 +273,7 @@ async def test_create_table_record_converts_dict_fields(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_create_table_record_raises_transport_query_error(mock_settings):
-    service = TableService(settings=mock_settings)
+    service = TableService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("x", errors=[{"message": "err"}])
     )
@@ -312,7 +315,7 @@ async def test_update_table_record_maps_status_id(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_update_table_record_raises_transport_query_error(mock_settings):
-    service = TableService(settings=mock_settings)
+    service = TableService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("x", errors=[{"message": "x"}])
     )
@@ -334,7 +337,7 @@ async def test_delete_table_record_sends_id(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_delete_table_record_raises_transport_query_error(mock_settings):
-    service = TableService(settings=mock_settings)
+    service = TableService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("x", errors=[{"message": "x"}])
     )
@@ -367,7 +370,7 @@ async def test_set_table_record_field_value_wraps_scalar(mock_settings):
 async def test_set_table_record_field_value_raises_transport_query_error(
     mock_settings,
 ):
-    service = TableService(settings=mock_settings)
+    service = TableService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("x", errors=[{"message": "x"}])
     )
@@ -409,7 +412,7 @@ async def test_create_table_field_sends_input(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_create_table_field_raises_transport_query_error(mock_settings):
-    service = TableService(settings=mock_settings)
+    service = TableService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("x", errors=[{"message": "e"}])
     )
@@ -434,7 +437,7 @@ async def test_update_table_field_merges_id_and_attrs(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_update_table_field_raises_transport_query_error(mock_settings):
-    service = TableService(settings=mock_settings)
+    service = TableService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("x", errors=[{"message": "e"}])
     )
@@ -457,7 +460,7 @@ async def test_delete_table_field_sends_id(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_delete_table_field_raises_transport_query_error(mock_settings):
-    service = TableService(settings=mock_settings)
+    service = TableService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("x", errors=[{"message": "e"}])
     )

--- a/packages/sdk/tests/services/pipefy/test_user_service.py
+++ b/packages/sdk/tests/services/pipefy/test_user_service.py
@@ -3,10 +3,13 @@
 from unittest.mock import AsyncMock
 
 import pytest
+from pipefy_auth import StaticBearerAuth
 
 from pipefy_sdk.queries.me_queries import GET_ME_QUERY
 from pipefy_sdk.services.user_service import UserService
 from pipefy_sdk.settings import PipefySettings
+
+_TEST_AUTH = StaticBearerAuth("test-bearer-token")
 
 
 @pytest.fixture
@@ -20,7 +23,7 @@ def mock_settings():
 
 
 def _make_service(mock_settings, return_value):
-    service = UserService(settings=mock_settings)
+    service = UserService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(return_value=return_value)
     return service
 

--- a/packages/sdk/tests/services/pipefy/test_webhook_service.py
+++ b/packages/sdk/tests/services/pipefy/test_webhook_service.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock
 import pytest
 from _shared.pagination_test_defaults import DEFAULT_FIRST
 from gql.transport.exceptions import TransportQueryError
+from pipefy_auth import StaticBearerAuth
 
 from pipefy_sdk.queries.webhook_queries import (
     CREATE_AND_SEND_INBOX_EMAIL_MUTATION,
@@ -19,6 +20,8 @@ from pipefy_sdk.queries.webhook_queries import (
 from pipefy_sdk.services.webhook_service import WebhookService
 from pipefy_sdk.settings import PipefySettings
 
+_TEST_AUTH = StaticBearerAuth("test-bearer-token")
+
 
 @pytest.fixture
 def mock_settings():
@@ -31,7 +34,7 @@ def mock_settings():
 
 
 def _make_service(mock_settings, return_value: dict):
-    service = WebhookService(settings=mock_settings)
+    service = WebhookService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(return_value=return_value)
     return service
 
@@ -184,7 +187,7 @@ async def test_send_email_with_template_success(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_send_email_with_template_rejects_non_numeric_card_id(mock_settings):
-    service = WebhookService(settings=mock_settings)
+    service = WebhookService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock()
     with pytest.raises(ValueError, match="numeric card ID"):
         await service.send_email_with_template("not-a-number", "tmpl-1")
@@ -193,7 +196,7 @@ async def test_send_email_with_template_rejects_non_numeric_card_id(mock_setting
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_send_inbox_email_transport_error(mock_settings):
-    service = WebhookService(settings=mock_settings)
+    service = WebhookService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "denied"}])
     )
@@ -258,7 +261,7 @@ async def test_create_webhook_uses_settings_default_name(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_create_webhook_transport_error(mock_settings):
-    service = WebhookService(settings=mock_settings)
+    service = WebhookService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "bad"}])
     )
@@ -269,7 +272,7 @@ async def test_create_webhook_transport_error(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_create_webhook_rejects_http_url(mock_settings):
-    service = WebhookService(settings=mock_settings)
+    service = WebhookService(settings=mock_settings, auth=_TEST_AUTH)
     with pytest.raises(ValueError, match="HTTPS"):
         await service.create_webhook("p1", "http://insecure.com/hook", ["card.create"])
 
@@ -277,7 +280,7 @@ async def test_create_webhook_rejects_http_url(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_create_webhook_rejects_https_loopback(mock_settings):
-    service = WebhookService(settings=mock_settings)
+    service = WebhookService(settings=mock_settings, auth=_TEST_AUTH)
     with pytest.raises(ValueError, match="127.0.0.1|private|loopback|link-local"):
         await service.create_webhook(
             "p1", "https://127.0.0.1:8080/hook", ["card.create"]
@@ -301,7 +304,7 @@ async def test_delete_webhook_success(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_delete_webhook_transport_error(mock_settings):
-    service = WebhookService(settings=mock_settings)
+    service = WebhookService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "gone"}])
     )
@@ -348,7 +351,7 @@ async def test_get_webhooks_empty(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_get_webhooks_transport_error(mock_settings):
-    service = WebhookService(settings=mock_settings)
+    service = WebhookService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "nope"}])
     )
@@ -407,7 +410,7 @@ async def test_update_webhook_ignores_id_kwarg(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_update_webhook_rejects_http_url(mock_settings):
-    service = WebhookService(settings=mock_settings)
+    service = WebhookService(settings=mock_settings, auth=_TEST_AUTH)
     with pytest.raises(ValueError, match="HTTPS"):
         await service.update_webhook("w1", url="http://insecure.example/hook")
 
@@ -415,7 +418,7 @@ async def test_update_webhook_rejects_http_url(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_update_webhook_transport_error(mock_settings):
-    service = WebhookService(settings=mock_settings)
+    service = WebhookService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "bad"}])
     )
@@ -517,7 +520,7 @@ async def test_get_card_inbox_emails_empty_inbox(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_get_card_inbox_emails_transport_error(mock_settings):
-    service = WebhookService(settings=mock_settings)
+    service = WebhookService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "not found"}])
     )

--- a/packages/sdk/tests/services/test_attachment_service.py
+++ b/packages/sdk/tests/services/test_attachment_service.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from graphql import print_ast
+from pipefy_auth import StaticBearerAuth
 
 from pipefy_sdk.client import PipefyClient
 from pipefy_sdk.queries.attachment_queries import (
@@ -11,6 +12,8 @@ from pipefy_sdk.queries.attachment_queries import (
 )
 from pipefy_sdk.services.attachment_service import AttachmentService
 from pipefy_sdk.settings import PipefySettings
+
+_TEST_AUTH = StaticBearerAuth("test-bearer-token")
 
 
 @pytest.fixture
@@ -24,7 +27,7 @@ def mock_settings():
 
 
 def _make_service(mock_settings, return_value):
-    service = AttachmentService(settings=mock_settings)
+    service = AttachmentService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(return_value=return_value)
     return service
 
@@ -144,7 +147,7 @@ async def test_upload_file_to_s3_success(mock_settings):
     mock_cm.__aenter__ = AsyncMock(return_value=mock_inner)
     mock_cm.__aexit__ = AsyncMock(return_value=False)
 
-    service = AttachmentService(settings=mock_settings)
+    service = AttachmentService(settings=mock_settings, auth=_TEST_AUTH)
     with patch("httpx.AsyncClient", return_value=mock_cm):
         result = await service.upload_file_to_s3(
             "https://s3.us-east-1.amazonaws.com/presigned",
@@ -171,7 +174,7 @@ async def test_upload_file_to_s3_forbidden_includes_body_snippet(mock_settings):
     mock_cm.__aenter__ = AsyncMock(return_value=mock_inner)
     mock_cm.__aexit__ = AsyncMock(return_value=False)
 
-    service = AttachmentService(settings=mock_settings)
+    service = AttachmentService(settings=mock_settings, auth=_TEST_AUTH)
     with patch("httpx.AsyncClient", return_value=mock_cm):
         result = await service.upload_file_to_s3(
             "https://s3.us-east-1.amazonaws.com/presigned",
@@ -198,7 +201,7 @@ async def test_upload_file_to_s3_sets_content_type_header(mock_settings):
     mock_cm.__aenter__ = AsyncMock(return_value=mock_inner)
     mock_cm.__aexit__ = AsyncMock(return_value=False)
 
-    service = AttachmentService(settings=mock_settings)
+    service = AttachmentService(settings=mock_settings, auth=_TEST_AUTH)
     with patch("httpx.AsyncClient", return_value=mock_cm):
         await service.upload_file_to_s3(
             "https://s3.us-east-1.amazonaws.com/presigned",
@@ -279,7 +282,7 @@ def test_pipefy_client_extract_storage_path_delegates_to_attachment_service():
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_upload_file_to_s3_rejects_non_allowed_host(mock_settings):
-    service = AttachmentService(settings=mock_settings)
+    service = AttachmentService(settings=mock_settings, auth=_TEST_AUTH)
     with pytest.raises(ValueError, match="not in the allow-list"):
         await service.upload_file_to_s3(
             "https://evil.example.com/upload",
@@ -299,7 +302,7 @@ async def test_upload_file_to_s3_accepts_pipefy_host(mock_settings):
     mock_cm.__aenter__ = AsyncMock(return_value=mock_inner)
     mock_cm.__aexit__ = AsyncMock(return_value=False)
 
-    service = AttachmentService(settings=mock_settings)
+    service = AttachmentService(settings=mock_settings, auth=_TEST_AUTH)
     with patch("httpx.AsyncClient", return_value=mock_cm):
         result = await service.upload_file_to_s3(
             "https://uploads.pipefy.com/presigned",

--- a/packages/sdk/tests/services/test_card_service.py
+++ b/packages/sdk/tests/services/test_card_service.py
@@ -6,6 +6,7 @@ Tests validate the card-related operations without requiring real API credential
 from unittest.mock import AsyncMock
 
 import pytest
+from pipefy_auth import StaticBearerAuth
 
 from pipefy_sdk.queries.card_queries import (
     FIND_CARDS_QUERY,
@@ -14,6 +15,8 @@ from pipefy_sdk.queries.card_queries import (
 )
 from pipefy_sdk.services.card_service import CardService
 from pipefy_sdk.settings import PipefySettings
+
+_TEST_AUTH = StaticBearerAuth("test-bearer-token")
 
 
 @pytest.fixture
@@ -27,7 +30,7 @@ def mock_settings() -> PipefySettings:
 
 
 def _make_service(mock_settings: PipefySettings, return_value: dict) -> CardService:
-    service = CardService(settings=mock_settings)
+    service = CardService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(return_value=return_value)
     return service
 

--- a/packages/sdk/tests/services/test_internal_api_client.py
+++ b/packages/sdk/tests/services/test_internal_api_client.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 import respx
+from pipefy_auth import StaticBearerAuth
 
 from pipefy_sdk.services.internal_api_client import InternalApiClient
 from pipefy_sdk.settings import PipefySettings
@@ -19,14 +20,23 @@ from pipefy_sdk.settings import PipefySettings
 DEFAULT_INTERNAL_API_URL = "https://app.pipefy.com/internal_api"
 
 
+def _build_client(
+    url: str = DEFAULT_INTERNAL_API_URL,
+    *,
+    allow_insecure_urls: bool = False,
+) -> InternalApiClient:
+    return InternalApiClient(
+        url=url,
+        auth=StaticBearerAuth("test-bearer-token"),
+        allow_insecure_urls=allow_insecure_urls,
+    )
+
+
 @pytest.mark.unit
 def test_pipefy_settings_internal_api_url_default():
     """Test that PipefySettings.internal_api_url defaults to the expected URL."""
     settings = PipefySettings()
     assert settings.internal_api_url == DEFAULT_INTERNAL_API_URL
-
-
-SERVICE_ACCOUNT_TOKEN_URL = "https://auth.pipefy.com/oauth/token"
 
 
 @pytest.mark.unit
@@ -38,26 +48,11 @@ async def test_execute_query_sends_post_with_correct_headers_and_body(respx_mock
     variables = {"key": "value"}
     expected_json = {"data": {"automation": {"id": "123"}}}
 
-    respx_mock.post(SERVICE_ACCOUNT_TOKEN_URL).mock(
-        return_value=httpx.Response(
-            200,
-            json={
-                "access_token": "test-bearer-token",
-                "token_type": "bearer",
-                "expires_in": 3600,
-            },
-        )
-    )
     route = respx_mock.post(DEFAULT_INTERNAL_API_URL).mock(
         return_value=httpx.Response(200, json=expected_json)
     )
 
-    client = InternalApiClient(
-        url=DEFAULT_INTERNAL_API_URL,
-        service_account_url=SERVICE_ACCOUNT_TOKEN_URL,
-        service_account_client_id="client_id",
-        service_account_client_secret="client_secret",
-    )
+    client = _build_client()
     result = await client.execute_query(query_string, variables)
 
     assert route.called
@@ -76,24 +71,11 @@ async def test_execute_query_sends_post_with_correct_headers_and_body(respx_mock
 async def test_execute_query_returns_parsed_json_response(respx_mock):
     """Test execute_query returns the parsed JSON response from the API."""
     api_response = {"data": {"automation": {"id": "456"}}}
-    respx_mock.post(SERVICE_ACCOUNT_TOKEN_URL).mock(
-        return_value=httpx.Response(
-            200,
-            json={"access_token": "tok", "token_type": "bearer", "expires_in": 3600},
-        )
-    )
     respx_mock.post(DEFAULT_INTERNAL_API_URL).mock(
         return_value=httpx.Response(200, json=api_response)
     )
 
-    client = InternalApiClient(
-        url=DEFAULT_INTERNAL_API_URL,
-        service_account_url=SERVICE_ACCOUNT_TOKEN_URL,
-        service_account_client_id="client_id",
-        service_account_client_secret="client_secret",
-    )
-    result = await client.execute_query("query { x }", {})
-
+    result = await _build_client().execute_query("query { x }", {})
     assert result == {"automation": {"id": "456"}}
 
 
@@ -102,25 +84,12 @@ async def test_execute_query_returns_parsed_json_response(respx_mock):
 @respx.mock(assert_all_mocked=False, assert_all_called=False)
 async def test_execute_query_raises_on_non_2xx_response(respx_mock):
     """Test execute_query raises when HTTP response is not 2xx."""
-    respx_mock.post(SERVICE_ACCOUNT_TOKEN_URL).mock(
-        return_value=httpx.Response(
-            200,
-            json={"access_token": "tok", "token_type": "bearer", "expires_in": 3600},
-        )
-    )
     respx_mock.post(DEFAULT_INTERNAL_API_URL).mock(
         return_value=httpx.Response(500, json={"error": "Internal Server Error"})
     )
 
-    client = InternalApiClient(
-        url=DEFAULT_INTERNAL_API_URL,
-        service_account_url=SERVICE_ACCOUNT_TOKEN_URL,
-        service_account_client_id="client_id",
-        service_account_client_secret="client_secret",
-    )
-
     with pytest.raises(httpx.HTTPStatusError):
-        await client.execute_query("query { x }", {})
+        await _build_client().execute_query("query { x }", {})
 
 
 @pytest.mark.unit
@@ -129,25 +98,12 @@ async def test_execute_query_raises_on_non_2xx_response(respx_mock):
 async def test_execute_query_raises_on_graphql_errors_in_body(respx_mock):
     """Test execute_query detects GraphQL errors (HTTP 200 but errors in JSON) and raises."""
     graphql_error_response = {"errors": [{"message": "Something went wrong"}]}
-    respx_mock.post(SERVICE_ACCOUNT_TOKEN_URL).mock(
-        return_value=httpx.Response(
-            200,
-            json={"access_token": "tok", "token_type": "bearer", "expires_in": 3600},
-        )
-    )
     respx_mock.post(DEFAULT_INTERNAL_API_URL).mock(
         return_value=httpx.Response(200, json=graphql_error_response)
     )
 
-    client = InternalApiClient(
-        url=DEFAULT_INTERNAL_API_URL,
-        service_account_url=SERVICE_ACCOUNT_TOKEN_URL,
-        service_account_client_id="client_id",
-        service_account_client_secret="client_secret",
-    )
-
     with pytest.raises(ValueError, match=r"^Something went wrong$"):
-        await client.execute_query("query { x }", {})
+        await _build_client().execute_query("query { x }", {})
 
 
 @pytest.mark.unit
@@ -168,28 +124,15 @@ async def test_execute_query_error_includes_extensions_code_and_correlation_id(
             }
         ]
     }
-    respx_mock.post(SERVICE_ACCOUNT_TOKEN_URL).mock(
-        return_value=httpx.Response(
-            200,
-            json={"access_token": "tok", "token_type": "bearer", "expires_in": 3600},
-        )
-    )
     respx_mock.post(DEFAULT_INTERNAL_API_URL).mock(
         return_value=httpx.Response(200, json=graphql_error_response)
-    )
-
-    client = InternalApiClient(
-        url=DEFAULT_INTERNAL_API_URL,
-        service_account_url=SERVICE_ACCOUNT_TOKEN_URL,
-        service_account_client_id="client_id",
-        service_account_client_secret="client_secret",
     )
 
     with pytest.raises(
         ValueError,
         match=r"Permission Denied \[code=PERMISSION_DENIED\] \[correlation_id=abc-123\]",
     ):
-        await client.execute_query("query { x }", {})
+        await _build_client().execute_query("query { x }", {})
 
 
 @pytest.mark.unit
@@ -207,28 +150,15 @@ async def test_execute_query_error_includes_correlation_id_when_code_absent(
             }
         ]
     }
-    respx_mock.post(SERVICE_ACCOUNT_TOKEN_URL).mock(
-        return_value=httpx.Response(
-            200,
-            json={"access_token": "tok", "token_type": "bearer", "expires_in": 3600},
-        )
-    )
     respx_mock.post(DEFAULT_INTERNAL_API_URL).mock(
         return_value=httpx.Response(200, json=graphql_error_response)
-    )
-
-    client = InternalApiClient(
-        url=DEFAULT_INTERNAL_API_URL,
-        service_account_url=SERVICE_ACCOUNT_TOKEN_URL,
-        service_account_client_id="client_id",
-        service_account_client_secret="client_secret",
     )
 
     with pytest.raises(
         ValueError,
         match=r"^Rate limited \[correlation_id=corr-only-99\]$",
     ):
-        await client.execute_query("query { x }", {})
+        await _build_client().execute_query("query { x }", {})
 
 
 @pytest.mark.unit
@@ -242,28 +172,15 @@ async def test_execute_query_error_concatenates_multiple_errors(respx_mock):
             {"message": "Error two", "extensions": {"code": "BAD_INPUT"}},
         ]
     }
-    respx_mock.post(SERVICE_ACCOUNT_TOKEN_URL).mock(
-        return_value=httpx.Response(
-            200,
-            json={"access_token": "tok", "token_type": "bearer", "expires_in": 3600},
-        )
-    )
     respx_mock.post(DEFAULT_INTERNAL_API_URL).mock(
         return_value=httpx.Response(200, json=graphql_error_response)
-    )
-
-    client = InternalApiClient(
-        url=DEFAULT_INTERNAL_API_URL,
-        service_account_url=SERVICE_ACCOUNT_TOKEN_URL,
-        service_account_client_id="client_id",
-        service_account_client_secret="client_secret",
     )
 
     with pytest.raises(
         ValueError,
         match=r"^Error one; Error two \[code=BAD_INPUT\]$",
     ):
-        await client.execute_query("query { x }", {})
+        await _build_client().execute_query("query { x }", {})
 
 
 @pytest.mark.unit
@@ -274,28 +191,15 @@ async def test_execute_query_error_without_message_uses_fallback(respx_mock):
     graphql_error_response = {
         "errors": [{"extensions": {"code": "UNKNOWN"}}],
     }
-    respx_mock.post(SERVICE_ACCOUNT_TOKEN_URL).mock(
-        return_value=httpx.Response(
-            200,
-            json={"access_token": "tok", "token_type": "bearer", "expires_in": 3600},
-        )
-    )
     respx_mock.post(DEFAULT_INTERNAL_API_URL).mock(
         return_value=httpx.Response(200, json=graphql_error_response)
-    )
-
-    client = InternalApiClient(
-        url=DEFAULT_INTERNAL_API_URL,
-        service_account_url=SERVICE_ACCOUNT_TOKEN_URL,
-        service_account_client_id="client_id",
-        service_account_client_secret="client_secret",
     )
 
     with pytest.raises(
         ValueError,
         match=r"^Unknown error \[code=UNKNOWN\]$",
     ):
-        await client.execute_query("query { x }", {})
+        await _build_client().execute_query("query { x }", {})
 
 
 @pytest.mark.unit
@@ -313,13 +217,7 @@ async def test_execute_query_raises_on_timeout():
         "pipefy_sdk.services.internal_api_client.httpx.AsyncClient",
         return_value=mock_client,
     ):
-        client = InternalApiClient(
-            url=DEFAULT_INTERNAL_API_URL,
-            service_account_url=SERVICE_ACCOUNT_TOKEN_URL,
-            service_account_client_id="client_id",
-            service_account_client_secret="client_secret",
-        )
-
+        client = _build_client()
         with pytest.raises(httpx.TimeoutException):
             await client.execute_query("query { x }", {})
 
@@ -327,64 +225,27 @@ async def test_execute_query_raises_on_timeout():
 @pytest.mark.unit
 def test_internal_api_client_rejects_http_url():
     with pytest.raises(ValueError, match="HTTPS"):
-        InternalApiClient(
-            url="http://app.pipefy.com/internal_api",
-            service_account_url="https://auth.pipefy.com/oauth/token",
-            service_account_client_id="id",
-            service_account_client_secret="secret",
-        )
-
-
-@pytest.mark.unit
-def test_internal_api_client_rejects_http_service_account_url():
-    with pytest.raises(ValueError, match="HTTPS"):
-        InternalApiClient(
-            url="https://app.pipefy.com/internal_api",
-            service_account_url="http://auth.pipefy.com/oauth/token",
-            service_account_client_id="id",
-            service_account_client_secret="secret",
-        )
+        _build_client(url="http://app.pipefy.com/internal_api")
 
 
 @pytest.mark.unit
 def test_internal_api_client_rejects_empty_hostname():
     with pytest.raises(ValueError, match="hostname"):
-        InternalApiClient(
-            url="https://",
-            service_account_url="https://auth.pipefy.com/oauth/token",
-            service_account_client_id="id",
-            service_account_client_secret="secret",
-        )
+        _build_client(url="https://")
 
 
 @pytest.mark.unit
 def test_internal_api_client_rejects_localhost():
     with pytest.raises(ValueError, match="localhost"):
-        InternalApiClient(
-            url="https://localhost/internal_api",
-            service_account_url="https://auth.pipefy.com/oauth/token",
-            service_account_client_id="id",
-            service_account_client_secret="secret",
-        )
+        _build_client(url="https://localhost/internal_api")
 
 
 @pytest.mark.unit
 def test_internal_api_client_rejects_private_literal_ip():
     with pytest.raises(ValueError, match="private|loopback|link-local"):
-        InternalApiClient(
-            url="https://10.0.0.1/internal_api",
-            service_account_url="https://auth.pipefy.com/oauth/token",
-            service_account_client_id="id",
-            service_account_client_secret="secret",
-        )
+        _build_client(url="https://10.0.0.1/internal_api")
 
 
 @pytest.mark.unit
 def test_internal_api_client_allow_insecure_accepts_http():
-    InternalApiClient(
-        url="http://127.0.0.1/internal_api",
-        service_account_url="http://127.0.0.1/oauth/token",
-        service_account_client_id="id",
-        service_account_client_secret="secret",
-        allow_insecure_urls=True,
-    )
+    _build_client(url="http://127.0.0.1/internal_api", allow_insecure_urls=True)

--- a/packages/sdk/tests/services/test_pipe_service.py
+++ b/packages/sdk/tests/services/test_pipe_service.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 from graphql import print_ast
+from pipefy_auth import StaticBearerAuth
 
 from pipefy_sdk.queries.pipe_queries import (
     GET_PHASE_ALLOWED_MOVES_QUERY,
@@ -16,6 +17,8 @@ from pipefy_sdk.queries.pipe_queries import (
 )
 from pipefy_sdk.services.pipe_service import PipeService
 from pipefy_sdk.settings import PipefySettings
+
+_TEST_AUTH = StaticBearerAuth("test-bearer-token")
 
 
 @pytest.fixture
@@ -29,7 +32,7 @@ def mock_settings() -> PipefySettings:
 
 
 def _make_service(mock_settings, return_value):
-    service = PipeService(settings=mock_settings)
+    service = PipeService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(return_value=return_value)
     return service
 
@@ -371,7 +374,7 @@ async def test_search_pipes_empty_organizations(mock_settings):
         },
     ]
 
-    service = PipeService(settings=mock_settings)
+    service = PipeService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(return_value={"organizations": mock_orgs})
 
     result = await service.search_pipes()
@@ -386,7 +389,7 @@ async def test_search_pipes_empty_organizations(mock_settings):
 @pytest.mark.asyncio
 async def test_search_pipes_all_organizations_empty(mock_settings):
     """Test search_pipes handles API response with no organizations."""
-    service = PipeService(settings=mock_settings)
+    service = PipeService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(return_value={"organizations": []})
 
     result = await service.search_pipes()
@@ -569,7 +572,7 @@ class TestGetPhaseFields:
         """Factory fixture to create a PipeService with mocked phase response."""
 
         def _create(phase_response: dict):
-            service = PipeService(settings=mock_settings)
+            service = PipeService(settings=mock_settings, auth=_TEST_AUTH)
             service.execute_query = AsyncMock(return_value={"phase": phase_response})
             return service, service.execute_query
 

--- a/packages/sdk/tests/services/test_pipefy_base_client.py
+++ b/packages/sdk/tests/services/test_pipefy_base_client.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pipefy_auth import StaticBearerAuth
 
 from pipefy_sdk.base_client import BasePipefyClient
 from pipefy_sdk.settings import PipefySettings
@@ -14,6 +15,10 @@ def valid_settings() -> PipefySettings:
         service_account_client_id="client_id",
         service_account_client_secret="client_secret",
     )
+
+
+def _bearer() -> StaticBearerAuth:
+    return StaticBearerAuth("test-token")
 
 
 @pytest.mark.unit
@@ -30,7 +35,7 @@ async def test_execute_query_passes_variables_to_session(valid_settings):
         mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
         mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=None)
 
-        base = BasePipefyClient(settings=valid_settings)
+        base = BasePipefyClient(settings=valid_settings, auth=_bearer())
         result = await base.execute_query(query, variables)
 
     mock_session.execute.assert_called_once_with(query, variable_values=variables)
@@ -66,7 +71,7 @@ async def test_execute_query_reuse_fetches_once_then_passes_cached_schema(
         second.schema = None
         mock_client_cls.side_effect = [first, second]
 
-        base = BasePipefyClient(settings=settings)
+        base = BasePipefyClient(settings=settings, auth=_bearer())
         assert await base.execute_query(query, variables) == {"one": 1}
         assert await base.execute_query(query, variables) == {"two": 2}
 
@@ -95,7 +100,7 @@ async def test_execute_query_bubbles_up_execute_errors_unchanged(valid_settings)
         mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
         mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=None)
 
-        base = BasePipefyClient(settings=valid_settings)
+        base = BasePipefyClient(settings=valid_settings, auth=_bearer())
 
         with pytest.raises(RuntimeError) as exc:
             await base.execute_query(query, variables)
@@ -114,56 +119,6 @@ def test_init_raises_when_graphql_url_is_none():
     )
 
     with pytest.raises(ValueError) as exc:
-        BasePipefyClient(settings=settings)
+        BasePipefyClient(settings=settings, auth=_bearer())
 
     assert "GraphQL URL must be provided in settings" in str(exc.value)
-
-
-@pytest.mark.unit
-def test_init_raises_when_service_account_url_is_none():
-    """Test that __init__ raises ValueError when service_account_url is None."""
-    settings = PipefySettings(
-        graphql_url="https://api.pipefy.com/graphql",
-        service_account_url=None,
-        service_account_client_id="client_id",
-        service_account_client_secret="client_secret",
-    )
-
-    with pytest.raises(ValueError) as exc:
-        BasePipefyClient(settings=settings)
-
-    assert "Service-account URL must be provided in settings" in str(exc.value)
-
-
-@pytest.mark.unit
-def test_init_raises_when_service_account_client_id_is_none():
-    """Test that __init__ raises ValueError when service_account_client_id is None."""
-    settings = PipefySettings(
-        graphql_url="https://api.pipefy.com/graphql",
-        service_account_url="https://auth.pipefy.com/oauth/token",
-        service_account_client_id=None,
-        service_account_client_secret="client_secret",
-    )
-
-    with pytest.raises(ValueError) as exc:
-        BasePipefyClient(settings=settings)
-
-    assert "Service-account client ID must be provided in settings" in str(exc.value)
-
-
-@pytest.mark.unit
-def test_init_raises_when_service_account_client_secret_is_none():
-    """Test that __init__ raises ValueError when service_account_client_secret is None."""
-    settings = PipefySettings(
-        graphql_url="https://api.pipefy.com/graphql",
-        service_account_url="https://auth.pipefy.com/oauth/token",
-        service_account_client_id="client_id",
-        service_account_client_secret=None,
-    )
-
-    with pytest.raises(ValueError) as exc:
-        BasePipefyClient(settings=settings)
-
-    assert "Service-account client secret must be provided in settings" in str(
-        exc.value
-    )

--- a/packages/sdk/tests/services/test_pipefy_client.py
+++ b/packages/sdk/tests/services/test_pipefy_client.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from pipefy_auth import StaticBearerAuth
 
 from pipefy_sdk.client import PipefyClient
 from pipefy_sdk.services.card_service import CardService
@@ -10,6 +11,8 @@ from pipefy_sdk.services.schema_introspection_service import (
     SchemaIntrospectionService,
 )
 from pipefy_sdk.settings import PipefySettings
+
+_TEST_AUTH = StaticBearerAuth("test-bearer-token")
 
 
 def _mock_settings() -> PipefySettings:
@@ -28,10 +31,12 @@ def _make_facade_client(execute_return_value: dict):
     """
     settings = _mock_settings()
     client = PipefyClient.__new__(PipefyClient)
-    client._pipe_service = PipeService(settings=settings)
-    client._card_service = CardService(settings=settings)
-    client._pipe_config_service = PipeConfigService(settings=settings)
-    client._introspection_service = SchemaIntrospectionService(settings=settings)
+    client._pipe_service = PipeService(settings=settings, auth=_TEST_AUTH)
+    client._card_service = CardService(settings=settings, auth=_TEST_AUTH)
+    client._pipe_config_service = PipeConfigService(settings=settings, auth=_TEST_AUTH)
+    client._introspection_service = SchemaIntrospectionService(
+        settings=settings, auth=_TEST_AUTH
+    )
 
     mock_execute = AsyncMock(return_value=execute_return_value)
     client._pipe_service.execute_query = mock_execute

--- a/packages/sdk/tests/services/test_pipefy_facade.py
+++ b/packages/sdk/tests/services/test_pipefy_facade.py
@@ -1,9 +1,8 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from httpx_auth import OAuth2ClientCredentials
+from pipefy_auth import StaticBearerAuth
 
-from pipefy_sdk.base_client import StaticBearerAuth
 from pipefy_sdk.client import PipefyClient
 from pipefy_sdk.services.ai_agent_service import AiAgentService
 from pipefy_sdk.services.attachment_service import AttachmentService
@@ -32,12 +31,11 @@ def mock_settings():
 
 
 @pytest.mark.unit
-def test_pipefy_client_bearer_token_uses_static_bearer_auth(mock_settings):
-    oauth_client = PipefyClient(mock_settings)
-    assert isinstance(oauth_client._card_service._auth, OAuth2ClientCredentials)
-
-    bearer_client = PipefyClient(mock_settings, bearer_token="unit-token")
-    assert isinstance(bearer_client._card_service._auth, StaticBearerAuth)
+def test_pipefy_client_forwards_caller_provided_auth(mock_settings):
+    auth = StaticBearerAuth("unit-token")
+    client = PipefyClient(mock_settings, auth=auth)
+    assert client._card_service._auth is auth
+    assert client._pipe_service._auth is auth
 
 
 @pytest.mark.unit
@@ -546,7 +544,7 @@ async def test_pipefy_client_facade_delegates_to_services_without_modifying_args
 
 @pytest.mark.unit
 def test_pipefy_client_creates_services_with_shared_auth():
-    """Test PipefyClient creates services that share the same OAuth auth instance."""
+    """Test PipefyClient creates services that share the same auth instance."""
 
     settings = PipefySettings(
         graphql_url="https://api.pipefy.com/graphql",
@@ -554,7 +552,8 @@ def test_pipefy_client_creates_services_with_shared_auth():
         service_account_client_id="client_id",
         service_account_client_secret="client_secret",
     )
-    client = PipefyClient(settings=settings)
+    auth = StaticBearerAuth("shared-token")
+    client = PipefyClient(settings=settings, auth=auth)
 
     assert isinstance(client._pipe_service, PipeService)
     assert isinstance(client._card_service, CardService)
@@ -726,7 +725,7 @@ async def test_delete_card_relation_delegates_to_internal_api_client(mock_settin
     )
     from pipefy_sdk.services.internal_api_client import InternalApiClient
 
-    client = PipefyClient(settings=mock_settings)
+    client = PipefyClient(settings=mock_settings, auth=StaticBearerAuth("t"))
     internal = MagicMock(spec=InternalApiClient)
     internal.execute_query = AsyncMock(
         return_value={"deleteCardRelation": {"success": True}}

--- a/packages/sdk/tests/services/test_table_service_search_tables.py
+++ b/packages/sdk/tests/services/test_table_service_search_tables.py
@@ -4,10 +4,13 @@ from unittest.mock import AsyncMock
 
 import pytest
 from _shared.pagination_test_defaults import DEFAULT_FIRST
+from pipefy_auth import StaticBearerAuth
 
 from pipefy_sdk.queries.table_queries import SEARCH_TABLES_QUERY
 from pipefy_sdk.services.table_service import TableService
 from pipefy_sdk.settings import PipefySettings
+
+_TEST_AUTH = StaticBearerAuth("test-bearer-token")
 
 
 def _table_connection(
@@ -36,7 +39,7 @@ def mock_settings() -> PipefySettings:
 
 
 def _make_service(mock_settings: PipefySettings, return_value: dict) -> TableService:
-    service = TableService(settings=mock_settings)
+    service = TableService(settings=mock_settings, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(return_value=return_value)
     return service
 

--- a/uv.lock
+++ b/uv.lock
@@ -816,6 +816,7 @@ name = "pipefy-auth"
 source = { editable = "packages/auth" }
 dependencies = [
     { name = "httpx" },
+    { name = "httpx-auth" },
     { name = "keyring" },
 ]
 
@@ -829,6 +830,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.28" },
+    { name = "httpx-auth", specifier = ">=0.23.1" },
     { name = "keyring", specifier = ">=24" },
 ]
 
@@ -881,6 +883,7 @@ source = { editable = "packages/mcp" }
 dependencies = [
     { name = "httpx" },
     { name = "mcp", extra = ["cli"] },
+    { name = "pipefy-auth" },
     { name = "pipefy-sdk" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -901,6 +904,7 @@ dev = [
 requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.25.0" },
+    { name = "pipefy-auth", editable = "packages/auth" },
     { name = "pipefy-sdk", editable = "packages/sdk" },
     { name = "pydantic", specifier = ">=2.11.3" },
     { name = "pydantic-settings", specifier = ">=2.8.1" },
@@ -924,7 +928,6 @@ dependencies = [
     { name = "email-validator" },
     { name = "gql", extra = ["httpx"] },
     { name = "httpx" },
-    { name = "httpx-auth" },
     { name = "openpyxl" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -946,7 +949,6 @@ requires-dist = [
     { name = "email-validator", specifier = ">=2.2.0" },
     { name = "gql", extras = ["httpx"], specifier = ">=3.5.2" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "httpx-auth", specifier = ">=0.23.1" },
     { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "pydantic", specifier = ">=2.11.3" },
     { name = "pydantic-settings", specifier = ">=2.8.1" },


### PR DESCRIPTION
Stacked on #216. Targets that branch directly so the diff stays focused on this step; will be retargeted to `dev` once #216 merges. Part of #213's resolver/settings work; closes #134 as a side effect.

## Summary

- `pipefy_auth.resolver` owns a fixed three-tier precedence chain: `static-token` → `service-account` → `stored-session`. `resolve_pipefy_auth(...)` short-circuits at the first tier that resolves and returns `httpx.Auth | None` directly — the tier identity is carried by the concrete subclass (`StaticBearerAuth`, `OAuth2ClientCredentials`, `CallableBearerAuth`). Use `tier_for(auth)` to recover the tier name when needed (e.g. for the `pipefy auth status` wire schema). `detect_pipefy_tiers(...)` is the diagnostics-only enumerator. No open Protocol, no policy class hierarchy.
- `pipefy_auth.bearer` exports `StaticBearerAuth` (moved out of the SDK) and a new `CallableBearerAuth` that resolves a fresh token per request, with an `asyncio.Lock` to dedup in-process refresh contention.
- SDK auth is now explicit. `PipefyClient(settings, *, auth)`, `InternalApiClient(url, *, auth, allow_insecure_urls)`, and `BasePipefyClient(settings, *, auth)` all require an `httpx.Auth`. `httpx-auth` moves from `pipefy-sdk`'s dependencies to `pipefy-auth`'s.
- CLI's `get_authenticated_client` becomes a thin wrapper around `pipefy_auth.resolve_pipefy_auth`. The bearer-token path now wires `InternalApiClient` whenever `PIPEFY_INTERNAL_API_URL` is set, closing #134 (AI-automation tools were silently unavailable on the bearer path).
- MCP container uses the same resolver. `PIPEFY_TOKEN` is wired as the static-token tier ahead of the service-account triple, matching CLI precedence by construction. The flag-vs-env distinction lives entirely in CLI display code.
- CLI in-process client cache: the cache key is now a SHA-256 digest over `model_dump(mode="json")` of the settings + `asdict(auth)` + tier name. Adding a new field anywhere in the inputs participates in the key by construction (no more hand-picked tuple to maintain), and the bearer/secret never linger in module state past the digest computation.
- `docs/cli/auth.md` refreshed: the "Limitations on the bearer path" section is gone (every tier wires `InternalApiClient` now), the precedence-table notes are updated, and the troubleshooting quote matches the new `missing_auth_message()` output.

## Naming

The resolver uses *tier* (a precedence slot) — `STATIC_TOKEN_TIER`, `SERVICE_ACCOUNT_TIER`, `STORED_SESSION_TIER`. *Source* was the wrong word at that layer: a source is the *surface* a value came from (flag, env var, config file). The CLI keeps `FLAG_TOKEN_SOURCE`/`ENV_TOKEN_SOURCE` for its display layer, where "source" is correct, and internal variables that hold tier values are named `tier` (not `source`). The wire-schema string values (`"static-token"`, `"service-account"`, `"stored-session"`) are unchanged.

## Test plan

- [x] `uv run pytest -m "not integration"` — 2312 passing locally.
- [x] `uv run ruff check` + `uv run ruff format --check` — clean.
- [x] CI green.
- [x] `pipefy auth status` reports the correct `flag-token` vs `env-token` source on a sample invocation. Manual smoke confirmed flag wins over env when both are set.
- [x] Bearer path wires `InternalApiClient` (regression for #134). Manual smoke confirmed `internal_api_available = True` and `ai_automation_available = True` when `PIPEFY_TOKEN` + `PIPEFY_INTERNAL_API_URL` are set.
- [x] MCP container boots on both auth paths (`PIPEFY_SERVICE_ACCOUNT_*` and `PIPEFY_TOKEN`); raises with the canonical `missing_auth_message()` when neither is configured.

## Related work

- #218 — settings split (`PipefySettings` endpoint-only + new `pipefy_auth.AuthSettings`). Stacked on this branch; review the two together when ready.

## Follow-ups against #213

- Picking up the stored OAuth user session in the MCP container (with eager refresh warmup) — separate PR once #218 lands.
- Cross-process refresh lock (#133) — separate PR.