### PR TITLE
feat(mcp): wire stored-session tier into ServicesContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **CLI**: `pipefy auth status [--json|-j]` — reports auth source, identity, session expiry, and exit codes.
 - **CLI**: `pipefy auth logout` — revokes the refresh token at the IdP and clears the stored session.
+- **MCP**: stored-session tier wired into `ServicesContainer`; setting `PIPEFY_AUTH_URL` after `pipefy auth login` now lets the MCP server reuse the keychain-backed session, with the refresh pre-warmed at startup so a stale or revoked session surfaces before the first tool call.
 
 ### Changed
 

--- a/packages/mcp/src/pipefy_mcp/core/container.py
+++ b/packages/mcp/src/pipefy_mcp/core/container.py
@@ -58,10 +58,11 @@ class ServicesContainer:
                     issuer=oidc_client.issuer_url,
                     client_id=oidc_client.client_id,
                 )
-            except RefreshError:
+            except RefreshError as exc:
                 logger.error(
-                    "Stored Pipefy session could not be refreshed at startup. "
-                    "Run `pipefy auth login` to sign in again."
+                    "Stored Pipefy session could not be refreshed at startup: %s. "
+                    "Run `pipefy auth login` to sign in again.",
+                    exc,
                 )
                 raise
             logger.info("Pipefy stored session warmed up at startup")

--- a/packages/mcp/src/pipefy_mcp/core/container.py
+++ b/packages/mcp/src/pipefy_mcp/core/container.py
@@ -6,6 +6,7 @@ from typing import Self
 
 from pipefy_auth import (
     STORED_SESSION_TIER,
+    RefreshError,
     ensure_fresh_session,
     missing_auth_message,
     resolve_pipefy_auth,
@@ -51,11 +52,18 @@ class ServicesContainer:
         if resolved is None:
             raise RuntimeError(missing_auth_message())
         if oidc_client is not None and tier_for(resolved) == STORED_SESSION_TIER:
-            await asyncio.to_thread(
-                ensure_fresh_session,
-                issuer=oidc_client.issuer_url,
-                client_id=oidc_client.client_id,
-            )
+            try:
+                await asyncio.to_thread(
+                    ensure_fresh_session,
+                    issuer=oidc_client.issuer_url,
+                    client_id=oidc_client.client_id,
+                )
+            except RefreshError:
+                logger.error(
+                    "Stored Pipefy session could not be refreshed at startup. "
+                    "Run `pipefy auth login` to sign in again."
+                )
+                raise
             logger.info("Pipefy stored session warmed up at startup")
         self.pipefy_client = PipefyClient(settings=pipefy, auth=resolved)
         if pipefy.internal_api_url:

--- a/packages/mcp/src/pipefy_mcp/core/container.py
+++ b/packages/mcp/src/pipefy_mcp/core/container.py
@@ -37,8 +37,6 @@ class ServicesContainer:
         When the resolved auth tier is the keychain-backed stored session,
         :func:`ensure_fresh_session` is invoked eagerly so a stale or revoked
         session surfaces at server startup rather than on first tool call.
-        The blocking refresh POST runs on a worker thread to keep the
-        lifespan event loop responsive.
 
         Args:
             settings: Application settings with Pipefy credentials.

--- a/packages/mcp/src/pipefy_mcp/core/container.py
+++ b/packages/mcp/src/pipefy_mcp/core/container.py
@@ -1,14 +1,21 @@
 from __future__ import annotations
 
+import asyncio
+import logging
 from typing import Self
 
 from pipefy_auth import (
+    STORED_SESSION_TIER,
+    ensure_fresh_session,
     missing_auth_message,
     resolve_pipefy_auth,
+    tier_for,
 )
 from pipefy_sdk import AiAutomationService, InternalApiClient, PipefyClient
 
 from pipefy_mcp.settings import Settings
+
+logger = logging.getLogger(__name__)
 
 
 class ServicesContainer:
@@ -24,20 +31,34 @@ class ServicesContainer:
             cls._instance = cls()
         return cls._instance
 
-    def initialize_services(self, settings: Settings) -> None:
+    async def initialize_services(self, settings: Settings) -> None:
         """Create and wire all services.
+
+        When the resolved auth tier is the keychain-backed stored session,
+        :func:`ensure_fresh_session` is invoked eagerly so a stale or revoked
+        session surfaces at server startup rather than on first tool call.
+        The blocking refresh POST runs on a worker thread to keep the
+        lifespan event loop responsive.
 
         Args:
             settings: Application settings with Pipefy credentials.
         """
         pipefy = settings.pipefy
-        # The stored-session tier is wired in a follow-up against #213.
+        oidc_client = settings.auth.to_oidc_client()
         resolved = resolve_pipefy_auth(
             static_token=settings.auth.static_token,
             service_account=settings.auth.to_service_account(),
+            oidc_client=oidc_client,
         )
         if resolved is None:
             raise RuntimeError(missing_auth_message())
+        if oidc_client is not None and tier_for(resolved) == STORED_SESSION_TIER:
+            await asyncio.to_thread(
+                ensure_fresh_session,
+                issuer=oidc_client.issuer_url,
+                client_id=oidc_client.client_id,
+            )
+            logger.info("Pipefy stored session warmed up at startup")
         self.pipefy_client = PipefyClient(settings=pipefy, auth=resolved)
         if pipefy.internal_api_url:
             internal_client = InternalApiClient(

--- a/packages/mcp/src/pipefy_mcp/server.py
+++ b/packages/mcp/src/pipefy_mcp/server.py
@@ -32,7 +32,7 @@ async def lifespan(app: FastMCP) -> AsyncIterator[FastMCP]:
         )
         install_pipefy_validation_envelope()
         services_container = ServicesContainer.get_instance()
-        services_container.initialize_services(settings)
+        await services_container.initialize_services(settings)
         prepare_app_for_repeat_pipefy_tool_registration(app)
         registry = ToolRegistry(
             mcp=app,

--- a/packages/mcp/tests/core/test_container.py
+++ b/packages/mcp/tests/core/test_container.py
@@ -1,7 +1,7 @@
 from unittest.mock import Mock, patch
 
 import pytest
-from pipefy_auth import AuthSettings, StaticBearerAuth
+from pipefy_auth import AuthSettings, CallableBearerAuth, StaticBearerAuth
 from pipefy_sdk import PipefyClient, PipefySettings
 
 from pipefy_mcp.core.container import ServicesContainer
@@ -25,6 +25,10 @@ def _service_account_auth_settings() -> AuthSettings:
         service_account_client_id="client_id",
         service_account_client_secret="client_secret",
     )
+
+
+def _stored_session_auth_settings() -> AuthSettings:
+    return AuthSettings(auth_url="https://signin.pipefy.com/realms/pipefy")
 
 
 class TestServicesContainer:
@@ -70,7 +74,7 @@ class TestServicesContainer:
     @patch("pipefy_mcp.core.container.AiAutomationService")
     @patch("pipefy_mcp.core.container.InternalApiClient")
     @patch("pipefy_mcp.core.container.PipefyClient")
-    def test_initialize_services_creates_pipefy_client(
+    async def test_initialize_services_creates_pipefy_client(
         self,
         mock_pipefy_client_class,
         mock_internal_api_client_class,
@@ -87,7 +91,7 @@ class TestServicesContainer:
         )
 
         container = ServicesContainer()
-        container.initialize_services(settings)
+        await container.initialize_services(settings)
 
         mock_pipefy_client_class.assert_called_once()
         kwargs = mock_pipefy_client_class.call_args.kwargs
@@ -98,7 +102,7 @@ class TestServicesContainer:
     @patch("pipefy_mcp.core.container.InternalApiClient")
     @patch("pipefy_mcp.core.container.AiAutomationService")
     @patch("pipefy_mcp.core.container.PipefyClient")
-    def test_initialize_services_creates_ai_services(
+    async def test_initialize_services_creates_ai_services(
         self,
         mock_pipefy_client_class,
         mock_ai_automation_service_class,
@@ -114,7 +118,7 @@ class TestServicesContainer:
         )
 
         container = ServicesContainer()
-        container.initialize_services(settings)
+        await container.initialize_services(settings)
 
         mock_internal_api_client_class.assert_called_once()
         mock_ai_automation_service_class.assert_called_once()
@@ -125,7 +129,7 @@ class TestServicesContainer:
     @patch("pipefy_mcp.core.container.AiAutomationService")
     @patch("pipefy_mcp.core.container.InternalApiClient")
     @patch("pipefy_mcp.core.container.PipefyClient")
-    def test_initialize_services_picks_up_pipefy_token_over_service_account(
+    async def test_initialize_services_picks_up_pipefy_token_over_service_account(
         self,
         mock_pipefy_client_class,
         mock_internal_api_client_class,
@@ -149,7 +153,7 @@ class TestServicesContainer:
                 service_account_client_secret="client_secret",
             ),
         )
-        ServicesContainer().initialize_services(settings)
+        await ServicesContainer().initialize_services(settings)
         pc_auth = mock_pipefy_client_class.call_args.kwargs["auth"]
         assert isinstance(pc_auth, StaticBearerAuth)
         mock_internal_api_client_class.assert_called_once()
@@ -162,7 +166,7 @@ class TestServicesContainer:
     @patch("pipefy_mcp.core.container.AiAutomationService")
     @patch("pipefy_mcp.core.container.InternalApiClient")
     @patch("pipefy_mcp.core.container.PipefyClient")
-    def test_initialize_services_raises_when_no_auth_source_configured(
+    async def test_initialize_services_raises_when_no_auth_source_configured(
         self,
         mock_pipefy_client_class,
         mock_internal_api_client_class,
@@ -174,4 +178,50 @@ class TestServicesContainer:
             auth=AuthSettings(),
         )
         with pytest.raises(RuntimeError, match="Missing Pipefy authentication"):
-            ServicesContainer().initialize_services(settings)
+            await ServicesContainer().initialize_services(settings)
+
+    @patch("pipefy_mcp.core.container.ensure_fresh_session")
+    @patch("pipefy_mcp.core.container.PipefyClient")
+    async def test_initialize_services_warms_up_stored_session(
+        self,
+        mock_pipefy_client_class,
+        mock_ensure_fresh_session,
+    ):
+        """When the resolved tier is the stored session, the refresh is pre-warmed."""
+        mock_pipefy_client_class.return_value = Mock(spec=PipefyClient)
+        settings = Settings(
+            pipefy=PipefySettings(graphql_url="https://api.pipefy.com/graphql"),
+            auth=_stored_session_auth_settings(),
+        )
+        with patch("pipefy_auth.resolver._has_stored_session", return_value=True):
+            await ServicesContainer().initialize_services(settings)
+
+        pc_auth = mock_pipefy_client_class.call_args.kwargs["auth"]
+        assert isinstance(pc_auth, CallableBearerAuth)
+        mock_ensure_fresh_session.assert_called_once_with(
+            issuer="https://signin.pipefy.com/realms/pipefy",
+            client_id=settings.auth.auth_client_id,
+        )
+
+    @patch("pipefy_mcp.core.container.ensure_fresh_session")
+    @patch("pipefy_mcp.core.container.PipefyClient")
+    async def test_initialize_services_does_not_warm_up_when_static_token_wins(
+        self,
+        mock_pipefy_client_class,
+        mock_ensure_fresh_session,
+    ):
+        """A configured ``PIPEFY_AUTH_URL`` is ignored at warm-up when a higher tier wins."""
+        mock_pipefy_client_class.return_value = Mock(spec=PipefyClient)
+        settings = Settings(
+            pipefy=PipefySettings(graphql_url="https://api.pipefy.com/graphql"),
+            auth=AuthSettings(
+                static_token="env-bearer",
+                auth_url="https://signin.pipefy.com/realms/pipefy",
+            ),
+        )
+        # Even if a stored session existed, the static-token tier wins —
+        # ``ensure_fresh_session`` must not be called.
+        with patch("pipefy_auth.resolver._has_stored_session", return_value=True):
+            await ServicesContainer().initialize_services(settings)
+
+        mock_ensure_fresh_session.assert_not_called()

--- a/packages/mcp/tests/core/test_container.py
+++ b/packages/mcp/tests/core/test_container.py
@@ -1,7 +1,9 @@
+import time
 from unittest.mock import Mock, patch
 
 import pytest
 from pipefy_auth import AuthSettings, CallableBearerAuth, StaticBearerAuth
+from pipefy_auth.storage import StoredSession
 from pipefy_sdk import PipefyClient, PipefySettings
 
 from pipefy_mcp.core.container import ServicesContainer
@@ -29,6 +31,21 @@ def _service_account_auth_settings() -> AuthSettings:
 
 def _stored_session_auth_settings() -> AuthSettings:
     return AuthSettings(auth_url="https://signin.pipefy.com/realms/pipefy")
+
+
+def _fresh_stored_session() -> StoredSession:
+    return StoredSession(
+        issuer="https://signin.pipefy.com/realms/pipefy",
+        client_id="pipefy-cli",
+        access_token="ACCESS",
+        refresh_token="REFRESH",
+        token_type="Bearer",
+        obtained_at=int(time.time()),
+        expires_in=3600,
+        refresh_expires_in=None,
+        scope=None,
+        id_token=None,
+    )
 
 
 class TestServicesContainer:
@@ -193,7 +210,10 @@ class TestServicesContainer:
             pipefy=PipefySettings(graphql_url="https://api.pipefy.com/graphql"),
             auth=_stored_session_auth_settings(),
         )
-        with patch("pipefy_auth.resolver._has_stored_session", return_value=True):
+        with patch(
+            "pipefy_auth.resolver.load_session",
+            return_value=_fresh_stored_session(),
+        ):
             await ServicesContainer().initialize_services(settings)
 
         pc_auth = mock_pipefy_client_class.call_args.kwargs["auth"]
@@ -219,9 +239,11 @@ class TestServicesContainer:
                 auth_url="https://signin.pipefy.com/realms/pipefy",
             ),
         )
-        # Even if a stored session existed, the static-token tier wins —
-        # ``ensure_fresh_session`` must not be called.
-        with patch("pipefy_auth.resolver._has_stored_session", return_value=True):
+        # Force a detectable stored session so we prove precedence, not absence.
+        with patch(
+            "pipefy_auth.resolver.load_session",
+            return_value=_fresh_stored_session(),
+        ):
             await ServicesContainer().initialize_services(settings)
 
         mock_ensure_fresh_session.assert_not_called()

--- a/packages/mcp/tests/core/test_container.py
+++ b/packages/mcp/tests/core/test_container.py
@@ -1,3 +1,4 @@
+import logging
 import time
 from unittest.mock import Mock, patch
 
@@ -254,8 +255,9 @@ class TestServicesContainer:
         self,
         mock_pipefy_client_class,
         mock_ensure_fresh_session,
+        caplog,
     ):
-        """A failed warm-up surfaces ``RefreshError`` *before* ``PipefyClient`` is constructed."""
+        """A failed warm-up logs the ``pipefy auth login`` hint and surfaces ``RefreshError`` *before* ``PipefyClient`` is constructed."""
         mock_ensure_fresh_session.side_effect = RefreshError("invalid_grant")
         settings = Settings(
             pipefy=PipefySettings(graphql_url="https://api.pipefy.com/graphql"),
@@ -265,7 +267,17 @@ class TestServicesContainer:
             "pipefy_auth.resolver.load_session",
             return_value=_fresh_stored_session(),
         ):
-            with pytest.raises(RefreshError, match="invalid_grant"):
-                await ServicesContainer().initialize_services(settings)
+            with caplog.at_level(logging.ERROR, logger="pipefy_mcp.core.container"):
+                with pytest.raises(RefreshError, match="invalid_grant"):
+                    await ServicesContainer().initialize_services(settings)
 
         mock_pipefy_client_class.assert_not_called()
+        hint_records = [
+            r
+            for r in caplog.records
+            if r.name == "pipefy_mcp.core.container" and r.levelno == logging.ERROR
+        ]
+        assert len(hint_records) == 1
+        hint_message = hint_records[0].getMessage()
+        assert "invalid_grant" in hint_message
+        assert "pipefy auth login" in hint_message

--- a/packages/mcp/tests/core/test_container.py
+++ b/packages/mcp/tests/core/test_container.py
@@ -2,7 +2,7 @@ import time
 from unittest.mock import Mock, patch
 
 import pytest
-from pipefy_auth import AuthSettings, CallableBearerAuth, StaticBearerAuth
+from pipefy_auth import AuthSettings, CallableBearerAuth, RefreshError, StaticBearerAuth
 from pipefy_auth.storage import StoredSession
 from pipefy_sdk import PipefyClient, PipefySettings
 
@@ -247,3 +247,25 @@ class TestServicesContainer:
             await ServicesContainer().initialize_services(settings)
 
         mock_ensure_fresh_session.assert_not_called()
+
+    @patch("pipefy_mcp.core.container.ensure_fresh_session")
+    @patch("pipefy_mcp.core.container.PipefyClient")
+    async def test_initialize_services_aborts_before_client_when_refresh_fails(
+        self,
+        mock_pipefy_client_class,
+        mock_ensure_fresh_session,
+    ):
+        """A failed warm-up surfaces ``RefreshError`` *before* ``PipefyClient`` is constructed."""
+        mock_ensure_fresh_session.side_effect = RefreshError("invalid_grant")
+        settings = Settings(
+            pipefy=PipefySettings(graphql_url="https://api.pipefy.com/graphql"),
+            auth=_stored_session_auth_settings(),
+        )
+        with patch(
+            "pipefy_auth.resolver.load_session",
+            return_value=_fresh_stored_session(),
+        ):
+            with pytest.raises(RefreshError, match="invalid_grant"):
+                await ServicesContainer().initialize_services(settings)
+
+        mock_pipefy_client_class.assert_not_called()

--- a/packages/mcp/tests/test_server.py
+++ b/packages/mcp/tests/test_server.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from mcp.server.fastmcp import FastMCP
@@ -69,6 +69,7 @@ async def test_repeat_lifespan_preserves_foreign_tools_and_stable_pipefy_names()
         return "ok"
 
     mock_container = MagicMock()
+    mock_container.initialize_services = AsyncMock()
     mock_container.pipefy_client = MagicMock()
 
     with (
@@ -101,7 +102,9 @@ async def test_lifespan_logs_error_when_initialization_raises():
         patch("pipefy_mcp.server.logger") as mock_logger,
     ):
         mock_container = MagicMock()
-        mock_container.initialize_services.side_effect = ValueError("init failed")
+        mock_container.initialize_services = AsyncMock(
+            side_effect=ValueError("init failed")
+        )
         mock_get_instance.return_value = mock_container
 
         with pytest.raises(ValueError, match="init failed"):
@@ -122,6 +125,7 @@ async def test_lifespan_failed_register_tools_does_not_mark_repeat_visit_state()
 
     app = FastMCP("fail-register-tools")
     mock_container = MagicMock()
+    mock_container.initialize_services = AsyncMock()
     mock_container.pipefy_client = MagicMock()
 
     with (
@@ -154,6 +158,7 @@ async def test_lifespan_retry_after_failed_register_tools_succeeds():
 
     app = FastMCP("retry-after-fail")
     mock_container = MagicMock()
+    mock_container.initialize_services = AsyncMock()
     mock_container.pipefy_client = MagicMock()
 
     with (
@@ -200,6 +205,7 @@ async def test_lifespan_tool_name_collision_fails_before_registration():
         return "foreign"
 
     mock_container = MagicMock()
+    mock_container.initialize_services = AsyncMock()
     mock_container.pipefy_client = MagicMock()
 
     with (
@@ -229,6 +235,7 @@ async def test_lifespan_partial_register_failure_cleans_pipefy_tools_retry_uses_
 
     app = FastMCP("partial-reg")
     mock_container = MagicMock()
+    mock_container.initialize_services = AsyncMock()
     client1 = MagicMock()
     client2 = MagicMock()
     mock_container.pipefy_client = client1


### PR DESCRIPTION
## Summary

Final step of #213 (umbrella). The MCP server now reaches the keychain-backed user session that PR-A (#216), PR-B (#217), the auth-settings split (#218), and PR-C (#225) put in place.

- ``ServicesContainer.initialize_services`` passes ``oidc_client=settings.auth.to_oidc_client()`` to ``resolve_pipefy_auth``, so the stored-session tier participates in the precedence chain.
- When the resolved tier is the stored session, ``ensure_fresh_session`` runs eagerly at lifespan init (wrapped in ``asyncio.to_thread``). Stale or revoked sessions surface as a startup error rather than as a confusing failure on the first MCP tool call.
- Higher-precedence tiers (``PIPEFY_TOKEN`` static-token, ``PIPEFY_SERVICE_ACCOUNT_*``) skip the warm-up; nothing about their wiring changes.
- ``initialize_services`` becomes ``async`` to host the awaited warm-up; the only caller (``lifespan`` in ``server.py``) is already async. ``test_server.py`` mocks swap ``MagicMock().initialize_services`` for ``AsyncMock``.

No new env vars: ``PIPEFY_AUTH_URL`` and ``PIPEFY_AUTH_CLIENT_ID`` already exist on ``AuthSettings`` (introduced by #218); this PR is the consumer.

## Stacking

Stacked on ``#224`` so the live-fixture rewrites in ``packages/mcp/tests/`` don't conflict. Once ``#224`` lands this rebases trivially onto ``dev``. ``#225`` (cross-process refresh lock) is independent — the lock is internal to ``ensure_fresh_session`` and the API surface used here is unchanged.

## Test plan

- [x] ``uv run pytest packages/mcp packages/auth -m "not integration"`` — green
- [x] ``uv run pytest -m "not integration"`` — full repo green (2358 passed)
- [x] ``uv run ruff check packages && uv run ruff format --check packages`` — clean
- [ ] Manual: run the MCP server with a stored session active (no ``PIPEFY_TOKEN`` / ``PIPEFY_SERVICE_ACCOUNT_*``), confirm a tool call succeeds and the startup log emits ``Pipefy stored session warmed up at startup``.
- [ ] Manual: run the MCP server with an expired/revoked stored session, confirm the lifespan raises a clear ``RefreshError`` instead of failing on the first tool call.