### PR TITLE
refactor(auth): own auth-related settings inside pipefy_auth

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -104,6 +104,45 @@ The legacy names will be removed in a later `0.2.0-beta.x` release; the change w
 
 ---
 
+## Settings model split (library / script users only)
+
+End users of `pipefy-cli` and `pipefy-mcp-server` are unaffected — every `PIPEFY_*` env var, `.env` entry, and `~/.config/pipefy/config.toml` key keeps loading exactly as before. The split matters only if you construct settings types directly in Python code that depends on `pipefy-sdk`.
+
+Auth-related fields have moved from `PipefySettings` (which now owns endpoint config only) to a new `pipefy_auth.AuthSettings`:
+
+| Was on `pipefy_sdk.PipefySettings` | Now on `pipefy_auth.AuthSettings` |
+|---|---|
+| `service_account_url` | `service_account_url` |
+| `service_account_client_id` | `service_account_client_id` |
+| `service_account_client_secret` | `service_account_client_secret` |
+| (read from env only) | `auth_url`, `auth_client_id`, `static_token` |
+
+Because `PipefySettings` is configured with `extra="ignore"`, code like `PipefySettings(service_account_url=...)` **silently drops the credentials** — no exception, no warning. Migrate by composing the two models side by side:
+
+```python
+from pipefy_auth import AuthSettings
+from pipefy_sdk import PipefySettings
+
+pipefy = PipefySettings(graphql_url="https://app.pipefy.com/graphql")
+auth = AuthSettings(
+    service_account_url="https://app.pipefy.com/oauth/token",
+    service_account_client_id="...",
+    service_account_client_secret="...",
+)
+```
+
+If you already build a `pipefy-mcp-server` or `pipefy-cli` settings object, the application-level `Settings` / `CliSettings` already nests both:
+
+```python
+from pipefy_mcp.settings import Settings
+
+s = Settings()  # s.pipefy + s.auth, env-loaded
+```
+
+The legacy `PIPEFY_OAUTH_*` env-var aliases and the deprecation warning live on `AuthSettings`; behaviour is preserved through the rename window above.
+
+---
+
 ## Questions?
 
 Open an issue at [github.com/<owner>/pipefy-labs/issues](https://github.com/<owner>/pipefy-labs/issues) or email **dev@pipefy.com**.

--- a/packages/auth/pyproject.toml
+++ b/packages/auth/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "httpx-auth>=0.23.1",
     "keyring>=24",
     "pydantic>=2.11.3",
+    "pydantic-settings>=2.8.1",
 ]
 
 [dependency-groups]

--- a/packages/auth/pyproject.toml
+++ b/packages/auth/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "httpx>=0.28",
     "httpx-auth>=0.23.1",
     "keyring>=24",
+    "pydantic>=2.11.3",
 ]
 
 [dependency-groups]

--- a/packages/auth/src/pipefy_auth/__init__.py
+++ b/packages/auth/src/pipefy_auth/__init__.py
@@ -39,6 +39,10 @@ from pipefy_auth.revoke import (
     RevocationUnsupportedError,
     revoke_session,
 )
+from pipefy_auth.settings import (
+    AuthSettings,
+    describe_missing_service_account_vars,
+)
 from pipefy_auth.storage import (
     SessionDeleteError,
     StoredSession,
@@ -50,6 +54,7 @@ from pipefy_auth.storage import (
 )
 
 __all__ = [
+    "AuthSettings",
     "CallableBearerAuth",
     "DEFAULT_AUTH_CLIENT_ID",
     "DiscoveryPolicy",
@@ -69,6 +74,7 @@ __all__ = [
     "StoredSession",
     "__version__",
     "delete_session",
+    "describe_missing_service_account_vars",
     "detect_pipefy_tiers",
     "ensure_fresh_session",
     "fetch_provider_metadata",

--- a/packages/auth/src/pipefy_auth/__init__.py
+++ b/packages/auth/src/pipefy_auth/__init__.py
@@ -39,10 +39,7 @@ from pipefy_auth.revoke import (
     RevocationUnsupportedError,
     revoke_session,
 )
-from pipefy_auth.settings import (
-    AuthSettings,
-    describe_missing_service_account_vars,
-)
+from pipefy_auth.settings import AuthSettings
 from pipefy_auth.storage import (
     SessionDeleteError,
     StoredSession,
@@ -74,7 +71,6 @@ __all__ = [
     "StoredSession",
     "__version__",
     "delete_session",
-    "describe_missing_service_account_vars",
     "detect_pipefy_tiers",
     "ensure_fresh_session",
     "fetch_provider_metadata",

--- a/packages/auth/src/pipefy_auth/settings.py
+++ b/packages/auth/src/pipefy_auth/settings.py
@@ -1,0 +1,204 @@
+"""Pydantic model for auth-related settings (env vars, config file fields).
+
+Owns every value that describes *how* to authenticate against Pipefy:
+
+* ``PIPEFY_SERVICE_ACCOUNT_*`` — OAuth2 client-credentials grant inputs
+  (legacy ``PIPEFY_OAUTH_*`` names still honoured via :class:`AliasChoices`).
+* ``PIPEFY_AUTH_URL`` — OIDC issuer URL for the stored-session tier.
+* ``PIPEFY_AUTH_CLIENT_ID`` — OIDC public client id (defaults to
+  :data:`pipefy_auth.identity.DEFAULT_AUTH_CLIENT_ID`).
+
+Endpoint settings (``PIPEFY_GRAPHQL_URL``, ``PIPEFY_INTERNAL_API_URL``) live
+on :class:`pipefy_sdk.PipefySettings` — they are SDK concerns, not auth.
+Consumers compose both models side by side in their own settings type.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from pydantic import AliasChoices, Field, model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from pipefy_auth.identity import DEFAULT_AUTH_CLIENT_ID, OidcClient
+from pipefy_auth.resolver import ServiceAccount
+
+# Legacy ``PIPEFY_OAUTH_*`` env vars still resolve to the new
+# ``PIPEFY_SERVICE_ACCOUNT_*`` fields. The mapping is exported for
+# diagnostics (e.g. CLI's ``pipefy auth status`` lists which legacy keys
+# would still mask a stored session).
+_LEGACY_ENV_KEYS_TO_NEW: dict[str, str] = {
+    "PIPEFY_OAUTH_URL": "PIPEFY_SERVICE_ACCOUNT_URL",
+    "PIPEFY_OAUTH_CLIENT": "PIPEFY_SERVICE_ACCOUNT_CLIENT_ID",
+    "PIPEFY_OAUTH_SECRET": "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET",
+}
+
+_warned_legacy_env_keys: set[str] = set()
+
+
+def _warn_once_for_legacy_oauth_env_keys() -> None:
+    """Emit a one-shot stderr deprecation warning for each legacy env var still set."""
+    if len(_warned_legacy_env_keys) == len(_LEGACY_ENV_KEYS_TO_NEW):
+        return
+    for legacy, new in _LEGACY_ENV_KEYS_TO_NEW.items():
+        if legacy in _warned_legacy_env_keys:
+            continue
+        if legacy in os.environ:
+            sys.stderr.write(
+                f"warning: {legacy} is deprecated; rename to {new}. "
+                "The legacy name will be removed in a future beta.\n"
+            )
+            _warned_legacy_env_keys.add(legacy)
+
+
+def _reset_legacy_oauth_warning_state() -> None:
+    """Test helper: clear the one-shot dedup so a fixture can re-trigger the warning."""
+    _warned_legacy_env_keys.clear()
+
+
+class AuthSettings(BaseSettings):
+    """Auth-related configuration loaded from env / config files.
+
+    Reads its own ``PIPEFY_*`` env vars directly (with the ``PIPEFY_`` prefix
+    folded into the field names). Pure data — SSRF validation happens via
+    :meth:`validate_urls` once the surrounding settings know whether insecure
+    URLs are allowed.
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="PIPEFY_",
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+        # Required so ``env_prefix`` is applied to the field name on top of the
+        # ``AliasChoices`` lookups (otherwise env lookups would only consider
+        # the aliases, and ``PIPEFY_SERVICE_ACCOUNT_URL`` would be ignored).
+        populate_by_name=True,
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _emit_legacy_oauth_env_var_warning(cls, data: object) -> object:
+        # Mirrors the pre-split behaviour: warn once per legacy env key still set.
+        _warn_once_for_legacy_oauth_env_keys()
+        return data
+
+    # ``AliasChoices`` precedence is left-to-right. The fully-prefixed
+    # canonical env var comes first to outrank the legacy ``PIPEFY_OAUTH_*``
+    # name. The unprefixed form (e.g. ``oauth_url``) keeps direct kwarg
+    # construction working (``AuthSettings(oauth_url=...)``).
+    service_account_url: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "PIPEFY_SERVICE_ACCOUNT_URL",
+            "service_account_url",
+            "oauth_url",
+            "PIPEFY_OAUTH_URL",
+        ),
+        description=(
+            "Service-account token endpoint (OAuth 2.0 client-credentials grant) "
+            "(env: PIPEFY_SERVICE_ACCOUNT_URL; legacy PIPEFY_OAUTH_URL still honored)."
+        ),
+    )
+
+    service_account_client_id: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "PIPEFY_SERVICE_ACCOUNT_CLIENT_ID",
+            "service_account_client_id",
+            "oauth_client",
+            "PIPEFY_OAUTH_CLIENT",
+        ),
+        description=(
+            "Service-account OAuth client_id "
+            "(env: PIPEFY_SERVICE_ACCOUNT_CLIENT_ID; legacy PIPEFY_OAUTH_CLIENT still honored)."
+        ),
+    )
+
+    service_account_client_secret: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET",
+            "service_account_client_secret",
+            "oauth_secret",
+            "PIPEFY_OAUTH_SECRET",
+        ),
+        description=(
+            "Service-account OAuth client_secret "
+            "(env: PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET; legacy PIPEFY_OAUTH_SECRET still honored)."
+        ),
+    )
+
+    auth_url: str | None = Field(
+        default=None,
+        description=(
+            "OIDC issuer URL for the stored-session tier "
+            "(env: PIPEFY_AUTH_URL, e.g. https://signin.pipefy.com/realms/pipefy)."
+        ),
+    )
+
+    auth_client_id: str = Field(
+        default=DEFAULT_AUTH_CLIENT_ID,
+        description=(
+            "OIDC public client id registered at the issuer "
+            "(env: PIPEFY_AUTH_CLIENT_ID; rarely overridden)."
+        ),
+    )
+
+    def to_service_account(self) -> ServiceAccount | None:
+        """Project the triple into a :class:`ServiceAccount`, or ``None`` if incomplete."""
+        if (
+            self.service_account_url
+            and self.service_account_client_id
+            and self.service_account_client_secret
+        ):
+            return ServiceAccount(
+                token_url=self.service_account_url,
+                client_id=self.service_account_client_id,
+                client_secret=self.service_account_client_secret,
+            )
+        return None
+
+    def to_oidc_client(self) -> OidcClient | None:
+        """Project the OIDC fields into an :class:`OidcClient`, or ``None`` without ``auth_url``."""
+        if self.auth_url and self.auth_url.strip():
+            return OidcClient(
+                issuer_url=self.auth_url.strip(),
+                client_id=self.auth_client_id.strip() or DEFAULT_AUTH_CLIENT_ID,
+            )
+        return None
+
+    def validate_urls(self, *, allow_insecure: bool) -> None:
+        """Run SSRF checks on every URL this model carries. Call after composing."""
+        from pipefy_auth._url_ssrf import validate_https_service_endpoint_url
+
+        if self.service_account_url and (u := self.service_account_url.strip()):
+            validate_https_service_endpoint_url(
+                u, "service_account_url", allow_insecure=allow_insecure
+            )
+        if self.auth_url and (u := self.auth_url.strip()):
+            validate_https_service_endpoint_url(
+                u, "auth_url", allow_insecure=allow_insecure
+            )
+
+
+def describe_missing_service_account_vars(auth: AuthSettings) -> str:
+    """Return a short message listing missing service-account credential variables."""
+    missing: list[str] = []
+    if not auth.service_account_url or not auth.service_account_url.strip():
+        missing.append("PIPEFY_SERVICE_ACCOUNT_URL")
+    if not auth.service_account_client_id or not auth.service_account_client_id.strip():
+        missing.append("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID")
+    if (
+        not auth.service_account_client_secret
+        or not auth.service_account_client_secret.strip()
+    ):
+        missing.append("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET")
+    return ", ".join(missing)
+
+
+__all__ = [
+    "AuthSettings",
+    "describe_missing_service_account_vars",
+]

--- a/packages/auth/src/pipefy_auth/settings.py
+++ b/packages/auth/src/pipefy_auth/settings.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import os
 import sys
 
-from pydantic import AliasChoices, Field, model_validator
+from pydantic import AliasChoices, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from pipefy_auth.identity import DEFAULT_AUTH_CLIENT_ID, OidcClient
@@ -83,6 +83,21 @@ class AuthSettings(BaseSettings):
         # Mirrors the pre-split behaviour: warn once per legacy env key still set.
         _warn_once_for_legacy_oauth_env_keys()
         return data
+
+    @field_validator(
+        "static_token",
+        "service_account_url",
+        "service_account_client_id",
+        "service_account_client_secret",
+        "auth_url",
+        mode="before",
+    )
+    @classmethod
+    def _blank_to_none(cls, value: object) -> object:
+        # Empty / whitespace-only env values mean "not set", not "set to ''".
+        if isinstance(value, str) and not value.strip():
+            return None
+        return value
 
     # ``AliasChoices`` precedence is left-to-right. The fully-prefixed
     # canonical env var comes first to outrank the legacy ``PIPEFY_OAUTH_*``

--- a/packages/auth/src/pipefy_auth/settings.py
+++ b/packages/auth/src/pipefy_auth/settings.py
@@ -207,22 +207,4 @@ class AuthSettings(BaseSettings):
             )
 
 
-def describe_missing_service_account_vars(auth: AuthSettings) -> str:
-    """Return a short message listing missing service-account credential variables."""
-    missing: list[str] = []
-    if not auth.service_account_url or not auth.service_account_url.strip():
-        missing.append("PIPEFY_SERVICE_ACCOUNT_URL")
-    if not auth.service_account_client_id or not auth.service_account_client_id.strip():
-        missing.append("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID")
-    if (
-        not auth.service_account_client_secret
-        or not auth.service_account_client_secret.strip()
-    ):
-        missing.append("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET")
-    return ", ".join(missing)
-
-
-__all__ = [
-    "AuthSettings",
-    "describe_missing_service_account_vars",
-]
+__all__ = ["AuthSettings"]

--- a/packages/auth/src/pipefy_auth/settings.py
+++ b/packages/auth/src/pipefy_auth/settings.py
@@ -88,6 +88,15 @@ class AuthSettings(BaseSettings):
     # canonical env var comes first to outrank the legacy ``PIPEFY_OAUTH_*``
     # name. The unprefixed form (e.g. ``oauth_url``) keeps direct kwarg
     # construction working (``AuthSettings(oauth_url=...)``).
+    static_token: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("PIPEFY_TOKEN", "static_token"),
+        description=(
+            "Pre-issued bearer for the static-token tier (env: PIPEFY_TOKEN). "
+            "When set, outranks both the service-account triple and any stored session."
+        ),
+    )
+
     service_account_url: str | None = Field(
         default=None,
         validation_alias=AliasChoices(

--- a/packages/auth/tests/test_settings_back_compat.py
+++ b/packages/auth/tests/test_settings_back_compat.py
@@ -1,6 +1,6 @@
 """Back-compat coverage for the ``PIPEFY_OAUTH_*`` → ``PIPEFY_SERVICE_ACCOUNT_*`` rename.
 
-The rename ships an ``AliasChoices`` shim on ``PipefySettings`` plus a one-shot
+The rename ships an ``AliasChoices`` shim on ``AuthSettings`` plus a one-shot
 stderr deprecation warning. These tests pin both behaviors so the eventual
 PR that drops the aliases (and the warning) has a clear regression surface.
 """
@@ -9,9 +9,9 @@ from __future__ import annotations
 
 import pytest
 
-from pipefy_sdk.settings import (
+from pipefy_auth.settings import (
     _LEGACY_ENV_KEYS_TO_NEW,
-    PipefySettings,
+    AuthSettings,
     _reset_legacy_oauth_warning_state,
     _warn_once_for_legacy_oauth_env_keys,
 )
@@ -31,9 +31,8 @@ def _reset_warning_dedup(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.mark.unit
 def test_legacy_kwargs_populate_new_fields():
-    """``PipefySettings(oauth_url=...)`` still validates and binds to ``service_account_url``."""
-    s = PipefySettings(
-        graphql_url="https://app.pipefy.com/graphql",
+    """``AuthSettings(oauth_url=...)`` still validates and binds to ``service_account_url``."""
+    s = AuthSettings(
         oauth_url="https://legacy.example.com/oauth/token",
         oauth_client="legacy-client",
         oauth_secret="legacy-secret",
@@ -45,8 +44,7 @@ def test_legacy_kwargs_populate_new_fields():
 
 @pytest.mark.unit
 def test_new_kwargs_populate_new_fields():
-    s = PipefySettings(
-        graphql_url="https://app.pipefy.com/graphql",
+    s = AuthSettings(
         service_account_url="https://new.example.com/oauth/token",
         service_account_client_id="new-client",
         service_account_client_secret="new-secret",
@@ -62,15 +60,10 @@ def test_legacy_env_var_emits_deprecation_warning(
     capsys: pytest.CaptureFixture[str],
 ):
     monkeypatch.setenv("PIPEFY_OAUTH_URL", "https://shell.example.com/oauth/token")
-
-    # Trigger via direct emitter call — model construction below would also trigger,
-    # but the emitter is the unit under test here.
     _warn_once_for_legacy_oauth_env_keys()
-
     err = capsys.readouterr().err
     assert "PIPEFY_OAUTH_URL is deprecated" in err
     assert "rename to PIPEFY_SERVICE_ACCOUNT_URL" in err
-    # Only the legacy key that is set should warn.
     assert "PIPEFY_OAUTH_CLIENT" not in err
     assert "PIPEFY_OAUTH_SECRET" not in err
 
@@ -81,11 +74,9 @@ def test_deprecation_warning_dedups_within_process(
     capsys: pytest.CaptureFixture[str],
 ):
     monkeypatch.setenv("PIPEFY_OAUTH_URL", "https://shell.example.com/oauth/token")
-
     _warn_once_for_legacy_oauth_env_keys()
     _warn_once_for_legacy_oauth_env_keys()
     _warn_once_for_legacy_oauth_env_keys()
-
     err = capsys.readouterr().err
     assert err.count("PIPEFY_OAUTH_URL is deprecated") == 1
 
@@ -100,28 +91,6 @@ def test_no_deprecation_warning_when_only_new_env_keys_set(
     )
     monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", "new-client")
     monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET", "new-secret")
-
-    PipefySettings(
-        graphql_url="https://app.pipefy.com/graphql",
-        service_account_url="https://new.example.com/oauth/token",
-        service_account_client_id="new-client",
-        service_account_client_secret="new-secret",
-    )
-
+    _warn_once_for_legacy_oauth_env_keys()
     err = capsys.readouterr().err
     assert "deprecated" not in err
-
-
-@pytest.mark.unit
-def test_pipefy_settings_construction_triggers_warning_via_model_validator(
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-):
-    """The ``mode="before"`` model_validator wires the warning into PipefySettings init."""
-    monkeypatch.setenv("PIPEFY_OAUTH_SECRET", "legacy-secret-in-shell")
-
-    PipefySettings(graphql_url="https://app.pipefy.com/graphql")
-
-    err = capsys.readouterr().err
-    assert "PIPEFY_OAUTH_SECRET is deprecated" in err
-    assert "rename to PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET" in err

--- a/packages/cli/src/pipefy_cli/auth.py
+++ b/packages/cli/src/pipefy_cli/auth.py
@@ -54,14 +54,16 @@ class BearerToken:
 
 @dataclass(frozen=True)
 class AuthContext:
-    """User-auth identity for a single CLI invocation.
+    """Auth inputs for a single CLI invocation.
 
-    Carries only identity. Where-to-call configuration (URLs, service-account
-    credentials, ``allow_insecure_urls``) lives on :class:`PipefySettings` and is
-    passed alongside.
+    Each field maps to one resolver tier (bearer-token, service-account,
+    stored-session). Built once at startup from the loaded
+    :class:`pipefy_auth.AuthSettings` plus the per-invocation ``--token`` /
+    ``PIPEFY_TOKEN`` resolution.
     """
 
     bearer_token: BearerToken | None
+    service_account: ServiceAccount | None
     oidc_client: OidcClient | None
 
 
@@ -78,24 +80,10 @@ def clear_authenticated_client_cache() -> None:
     _cached_client = None
 
 
-def _service_account(pipefy_settings: PipefySettings) -> ServiceAccount | None:
-    if (
-        pipefy_settings.service_account_url
-        and pipefy_settings.service_account_client_id
-        and pipefy_settings.service_account_client_secret
-    ):
-        return ServiceAccount(
-            token_url=pipefy_settings.service_account_url,
-            client_id=pipefy_settings.service_account_client_id,
-            client_secret=pipefy_settings.service_account_client_secret,
-        )
-    return None
-
-
-def _resolve(pipefy_settings: PipefySettings, auth: AuthContext) -> Auth | None:
+def _resolve(auth: AuthContext) -> Auth | None:
     return resolve_pipefy_auth(
         static_token=auth.bearer_token.value if auth.bearer_token else None,
-        service_account=_service_account(pipefy_settings),
+        service_account=auth.service_account,
         oidc_client=auth.oidc_client,
     )
 
@@ -111,11 +99,11 @@ def _to_display_source(tier: str, bearer: BearerToken | None) -> str:
     return tier
 
 
-def detect_cli_sources(pipefy_settings: PipefySettings, auth: AuthContext) -> list[str]:
+def detect_cli_sources(auth: AuthContext) -> list[str]:
     """Return detected sources mapped to CLI display labels."""
     detected = detect_pipefy_tiers(
         static_token=auth.bearer_token.value if auth.bearer_token else None,
-        service_account=_service_account(pipefy_settings),
+        service_account=auth.service_account,
         oidc_client=auth.oidc_client,
     )
     return [_to_display_source(tier, auth.bearer_token) for tier in detected]
@@ -164,7 +152,7 @@ def get_authenticated_client(
         typer.echo(str(exc), err=True)
         raise typer.Exit(2) from exc
 
-    resolved = _resolve(pipefy_settings, auth)
+    resolved = _resolve(auth)
     if resolved is None:
         typer.echo(f"{missing_auth_message()} See {DOCS_CLI_AUTH_REF}.", err=True)
         raise typer.Exit(2)

--- a/packages/cli/src/pipefy_cli/commands/_common.py
+++ b/packages/cli/src/pipefy_cli/commands/_common.py
@@ -11,7 +11,6 @@ from typing import Any, TypeVar
 
 import typer
 from gql.transport.exceptions import TransportError, TransportQueryError
-from pipefy_auth import OidcClient
 from pipefy_sdk import PipefyClient, PipefySettings, stream_bytes
 from pipefy_sdk.exceptions import PipefyError
 
@@ -212,13 +211,12 @@ def settings_and_auth_from_ctx(
 ) -> tuple[PipefySettings, AuthContext]:
     """Resolve root ``ctx.obj`` into the (settings, auth) pair the client boundary needs."""
     obj = ctx.find_root().obj
-    auth_url = obj.get("auth_url")
-    oidc_client = (
-        OidcClient(issuer_url=auth_url, client_id=obj["auth_client_id"])
-        if auth_url
-        else None
+    auth_settings = obj["auth_settings"]
+    auth = AuthContext(
+        bearer_token=obj.get("token"),
+        service_account=auth_settings.to_service_account(),
+        oidc_client=auth_settings.to_oidc_client(),
     )
-    auth = AuthContext(bearer_token=obj.get("token"), oidc_client=oidc_client)
     return obj["pipefy_settings"], auth
 
 

--- a/packages/cli/src/pipefy_cli/commands/auth.py
+++ b/packages/cli/src/pipefy_cli/commands/auth.py
@@ -31,8 +31,8 @@ from pipefy_auth import (
     run_login,
     store_session,
 )
+from pipefy_auth.settings import _LEGACY_ENV_KEYS_TO_NEW
 from pipefy_sdk import MePayload, PipefySettings
-from pipefy_sdk.settings import _LEGACY_ENV_KEYS_TO_NEW
 
 from pipefy_cli._docs import DOCS_CLI_AUTH_REF
 from pipefy_cli.auth import (
@@ -416,7 +416,7 @@ def auth_status(
 ) -> None:
     """Print which auth source is active, the authenticated identity, and session expiry."""
     settings, auth = settings_and_auth_from_ctx(ctx)
-    detected_names = detect_cli_sources(settings, auth)
+    detected_names = detect_cli_sources(auth)
     # The locked JSON wire schema matches the policy names exactly; cast for
     # typing only — values are already constrained by ``build_policies``.
     detected: list[DisplaySource] = [

--- a/packages/cli/src/pipefy_cli/config.py
+++ b/packages/cli/src/pipefy_cli/config.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import os
 import sys
 import tomllib
-from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Self, TypeVar
 
@@ -27,8 +26,12 @@ _LEGACY_TOML_KEYS_TO_NEW: dict[str, str] = {
 }
 
 # Keys under ``[pipefy]`` that belong to auth, not the SDK. Derived from the
-# model so a field rename does not need a second edit here.
-_AUTH_TOML_KEYS: frozenset[str] = frozenset(AuthSettings.model_fields)
+# model so a field rename does not need a second edit here. ``static_token``
+# is excluded: bearers are short-lived secrets and don't belong in a long-
+# lived plaintext user config file (use ``PIPEFY_TOKEN`` env or ``--token``).
+_AUTH_TOML_KEYS: frozenset[str] = frozenset(AuthSettings.model_fields) - {
+    "static_token"
+}
 
 _warned_legacy_toml_keys: set[str] = set()
 
@@ -71,27 +74,12 @@ class CliSettings(BaseSettings):
 _ModelT = TypeVar("_ModelT", bound=BaseModel)
 
 
-def _revalidate(
-    model: _ModelT,
-    patch: dict[str, Any],
-    *,
-    post: Callable[[_ModelT], None] | None = None,
-) -> _ModelT:
-    """Merge ``patch`` and re-validate (``model_copy`` would skip URL validators).
-
-    ``post`` runs after validation for follow-up checks the model itself does
-    not own (e.g. SSRF validation on :class:`AuthSettings` that needs the
-    sibling ``allow_insecure_urls`` flag).
-    """
+def _revalidate(model: _ModelT, patch: dict[str, Any]) -> _ModelT:
+    """Merge ``patch`` and re-validate (``model_copy`` would skip URL validators)."""
     if not patch:
-        if post is not None:
-            post(model)
         return model
     merged = {**model.model_dump(), **patch}
-    fresh = type(model).model_validate(merged)
-    if post is not None:
-        post(fresh)
-    return fresh
+    return type(model).model_validate(merged)
 
 
 def _read_toml_pipefy_dict() -> dict[str, Any]:

--- a/packages/cli/src/pipefy_cli/config.py
+++ b/packages/cli/src/pipefy_cli/config.py
@@ -1,4 +1,4 @@
-"""Resolve Pipefy settings for the CLI (aligned with MCP ``PIPEFY_*`` keys)."""
+"""Resolve Pipefy + auth settings for the CLI (aligned with MCP ``PIPEFY_*`` keys)."""
 
 from __future__ import annotations
 
@@ -8,9 +8,8 @@ import tomllib
 from pathlib import Path
 from typing import Any, Self
 
-from pipefy_auth import DEFAULT_AUTH_CLIENT_ID
+from pipefy_auth import AuthSettings
 from pipefy_sdk import PipefySettings
-from pipefy_sdk.utils.url_ssrf import validate_https_service_endpoint_url
 from pydantic import Field, ValidationError, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -25,6 +24,19 @@ _LEGACY_TOML_KEYS_TO_NEW: dict[str, str] = {
     "oauth_client": "service_account_client_id",
     "oauth_secret": "service_account_client_secret",
 }
+
+# Keys recognised under ``[pipefy]`` that belong to auth, not the SDK. Used by
+# the TOML loader to route values into ``AuthSettings`` instead of
+# ``PipefySettings``.
+_AUTH_TOML_KEYS: frozenset[str] = frozenset(
+    {
+        "service_account_url",
+        "service_account_client_id",
+        "service_account_client_secret",
+        "auth_url",
+        "auth_client_id",
+    }
+)
 
 _warned_legacy_toml_keys: set[str] = set()
 
@@ -56,26 +68,31 @@ class CliSettings(BaseSettings):
     )
 
     pipefy: PipefySettings = Field(default_factory=PipefySettings)
-    auth_url: str | None = Field(default=None, alias="PIPEFY_AUTH_URL")
-    auth_client_id: str = Field(
-        default=DEFAULT_AUTH_CLIENT_ID, alias="PIPEFY_AUTH_CLIENT_ID"
-    )
+    auth: AuthSettings = Field(default_factory=AuthSettings)
 
     @model_validator(mode="after")
-    def _validate_auth_url(self) -> Self:
-        if self.auth_url is not None and (u := self.auth_url.strip()):
-            validate_https_service_endpoint_url(
-                u, "auth_url", allow_insecure=self.pipefy.allow_insecure_urls
-            )
+    def _validate_auth_urls(self) -> Self:
+        self.auth.validate_urls(allow_insecure=self.pipefy.allow_insecure_urls)
         return self
 
 
-def _revalidate(pipefy: PipefySettings, patch: dict[str, Any]) -> PipefySettings:
+def _revalidate_pipefy(pipefy: PipefySettings, patch: dict[str, Any]) -> PipefySettings:
     """Merge ``patch`` and re-validate (``model_copy`` would skip URL validators)."""
     if not patch:
         return pipefy
     merged = {**pipefy.model_dump(), **patch}
     return PipefySettings.model_validate(merged)
+
+
+def _revalidate_auth(
+    auth: AuthSettings, patch: dict[str, Any], *, allow_insecure: bool
+) -> AuthSettings:
+    if not patch:
+        return auth
+    merged = {**auth.model_dump(), **patch}
+    fresh = AuthSettings.model_validate(merged)
+    fresh.validate_urls(allow_insecure=allow_insecure)
+    return fresh
 
 
 def _read_toml_pipefy_dict() -> dict[str, Any]:
@@ -105,22 +122,8 @@ def _is_missing(value: object) -> bool:
     return False
 
 
-def _fill_if_missing_str(
-    pipefy: PipefySettings,
-    blob: dict[str, Any],
-    field: str,
-    key: str,
-    patch: dict[str, Any],
-) -> None:
-    if _is_missing(getattr(pipefy, field)) and blob.get(key):
-        patch[field] = str(blob[key]).strip()
-
-
 def _normalize_legacy_toml_keys(blob: dict[str, Any]) -> dict[str, Any]:
-    """Translate legacy ``oauth_*`` TOML keys to ``service_account_*``; warn once per legacy key.
-
-    When both keys are present, the new key wins (mirrors ``AliasChoices`` precedence).
-    """
+    """Translate legacy ``oauth_*`` TOML keys to ``service_account_*``; warn once per legacy key."""
     if not any(legacy in blob for legacy in _LEGACY_TOML_KEYS_TO_NEW):
         return blob
     for legacy, new in _LEGACY_TOML_KEYS_TO_NEW.items():
@@ -131,33 +134,45 @@ def _normalize_legacy_toml_keys(blob: dict[str, Any]) -> dict[str, Any]:
     return blob
 
 
-def apply_toml_fallback(pipefy: PipefySettings) -> PipefySettings:
-    """Fill only attributes still unset after env / ``.env`` (lowest precedence)."""
+def _fill_if_missing_str(
+    model: PipefySettings | AuthSettings,
+    blob: dict[str, Any],
+    field: str,
+    key: str,
+    patch: dict[str, Any],
+) -> None:
+    if _is_missing(getattr(model, field)) and blob.get(key):
+        patch[field] = str(blob[key]).strip()
+
+
+def apply_toml_fallback(
+    pipefy: PipefySettings, auth: AuthSettings
+) -> tuple[PipefySettings, AuthSettings]:
+    """Fill attributes still unset after env / ``.env`` from the user TOML file (lowest precedence)."""
     blob = _read_toml_pipefy_dict()
     if not blob:
-        return pipefy
+        return pipefy, auth
     blob = _normalize_legacy_toml_keys(blob)
-    patch: dict[str, Any] = {}
-    _fill_if_missing_str(pipefy, blob, "graphql_url", "graphql_url", patch)
-    _fill_if_missing_str(pipefy, blob, "internal_api_url", "internal_api_url", patch)
+
+    pipefy_patch: dict[str, Any] = {}
+    _fill_if_missing_str(pipefy, blob, "graphql_url", "graphql_url", pipefy_patch)
     _fill_if_missing_str(
-        pipefy, blob, "service_account_url", "service_account_url", patch
-    )
-    _fill_if_missing_str(
-        pipefy, blob, "service_account_client_id", "service_account_client_id", patch
-    )
-    _fill_if_missing_str(
-        pipefy,
-        blob,
-        "service_account_client_secret",
-        "service_account_client_secret",
-        patch,
+        pipefy, blob, "internal_api_url", "internal_api_url", pipefy_patch
     )
     if blob.get("service_account_ids") is not None and not pipefy.service_account_ids:
-        patch["service_account_ids"] = blob["service_account_ids"]
+        pipefy_patch["service_account_ids"] = blob["service_account_ids"]
     if blob.get("allow_insecure_urls") is not None and not pipefy.allow_insecure_urls:
-        patch["allow_insecure_urls"] = bool(blob["allow_insecure_urls"])
-    return _revalidate(pipefy, patch)
+        pipefy_patch["allow_insecure_urls"] = bool(blob["allow_insecure_urls"])
+
+    auth_patch: dict[str, Any] = {}
+    for key in _AUTH_TOML_KEYS:
+        _fill_if_missing_str(auth, blob, key, key, auth_patch)
+
+    new_pipefy = _revalidate_pipefy(pipefy, pipefy_patch)
+    new_auth = _revalidate_auth(
+        auth, auth_patch, allow_insecure=new_pipefy.allow_insecure_urls
+    )
+    return new_pipefy, new_auth
 
 
 def resolve_cli_settings(
@@ -166,10 +181,6 @@ def resolve_cli_settings(
     allow_insecure_urls_flag: bool | None,
 ) -> CliSettings:
     """Resolve the full :class:`CliSettings`: env, ``.env``, TOML fallback, then flags.
-
-    Returns a single ``CliSettings`` instance with the nested ``.pipefy`` field
-    fully resolved (TOML + flag overrides applied) and the top-level auth fields
-    (``auth_url``, ``auth_client_id``) populated from env / ``.env``.
 
     Raises:
         ValueError: When validation fails (e.g. SSRF guard); message is user-facing.
@@ -189,17 +200,19 @@ def resolve_cli_settings(
                 os.environ[_ALLOW_INSECURE_ENV_KEY] = prev_allow
 
     try:
-        pipefy = apply_toml_fallback(cli.pipefy)
-        patch: dict[str, Any] = {}
+        pipefy, auth = apply_toml_fallback(cli.pipefy, cli.auth)
+        pipefy_patch: dict[str, Any] = {}
         if graphql_url_flag:
-            patch["graphql_url"] = graphql_url_flag.strip()
+            pipefy_patch["graphql_url"] = graphql_url_flag.strip()
         if allow_insecure_urls_flag is not None:
-            patch["allow_insecure_urls"] = allow_insecure_urls_flag
-        pipefy = _revalidate(pipefy, patch)
+            pipefy_patch["allow_insecure_urls"] = allow_insecure_urls_flag
+        pipefy = _revalidate_pipefy(pipefy, pipefy_patch)
+        # Re-validate auth URLs against the (possibly newly-flipped) allow_insecure_urls.
+        auth.validate_urls(allow_insecure=pipefy.allow_insecure_urls)
     except ValidationError as exc:
         raise ValueError(str(exc)) from exc
 
-    return cli.model_copy(update={"pipefy": pipefy})
+    return cli.model_copy(update={"pipefy": pipefy, "auth": auth})
 
 
 def ensure_public_graphql_configured(pipefy: PipefySettings) -> None:
@@ -216,23 +229,10 @@ def ensure_public_graphql_configured(pipefy: PipefySettings) -> None:
         raise ValueError(msg)
 
 
-def describe_missing_service_account_vars(pipefy: PipefySettings) -> str:
-    """Return a short message listing missing service-account credential variables."""
-    missing: list[str] = []
-    if _is_missing(pipefy.service_account_url):
-        missing.append("PIPEFY_SERVICE_ACCOUNT_URL")
-    if _is_missing(pipefy.service_account_client_id):
-        missing.append("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID")
-    if _is_missing(pipefy.service_account_client_secret):
-        missing.append("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET")
-    return ", ".join(missing)
-
-
 __all__ = [
     "CliSettings",
     "USER_CONFIG_PATH",
     "apply_toml_fallback",
-    "describe_missing_service_account_vars",
     "ensure_public_graphql_configured",
     "resolve_cli_settings",
 ]

--- a/packages/cli/src/pipefy_cli/config.py
+++ b/packages/cli/src/pipefy_cli/config.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 import os
 import sys
 import tomllib
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Self
+from typing import Any, Self, TypeVar
 
 from pipefy_auth import AuthSettings
 from pipefy_sdk import PipefySettings
-from pydantic import Field, ValidationError, model_validator
+from pydantic import BaseModel, Field, ValidationError, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from pipefy_cli._docs import DOCS_SETUP_REF
@@ -25,18 +26,9 @@ _LEGACY_TOML_KEYS_TO_NEW: dict[str, str] = {
     "oauth_secret": "service_account_client_secret",
 }
 
-# Keys recognised under ``[pipefy]`` that belong to auth, not the SDK. Used by
-# the TOML loader to route values into ``AuthSettings`` instead of
-# ``PipefySettings``.
-_AUTH_TOML_KEYS: frozenset[str] = frozenset(
-    {
-        "service_account_url",
-        "service_account_client_id",
-        "service_account_client_secret",
-        "auth_url",
-        "auth_client_id",
-    }
-)
+# Keys under ``[pipefy]`` that belong to auth, not the SDK. Derived from the
+# model so a field rename does not need a second edit here.
+_AUTH_TOML_KEYS: frozenset[str] = frozenset(AuthSettings.model_fields)
 
 _warned_legacy_toml_keys: set[str] = set()
 
@@ -76,22 +68,29 @@ class CliSettings(BaseSettings):
         return self
 
 
-def _revalidate_pipefy(pipefy: PipefySettings, patch: dict[str, Any]) -> PipefySettings:
-    """Merge ``patch`` and re-validate (``model_copy`` would skip URL validators)."""
-    if not patch:
-        return pipefy
-    merged = {**pipefy.model_dump(), **patch}
-    return PipefySettings.model_validate(merged)
+_ModelT = TypeVar("_ModelT", bound=BaseModel)
 
 
-def _revalidate_auth(
-    auth: AuthSettings, patch: dict[str, Any], *, allow_insecure: bool
-) -> AuthSettings:
+def _revalidate(
+    model: _ModelT,
+    patch: dict[str, Any],
+    *,
+    post: Callable[[_ModelT], None] | None = None,
+) -> _ModelT:
+    """Merge ``patch`` and re-validate (``model_copy`` would skip URL validators).
+
+    ``post`` runs after validation for follow-up checks the model itself does
+    not own (e.g. SSRF validation on :class:`AuthSettings` that needs the
+    sibling ``allow_insecure_urls`` flag).
+    """
     if not patch:
-        return auth
-    merged = {**auth.model_dump(), **patch}
-    fresh = AuthSettings.model_validate(merged)
-    fresh.validate_urls(allow_insecure=allow_insecure)
+        if post is not None:
+            post(model)
+        return model
+    merged = {**model.model_dump(), **patch}
+    fresh = type(model).model_validate(merged)
+    if post is not None:
+        post(fresh)
     return fresh
 
 
@@ -168,10 +167,11 @@ def apply_toml_fallback(
     for key in _AUTH_TOML_KEYS:
         _fill_if_missing_str(auth, blob, key, key, auth_patch)
 
-    new_pipefy = _revalidate_pipefy(pipefy, pipefy_patch)
-    new_auth = _revalidate_auth(
-        auth, auth_patch, allow_insecure=new_pipefy.allow_insecure_urls
-    )
+    new_pipefy = _revalidate(pipefy, pipefy_patch)
+    # Auth URLs are SSRF-checked once at the end of ``resolve_cli_settings``
+    # against the final ``allow_insecure_urls`` value, so we skip the post-hook
+    # here to avoid validating twice.
+    new_auth = _revalidate(auth, auth_patch)
     return new_pipefy, new_auth
 
 
@@ -206,8 +206,9 @@ def resolve_cli_settings(
             pipefy_patch["graphql_url"] = graphql_url_flag.strip()
         if allow_insecure_urls_flag is not None:
             pipefy_patch["allow_insecure_urls"] = allow_insecure_urls_flag
-        pipefy = _revalidate_pipefy(pipefy, pipefy_patch)
-        # Re-validate auth URLs against the (possibly newly-flipped) allow_insecure_urls.
+        pipefy = _revalidate(pipefy, pipefy_patch)
+        # The flag may have flipped ``allow_insecure_urls``; re-run the auth-URL
+        # SSRF guard against the resolved value rather than the env-loaded one.
         auth.validate_urls(allow_insecure=pipefy.allow_insecure_urls)
     except ValidationError as exc:
         raise ValueError(str(exc)) from exc

--- a/packages/cli/src/pipefy_cli/main.py
+++ b/packages/cli/src/pipefy_cli/main.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import os
 
 import typer
-from pipefy_auth import DEFAULT_AUTH_CLIENT_ID
 
 from pipefy_cli import __version__ as _cli_version
 from pipefy_cli.auth import BearerToken
@@ -88,10 +87,7 @@ def main(
         typer.echo(str(exc), err=True)
         raise typer.Exit(2) from exc
     ctx.obj["pipefy_settings"] = cli_settings.pipefy
-    ctx.obj["auth_url"] = (cli_settings.auth_url or "").strip() or None
-    ctx.obj["auth_client_id"] = (
-        cli_settings.auth_client_id or DEFAULT_AUTH_CLIENT_ID
-    ).strip()
+    ctx.obj["auth_settings"] = cli_settings.auth
     from_env = os.environ.get("PIPEFY_TOKEN")
     cli_token = token.strip() if token else None
     env_token = from_env.strip() if from_env else None

--- a/packages/cli/src/pipefy_cli/main.py
+++ b/packages/cli/src/pipefy_cli/main.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import os
-
 import typer
 
 from pipefy_cli import __version__ as _cli_version
@@ -88,14 +86,17 @@ def main(
         raise typer.Exit(2) from exc
     ctx.obj["pipefy_settings"] = cli_settings.pipefy
     ctx.obj["auth_settings"] = cli_settings.auth
-    from_env = os.environ.get("PIPEFY_TOKEN")
     cli_token = token.strip() if token else None
-    env_token = from_env.strip() if from_env else None
+    settings_token = (
+        cli_settings.auth.static_token.strip()
+        if cli_settings.auth.static_token
+        else None
+    )
     bearer: BearerToken | None
     if cli_token:
         bearer = BearerToken(value=cli_token, source="flag")
-    elif env_token:
-        bearer = BearerToken(value=env_token, source="env")
+    elif settings_token:
+        bearer = BearerToken(value=settings_token, source="env")
     else:
         bearer = None
     ctx.obj["token"] = bearer

--- a/packages/cli/src/pipefy_cli/main.py
+++ b/packages/cli/src/pipefy_cli/main.py
@@ -87,16 +87,11 @@ def main(
     ctx.obj["pipefy_settings"] = cli_settings.pipefy
     ctx.obj["auth_settings"] = cli_settings.auth
     cli_token = token.strip() if token else None
-    settings_token = (
-        cli_settings.auth.static_token.strip()
-        if cli_settings.auth.static_token
-        else None
-    )
     bearer: BearerToken | None
     if cli_token:
         bearer = BearerToken(value=cli_token, source="flag")
-    elif settings_token:
-        bearer = BearerToken(value=settings_token, source="env")
+    elif cli_settings.auth.static_token:
+        bearer = BearerToken(value=cli_settings.auth.static_token, source="env")
     else:
         bearer = None
     ctx.obj["token"] = bearer

--- a/packages/cli/tests/test_auth.py
+++ b/packages/cli/tests/test_auth.py
@@ -10,6 +10,7 @@ import typer
 from pipefy_auth import (
     CallableBearerAuth,
     OidcClient,
+    ServiceAccount,
     StaticBearerAuth,
     StoredSession,
 )
@@ -24,14 +25,24 @@ from pipefy_cli.auth import (
 from pipefy_cli.main import app
 
 
-def _minimal_service_account_settings() -> PipefySettings:
+def _minimal_settings() -> PipefySettings:
     return PipefySettings(
         graphql_url="https://unit.example.com/graphql",
         internal_api_url="https://unit.example.com/internal_api",
-        service_account_url="https://unit.example.com/oauth/token",
-        service_account_client_id="cid",
-        service_account_client_secret="csecret",
     )
+
+
+def _service_account() -> ServiceAccount:
+    return ServiceAccount(
+        token_url="https://unit.example.com/oauth/token",
+        client_id="cid",
+        client_secret="csecret",
+    )
+
+
+# Backwards-compatible alias for tests that pre-date the settings split.
+def _minimal_service_account_settings() -> PipefySettings:
+    return _minimal_settings()
 
 
 def _auth(
@@ -40,8 +51,10 @@ def _auth(
     bearer_source: str = "flag",
     issuer_url: str | None = None,
     client_id: str | None = None,
+    service_account: ServiceAccount | None = None,
+    include_service_account: bool = True,
 ) -> AuthContext:
-    """Build an :class:`AuthContext` for tests; constructs :class:`OidcClient` iff both halves are provided."""
+    """Build an :class:`AuthContext` for tests."""
     oidc_client = (
         OidcClient(issuer_url=issuer_url, client_id=client_id)
         if issuer_url and client_id
@@ -52,7 +65,12 @@ def _auth(
         if bearer_token is not None
         else None
     )
-    return AuthContext(bearer_token=bearer, oidc_client=oidc_client)
+    sa = (
+        service_account
+        if service_account is not None
+        else (_service_account() if include_service_account else None)
+    )
+    return AuthContext(bearer_token=bearer, service_account=sa, oidc_client=oidc_client)
 
 
 def test_get_authenticated_client_passes_auth_to_pipefy_client(clean_pipefy_env):
@@ -159,17 +177,13 @@ def test_cli_uses_pipefy_token_env_when_no_flag(
 
 def test_detect_cli_sources_maps_static_token_to_flag_label(clean_pipefy_env):
     """``--token`` source surfaces as the locked ``flag-token`` wire value."""
-    settings = _minimal_service_account_settings()
-    sources = detect_cli_sources(
-        settings, _auth(bearer_token="t", bearer_source="flag")
-    )
+    sources = detect_cli_sources(_auth(bearer_token="t", bearer_source="flag"))
     assert sources[0] == "flag-token"
 
 
 def test_detect_cli_sources_maps_env_token_to_env_label(clean_pipefy_env):
     """``PIPEFY_TOKEN`` source surfaces as the locked ``env-token`` wire value."""
-    settings = _minimal_service_account_settings()
-    sources = detect_cli_sources(settings, _auth(bearer_token="t", bearer_source="env"))
+    sources = detect_cli_sources(_auth(bearer_token="t", bearer_source="env"))
     assert sources[0] == "env-token"
 
 
@@ -200,6 +214,23 @@ def _fresh_stored_session(*, access_token: str = "SESSION_ACCESS") -> StoredSess
 def _public_only_settings() -> PipefySettings:
     """``PIPEFY_SERVICE_ACCOUNT_*`` triple absent → service-account tier unavailable, stored session wins."""
     return PipefySettings(graphql_url="https://unit.example.com/graphql")
+
+
+def _public_only_auth(
+    *,
+    bearer_token: str | None = None,
+    bearer_source: str = "flag",
+    issuer_url: str | None = None,
+    client_id: str | None = None,
+) -> AuthContext:
+    """``AuthContext`` without a service-account tier (stored-session scenario)."""
+    return _auth(
+        bearer_token=bearer_token,
+        bearer_source=bearer_source,
+        issuer_url=issuer_url,
+        client_id=client_id,
+        include_service_account=False,
+    )
 
 
 def test_bearer_token_wins_over_stored_session(clean_pipefy_env):
@@ -257,7 +288,8 @@ def test_stored_session_used_when_no_other_source(clean_pipefy_env):
     ):
         mock_pc.return_value = MagicMock()
         get_authenticated_client(
-            settings, _auth(issuer_url=_ISSUER, client_id="pipefy-cli")
+            settings,
+            _public_only_auth(issuer_url=_ISSUER, client_id="pipefy-cli"),
         )
         mock_pc.assert_called_once()
         assert isinstance(mock_pc.call_args.kwargs["auth"], CallableBearerAuth)
@@ -274,10 +306,12 @@ def test_cache_reuses_resolved_auth_for_stored_session(clean_pipefy_env):
     ):
         mock_pc.return_value = MagicMock()
         first = get_authenticated_client(
-            settings, _auth(issuer_url=_ISSUER, client_id="pipefy-cli")
+            settings,
+            _public_only_auth(issuer_url=_ISSUER, client_id="pipefy-cli"),
         )
         second = get_authenticated_client(
-            settings, _auth(issuer_url=_ISSUER, client_id="pipefy-cli")
+            settings,
+            _public_only_auth(issuer_url=_ISSUER, client_id="pipefy-cli"),
         )
         assert first is second
         assert mock_pc.call_count == 1
@@ -304,7 +338,8 @@ def test_refresh_error_exits_2_with_relogin_hint(clean_pipefy_env, capsys):
         mock_resolve.return_value = CallableBearerAuth(lambda: "ACCESS")
         with pytest.raises(typer.Exit) as excinfo:
             get_authenticated_client(
-                settings, _auth(issuer_url=_ISSUER, client_id="pipefy-cli")
+                settings,
+                _public_only_auth(issuer_url=_ISSUER, client_id="pipefy-cli"),
             )
         assert excinfo.value.exit_code == 2
     err = capsys.readouterr().err

--- a/packages/cli/tests/test_auth.py
+++ b/packages/cli/tests/test_auth.py
@@ -40,11 +40,6 @@ def _service_account() -> ServiceAccount:
     )
 
 
-# Backwards-compatible alias for tests that pre-date the settings split.
-def _minimal_service_account_settings() -> PipefySettings:
-    return _minimal_settings()
-
-
 def _auth(
     *,
     bearer_token: str | None = None,
@@ -74,7 +69,7 @@ def _auth(
 
 
 def test_get_authenticated_client_passes_auth_to_pipefy_client(clean_pipefy_env):
-    settings = _minimal_service_account_settings()
+    settings = _minimal_settings()
     with patch("pipefy_cli.auth.PipefyClient") as mock_pc:
         mock_pc.return_value = MagicMock()
         client = get_authenticated_client(settings, _auth(bearer_token="tok"))
@@ -85,7 +80,7 @@ def test_get_authenticated_client_passes_auth_to_pipefy_client(clean_pipefy_env)
 
 
 def test_get_authenticated_client_service_account_wires_internal_api(clean_pipefy_env):
-    settings = _minimal_service_account_settings()
+    settings = _minimal_settings()
     with (
         patch("pipefy_cli.auth.PipefyClient") as mock_pc,
         patch("pipefy_cli.auth.InternalApiClient") as mock_internal,
@@ -118,7 +113,7 @@ def test_get_authenticated_client_bearer_path_shares_auth_with_internal_api(
 def test_cache_returns_same_instance_for_identical_service_account_settings(
     clean_pipefy_env,
 ):
-    settings = _minimal_service_account_settings()
+    settings = _minimal_settings()
     with (
         patch("pipefy_cli.auth.PipefyClient") as mock_pc,
         patch("pipefy_cli.auth.InternalApiClient"),
@@ -235,7 +230,7 @@ def _public_only_auth(
 
 def test_bearer_token_wins_over_stored_session(clean_pipefy_env):
     """The static-token tier MUST short-circuit before the keychain is even consulted."""
-    settings = _minimal_service_account_settings()
+    settings = _minimal_settings()
     with (
         patch("pipefy_cli.auth.PipefyClient") as mock_pc,
         patch("pipefy_cli.auth.InternalApiClient"),
@@ -259,7 +254,7 @@ def test_bearer_token_wins_over_stored_session(clean_pipefy_env):
 
 def test_service_account_creds_win_over_stored_session(clean_pipefy_env):
     """The service-account tier MUST short-circuit before the keychain is consulted."""
-    settings = _minimal_service_account_settings()
+    settings = _minimal_settings()
     with (
         patch("pipefy_cli.auth.PipefyClient") as mock_pc,
         patch("pipefy_cli.auth.InternalApiClient"),

--- a/packages/cli/tests/test_auth.py
+++ b/packages/cli/tests/test_auth.py
@@ -96,7 +96,7 @@ def test_get_authenticated_client_bearer_path_shares_auth_with_internal_api(
     clean_pipefy_env,
 ):
     """Both clients receive the SAME ``auth`` instance on the bearer path."""
-    settings = _minimal_service_account_settings()
+    settings = _minimal_settings()
     with (
         patch("pipefy_cli.auth.PipefyClient") as mock_pc,
         patch("pipefy_cli.auth.InternalApiClient") as mock_internal,

--- a/packages/cli/tests/test_common_helpers.py
+++ b/packages/cli/tests/test_common_helpers.py
@@ -172,6 +172,7 @@ def test_run_pipefy_client_coroutine_runs_factory_and_returns(monkeypatch):
     sentinel_settings = object()
     sentinel_auth = _common.AuthContext(
         bearer_token=_common.BearerToken(value="abc", source="flag"),
+        service_account=None,
         oidc_client=None,
     )
     monkeypatch.setattr(_common, "get_authenticated_client", fake_get_client)
@@ -209,7 +210,9 @@ def test_run_pipefy_client_coroutine_maps_pipefy_error_to_exit_1(monkeypatch):
         "settings_and_auth_from_ctx",
         lambda ctx: (
             object(),
-            _common.AuthContext(bearer_token=None, oidc_client=None),
+            _common.AuthContext(
+                bearer_token=None, service_account=None, oidc_client=None
+            ),
         ),
     )
 
@@ -235,7 +238,9 @@ def test_run_pipefy_client_coroutine_maps_value_error_when_configured(monkeypatc
         "settings_and_auth_from_ctx",
         lambda ctx: (
             object(),
-            _common.AuthContext(bearer_token=None, oidc_client=None),
+            _common.AuthContext(
+                bearer_token=None, service_account=None, oidc_client=None
+            ),
         ),
     )
 
@@ -261,7 +266,9 @@ def test_run_pipefy_client_coroutine_broken_pipe_exits_0(monkeypatch):
         "settings_and_auth_from_ctx",
         lambda ctx: (
             object(),
-            _common.AuthContext(bearer_token=None, oidc_client=None),
+            _common.AuthContext(
+                bearer_token=None, service_account=None, oidc_client=None
+            ),
         ),
     )
 

--- a/packages/cli/tests/test_config.py
+++ b/packages/cli/tests/test_config.py
@@ -37,13 +37,17 @@ def test_env_only_resolution(
     resolved = resolve_cli_settings(
         graphql_url_flag=None,
         allow_insecure_urls_flag=None,
-    ).pipefy
+    )
 
-    assert resolved.graphql_url == "https://env-only.example.com/graphql"
-    assert resolved.internal_api_url == "https://env-only.example.com/internal_api"
-    assert resolved.service_account_url == "https://env-only.example.com/oauth/token"
-    assert resolved.service_account_client_id == "env-client"
-    assert resolved.service_account_client_secret == "env-secret"
+    assert resolved.pipefy.graphql_url == "https://env-only.example.com/graphql"
+    assert (
+        resolved.pipefy.internal_api_url == "https://env-only.example.com/internal_api"
+    )
+    assert (
+        resolved.auth.service_account_url == "https://env-only.example.com/oauth/token"
+    )
+    assert resolved.auth.service_account_client_id == "env-client"
+    assert resolved.auth.service_account_client_secret == "env-secret"
 
 
 def test_dotenv_only_resolution(
@@ -68,10 +72,10 @@ def test_dotenv_only_resolution(
     resolved = resolve_cli_settings(
         graphql_url_flag=None,
         allow_insecure_urls_flag=None,
-    ).pipefy
+    )
 
-    assert resolved.graphql_url == "https://dotenv.example.com/graphql"
-    assert resolved.service_account_client_id == "dotenv-client"
+    assert resolved.pipefy.graphql_url == "https://dotenv.example.com/graphql"
+    assert resolved.auth.service_account_client_id == "dotenv-client"
 
 
 def test_process_env_overrides_dotenv(
@@ -179,10 +183,10 @@ def test_user_toml_fallback_lowest_precedence(
     resolved = resolve_cli_settings(
         graphql_url_flag=None,
         allow_insecure_urls_flag=None,
-    ).pipefy
+    )
 
-    assert resolved.graphql_url == "https://from-toml.example.com/graphql"
-    assert resolved.service_account_client_id == "toml-client"
+    assert resolved.pipefy.graphql_url == "https://from-toml.example.com/graphql"
+    assert resolved.auth.service_account_client_id == "toml-client"
 
 
 def test_env_overrides_user_toml(
@@ -221,6 +225,7 @@ def test_apply_toml_fills_only_missing_fields(
     saved_cwd,
     monkeypatch: pytest.MonkeyPatch,
 ):
+    from pipefy_auth import AuthSettings
     from pipefy_sdk import PipefySettings
 
     cfg_path = saved_cwd / "config.toml"
@@ -236,11 +241,13 @@ def test_apply_toml_fills_only_missing_fields(
     )
     monkeypatch.setattr(config_module, "USER_CONFIG_PATH", cfg_path)
 
-    base = PipefySettings(service_account_client_id="from-env")
-    merged = apply_toml_fallback(base)
+    pipefy, auth = apply_toml_fallback(
+        PipefySettings(),
+        AuthSettings(service_account_client_id="from-env"),
+    )
 
-    assert merged.graphql_url == "https://toml-only.example.com/graphql"
-    assert merged.service_account_client_id == "from-env"
+    assert pipefy.graphql_url == "https://toml-only.example.com/graphql"
+    assert auth.service_account_client_id == "from-env"
 
 
 def test_graphql_url_flag_localhost_rejected_without_insecure(
@@ -337,4 +344,4 @@ def test_auth_url_validation(
             graphql_url_flag=None,
             allow_insecure_urls_flag=allow_insecure_flag,
         )
-        assert resolved.auth_url == url
+        assert resolved.auth.auth_url == url

--- a/packages/cli/tests/test_config_back_compat.py
+++ b/packages/cli/tests/test_config_back_compat.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import textwrap
 
 import pytest
-from pipefy_sdk.settings import _reset_legacy_oauth_warning_state
+from pipefy_auth.settings import _reset_legacy_oauth_warning_state
 
 from pipefy_cli import config as config_module
 from pipefy_cli.config import (
@@ -41,7 +41,7 @@ def test_legacy_env_vars_still_populate_new_fields(
     resolved = resolve_cli_settings(
         graphql_url_flag=None,
         allow_insecure_urls_flag=None,
-    ).pipefy
+    ).auth
 
     assert resolved.service_account_url == "https://legacy.example.com/oauth/token"
     assert resolved.service_account_client_id == "legacy-client"
@@ -62,7 +62,7 @@ def test_new_env_var_wins_when_both_legacy_and_new_set(
     resolved = resolve_cli_settings(
         graphql_url_flag=None,
         allow_insecure_urls_flag=None,
-    ).pipefy
+    ).auth
 
     assert resolved.service_account_url == "https://new.example.com/oauth/token"
 
@@ -109,7 +109,7 @@ def test_legacy_toml_keys_still_populate_new_fields(
     resolved = resolve_cli_settings(
         graphql_url_flag=None,
         allow_insecure_urls_flag=None,
-    ).pipefy
+    ).auth
 
     assert resolved.service_account_url == "https://legacy-toml.example.com/oauth/token"
     assert resolved.service_account_client_id == "legacy-toml-client"
@@ -138,7 +138,7 @@ def test_toml_new_key_wins_when_both_legacy_and_new_present(
     resolved = resolve_cli_settings(
         graphql_url_flag=None,
         allow_insecure_urls_flag=None,
-    ).pipefy
+    ).auth
 
     assert resolved.service_account_url == "https://new-toml.example.com/oauth/token"
 

--- a/packages/mcp/src/pipefy_mcp/core/container.py
+++ b/packages/mcp/src/pipefy_mcp/core/container.py
@@ -4,7 +4,6 @@ import os
 from typing import Self
 
 from pipefy_auth import (
-    ServiceAccount,
     missing_auth_message,
     resolve_pipefy_auth,
 )
@@ -33,21 +32,10 @@ class ServicesContainer:
             settings: Application settings with Pipefy credentials.
         """
         pipefy = settings.pipefy
-        service_account: ServiceAccount | None = None
-        if (
-            pipefy.service_account_url
-            and pipefy.service_account_client_id
-            and pipefy.service_account_client_secret
-        ):
-            service_account = ServiceAccount(
-                token_url=pipefy.service_account_url,
-                client_id=pipefy.service_account_client_id,
-                client_secret=pipefy.service_account_client_secret,
-            )
         # The stored-session tier is wired in a follow-up against #213.
         resolved = resolve_pipefy_auth(
             static_token=os.environ.get("PIPEFY_TOKEN"),
-            service_account=service_account,
+            service_account=settings.auth.to_service_account(),
         )
         if resolved is None:
             raise RuntimeError(missing_auth_message())

--- a/packages/mcp/src/pipefy_mcp/core/container.py
+++ b/packages/mcp/src/pipefy_mcp/core/container.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from typing import Self
 
 from pipefy_auth import (
@@ -34,7 +33,7 @@ class ServicesContainer:
         pipefy = settings.pipefy
         # The stored-session tier is wired in a follow-up against #213.
         resolved = resolve_pipefy_auth(
-            static_token=os.environ.get("PIPEFY_TOKEN"),
+            static_token=settings.auth.static_token,
             service_account=settings.auth.to_service_account(),
         )
         if resolved is None:

--- a/packages/mcp/src/pipefy_mcp/settings.py
+++ b/packages/mcp/src/pipefy_mcp/settings.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pipefy_auth import AuthSettings
 from pipefy_sdk import PipefySettings
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -11,7 +12,9 @@ class Settings(BaseSettings):
     On import, values are read from process environment variables and from a ``.env`` file
     in the current working directory (see ``env_file`` in ``model_config``). The nested
     ``pipefy`` model uses names ``PIPEFY_*`` (e.g. ``PIPEFY_GRAPHQL_URL`` →
-    ``pipefy.graphql_url``). Environment variables override values from ``.env``. See
+    ``pipefy.graphql_url``); the nested ``auth`` model owns
+    ``PIPEFY_SERVICE_ACCOUNT_*``, ``PIPEFY_AUTH_URL``, and
+    ``PIPEFY_AUTH_CLIENT_ID``. See
     https://docs.pydantic.dev/latest/concepts/pydantic_settings/
     """
 
@@ -23,8 +26,9 @@ class Settings(BaseSettings):
     )
 
     pipefy: PipefySettings = Field(default_factory=PipefySettings)
+    auth: AuthSettings = Field(default_factory=AuthSettings)
 
 
 settings = Settings()
 
-__all__ = ["PipefySettings", "Settings", "settings"]
+__all__ = ["AuthSettings", "PipefySettings", "Settings", "settings"]

--- a/packages/mcp/src/pipefy_mcp/settings.py
+++ b/packages/mcp/src/pipefy_mcp/settings.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from typing import Self
+
 from pipefy_auth import AuthSettings
 from pipefy_sdk import PipefySettings
-from pydantic import Field
+from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -27,6 +29,14 @@ class Settings(BaseSettings):
 
     pipefy: PipefySettings = Field(default_factory=PipefySettings)
     auth: AuthSettings = Field(default_factory=AuthSettings)
+
+    @model_validator(mode="after")
+    def _validate_auth_urls(self) -> Self:
+        # PipefySettings validates its own endpoint URLs on construction; mirror
+        # that for AuthSettings here so unsafe service-account / OIDC URLs fail
+        # fast at settings load (matches CliSettings.resolve_cli_settings).
+        self.auth.validate_urls(allow_insecure=self.pipefy.allow_insecure_urls)
+        return self
 
 
 settings = Settings()

--- a/packages/mcp/tests/core/test_container.py
+++ b/packages/mcp/tests/core/test_container.py
@@ -7,9 +7,34 @@ from pipefy_sdk import PipefyClient, PipefySettings
 from pipefy_mcp.core.container import ServicesContainer
 from pipefy_mcp.settings import Settings
 
+_AUTH_ENV_KEYS = (
+    "PIPEFY_TOKEN",
+    "PIPEFY_SERVICE_ACCOUNT_URL",
+    "PIPEFY_SERVICE_ACCOUNT_CLIENT_ID",
+    "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET",
+    "PIPEFY_OAUTH_URL",
+    "PIPEFY_OAUTH_CLIENT",
+    "PIPEFY_OAUTH_SECRET",
+    "PIPEFY_AUTH_URL",
+)
+
+
+def _service_account_auth_settings() -> AuthSettings:
+    return AuthSettings(
+        service_account_url="https://auth.pipefy.com/oauth/token",
+        service_account_client_id="client_id",
+        service_account_client_secret="client_secret",
+    )
+
 
 class TestServicesContainer:
     """Test cases for ServicesContainer"""
+
+    @pytest.fixture(autouse=True)
+    def clear_auth_env(self, monkeypatch):
+        """Strip ambient ``PIPEFY_*`` auth env so ``AuthSettings()`` is hermetic."""
+        for key in _AUTH_ENV_KEYS:
+            monkeypatch.delenv(key, raising=False)
 
     @pytest.fixture(autouse=True)
     def reset_singleton(self):
@@ -57,12 +82,8 @@ class TestServicesContainer:
         mock_pipefy_client_class.return_value = mock_client
 
         settings = Settings(
-            pipefy=PipefySettings(
-                graphql_url="https://api.pipefy.com/graphql",
-                service_account_url="https://auth.pipefy.com/oauth/token",
-                service_account_client_id="client_id",
-                service_account_client_secret="client_secret",
-            )
+            pipefy=PipefySettings(graphql_url="https://api.pipefy.com/graphql"),
+            auth=_service_account_auth_settings(),
         )
 
         container = ServicesContainer()
@@ -88,12 +109,8 @@ class TestServicesContainer:
         mock_pipefy_client_class.return_value = mock_client
 
         settings = Settings(
-            pipefy=PipefySettings(
-                graphql_url="https://api.pipefy.com/graphql",
-                service_account_url="https://auth.pipefy.com/oauth/token",
-                service_account_client_id="client_id",
-                service_account_client_secret="client_secret",
-            )
+            pipefy=PipefySettings(graphql_url="https://api.pipefy.com/graphql"),
+            auth=_service_account_auth_settings(),
         )
 
         container = ServicesContainer()
@@ -113,7 +130,6 @@ class TestServicesContainer:
         mock_pipefy_client_class,
         mock_internal_api_client_class,
         mock_ai_automation_service_class,
-        monkeypatch,
     ):
         """``PIPEFY_TOKEN`` outranks ``PIPEFY_SERVICE_ACCOUNT_*`` (same precedence as the CLI).
 
@@ -124,14 +140,14 @@ class TestServicesContainer:
         mock_client = Mock(spec=PipefyClient)
         mock_client.client = Mock()
         mock_pipefy_client_class.return_value = mock_client
-        monkeypatch.setenv("PIPEFY_TOKEN", "env-bearer")
         settings = Settings(
-            pipefy=PipefySettings(
-                graphql_url="https://api.pipefy.com/graphql",
+            pipefy=PipefySettings(graphql_url="https://api.pipefy.com/graphql"),
+            auth=AuthSettings(
+                static_token="env-bearer",
                 service_account_url="https://auth.pipefy.com/oauth/token",
                 service_account_client_id="client_id",
                 service_account_client_secret="client_secret",
-            )
+            ),
         )
         ServicesContainer().initialize_services(settings)
         pc_auth = mock_pipefy_client_class.call_args.kwargs["auth"]
@@ -151,19 +167,8 @@ class TestServicesContainer:
         mock_pipefy_client_class,
         mock_internal_api_client_class,
         mock_ai_automation_service_class,
-        monkeypatch,
     ):
         """No PIPEFY_TOKEN and no service-account triple → runtime error."""
-        for key in (
-            "PIPEFY_TOKEN",
-            "PIPEFY_SERVICE_ACCOUNT_URL",
-            "PIPEFY_SERVICE_ACCOUNT_CLIENT_ID",
-            "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET",
-            "PIPEFY_OAUTH_URL",
-            "PIPEFY_OAUTH_CLIENT",
-            "PIPEFY_OAUTH_SECRET",
-        ):
-            monkeypatch.delenv(key, raising=False)
         settings = Settings(
             pipefy=PipefySettings(graphql_url="https://api.pipefy.com/graphql"),
             auth=AuthSettings(),

--- a/packages/mcp/tests/core/test_container.py
+++ b/packages/mcp/tests/core/test_container.py
@@ -1,7 +1,7 @@
 from unittest.mock import Mock, patch
 
 import pytest
-from pipefy_auth import StaticBearerAuth
+from pipefy_auth import AuthSettings, StaticBearerAuth
 from pipefy_sdk import PipefyClient, PipefySettings
 
 from pipefy_mcp.core.container import ServicesContainer
@@ -153,12 +153,20 @@ class TestServicesContainer:
         mock_ai_automation_service_class,
         monkeypatch,
     ):
-        """No PIPEFY_TOKEN and no service-account triple → runtime error with policy chain."""
-        monkeypatch.delenv("PIPEFY_TOKEN", raising=False)
+        """No PIPEFY_TOKEN and no service-account triple → runtime error."""
+        for key in (
+            "PIPEFY_TOKEN",
+            "PIPEFY_SERVICE_ACCOUNT_URL",
+            "PIPEFY_SERVICE_ACCOUNT_CLIENT_ID",
+            "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET",
+            "PIPEFY_OAUTH_URL",
+            "PIPEFY_OAUTH_CLIENT",
+            "PIPEFY_OAUTH_SECRET",
+        ):
+            monkeypatch.delenv(key, raising=False)
         settings = Settings(
-            pipefy=PipefySettings(
-                graphql_url="https://api.pipefy.com/graphql",
-            )
+            pipefy=PipefySettings(graphql_url="https://api.pipefy.com/graphql"),
+            auth=AuthSettings(),
         )
         with pytest.raises(RuntimeError, match="Missing Pipefy authentication"):
             ServicesContainer().initialize_services(settings)

--- a/packages/mcp/tests/test_server.py
+++ b/packages/mcp/tests/test_server.py
@@ -6,6 +6,7 @@ from mcp.server.fastmcp import FastMCP
 from mcp.shared.memory import (
     create_connected_server_and_client_session as create_client_session,
 )
+from pipefy_auth import AuthSettings
 from pipefy_sdk import PipefySettings
 
 from pipefy_mcp.server import mcp as mcp_server
@@ -24,12 +25,12 @@ def client_session():
 
 
 _MINIMAL_PIPEFY_SETTINGS = Settings(
-    pipefy=PipefySettings(
-        graphql_url="https://api.pipefy.com/graphql",
+    pipefy=PipefySettings(graphql_url="https://api.pipefy.com/graphql"),
+    auth=AuthSettings(
         service_account_url="https://api.pipefy.com/oauth/token",
         service_account_client_id="test-client",
         service_account_client_secret="test-secret",
-    )
+    ),
 )
 
 

--- a/packages/mcp/tests/test_settings.py
+++ b/packages/mcp/tests/test_settings.py
@@ -131,3 +131,29 @@ def test_default_webhook_name_from_env(monkeypatch):
 def test_default_webhook_name_rejects_empty_string():
     with pytest.raises(ValidationError):
         PipefySettings(default_webhook_name="")
+
+
+@pytest.mark.unit
+def test_settings_rejects_link_local_service_account_url(monkeypatch):
+    """Settings load must SSRF-check ``AuthSettings`` URLs (regression: MCP forgot this after the split)."""
+    monkeypatch.setenv(
+        "PIPEFY_SERVICE_ACCOUNT_URL", "https://169.254.169.254/oauth/token"
+    )
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", "cid")
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET", "csecret")
+    with pytest.raises(ValidationError, match="link-local|private|loopback"):
+        Settings()
+
+
+@pytest.mark.unit
+def test_settings_picks_up_pipefy_token_from_env(monkeypatch):
+    """``PIPEFY_TOKEN`` must populate ``auth.static_token`` so MCP boots from ``.env``-only setups."""
+    monkeypatch.setenv("PIPEFY_GRAPHQL_URL", "https://api.pipefy.com/graphql")
+    monkeypatch.setenv("PIPEFY_TOKEN", "env-bearer")
+    monkeypatch.delenv("PIPEFY_SERVICE_ACCOUNT_URL", raising=False)
+    monkeypatch.delenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", raising=False)
+    monkeypatch.delenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET", raising=False)
+    monkeypatch.delenv("PIPEFY_OAUTH_URL", raising=False)
+    monkeypatch.delenv("PIPEFY_OAUTH_CLIENT", raising=False)
+    monkeypatch.delenv("PIPEFY_OAUTH_SECRET", raising=False)
+    assert Settings().auth.static_token == "env-bearer"

--- a/packages/sdk/src/pipefy_sdk/settings.py
+++ b/packages/sdk/src/pipefy_sdk/settings.py
@@ -1,53 +1,23 @@
 from __future__ import annotations
 
-import os
-import sys
 from typing import Annotated, Self
 
-from pydantic import AliasChoices, BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 from pydantic_settings import NoDecode
-
-_LEGACY_ENV_KEYS_TO_NEW: dict[str, str] = {
-    "PIPEFY_OAUTH_URL": "PIPEFY_SERVICE_ACCOUNT_URL",
-    "PIPEFY_OAUTH_CLIENT": "PIPEFY_SERVICE_ACCOUNT_CLIENT_ID",
-    "PIPEFY_OAUTH_SECRET": "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET",
-}
-
-_warned_legacy_env_keys: set[str] = set()
-
-
-def _warn_once_for_legacy_oauth_env_keys() -> None:
-    """Print a one-shot stderr deprecation warning for each ``PIPEFY_OAUTH_*`` env var still set.
-
-    Pydantic accepts the legacy names via ``AliasChoices`` so old configs keep working;
-    this nudge tells users to rename. Dedup state is process-global; tests reset via
-    :func:`_reset_legacy_oauth_warning_state`.
-    """
-    if len(_warned_legacy_env_keys) == len(_LEGACY_ENV_KEYS_TO_NEW):
-        return
-    for legacy, new in _LEGACY_ENV_KEYS_TO_NEW.items():
-        if legacy in _warned_legacy_env_keys:
-            continue
-        if legacy in os.environ:
-            sys.stderr.write(
-                f"warning: {legacy} is deprecated; rename to {new}. "
-                "The legacy name will be removed in a future beta.\n"
-            )
-            _warned_legacy_env_keys.add(legacy)
-
-
-def _reset_legacy_oauth_warning_state() -> None:
-    """Test helper: clear the one-shot dedup so a fixture can re-trigger the warning."""
-    _warned_legacy_env_keys.clear()
 
 
 class PipefySettings(BaseModel):
-    """Pipefy API connection and shared runtime knobs (MCP, CLI, scripts)."""
+    """Pipefy API connection and shared runtime knobs (MCP, CLI, scripts).
+
+    Endpoint configuration only — credentials live on
+    :class:`pipefy_auth.AuthSettings`. Consumers compose both side by side in
+    their own settings type.
+    """
 
     allow_insecure_urls: bool = Field(
         default=False,
         description=(
-            "When true (env: PIPEFY_ALLOW_INSECURE_URLS), GraphQL/OAuth/internal API URLs "
+            "When true (env: PIPEFY_ALLOW_INSECURE_URLS), GraphQL/auth/internal API URLs "
             "may use http:// and internal hosts; local development only; do not enable in production."
         ),
     )
@@ -65,33 +35,6 @@ class PipefySettings(BaseModel):
     interfaces_graphql_url: str = Field(
         default="https://app.pipefy.com/graphql/interfaces",
         description="GraphQL URL for Pipefy Interfaces schema (portals, pages, elements)",
-    )
-
-    service_account_url: str | None = Field(
-        default=None,
-        validation_alias=AliasChoices("service_account_url", "oauth_url"),
-        description=(
-            "Service-account token endpoint (OAuth 2.0 client-credentials grant) "
-            "(env: PIPEFY_SERVICE_ACCOUNT_URL; legacy PIPEFY_OAUTH_URL still honored)."
-        ),
-    )
-
-    service_account_client_id: str | None = Field(
-        default=None,
-        validation_alias=AliasChoices("service_account_client_id", "oauth_client"),
-        description=(
-            "Service-account OAuth client_id "
-            "(env: PIPEFY_SERVICE_ACCOUNT_CLIENT_ID; legacy PIPEFY_OAUTH_CLIENT still honored)."
-        ),
-    )
-
-    service_account_client_secret: str | None = Field(
-        default=None,
-        validation_alias=AliasChoices("service_account_client_secret", "oauth_secret"),
-        description=(
-            "Service-account OAuth client_secret "
-            "(env: PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET; legacy PIPEFY_OAUTH_SECRET still honored)."
-        ),
     )
 
     org_id: str | None = Field(
@@ -165,13 +108,6 @@ class PipefySettings(BaseModel):
         msg = "service_account_ids must be a list or a comma-separated string"
         raise ValueError(msg)
 
-    @model_validator(mode="before")
-    @classmethod
-    def _emit_legacy_oauth_env_var_warning(cls, data: object) -> object:
-        # Runs before field validation so the nudge surfaces even if SSRF/URL checks fail.
-        _warn_once_for_legacy_oauth_env_keys()
-        return data
-
     @model_validator(mode="after")
     def _validate_pipefy_endpoint_urls(self) -> Self:
         # Deferred import: ``url_ssrf`` validates URLs that may reference settings types (cycle if top-level).
@@ -180,12 +116,6 @@ class PipefySettings(BaseModel):
         allow = self.allow_insecure_urls
         if self.graphql_url is not None and (u := self.graphql_url.strip()):
             validate_https_service_endpoint_url(u, "graphql_url", allow_insecure=allow)
-        if self.service_account_url is not None and (
-            u := self.service_account_url.strip()
-        ):
-            validate_https_service_endpoint_url(
-                u, "service_account_url", allow_insecure=allow
-            )
         if u := self.internal_api_url.strip():
             validate_https_service_endpoint_url(
                 u, "internal_api_url", allow_insecure=allow

--- a/uv.lock
+++ b/uv.lock
@@ -818,6 +818,7 @@ dependencies = [
     { name = "httpx" },
     { name = "httpx-auth" },
     { name = "keyring" },
+    { name = "pydantic" },
 ]
 
 [package.dev-dependencies]
@@ -832,6 +833,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28" },
     { name = "httpx-auth", specifier = ">=0.23.1" },
     { name = "keyring", specifier = ">=24" },
+    { name = "pydantic", specifier = ">=2.11.3" },
 ]
 
 [package.metadata.requires-dev]

--- a/uv.lock
+++ b/uv.lock
@@ -819,6 +819,7 @@ dependencies = [
     { name = "httpx-auth" },
     { name = "keyring" },
     { name = "pydantic" },
+    { name = "pydantic-settings" },
 ]
 
 [package.dev-dependencies]
@@ -834,6 +835,7 @@ requires-dist = [
     { name = "httpx-auth", specifier = ">=0.23.1" },
     { name = "keyring", specifier = ">=24" },
     { name = "pydantic", specifier = ">=2.11.3" },
+    { name = "pydantic-settings", specifier = ">=2.8.1" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Stacked on #217. Targets that branch directly so the diff is just the settings split; will be retargeted to `dev` once #217 merges. Second of two PRs that together close out #213's resolver/settings work.

## Summary

Splits the fat `PipefySettings` into endpoint config (stays in `pipefy-sdk`) and auth config (new `pipefy_auth.AuthSettings`). Both consumers (`pipefy-cli`, `pipefy-mcp`) compose the two models side by side in their own settings type.

- `pipefy_auth.AuthSettings` (new) is a `BaseSettings` with `env_prefix="PIPEFY_"`. It owns the service-account triple, the legacy `PIPEFY_OAUTH_*` aliases + one-shot deprecation warning, and the OIDC fields (`auth_url`, `auth_client_id`). Exposes `to_service_account()` / `to_oidc_client()` projections and `validate_urls(allow_insecure=...)`.
- `pipefy_sdk.PipefySettings` shrinks to endpoint + runtime concerns (`graphql_url`, `internal_api_url`, `allow_insecure_urls`, etc.). Drops the SA fields and the `_LEGACY_ENV_KEYS_TO_NEW` machinery (moves with the fields).
- `pipefy_cli.config.CliSettings` and `pipefy_mcp.settings.Settings` embed `auth: AuthSettings` alongside `pipefy: PipefySettings`. The CLI's `AuthContext` gains a `service_account` slot so the resolver receives its three inputs in one shape; the CLI projects `AuthSettings` into `ServiceAccount` / `OidcClient` at the boundary.
- The `describe_missing_service_account_vars` helper moves to `pipefy_auth.settings`. The TOML loader routes auth keys to `AuthSettings` (derived from `AuthSettings.model_fields` so renames stay in sync).
- Auth-URL SSRF validation runs once per `resolve_cli_settings` call against the final `allow_insecure_urls` value.

Drive-by `/simplify` cleanups also included:
- `_revalidate_pipefy` + `_revalidate_auth` unified into one generic helper.
- `_detect_stored_session` trivial wrapper inlined in `detect_pipefy_sources`.
- `_minimal_service_account_settings` test alias dropped (call sites now use `_minimal_settings` directly).

## Test plan

- [x] `uv run pytest -m "not integration"` — 2310 passing locally.
- [x] `uv run ruff check` + `uv run ruff format --check` — clean.
- [x] CI green.
- [x] Smoke: legacy `PIPEFY_OAUTH_*` env vars still populate `AuthSettings.service_account_*` and emit the deprecation warning once per process.
- [x] Smoke: `pipefy auth status` reports the correct source after the split.
- [x] Smoke: MCP server boots with both flavours of env (`PIPEFY_SERVICE_ACCOUNT_*` and `PIPEFY_TOKEN`).

## Migration

`PipefySettings` no longer accepts `service_account_url` / `service_account_client_id` / `service_account_client_secret`. In-repo callers are updated; out-of-repo consumers should migrate to `AuthSettings`.

The back-compat suite for the `PIPEFY_OAUTH_*` rename moves from `packages/sdk/tests/test_settings_back_compat.py` to `packages/auth/tests/test_settings_back_compat.py` and asserts against `AuthSettings`.


## Follow-ups

- #220 — tighten ``auth: Auth | None = None`` on 14 SDK service constructors (loose end from #217 caught while reviewing this PR).
- #221 — collapse ``InternalApiClient`` into ``BasePipefyClient`` (surfaced during this review; design discussion in the issue).
