### PR TITLE
fix(sdk-tests): repair live-integration fixtures post-#218

### DIFF
--- a/packages/sdk/tests/_shared/live_settings.py
+++ b/packages/sdk/tests/_shared/live_settings.py
@@ -4,11 +4,16 @@ from __future__ import annotations
 
 import pytest
 from httpx import Auth
-from pipefy_auth import AuthSettings, resolve_pipefy_auth
+from pipefy_auth import AuthSettings, missing_auth_message, resolve_pipefy_auth
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from pipefy_sdk.settings import PipefySettings
+
+_MISSING_CREDS_MESSAGE = (
+    "Pipefy credentials not configured: PIPEFY_GRAPHQL_URL required; "
+    + missing_auth_message()
+)
 
 
 class _LiveEnvSettings(BaseSettings):
@@ -38,41 +43,38 @@ def live_auth_settings() -> AuthSettings:
     return AuthSettings()
 
 
-def live_resolved_auth() -> Auth:
-    """Resolve a live ``httpx.Auth`` via the production precedence chain, or skip the test."""
+def _try_resolve_live_auth() -> Auth | None:
     a = live_auth_settings()
-    resolved = resolve_pipefy_auth(
+    return resolve_pipefy_auth(
         static_token=a.static_token,
         service_account=a.to_service_account(),
         oidc_client=a.to_oidc_client(),
     )
+
+
+def live_resolved_auth() -> Auth:
+    """Resolve a live ``httpx.Auth`` via the production precedence chain, or skip the test."""
+    resolved = _try_resolve_live_auth()
     if resolved is None:
-        pytest.skip(
-            "No live Pipefy auth configured "
-            "(set PIPEFY_TOKEN or PIPEFY_SERVICE_ACCOUNT_* in .env)"
-        )
+        pytest.skip(_MISSING_CREDS_MESSAGE)
     return resolved
 
 
 def pipefy_live_configured() -> bool:
-    """Return True when GraphQL URL plus at least one auth tier is configured."""
+    """Return True when GraphQL URL plus a resolvable auth tier is configured.
+
+    Auth detection delegates to :func:`pipefy_auth.resolve_pipefy_auth` so a
+    setup that names a stored-session tier but has no keychain entry is
+    reported as unconfigured (matches what ``live_resolved_auth`` would do).
+    """
     p = _resolved_pipefy()
-    a = live_auth_settings()
     has_url = bool(
         p.graphql_url and str(p.graphql_url).startswith(("http://", "https://"))
     )
-    has_auth = bool(
-        (a.static_token and a.static_token.strip())
-        or a.to_service_account() is not None
-        or a.to_oidc_client() is not None
-    )
-    return has_url and has_auth
+    return has_url and _try_resolve_live_auth() is not None
 
 
 def require_live_creds() -> None:
     """Skip the current test if live credentials are not configured."""
     if not pipefy_live_configured():
-        pytest.skip(
-            "Pipefy credentials not configured "
-            "(PIPEFY_GRAPHQL_URL plus PIPEFY_TOKEN or PIPEFY_SERVICE_ACCOUNT_* in .env)"
-        )
+        pytest.skip(_MISSING_CREDS_MESSAGE)

--- a/packages/sdk/tests/_shared/live_settings.py
+++ b/packages/sdk/tests/_shared/live_settings.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import pytest
+from httpx import Auth
+from pipefy_auth import AuthSettings, resolve_pipefy_auth
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -31,17 +33,40 @@ def live_pipefy_settings() -> PipefySettings:
     return _resolved_pipefy()
 
 
-def pipefy_live_configured() -> bool:
-    """Return True when all service-account + GraphQL credentials are present."""
-    p = _resolved_pipefy()
-    return bool(
-        p.graphql_url
-        and str(p.graphql_url).startswith(("http://", "https://"))
-        and p.service_account_url
-        and str(p.service_account_url).startswith(("http://", "https://"))
-        and p.service_account_client_id
-        and p.service_account_client_secret
+def live_auth_settings() -> AuthSettings:
+    """Load ``AuthSettings`` from the process environment and optional ``.env`` file."""
+    return AuthSettings()
+
+
+def live_resolved_auth() -> Auth:
+    """Resolve a live ``httpx.Auth`` via the production precedence chain, or skip the test."""
+    a = live_auth_settings()
+    resolved = resolve_pipefy_auth(
+        static_token=a.static_token,
+        service_account=a.to_service_account(),
+        oidc_client=a.to_oidc_client(),
     )
+    if resolved is None:
+        pytest.skip(
+            "No live Pipefy auth configured "
+            "(set PIPEFY_TOKEN or PIPEFY_SERVICE_ACCOUNT_* in .env)"
+        )
+    return resolved
+
+
+def pipefy_live_configured() -> bool:
+    """Return True when GraphQL URL plus at least one auth tier is configured."""
+    p = _resolved_pipefy()
+    a = live_auth_settings()
+    has_url = bool(
+        p.graphql_url and str(p.graphql_url).startswith(("http://", "https://"))
+    )
+    has_auth = bool(
+        (a.static_token and a.static_token.strip())
+        or a.to_service_account() is not None
+        or a.to_oidc_client() is not None
+    )
+    return has_url and has_auth
 
 
 def require_live_creds() -> None:
@@ -49,5 +74,5 @@ def require_live_creds() -> None:
     if not pipefy_live_configured():
         pytest.skip(
             "Pipefy credentials not configured "
-            "(PIPEFY_GRAPHQL_URL + PIPEFY_SERVICE_ACCOUNT_* in .env)"
+            "(PIPEFY_GRAPHQL_URL plus PIPEFY_TOKEN or PIPEFY_SERVICE_ACCOUNT_* in .env)"
         )

--- a/packages/sdk/tests/services/pipefy/test_portal_service_integration.py
+++ b/packages/sdk/tests/services/pipefy/test_portal_service_integration.py
@@ -15,8 +15,11 @@ from __future__ import annotations
 import os
 
 import pytest
-from _shared.live_settings import live_pipefy_settings, require_live_creds
-from httpx_auth import OAuth2ClientCredentials
+from _shared.live_settings import (
+    live_pipefy_settings,
+    live_resolved_auth,
+    require_live_creds,
+)
 
 from pipefy_sdk.services.portal_service import PortalService
 
@@ -25,13 +28,7 @@ from pipefy_sdk.services.portal_service import PortalService
 def live_portal_service() -> PortalService:
     """PortalService wired against live Interfaces schema credentials."""
     require_live_creds()
-    settings = live_pipefy_settings()
-    auth = OAuth2ClientCredentials(
-        token_url=settings.oauth_url,
-        client_id=settings.oauth_client,
-        client_secret=settings.oauth_secret,
-    )
-    return PortalService(settings=settings, auth=auth)
+    return PortalService(settings=live_pipefy_settings(), auth=live_resolved_auth())
 
 
 def _portal_org_uuid() -> str | None:

--- a/packages/sdk/tests/services/pipefy/test_schema_introspection_integration.py
+++ b/packages/sdk/tests/services/pipefy/test_schema_introspection_integration.py
@@ -10,7 +10,11 @@ Run locally:
 from __future__ import annotations
 
 import pytest
-from _shared.live_settings import live_pipefy_settings, pipefy_live_configured
+from _shared.live_settings import (
+    live_pipefy_settings,
+    live_resolved_auth,
+    require_live_creds,
+)
 
 from pipefy_sdk.services.schema_introspection_service import (
     SchemaIntrospectionService,
@@ -19,11 +23,10 @@ from pipefy_sdk.services.schema_introspection_service import (
 
 @pytest.fixture
 def live_svc():
-    if not pipefy_live_configured():
-        pytest.skip(
-            "Pipefy credentials not configured (PIPEFY_GRAPHQL_URL + OAuth in .env)"
-        )
-    return SchemaIntrospectionService(settings=live_pipefy_settings())
+    require_live_creds()
+    return SchemaIntrospectionService(
+        settings=live_pipefy_settings(), auth=live_resolved_auth()
+    )
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Follow-up to [#220's review comment](https://github.com/gbrlcustodio/pipefy-mcp-server/pull/220#pullrequestreview-4349172218). Investigating the flagged `SchemaIntrospectionService(settings=...)` call surfaced two adjacent breakages with the same root cause: nothing under `-m integration` had been exercised since #218 moved credentials onto `pipefy_auth.AuthSettings` and #220 made `auth` required.

## Summary

- `_shared/live_settings.py` accessed `PipefySettings.service_account_url` (AttributeError post-#218); the helper now loads `AuthSettings` and exposes a `live_resolved_auth()` that runs through `pipefy_auth.resolve_pipefy_auth` — same precedence chain the CLI / MCP container use in production.
- `test_portal_service_integration.py` built `OAuth2ClientCredentials` by hand from `settings.oauth_url` / `oauth_client` / `oauth_secret` (also gone post-#218) — now calls `live_resolved_auth()`.
- `test_schema_introspection_integration.py` was missing the `auth=` kwarg the reviewer flagged; same shape as the portal fixture.

`pipefy_live_configured()` is also broadened to accept any single auth tier (static-token, service-account, or stored-session) — previously it required the full service-account triple.

## Test plan

- [x] `uv run pytest -m "not integration" packages/sdk` — 747 passed
- [x] `uv run pytest --collect-only` on both integration files — 12 tests collected without error
- [x] `uv run ruff check packages && uv run ruff format --check packages` — clean
- [ ] Local `uv run pytest -m integration` with credentials — to confirm at the next live run