### PR TITLE
fix(mcp/cli-tests): wire live fixtures through resolve_pipefy_auth

### DIFF
--- a/packages/cli/tests/test_auth_integration.py
+++ b/packages/cli/tests/test_auth_integration.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import asyncio
 
 import pytest
-from _shared.live_settings import live_pipefy_settings, require_live_creds
+from _shared.live_settings import (
+    live_auth_settings,
+    live_pipefy_settings,
+    require_live_creds,
+)
 
 from pipefy_cli.auth import AuthContext, get_authenticated_client
 
@@ -16,10 +20,16 @@ def test_live_oauth_round_trip_triggers_graphql_auth():
 
     require_live_creds()
     settings = live_pipefy_settings()
+    auth_settings = live_auth_settings()
 
     async def run():
         client = get_authenticated_client(
-            settings, AuthContext(bearer_token=None, oidc_client=None)
+            settings,
+            AuthContext(
+                bearer_token=None,
+                service_account=auth_settings.to_service_account(),
+                oidc_client=auth_settings.to_oidc_client(),
+            ),
         )
         return await client.search_schema("Card", kind="OBJECT")
 

--- a/packages/mcp/tests/tools/test_attachment_tools_live.py
+++ b/packages/mcp/tests/tools/test_attachment_tools_live.py
@@ -26,7 +26,7 @@ from unittest.mock import patch
 
 import httpx
 import pytest
-from _shared.live_settings import require_live_creds
+from _shared.live_settings import live_resolved_auth, require_live_creds
 from mcp.server.fastmcp import FastMCP
 from mcp.shared.memory import (
     create_connected_server_and_client_session as create_client_session,
@@ -36,6 +36,11 @@ from pipefy_sdk import PipefyClient
 from pipefy_mcp.server import mcp as mcp_server
 from pipefy_mcp.settings import settings
 from pipefy_mcp.tools.attachment_tools import AttachmentTools
+
+
+def _live_pipefy_client() -> PipefyClient:
+    """PipefyClient wired with auth via the production precedence chain."""
+    return PipefyClient(settings=settings.pipefy, auth=live_resolved_auth())
 
 
 def _card_upload_env():
@@ -73,7 +78,7 @@ def _assert_field_shows_upload(value, file_name: str) -> None:
 @pytest.fixture
 def live_pipefy_client():
     require_live_creds()
-    return PipefyClient(settings=settings.pipefy)
+    return _live_pipefy_client()
 
 
 @pytest.fixture
@@ -126,7 +131,7 @@ async def test_live_upload_attachment_to_card_end_to_end(
     assert payload.get("field_id") == field_id
     assert payload.get("card_id") == card_id
 
-    client = PipefyClient(settings=settings.pipefy)
+    client = _live_pipefy_client()
     data = await client.get_card(card_id, include_fields=True)
     card = data.get("card") or {}
     value = _find_named_field_value(card.get("fields"), field_id)
@@ -174,7 +179,7 @@ async def test_live_upload_attachment_to_table_record_end_to_end(
     assert payload.get("success") is True
     assert payload.get("table_record_id") == record_id
 
-    client = PipefyClient(settings=settings.pipefy)
+    client = _live_pipefy_client()
     data = await client.get_table_record(record_id)
     rec = data.get("table_record") or {}
     value = _find_named_field_value(rec.get("record_fields"), field_id)
@@ -238,7 +243,7 @@ async def test_live_s3_put_mismatched_content_length():
     if not _s3_matrix_enabled():
         pytest.skip("Set PIPE_ATTACHMENT_LIVE_S3_MATRIX=1 to run S3 PUT matrix tests")
 
-    client = PipefyClient(settings=settings.pipefy)
+    client = _live_pipefy_client()
     file_name = f"s3-mismatch-{uuid.uuid4().hex[:10]}.bin"
     signed_len = 200
     presigned = await client.create_presigned_url(
@@ -283,7 +288,7 @@ async def test_live_s3_put_expired_presigned_url():
         )
     wait_sec = int(wait_raw)
 
-    client = PipefyClient(settings=settings.pipefy)
+    client = _live_pipefy_client()
     file_name = f"s3-expiry-{uuid.uuid4().hex[:10]}.txt"
     presigned = await client.create_presigned_url(
         organization_id=org,
@@ -319,7 +324,7 @@ async def test_live_s3_put_omits_content_type_when_signed():
     if not _s3_matrix_enabled():
         pytest.skip("Set PIPE_ATTACHMENT_LIVE_S3_MATRIX=1 for S3 matrix tests")
 
-    client = PipefyClient(settings=settings.pipefy)
+    client = _live_pipefy_client()
     file_name = f"s3-no-ctype-{uuid.uuid4().hex[:10]}.txt"
     body = b"abcd"
     presigned = await client.create_presigned_url(

--- a/packages/mcp/tests/tools/test_introspection_tools_live.py
+++ b/packages/mcp/tests/tools/test_introspection_tools_live.py
@@ -10,7 +10,11 @@ Run:
 from datetime import timedelta
 
 import pytest
-from _shared.live_settings import live_pipefy_settings, pipefy_live_configured
+from _shared.live_settings import (
+    live_pipefy_settings,
+    live_resolved_auth,
+    require_live_creds,
+)
 from mcp.server.fastmcp import FastMCP
 from mcp.shared.memory import (
     create_connected_server_and_client_session as create_client_session,
@@ -22,11 +26,8 @@ from pipefy_mcp.tools.introspection_tools import IntrospectionTools
 
 @pytest.fixture
 def live_pipefy_client():
-    if not pipefy_live_configured():
-        pytest.skip(
-            "Pipefy credentials not configured (PIPEFY_GRAPHQL_URL + OAuth in .env)"
-        )
-    return PipefyClient(settings=live_pipefy_settings())
+    require_live_creds()
+    return PipefyClient(settings=live_pipefy_settings(), auth=live_resolved_auth())
 
 
 @pytest.fixture


### PR DESCRIPTION
Companion to #223. Same root cause (live-integration fixtures drifted off post-#218 / post-#220 invariants), surfaced by reviewer's out-of-scope note on [#223's review](https://github.com/gbrlcustodio/pipefy-mcp-server/pull/223#pullrequestreview-4349207940).

**Stacked on #223** — uses the ``live_resolved_auth`` / ``live_auth_settings`` helpers it adds to ``packages/sdk/tests/_shared/live_settings.py``. Will rebase cleanly once #223 merges.

## Summary

- ``packages/mcp/tests/tools/test_introspection_tools_live.py`` — fixture passes ``auth=live_resolved_auth()`` to ``PipefyClient``.
- ``packages/mcp/tests/tools/test_attachment_tools_live.py`` — extract a module-level ``_live_pipefy_client`` helper (one source of truth for the five ``PipefyClient(settings=settings.pipefy)`` sites inside the S3 / upload tests) so each call goes through ``live_resolved_auth``.
- ``packages/cli/tests/test_auth_integration.py`` — ``AuthContext`` was missing the ``service_account=`` field (required, no default post-#218); now built from ``live_auth_settings().to_service_account()`` + ``to_oidc_client()``.

## Test plan

- [x] ``uv run pytest --collect-only`` on the three files — 11 tests collect without error
- [x] ``uv run pytest -m "not integration"`` — 2356 passing
- [x] ``uv run ruff check packages && uv run ruff format --check packages`` — clean
- [ ] Local ``uv run pytest -m integration`` with credentials — confirm at next live run