### PR TITLE
refactor(sdk): collapse InternalApiClient onto BasePipefyClient

### DIFF
--- a/packages/sdk/src/pipefy_sdk/base_client.py
+++ b/packages/sdk/src/pipefy_sdk/base_client.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from typing import Any, ClassVar
 
 from gql import Client
+from gql.transport.exceptions import TransportQueryError
 from gql.transport.httpx import HTTPXAsyncTransport
 from graphql import GraphQLSchema
 from httpx import Auth, Timeout
@@ -45,12 +47,18 @@ class BasePipefyClient:
         settings: PipefySettings,
         *,
         auth: Auth,
+        on_graphql_error: Callable[[list[dict]], str] | None = None,
     ) -> None:
         if settings.graphql_url is None:
             raise ValueError("GraphQL URL must be provided in settings.")
 
         self.settings = settings
         self._auth = auth
+        # When set, ``TransportQueryError`` is converted to ``ValueError`` using the
+        # formatter's output. Used by ``InternalApiClient`` to surface its
+        # ``[code=…] [correlation_id=…]`` envelope; ``None`` leaves gql exceptions
+        # untouched (PipefyClient's behaviour).
+        self._on_graphql_error = on_graphql_error
         # Populated when gql_reuse_fetched_graphql_schema is True; avoids repeating
         # introspection on every new Client (see Cons5 code review).
         self._fetched_gql_schema: GraphQLSchema | None = None
@@ -70,30 +78,35 @@ class BasePipefyClient:
             auth=self._auth,
             timeout=Timeout(timeout=self.GRAPHQL_REQUEST_TIMEOUT_SECONDS),
         )
-        if self.settings.gql_reuse_fetched_graphql_schema:
-            if self._fetched_gql_schema is None:
-                async with self._fetched_gql_schema_lock:
-                    if self._fetched_gql_schema is None:
-                        client = Client(
-                            transport=transport,
-                            fetch_schema_from_transport=True,
-                        )
-                        async with client as session:
-                            result = await session.execute(
-                                query, variable_values=variables
+        try:
+            if self.settings.gql_reuse_fetched_graphql_schema:
+                if self._fetched_gql_schema is None:
+                    async with self._fetched_gql_schema_lock:
+                        if self._fetched_gql_schema is None:
+                            client = Client(
+                                transport=transport,
+                                fetch_schema_from_transport=True,
                             )
-                        if client.schema is not None:
-                            self._fetched_gql_schema = client.schema
-                        return result
-            reuse_client = Client(
-                transport=transport,
-                schema=self._fetched_gql_schema,
-                fetch_schema_from_transport=False,
-            )
-            async with reuse_client as session:
-                return await session.execute(query, variable_values=variables)
+                            async with client as session:
+                                result = await session.execute(
+                                    query, variable_values=variables
+                                )
+                            if client.schema is not None:
+                                self._fetched_gql_schema = client.schema
+                            return result
+                reuse_client = Client(
+                    transport=transport,
+                    schema=self._fetched_gql_schema,
+                    fetch_schema_from_transport=False,
+                )
+                async with reuse_client as session:
+                    return await session.execute(query, variable_values=variables)
 
-        async with Client(
-            transport=transport, fetch_schema_from_transport=False
-        ) as session:
-            return await session.execute(query, variable_values=variables)
+            async with Client(
+                transport=transport, fetch_schema_from_transport=False
+            ) as session:
+                return await session.execute(query, variable_values=variables)
+        except TransportQueryError as exc:
+            if self._on_graphql_error is None:
+                raise
+            raise ValueError(self._on_graphql_error(exc.errors or [])) from exc

--- a/packages/sdk/src/pipefy_sdk/services/internal_api_client.py
+++ b/packages/sdk/src/pipefy_sdk/services/internal_api_client.py
@@ -1,25 +1,41 @@
-"""HTTP client for Pipefy's internal_api endpoint."""
+"""GraphQL client for Pipefy's internal_api endpoint.
+
+A thin :class:`pipefy_sdk.base_client.BasePipefyClient` subclass — the only
+real difference from the public-API client is the error envelope: each GraphQL
+error is decorated with ``[code=…]`` / ``[correlation_id=…]`` suffixes drawn
+from ``extensions``. AI-automation MCP tools strip those suffixes via
+``pipefy_mcp.tools.graphql_error_helpers.strip_internal_api_diagnostic_markers``
+before surfacing the message to end users; service-layer tests assert the
+fully suffixed text.
+"""
 
 from __future__ import annotations
 
 from typing import Any
 
-import httpx
-from httpx import Auth, Timeout
+from gql import gql as parse_gql
+from httpx import Auth
 
-from pipefy_sdk.utils.url_ssrf import (
-    validate_https_service_endpoint_url,
-)
-
-REQUEST_TIMEOUT_SECONDS = 30
+from pipefy_sdk.base_client import BasePipefyClient
+from pipefy_sdk.settings import PipefySettings
+from pipefy_sdk.utils.url_ssrf import validate_https_service_endpoint_url
 
 
-class InternalApiClient:
-    """HTTP client for Pipefy internal API (AI Automation mutations).
+def _format_internal_api_error(errors: list[dict]) -> str:
+    parts: list[str] = []
+    for err in errors:
+        msg = err.get("message", "Unknown error")
+        ext = err.get("extensions", {})
+        code = ext.get("code", "")
+        corr = ext.get("correlation_id", "")
+        suffix = f" [code={code}]" if code else ""
+        suffix += f" [correlation_id={corr}]" if corr else ""
+        parts.append(f"{msg}{suffix}")
+    return "; ".join(parts)
 
-    Sends GraphQL requests as JSON POST to the configured internal_api URL,
-    using the ``httpx.Auth`` supplied at construction time.
-    """
+
+class InternalApiClient(BasePipefyClient):
+    """GraphQL client for Pipefy internal API (AI Automation mutations)."""
 
     def __init__(
         self,
@@ -33,53 +49,20 @@ class InternalApiClient:
         Args:
             url: URL of the internal_api endpoint (e.g. https://app.pipefy.com/internal_api).
             auth: Pre-constructed ``httpx.Auth`` (e.g. from ``pipefy_auth.resolve``).
-            allow_insecure_urls: When True, allow http and internal hosts (must match settings).
+            allow_insecure_urls: When True, allow http and internal hosts.
         """
         validate_https_service_endpoint_url(
             url.strip(), "internal_api URL", allow_insecure=allow_insecure_urls
         )
-        self._url = url
-        self._auth = auth
+        # SSRF is already enforced above with the right error label; pass
+        # ``allow_insecure_urls=True`` here so ``PipefySettings`` does not re-validate
+        # the same URL under the misleading ``graphql_url`` label.
+        settings = PipefySettings(graphql_url=url, allow_insecure_urls=True)
+        super().__init__(
+            settings, auth=auth, on_graphql_error=_format_internal_api_error
+        )
 
-    async def execute_query(self, query: str, variables: dict[str, Any]) -> dict:
-        """Execute a GraphQL query/mutation via POST.
-
-        Args:
-            query: GraphQL query string.
-            variables: Variables for the query.
-
-        Returns:
-            Parsed JSON response from the API.
-
-        Raises:
-            httpx.HTTPStatusError: When response status is not 2xx.
-            httpx.TimeoutException: When the request times out.
-            ValueError: When response contains GraphQL errors (HTTP 200 but {"errors": [...]}).
-        """
-        async with httpx.AsyncClient(
-            auth=self._auth,
-            timeout=Timeout(timeout=REQUEST_TIMEOUT_SECONDS),
-        ) as client:
-            response = await client.post(
-                self._url,
-                json={"query": query, "variables": variables},
-                headers={"Content-Type": "application/json"},
-            )
-            response.raise_for_status()
-
-            data = response.json()
-            if "errors" in data and data["errors"]:
-                error_msgs = []
-                for err in data["errors"]:
-                    msg = err.get("message", "Unknown error")
-                    ext = err.get("extensions", {})
-                    code = ext.get("code", "")
-                    corr = ext.get("correlation_id", "")
-                    # Include extensions for logs and service-layer tests; MCP-facing tools
-                    # should omit these suffixes from default user-visible errors.
-                    suffix = f" [code={code}]" if code else ""
-                    suffix += f" [correlation_id={corr}]" if corr else ""
-                    error_msgs.append(f"{msg}{suffix}")
-                raise ValueError("; ".join(error_msgs))
-            # Unwrap the "data" envelope to match BasePipefyClient.execute_query
-            return data.get("data", data)
+    async def execute_query(  # type: ignore[override]
+        self, query: str, variables: dict[str, Any]
+    ) -> dict:
+        return await super().execute_query(parse_gql(query), variables)

--- a/packages/sdk/tests/services/test_internal_api_client.py
+++ b/packages/sdk/tests/services/test_internal_api_client.py
@@ -7,11 +7,11 @@ tool handlers and ``strip_internal_api_diagnostic_markers``.
 """
 
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 import respx
+from gql.transport.exceptions import TransportServerError
 from pipefy_auth import StaticBearerAuth
 
 from pipefy_sdk.services.internal_api_client import InternalApiClient
@@ -59,10 +59,13 @@ async def test_execute_query_sends_post_with_correct_headers_and_body(respx_mock
     request = route.calls.last.request
     assert request.content
     body = json.loads(request.content)
-    assert body == {"query": query_string, "variables": variables}
+    # gql serialises the parsed AST back to a string (plus may attach
+    # ``operationName``); pin only the contract we care about.
+    assert body["variables"] == variables
+    assert "test" in body["query"]
     assert "authorization" in (h.lower() for h in request.headers.keys())
     assert "content-type" in (h.lower() for h in request.headers.keys())
-    assert result == expected_json.get("data", expected_json)
+    assert result == expected_json["data"]
 
 
 @pytest.mark.unit
@@ -88,7 +91,9 @@ async def test_execute_query_raises_on_non_2xx_response(respx_mock):
         return_value=httpx.Response(500, json={"error": "Internal Server Error"})
     )
 
-    with pytest.raises(httpx.HTTPStatusError):
+    # gql's HTTPXAsyncTransport wraps ``httpx.HTTPStatusError`` as
+    # ``TransportServerError`` — same path as the public-API client.
+    with pytest.raises(TransportServerError):
         await _build_client().execute_query("query { x }", {})
 
 
@@ -204,22 +209,15 @@ async def test_execute_query_error_without_message_uses_fallback(respx_mock):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_execute_query_raises_on_timeout():
+@respx.mock(assert_all_mocked=False, assert_all_called=False)
+async def test_execute_query_raises_on_timeout(respx_mock):
     """Test execute_query raises appropriate error when HTTP request times out."""
-    mock_client = MagicMock()
-    mock_client.post = AsyncMock(
+    respx_mock.post(DEFAULT_INTERNAL_API_URL).mock(
         side_effect=httpx.TimeoutException("Request timed out")
     )
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
 
-    with patch(
-        "pipefy_sdk.services.internal_api_client.httpx.AsyncClient",
-        return_value=mock_client,
-    ):
-        client = _build_client()
-        with pytest.raises(httpx.TimeoutException):
-            await client.execute_query("query { x }", {})
+    with pytest.raises(httpx.TimeoutException):
+        await _build_client().execute_query("query { x }", {})
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- `InternalApiClient` now subclasses `BasePipefyClient` and runs over the same `gql.Client` transport as the rest of the SDK, removing the duplicated raw-httpx POST loop / `raise_for_status` / `data`-envelope / `errors` extraction.
- The `[code=…] [correlation_id=…]` error envelope AI-automation MCP tools depend on is preserved verbatim via a new `on_graphql_error: Callable[[list[dict]], str] | None` hook on `BasePipefyClient.__init__` (passed by `InternalApiClient` only — `PipefyClient` is unchanged).
- All call-site type contracts (`set_internal_api_client`, `PortalService`, `AiAutomationService`) keep their current shapes — internal refactor.

## Behaviour change worth flagging

5xx responses from `internal_api` now raise `gql.transport.exceptions.TransportServerError` instead of `httpx.HTTPStatusError`. This brings internal_api into line with how the public-API client surfaces server errors; no source-level caller catches `HTTPStatusError` from this path. The 500-response test was updated accordingly.

## Acceptance criteria

- [x] ``InternalApiClient`` no longer maintains its own ``httpx.AsyncClient`` POST loop.
- [x] The ``[code=…] [correlation_id=…]`` error suffix is preserved verbatim.
- [x] ``data.get("data", data)`` fallback dropped — `gql.Client` unwraps the `data` envelope natively; the no-`data` edge case is dead and not exercised.
- [x] All call sites keep their current shapes.
- [x] `uv run pytest -m "not integration"` — 2356 passed.
- [x] `uv run ruff check && uv run ruff format --check` — clean.

Closes #221.

## Test plan

- [x] `uv run pytest packages/sdk/tests/services/test_internal_api_client.py` — 15/15 green
- [x] `uv run pytest -m "not integration"` — full suite green (2356 passed)
- [x] `uv run ruff check packages && uv run ruff format --check packages` — clean
- [ ] Smoke: exercise an AI-automation CLI command against real Pipefy and confirm the success path
- [ ] Smoke: trigger a `PERMISSION_DENIED` on `internal_api` and confirm the raised `ValueError` still carries `[code=PERMISSION_DENIED] [correlation_id=…]`
- [ ] Smoke: boot the MCP server, dispatch an AI-automation tool, confirm `strip_internal_api_diagnostic_markers` still matches and removes the suffix from end-user output