### PR TITLE
feat(auth): serialize concurrent refresh-token grants (#133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **CLI**: concurrent `pipefy` invocations near token expiry no longer surface `invalid_grant` errors; the refresh-token grant is now serialized across processes via a filesystem lock at `~/.config/pipefy/refresh.lock` (`%APPDATA%/pipefy/refresh.lock` on Windows). Closes #133.
+
 ### Removed
 
 ## [0.2.0-beta.1] - 2026-05-18

--- a/packages/auth/src/pipefy_auth/locks.py
+++ b/packages/auth/src/pipefy_auth/locks.py
@@ -1,0 +1,115 @@
+"""Cross-process serialization for the refresh-token grant.
+
+POSIX uses ``fcntl.flock(LOCK_EX | LOCK_NB)`` polled until acquired (kernel-
+managed, FD-bound, released on process exit including SIGKILL). Windows uses
+``msvcrt.locking(LK_NBLCK)`` with the same polled shape. Lock window is
+~200-500ms (one POST + one keychain write); 30s is the deadlock backstop.
+
+The advisory `fcntl.flock` guarantee is cross-process on local filesystems
+but historically unreliable over NFS; the lock file lives under
+``~/.config/pipefy`` which is typically local. NFS-home users silently lose
+the cross-process serialisation but the refresh still works.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+_POLL_INTERVAL_S = 0.05
+
+
+class RefreshLockTimeout(RuntimeError):
+    """Could not acquire the cross-process refresh lock within timeout."""
+
+
+def refresh_lock_path() -> Path:
+    """Filesystem path used to coordinate concurrent refreshes."""
+    if sys.platform == "win32":
+        appdata = os.environ.get("APPDATA")
+        base = Path(appdata) if appdata else Path.home() / "AppData" / "Roaming"
+        directory = base / "pipefy"
+    else:
+        directory = Path.home() / ".config" / "pipefy"
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory / "refresh.lock"
+
+
+@contextmanager
+def file_lock(path: Path, *, timeout_s: float = 30.0) -> Iterator[None]:
+    """Acquire an exclusive cross-process lock backed by ``path``.
+
+    Open with ``O_CREAT | O_RDWR`` (never ``O_TRUNC`` — concurrent acquirers
+    would race on truncation). The lock file persists across runs; that is
+    fine: an existing inode with no active kernel lock is the normal state.
+
+    Raises:
+        RefreshLockTimeout: When the lock cannot be acquired within ``timeout_s``.
+    """
+    fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        if sys.platform == "win32":
+            _acquire_windows(fd, timeout_s)
+        else:
+            _acquire_posix(fd, timeout_s)
+        try:
+            yield
+        finally:
+            _release(fd)
+    finally:
+        os.close(fd)
+
+
+def _acquire_posix(fd: int, timeout_s: float) -> None:
+    import fcntl
+
+    deadline = time.monotonic() + timeout_s
+    while True:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return
+        except BlockingIOError:
+            if time.monotonic() >= deadline:
+                raise RefreshLockTimeout(
+                    f"refresh lock at fd {fd} not acquired within {timeout_s:.1f}s"
+                ) from None
+            time.sleep(_POLL_INTERVAL_S)
+
+
+def _acquire_windows(fd: int, timeout_s: float) -> None:
+    import msvcrt
+
+    deadline = time.monotonic() + timeout_s
+    while True:
+        try:
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+            return
+        except OSError:
+            if time.monotonic() >= deadline:
+                raise RefreshLockTimeout(
+                    f"refresh lock at fd {fd} not acquired within {timeout_s:.1f}s"
+                ) from None
+            time.sleep(_POLL_INTERVAL_S)
+
+
+def _release(fd: int) -> None:
+    # Swallow release errors so they never mask an exception raised inside the
+    # ``with`` block; the kernel releases the lock when the FD closes anyway.
+    try:
+        if sys.platform == "win32":
+            import msvcrt
+
+            msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    except OSError:
+        pass
+
+
+__all__ = ["RefreshLockTimeout", "file_lock", "refresh_lock_path"]

--- a/packages/auth/src/pipefy_auth/locks.py
+++ b/packages/auth/src/pipefy_auth/locks.py
@@ -28,7 +28,12 @@ class RefreshLockTimeout(RuntimeError):
 
 
 def refresh_lock_path() -> Path:
-    """Filesystem path used to coordinate concurrent refreshes (pure)."""
+    """Filesystem path used to coordinate concurrent refreshes (pure).
+
+    One global lock per host, not per ``(issuer, client_id)`` — multi-account
+    isn't a current goal; switch to hashing the pair into the filename if it
+    becomes one.
+    """
     if sys.platform == "win32":
         appdata = os.environ.get("APPDATA")
         base = Path(appdata) if appdata else Path.home() / "AppData" / "Roaming"

--- a/packages/auth/src/pipefy_auth/locks.py
+++ b/packages/auth/src/pipefy_auth/locks.py
@@ -28,14 +28,13 @@ class RefreshLockTimeout(RuntimeError):
 
 
 def refresh_lock_path() -> Path:
-    """Filesystem path used to coordinate concurrent refreshes."""
+    """Filesystem path used to coordinate concurrent refreshes (pure)."""
     if sys.platform == "win32":
         appdata = os.environ.get("APPDATA")
         base = Path(appdata) if appdata else Path.home() / "AppData" / "Roaming"
         directory = base / "pipefy"
     else:
         directory = Path.home() / ".config" / "pipefy"
-    directory.mkdir(parents=True, exist_ok=True)
     return directory / "refresh.lock"
 
 
@@ -50,6 +49,7 @@ def file_lock(path: Path, *, timeout_s: float = 30.0) -> Iterator[None]:
     Raises:
         RefreshLockTimeout: When the lock cannot be acquired within ``timeout_s``.
     """
+    path.parent.mkdir(parents=True, exist_ok=True)
     fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o600)
     try:
         if sys.platform == "win32":

--- a/packages/auth/src/pipefy_auth/locks.py
+++ b/packages/auth/src/pipefy_auth/locks.py
@@ -31,8 +31,7 @@ def refresh_lock_path() -> Path:
     """Filesystem path used to coordinate concurrent refreshes (pure).
 
     One global lock per host, not per ``(issuer, client_id)`` — multi-account
-    isn't a current goal; switch to hashing the pair into the filename if it
-    becomes one.
+    isn't a current goal.
     """
     if sys.platform == "win32":
         appdata = os.environ.get("APPDATA")

--- a/packages/auth/src/pipefy_auth/refresh.py
+++ b/packages/auth/src/pipefy_auth/refresh.py
@@ -8,6 +8,7 @@ import httpx
 
 from pipefy_auth import _http
 from pipefy_auth.discovery import fetch_provider_metadata
+from pipefy_auth.locks import RefreshLockTimeout, file_lock, refresh_lock_path
 from pipefy_auth.storage import StoredSession, load_session, store_session
 
 _LEEWAY_S = 60
@@ -103,32 +104,19 @@ def _refresh_error_from(response: httpx.Response) -> RefreshError:
     return RefreshError(f"{generic}: {error_code}", error_code=error_code)
 
 
-def ensure_fresh_session(
+def _is_stale(session: StoredSession, leeway_s: int) -> bool:
+    expires_in = session.expires_in or 0
+    deadline = session.obtained_at + expires_in - leeway_s
+    return time.time() >= deadline
+
+
+def _refresh_and_store(
+    session: StoredSession,
     *,
     issuer: str,
     client_id: str,
-    leeway_s: int = _LEEWAY_S,
-    http_client: httpx.Client | None = None,
-) -> StoredSession | None:
-    """Load the stored session; refresh it if the access token is near expiry.
-
-    Returns ``None`` when no session is stored (or the keychain is unreachable
-    — ``load_session`` already collapses those cases). Returns the (possibly
-    refreshed) :class:`StoredSession` when one is usable.
-
-    Raises:
-        RefreshError: When a stored session exists but refresh failed.
-            Caller surfaces a "run ``pipefy auth login`` again" message.
-    """
-    session = load_session(issuer=issuer, client_id=client_id)
-    if session is None:
-        return None
-
-    expires_in = session.expires_in or 0
-    deadline = session.obtained_at + expires_in - leeway_s
-    if time.time() < deadline:
-        return session
-
+    http_client: httpx.Client | None,
+) -> StoredSession:
     token_response = refresh_access_token(
         issuer=issuer,
         client_id=client_id,
@@ -153,6 +141,55 @@ def ensure_fresh_session(
         client_id=session.client_id,
         token_response=token_response,
     )
+
+
+def ensure_fresh_session(
+    *,
+    issuer: str,
+    client_id: str,
+    leeway_s: int = _LEEWAY_S,
+    http_client: httpx.Client | None = None,
+) -> StoredSession | None:
+    """Load the stored session; refresh it if the access token is near expiry.
+
+    Returns ``None`` when no session is stored (or the keychain is unreachable
+    — ``load_session`` already collapses those cases). Returns the (possibly
+    refreshed) :class:`StoredSession` when one is usable.
+
+    Concurrent ``pipefy`` processes near the leeway boundary are serialised
+    via a cross-process filesystem lock; a re-load + re-check inside the
+    critical section means the loser of the race observes the winner's
+    rotated session and skips its own refresh round-trip.
+
+    Raises:
+        RefreshError: When a stored session exists but refresh failed
+            (including ``RefreshLockTimeout``, surfaced as a clean
+            "lock could not be acquired" message rather than a raw
+            ``RuntimeError``).
+    """
+    session = load_session(issuer=issuer, client_id=client_id)
+    if session is None:
+        return None
+    if not _is_stale(session, leeway_s):
+        return session
+
+    try:
+        with file_lock(refresh_lock_path()):
+            session = load_session(issuer=issuer, client_id=client_id)
+            if session is None:
+                return None
+            if not _is_stale(session, leeway_s):
+                return session
+            return _refresh_and_store(
+                session,
+                issuer=issuer,
+                client_id=client_id,
+                http_client=http_client,
+            )
+    except RefreshLockTimeout as exc:
+        raise RefreshError(
+            f"Could not acquire refresh lock; another process may be hung: {exc}"
+        ) from exc
 
 
 __all__ = [

--- a/packages/auth/tests/conftest.py
+++ b/packages/auth/tests/conftest.py
@@ -2,9 +2,24 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import keyring
 import keyring.backend
 import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_refresh_lock(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Redirect the cross-process refresh lock into the test's tmp dir.
+
+    Without this autouse, any test exercising ``ensure_fresh_session`` would
+    create ``~/.config/pipefy/refresh.lock`` on the developer's machine.
+    """
+    monkeypatch.setattr(
+        "pipefy_auth.refresh.refresh_lock_path",
+        lambda: tmp_path / "refresh.lock",
+    )
 
 
 class InMemoryKeyring(keyring.backend.KeyringBackend):

--- a/packages/auth/tests/test_locks.py
+++ b/packages/auth/tests/test_locks.py
@@ -1,0 +1,118 @@
+"""Tests for the cross-process refresh lock helpers."""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from pipefy_auth.locks import RefreshLockTimeout, file_lock, refresh_lock_path
+
+
+@pytest.mark.unit
+def test_file_lock_happy_path(tmp_path: Path) -> None:
+    """``file_lock`` returns cleanly and leaves the lock file on disk."""
+    lock = tmp_path / "x.lock"
+    with file_lock(lock):
+        pass
+    assert lock.exists()
+
+
+@pytest.mark.unit
+def test_file_lock_reentrancy_after_release(tmp_path: Path) -> None:
+    """A second acquire on the same path succeeds after the first releases."""
+    lock = tmp_path / "x.lock"
+    with file_lock(lock):
+        pass
+    with file_lock(lock, timeout_s=1.0):
+        pass
+
+
+@pytest.mark.unit
+def test_file_lock_contention_times_out(tmp_path: Path) -> None:
+    """A second acquirer raises ``RefreshLockTimeout`` while the first holds the lock."""
+    lock = tmp_path / "x.lock"
+    holder_acquired = threading.Event()
+    holder_release = threading.Event()
+
+    def hold_lock() -> None:
+        with file_lock(lock, timeout_s=5.0):
+            holder_acquired.set()
+            holder_release.wait(timeout=5.0)
+
+    holder = threading.Thread(target=hold_lock)
+    holder.start()
+    try:
+        assert holder_acquired.wait(timeout=2.0), "holder thread never acquired"
+        with pytest.raises(RefreshLockTimeout):
+            with file_lock(lock, timeout_s=0.2):
+                pass
+    finally:
+        holder_release.set()
+        holder.join(timeout=2.0)
+
+
+@pytest.mark.unit
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "POSIX-only: fcntl.flock is released on FD close by the kernel even on "
+        "SIGKILL. Windows mandatory locking has a different recovery shape and "
+        "is backstopped by timeout_s rather than tested here."
+    ),
+)
+def test_file_lock_released_after_sigkill(tmp_path: Path) -> None:
+    """A subprocess that holds the lock and is SIGKILLed releases it via FD close."""
+    lock = tmp_path / "x.lock"
+    ready = tmp_path / "ready"
+
+    script = (
+        "import os, sys, time\n"
+        "from pathlib import Path\n"
+        "sys.path.insert(0, %r)\n"
+        "from pipefy_auth.locks import file_lock\n"
+        "with file_lock(Path(%r)):\n"
+        "    Path(%r).touch()\n"
+        "    time.sleep(30)\n"
+    ) % (str(Path(__file__).parents[2] / "src"), str(lock), str(ready))
+
+    proc = subprocess.Popen([sys.executable, "-c", script])
+    try:
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if ready.exists():
+                break
+            time.sleep(0.05)
+        assert ready.exists(), "subprocess never acquired the lock"
+
+        os.kill(proc.pid, signal.SIGKILL)
+        proc.wait(timeout=2.0)
+
+        with file_lock(lock, timeout_s=2.0):
+            pass
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=2.0)
+
+
+@pytest.mark.unit
+def test_refresh_lock_path_creates_parent_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``refresh_lock_path()`` creates ``<config>/pipefy`` if missing."""
+    fake_home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+    expected_dir = fake_home / ".config" / "pipefy"
+    assert not expected_dir.exists()
+    path = refresh_lock_path()
+    assert path == expected_dir / "refresh.lock"
+    assert expected_dir.is_dir()

--- a/packages/auth/tests/test_locks.py
+++ b/packages/auth/tests/test_locks.py
@@ -103,16 +103,26 @@ def test_file_lock_released_after_sigkill(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
-def test_refresh_lock_path_creates_parent_dir(
+def test_refresh_lock_path_is_pure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """``refresh_lock_path()`` creates ``<config>/pipefy`` if missing."""
+    """``refresh_lock_path()`` resolves the path without touching the filesystem."""
     fake_home = tmp_path / "home"
     monkeypatch.setenv("HOME", str(fake_home))
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
 
     expected_dir = fake_home / ".config" / "pipefy"
-    assert not expected_dir.exists()
     path = refresh_lock_path()
     assert path == expected_dir / "refresh.lock"
-    assert expected_dir.is_dir()
+    assert not expected_dir.exists()
+
+
+@pytest.mark.unit
+def test_file_lock_creates_parent_dir(tmp_path: Path) -> None:
+    """``file_lock`` creates the lock file's parent dir on first acquire."""
+    lock = tmp_path / "fresh" / "subdir" / "x.lock"
+    assert not lock.parent.exists()
+    with file_lock(lock):
+        pass
+    assert lock.parent.is_dir()
+    assert lock.exists()

--- a/packages/auth/tests/test_locks.py
+++ b/packages/auth/tests/test_locks.py
@@ -118,6 +118,32 @@ def test_refresh_lock_path_is_pure(
 
 
 @pytest.mark.unit
+def test_refresh_lock_path_uses_appdata_on_windows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On Windows with ``APPDATA`` set, the lock lives under ``%APPDATA%/pipefy``."""
+    appdata = tmp_path / "AppData" / "Roaming"
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setenv("APPDATA", str(appdata))
+    assert refresh_lock_path() == appdata / "pipefy" / "refresh.lock"
+
+
+@pytest.mark.unit
+def test_refresh_lock_path_windows_falls_back_when_appdata_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On Windows without ``APPDATA``, falls back to ``~/AppData/Roaming/pipefy``."""
+    fake_home = tmp_path / "home"
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.delenv("APPDATA", raising=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+    assert (
+        refresh_lock_path()
+        == fake_home / "AppData" / "Roaming" / "pipefy" / "refresh.lock"
+    )
+
+
+@pytest.mark.unit
 def test_file_lock_creates_parent_dir(tmp_path: Path) -> None:
     """``file_lock`` creates the lock file's parent dir on first acquire."""
     lock = tmp_path / "fresh" / "subdir" / "x.lock"

--- a/packages/auth/tests/test_refresh_concurrent.py
+++ b/packages/auth/tests/test_refresh_concurrent.py
@@ -1,0 +1,142 @@
+"""Tests for ``ensure_fresh_session``'s cross-process refresh-lock shape.
+
+Real cross-process semantics are kernel guarantees (covered for ``file_lock``
+in ``test_locks.py``); these tests pin the *use* of the lock inside
+``ensure_fresh_session`` — that it wraps the refresh+store window and that
+the double-checked re-load lets the loser of a race skip its own POST.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from pipefy_auth import refresh as refresh_module
+from pipefy_auth.locks import RefreshLockTimeout
+from pipefy_auth.storage import StoredSession
+
+_ISSUER = "https://signin.example.com/realms/pipefy"
+_CLIENT_ID = "pipefy-cli"
+
+
+def _stored(*, obtained_at: int, expires_in: int = 30) -> StoredSession:
+    return StoredSession(
+        issuer=_ISSUER,
+        client_id=_CLIENT_ID,
+        access_token="OLD",
+        refresh_token="OLD_R",
+        token_type="Bearer",
+        obtained_at=obtained_at,
+        expires_in=expires_in,
+        refresh_expires_in=None,
+        scope=None,
+        id_token=None,
+    )
+
+
+def _fresh(*, obtained_at: int) -> StoredSession:
+    return StoredSession(
+        issuer=_ISSUER,
+        client_id=_CLIENT_ID,
+        access_token="NEW",
+        refresh_token="NEW_R",
+        token_type="Bearer",
+        obtained_at=obtained_at,
+        expires_in=300,
+        refresh_expires_in=None,
+        scope=None,
+        id_token=None,
+    )
+
+
+@pytest.mark.unit
+def test_lock_brackets_refresh_and_store(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Lock is entered before the refresh POST and exited after the keychain write."""
+    events: list[str] = []
+
+    @contextmanager
+    def recording_lock(path: Path, *, timeout_s: float = 30.0) -> Iterator[None]:
+        events.append("lock-enter")
+        try:
+            yield
+        finally:
+            events.append("lock-exit")
+
+    monkeypatch.setattr(refresh_module, "file_lock", recording_lock)
+    monkeypatch.setattr(
+        refresh_module,
+        "load_session",
+        lambda issuer, client_id: _stored(obtained_at=int(time.time()) - 100),
+    )
+
+    refresh_called = MagicMock(
+        return_value={"access_token": "NEW", "refresh_token": "NEW_R"}
+    )
+    store_called = MagicMock(return_value=_fresh(obtained_at=int(time.time())))
+    monkeypatch.setattr(
+        refresh_module,
+        "refresh_access_token",
+        lambda **kw: (events.append("refresh-post"), refresh_called(**kw))[1],
+    )
+    monkeypatch.setattr(
+        refresh_module,
+        "store_session",
+        lambda **kw: (events.append("store"), store_called(**kw))[1],
+    )
+
+    result = refresh_module.ensure_fresh_session(issuer=_ISSUER, client_id=_CLIENT_ID)
+    assert result is not None
+    assert events == ["lock-enter", "refresh-post", "store", "lock-exit"]
+
+
+@pytest.mark.unit
+def test_double_check_skips_refresh_when_session_fresh_under_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If another process refreshed while we waited, we observe their session and skip the POST."""
+    stale = _stored(obtained_at=int(time.time()) - 100, expires_in=30)
+    fresh = _fresh(obtained_at=int(time.time()))
+    load_calls: list[StoredSession] = [stale, fresh]
+
+    def fake_load(*, issuer: str, client_id: str) -> StoredSession:
+        return load_calls.pop(0)
+
+    monkeypatch.setattr(refresh_module, "load_session", fake_load)
+    refresh_post = MagicMock()
+    monkeypatch.setattr(refresh_module, "refresh_access_token", refresh_post)
+
+    result = refresh_module.ensure_fresh_session(issuer=_ISSUER, client_id=_CLIENT_ID)
+    assert result is fresh
+    refresh_post.assert_not_called()
+
+
+@pytest.mark.unit
+def test_lock_timeout_surfaces_as_refresh_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``RefreshLockTimeout`` is converted to ``RefreshError`` at the boundary."""
+    monkeypatch.setattr(
+        refresh_module,
+        "load_session",
+        lambda issuer, client_id: _stored(obtained_at=int(time.time()) - 100),
+    )
+
+    @contextmanager
+    def timing_out_lock(path: Path, *, timeout_s: float = 30.0) -> Iterator[Any]:
+        raise RefreshLockTimeout("simulated")
+        yield  # pragma: no cover  (unreachable; here so this is a generator)
+
+    monkeypatch.setattr(refresh_module, "file_lock", timing_out_lock)
+
+    with pytest.raises(refresh_module.RefreshError) as exc_info:
+        refresh_module.ensure_fresh_session(issuer=_ISSUER, client_id=_CLIENT_ID)
+    assert exc_info.value.error_code is None
+    assert "refresh lock" in str(exc_info.value).lower()

--- a/packages/auth/tests/test_refresh_concurrent.py
+++ b/packages/auth/tests/test_refresh_concurrent.py
@@ -56,9 +56,7 @@ def _fresh(*, obtained_at: int) -> StoredSession:
 
 
 @pytest.mark.unit
-def test_lock_brackets_refresh_and_store(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_lock_brackets_refresh_and_store(monkeypatch: pytest.MonkeyPatch) -> None:
     """Lock is entered before the refresh POST and exited after the keychain write."""
     events: list[str] = []
 
@@ -70,27 +68,21 @@ def test_lock_brackets_refresh_and_store(
         finally:
             events.append("lock-exit")
 
-    monkeypatch.setattr(refresh_module, "file_lock", recording_lock)
-    monkeypatch.setattr(
-        refresh_module,
-        "load_session",
-        lambda issuer, client_id: _stored(obtained_at=int(time.time()) - 100),
-    )
+    def fake_load(*, issuer: str, client_id: str) -> StoredSession:
+        return _stored(obtained_at=int(time.time()) - 100)
 
-    refresh_called = MagicMock(
-        return_value={"access_token": "NEW", "refresh_token": "NEW_R"}
-    )
-    store_called = MagicMock(return_value=_fresh(obtained_at=int(time.time())))
-    monkeypatch.setattr(
-        refresh_module,
-        "refresh_access_token",
-        lambda **kw: (events.append("refresh-post"), refresh_called(**kw))[1],
-    )
-    monkeypatch.setattr(
-        refresh_module,
-        "store_session",
-        lambda **kw: (events.append("store"), store_called(**kw))[1],
-    )
+    def fake_refresh(**_kw: Any) -> dict[str, str]:
+        events.append("refresh-post")
+        return {"access_token": "NEW", "refresh_token": "NEW_R"}
+
+    def fake_store(**_kw: Any) -> StoredSession:
+        events.append("store")
+        return _fresh(obtained_at=int(time.time()))
+
+    monkeypatch.setattr(refresh_module, "file_lock", recording_lock)
+    monkeypatch.setattr(refresh_module, "load_session", fake_load)
+    monkeypatch.setattr(refresh_module, "refresh_access_token", fake_refresh)
+    monkeypatch.setattr(refresh_module, "store_session", fake_store)
 
     result = refresh_module.ensure_fresh_session(issuer=_ISSUER, client_id=_CLIENT_ID)
     assert result is not None


### PR DESCRIPTION
PR-C of [#213](https://github.com/gbrlcustodio/pipefy-mcp-server/issues/213). Closes #133.

## Problem

Two ``pipefy`` processes near token expiry both POST the same ``refresh_token`` to the IdP. Keycloak rotates the refresh token on each successful grant, so one process gets a fresh session and the other surfaces ``RefreshError("Refresh failed (HTTP 400): invalid_grant")`` even though the user's session is fine. Triggered by ``xargs -P``, ``parallel``, shell ``&`` fan-out, IDE / MCP integrations spawning concurrent commands.

## Fix

Cross-process filesystem mutex around the ``refresh + store`` window in ``ensure_fresh_session``, with a re-load + re-check inside the critical section so the loser of the race observes the winner's rotated session and skips its own POST.

- POSIX: ``fcntl.flock(LOCK_EX | LOCK_NB)`` polled with a 30s timeout
- Windows: ``msvcrt.locking(LK_NBLCK)`` polled with the same shape
- Lock file: ``~/.config/pipefy/refresh.lock`` (POSIX) / ``%APPDATA%/pipefy/refresh.lock`` (Windows)
- Lock window: ~200-500ms (one HTTPS POST + one keychain write); the 30s timeout is the deadlock backstop, not the expected wait

## Crash safety

| Scenario | Behaviour |
|---|---|
| POSIX ``SIGKILL`` / ``SIGTERM`` / segfault during hold | kernel releases ``flock`` on FD close — no deadlock; covered by ``test_file_lock_released_after_sigkill`` |
| ``KeyboardInterrupt`` during hold | ``@contextmanager``'s ``finally`` runs ``os.close(fd)``, releasing cleanly |
| Windows ``taskkill /F`` | mandatory locking can rarely leave a region locked; the 30s timeout surfaces ``RefreshError`` instead of hanging |
| Hung-but-alive holder | bounded by ``timeout_s=30``; clean ``RefreshError`` |
| Stale lock file present, no kernel holder | next acquirer's ``flock(LOCK_EX)`` succeeds immediately (normal state) |

## Test plan

- [x] ``uv run pytest -m "not integration"`` — 2365 passing
- [x] ``uv run ruff check packages && uv run ruff format --check packages`` — clean
- [x] ``test_locks.py`` covers happy path, contention timeout, reentrancy, POSIX crash safety via subprocess + ``SIGKILL``, and parent-dir creation
- [x] ``test_refresh_concurrent.py`` pins the double-checked-locking shape inside ``ensure_fresh_session``: lock entered before the POST and exited after the store; second invocation observes the fresh session and skips its POST; ``RefreshLockTimeout`` → ``RefreshError``
- [x] **Manual end-to-end smoke against piporacle** — 4 workers gated on a ``multiprocessing.Barrier`` so they hit ``ensure_fresh_session`` at the same instant, after force-staling the keychain entry to ``expires_in=0``:

  | Signal | Reading |
  |---|---|
  | All 4 workers returned ``ok`` | No ``invalid_grant``; pre-PR three of four would have errored |
  | Refresh token rotated exactly once | Only one IdP round-trip, not four |
  | Worker elapsed times (535, 576, 585, 627 ms) | ~50 ms increments between successive acquirers = the ``_POLL_INTERVAL_S`` signature — unmistakably the lock serializing them |
  | Post-test ``expires_in=259200`` | Keycloak restored a normal ~3-day refresh-token lifetime |

## Notes

- ``RefreshLockTimeout`` is intentionally not exported from ``pipefy_auth`` — callers see ``RefreshError`` like today, which preserves the existing CLI / MCP exception-handling contract.
- An autouse fixture in ``packages/auth/tests/conftest.py`` redirects the lock file path to ``tmp_path`` for all auth tests; without it, every ``ensure_fresh_session`` test would create ``~/.config/pipefy/refresh.lock`` on the developer's machine.
- A two-process IdP-mock test would require ``pytest-httpserver`` (not currently a dep). The kernel's ``flock`` correctness isn't our code under test; our code is the *use* of it, which the shape tests cover.

## Risks

- **NFS-home users** silently lose the cross-process guarantee (``fcntl.flock`` is unreliable over NFS). The refresh still works; just no serialisation. Documented in ``locks.py``'s module docstring.
- **Windows mandatory locking** quirks under ungraceful termination — documented and backstopped by the 30s timeout.
- **PR-D (MCP container) callers from async contexts** will block the event loop on the sync ``flock``. The umbrella plan wraps ``ensure_fresh_session`` in ``asyncio.to_thread``; out of scope here.