### PR TITLE
refactor(sdk): require explicit auth on service constructors

### DIFF
--- a/packages/sdk/src/pipefy_sdk/services/ai_agent_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/ai_agent_service.py
@@ -65,7 +65,8 @@ class AiAgentService(BasePipefyClient):
     def __init__(
         self,
         settings: PipefySettings,
-        auth: Auth | None = None,
+        *,
+        auth: Auth,
     ) -> None:
         """Initialize the GraphQL client.
 

--- a/packages/sdk/src/pipefy_sdk/services/attachment_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/attachment_service.py
@@ -27,7 +27,8 @@ class AttachmentService(BasePipefyClient):
     def __init__(
         self,
         settings: PipefySettings,
-        auth: Auth | None = None,
+        *,
+        auth: Auth,
     ) -> None:
         super().__init__(settings=settings, auth=auth)
 

--- a/packages/sdk/src/pipefy_sdk/services/card_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/card_service.py
@@ -34,7 +34,8 @@ class CardService(BasePipefyClient):
     def __init__(
         self,
         settings: PipefySettings,
-        auth: Auth | None = None,
+        *,
+        auth: Auth,
     ) -> None:
         super().__init__(settings=settings, auth=auth)
 

--- a/packages/sdk/src/pipefy_sdk/services/member_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/member_service.py
@@ -40,8 +40,8 @@ class MemberService(BasePipefyClient):
     def __init__(
         self,
         settings: PipefySettings,
-        auth: Auth | None = None,
         *,
+        auth: Auth,
         pipe_service: PipeService | None = None,
     ) -> None:
         super().__init__(settings=settings, auth=auth)

--- a/packages/sdk/src/pipefy_sdk/services/organization_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/organization_service.py
@@ -19,7 +19,8 @@ class OrganizationService(BasePipefyClient):
     def __init__(
         self,
         settings: PipefySettings,
-        auth: Auth | None = None,
+        *,
+        auth: Auth,
     ) -> None:
         super().__init__(settings=settings, auth=auth)
 

--- a/packages/sdk/src/pipefy_sdk/services/pipe_config_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/pipe_config_service.py
@@ -52,8 +52,8 @@ class PipeConfigService(BasePipefyClient):
     def __init__(
         self,
         settings: PipefySettings,
-        auth: Auth | None = None,
         *,
+        auth: Auth,
         pipe_service: PipeService | None = None,
     ) -> None:
         super().__init__(settings=settings, auth=auth)

--- a/packages/sdk/src/pipefy_sdk/services/pipe_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/pipe_service.py
@@ -41,7 +41,8 @@ class PipeService(BasePipefyClient):
     def __init__(
         self,
         settings: PipefySettings,
-        auth: Auth | None = None,
+        *,
+        auth: Auth,
     ) -> None:
         super().__init__(settings=settings, auth=auth)
 

--- a/packages/sdk/src/pipefy_sdk/services/portal_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/portal_service.py
@@ -50,8 +50,8 @@ class PortalService:
     def __init__(
         self,
         settings: PipefySettings,
-        auth: Auth | None = None,
         *,
+        auth: Auth,
         internal_api_client: InternalApiClient | None = None,
     ) -> None:
         """Wire clients for Interfaces schema and optional internal_api mutations.

--- a/packages/sdk/src/pipefy_sdk/services/relation_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/relation_service.py
@@ -46,7 +46,8 @@ class RelationService(BasePipefyClient):
     def __init__(
         self,
         settings: PipefySettings,
-        auth: Auth | None = None,
+        *,
+        auth: Auth,
     ) -> None:
         super().__init__(settings=settings, auth=auth)
 

--- a/packages/sdk/src/pipefy_sdk/services/report_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/report_service.py
@@ -34,7 +34,8 @@ class ReportService(BasePipefyClient):
     def __init__(
         self,
         settings: PipefySettings,
-        auth: Auth | None = None,
+        *,
+        auth: Auth,
     ) -> None:
         super().__init__(settings=settings, auth=auth)
 

--- a/packages/sdk/src/pipefy_sdk/services/schema_introspection_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/schema_introspection_service.py
@@ -29,7 +29,8 @@ class SchemaIntrospectionService(BasePipefyClient):
     def __init__(
         self,
         settings: PipefySettings,
-        auth: Auth | None = None,
+        *,
+        auth: Auth,
     ) -> None:
         super().__init__(settings=settings, auth=auth)
 

--- a/packages/sdk/src/pipefy_sdk/services/table_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/table_service.py
@@ -52,7 +52,8 @@ class TableService(BasePipefyClient):
     def __init__(
         self,
         settings: PipefySettings,
-        auth: Auth | None = None,
+        *,
+        auth: Auth,
     ) -> None:
         super().__init__(settings=settings, auth=auth)
 

--- a/packages/sdk/src/pipefy_sdk/services/user_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/user_service.py
@@ -16,7 +16,8 @@ class UserService(BasePipefyClient):
     def __init__(
         self,
         settings: PipefySettings,
-        auth: Auth | None = None,
+        *,
+        auth: Auth,
     ) -> None:
         super().__init__(settings=settings, auth=auth)
 

--- a/packages/sdk/src/pipefy_sdk/services/webhook_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/webhook_service.py
@@ -34,8 +34,8 @@ class WebhookService(BasePipefyClient):
     def __init__(
         self,
         settings: PipefySettings,
-        auth: Auth | None = None,
         *,
+        auth: Auth,
         card_service: CardService | None = None,
     ) -> None:
         super().__init__(settings=settings, auth=auth)

--- a/packages/sdk/tests/services/pipefy/test_member_service.py
+++ b/packages/sdk/tests/services/pipefy/test_member_service.py
@@ -153,7 +153,9 @@ async def test_remove_members_from_pipe_success(mock_settings):
     pipe_service.get_pipe = AsyncMock(
         return_value={"pipe": {"uuid": "pipe-uuid-1", "id": 99}}
     )
-    service = MemberService(settings=mock_settings, pipe_service=pipe_service)
+    service = MemberService(
+        settings=mock_settings, auth=_TEST_AUTH, pipe_service=pipe_service
+    )
     service.execute_query = AsyncMock(return_value=payload)
     result = await service.remove_members_from_pipe(
         "99",
@@ -180,7 +182,9 @@ async def test_remove_members_from_pipe_success(mock_settings):
 async def test_remove_members_from_pipe_transport_error(mock_settings):
     pipe_service = AsyncMock(spec=PipeService)
     pipe_service.get_pipe = AsyncMock(return_value={"pipe": {"uuid": "pu", "id": 1}})
-    service = MemberService(settings=mock_settings, pipe_service=pipe_service)
+    service = MemberService(
+        settings=mock_settings, auth=_TEST_AUTH, pipe_service=pipe_service
+    )
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "forbidden"}])
     )
@@ -220,7 +224,9 @@ async def test_remove_members_from_pipe_resolves_numeric_user_ids(mock_settings)
             }
         }
     )
-    service = MemberService(settings=mock_settings, pipe_service=pipe_service)
+    service = MemberService(
+        settings=mock_settings, auth=_TEST_AUTH, pipe_service=pipe_service
+    )
     service.execute_query = AsyncMock(return_value=payload)
     await service.remove_members_from_pipe("42", ["7", "8"])
 

--- a/packages/sdk/tests/services/pipefy/test_pipe_config_service.py
+++ b/packages/sdk/tests/services/pipefy/test_pipe_config_service.py
@@ -49,7 +49,9 @@ def _make_service(mock_settings, return_value: dict):
 
 
 def _make_service_with_pipe(mock_settings, return_value: dict, pipe_service: AsyncMock):
-    service = PipeConfigService(settings=mock_settings, pipe_service=pipe_service)
+    service = PipeConfigService(
+        settings=mock_settings, auth=_TEST_AUTH, pipe_service=pipe_service
+    )
     service.execute_query = AsyncMock(return_value=return_value)
     return service
 

--- a/packages/sdk/tests/services/pipefy/test_webhook_service.py
+++ b/packages/sdk/tests/services/pipefy/test_webhook_service.py
@@ -149,7 +149,9 @@ async def test_send_email_with_template_success(mock_settings):
             }
         }
     )
-    service = WebhookService(settings=mock_settings, card_service=card_service)
+    service = WebhookService(
+        settings=mock_settings, auth=_TEST_AUTH, card_service=card_service
+    )
     service.execute_query = AsyncMock(
         side_effect=[
             {

--- a/packages/sdk/tests/services/test_ai_agent_service.py
+++ b/packages/sdk/tests/services/test_ai_agent_service.py
@@ -12,6 +12,7 @@ from _shared.ai_agent_test_payloads import (
 )
 from gql.transport.exceptions import TransportQueryError
 from graphql import print_ast
+from pipefy_auth import StaticBearerAuth
 
 from pipefy_sdk.base_client import unwrap_relay_connection_nodes
 from pipefy_sdk.models.ai_agent import CreateAiAgentInput, UpdateAiAgentInput
@@ -72,11 +73,12 @@ _MOCK_SETTINGS = PipefySettings(
     oauth_client="test-client",
     oauth_secret="test-secret",
 )
+_TEST_AUTH = StaticBearerAuth("test-bearer-token")
 
 
 def _create_mock_service(execute_return=None):
     """Create an AiAgentService with mocked execute_query."""
-    service = AiAgentService(settings=_MOCK_SETTINGS)
+    service = AiAgentService(settings=_MOCK_SETTINGS, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         return_value=execute_return or {"createAiAgent": {"agent": {"uuid": "abc-123"}}}
     )
@@ -545,7 +547,7 @@ async def test_get_agent_returns_empty_when_ai_agent_null():
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_get_agent_transport_error():
-    service = AiAgentService(settings=_MOCK_SETTINGS)
+    service = AiAgentService(settings=_MOCK_SETTINGS, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "denied"}])
     )
@@ -572,7 +574,7 @@ async def test_get_agents_success():
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_get_agents_transport_error():
-    service = AiAgentService(settings=_MOCK_SETTINGS)
+    service = AiAgentService(settings=_MOCK_SETTINGS, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "missing"}])
     )
@@ -597,7 +599,7 @@ async def test_delete_agent_success():
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_delete_agent_transport_error():
-    service = AiAgentService(settings=_MOCK_SETTINGS)
+    service = AiAgentService(settings=_MOCK_SETTINGS, auth=_TEST_AUTH)
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "gone"}])
     )


### PR DESCRIPTION
Follow-up to #217 (which tightened ``BasePipefyClient`` / ``PipefyClient`` / ``InternalApiClient`` to require ``auth: httpx.Auth``).

## Summary

14 SDK service-layer constructors still declared ``auth: Auth | None = None`` and forwarded the value to the now-required base. That was type-system rot rather than a runtime bug — every actual call site already passed a real ``Auth`` — but the stale signature undermined the post-#217 invariant that ``auth`` is required. This sweep tightens them all to the same ``*, auth: Auth`` shape as the base classes.

Touched: ``attachment``, ``ai_agent``, ``card``, ``member``, ``organization``, ``pipe``, ``pipe_config``, ``portal``, ``relation``, ``report``, ``schema_introspection``, ``table``, ``user``, ``webhook``.

## Test plan

- [x] ``uv run pytest -m \"not integration\"`` — 2355 passing.
- [x] ``uv run ruff check`` + ``uv run ruff format --check`` — clean.
- [x] Seven test sites that relied on the ``None`` default (4 ``AiAgentService`` constructions and 3 in ``pipefy/*`` suites focused on auxiliary kwargs like ``pipe_service`` / ``card_service``) now pass the standard ``StaticBearerAuth`` stub.

## Background

When reviewing #218, I noticed ``PortalService`` (the Interfaces client) still accepted ``auth: Auth | None`` even though it passes the value straight to ``BasePipefyClient`` which now rejects ``None``. Grepping showed 14 services with the same stale shape — every one a forwarder. This PR is the mechanical fix.