### PR TITLE
feat(auth): reactive refresh-on-401 for stored-session tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **CLI**: `pipefy auth status [--json|-j]` — reports auth source, identity, session expiry, and exit codes.
 - **CLI**: `pipefy auth logout` — revokes the refresh token at the IdP and clears the stored session.
 - **MCP**: stored-session tier wired into `ServicesContainer`; setting `PIPEFY_AUTH_URL` after `pipefy auth login` now lets the MCP server reuse the keychain-backed session, with the refresh pre-warmed at startup so a stale or revoked session surfaces before the first tool call.
+- **Auth**: reactive refresh-on-401 for the stored-session tier (`RefreshableBearerAuth`). When an API call returns 401, the SDK transport forces a refresh via `ensure_fresh_session(force=True)`, persists any rotated tokens, and retries the request once before surfacing the error. Complements the eager refresh path for IdP-side revocation and mid-process token expiry. Closes #137.
 
 ### Changed
 

--- a/packages/auth/src/pipefy_auth/__init__.py
+++ b/packages/auth/src/pipefy_auth/__init__.py
@@ -11,7 +11,11 @@ from __future__ import annotations
 
 __version__ = "0.2.0-beta.1"
 
-from pipefy_auth.bearer import CallableBearerAuth, StaticBearerAuth
+from pipefy_auth.bearer import (
+    CallableBearerAuth,
+    RefreshableBearerAuth,
+    StaticBearerAuth,
+)
 from pipefy_auth.discovery import (
     DiscoveryPolicy,
     ProviderMetadata,
@@ -60,6 +64,7 @@ __all__ = [
     "OidcClient",
     "ProviderMetadata",
     "RefreshError",
+    "RefreshableBearerAuth",
     "RevocationError",
     "RevocationUnsupportedError",
     "SERVICE_ACCOUNT_TIER",

--- a/packages/auth/src/pipefy_auth/bearer.py
+++ b/packages/auth/src/pipefy_auth/bearer.py
@@ -8,6 +8,8 @@ from typing import AsyncGenerator
 
 from httpx import Auth, Request, Response
 
+from pipefy_auth.refresh import RefreshError
+
 
 class StaticBearerAuth(Auth):
     """Attach a fixed ``Authorization: Bearer …`` header."""
@@ -46,7 +48,78 @@ class CallableBearerAuth(Auth):
         yield request
 
 
+class RefreshableBearerAuth(Auth):
+    """Per-request bearer + reactive refresh-on-401 retry.
+
+    Pairs the per-request token rotation behaviour of :class:`CallableBearerAuth`
+    with a 401 safety net: when an API call returns 401, ``force_refresh`` is
+    invoked to obtain a new bearer and the request is retried exactly once. If
+    the refresh fails (raises) or returns ``None`` / the same token, the 401
+    propagates so callers surface a "session expired, re-login" error instead
+    of looping.
+
+    The eager refresh path (``token_provider`` calling
+    :func:`pipefy_auth.refresh.ensure_fresh_session`) still handles the common
+    "token expired by our clock" case. This class fills the gap eager refresh
+    cannot see — IdP-side revocation, and the narrow race between the eager
+    check and the API call.
+
+    Concurrency model: under async fan-out, the internal lock **serializes**
+    ``force_refresh`` calls — three concurrent 401s will run three refreshes
+    back-to-back, not one shared refresh. Coalescing belongs to a future
+    cross-process mutex (issue #133); the in-class lock only guarantees that
+    refreshes are not interleaved.
+    """
+
+    def __init__(
+        self,
+        *,
+        token_provider: Callable[[], str],
+        force_refresh: Callable[[], str | None],
+    ) -> None:
+        self._token_provider = token_provider
+        self._force_refresh = force_refresh
+        self._async_lock = asyncio.Lock()
+
+    def auth_flow(self, request: Request) -> Generator[Request, Response, None]:
+        token = self._token_provider()
+        request.headers["Authorization"] = f"Bearer {token}"
+        response = yield request
+        if response.status_code != 401:
+            return
+        new_token = self._safe_force_refresh()
+        if new_token is None or new_token == token:
+            return
+        request.headers["Authorization"] = f"Bearer {new_token}"
+        yield request
+
+    async def async_auth_flow(
+        self, request: Request
+    ) -> AsyncGenerator[Request, Response]:
+        async with self._async_lock:
+            token = await asyncio.to_thread(self._token_provider)
+        request.headers["Authorization"] = f"Bearer {token}"
+        response = yield request
+        if response.status_code != 401:
+            return
+        async with self._async_lock:
+            new_token = await asyncio.to_thread(self._safe_force_refresh)
+        if new_token is None or new_token == token:
+            return
+        request.headers["Authorization"] = f"Bearer {new_token}"
+        yield request
+
+    def _safe_force_refresh(self) -> str | None:
+        # Narrow on purpose: programming errors (AttributeError, TypeError, …)
+        # should surface, not collapse into a 401.
+        try:
+            return self._force_refresh()
+        except (RefreshError, RuntimeError):
+            return None
+
+
 __all__ = [
     "CallableBearerAuth",
+    "RefreshableBearerAuth",
     "StaticBearerAuth",
 ]

--- a/packages/auth/src/pipefy_auth/bearer.py
+++ b/packages/auth/src/pipefy_auth/bearer.py
@@ -65,10 +65,11 @@ class RefreshableBearerAuth(Auth):
     check and the API call.
 
     Concurrency model: under async fan-out, the internal lock **serializes**
-    ``force_refresh`` calls — three concurrent 401s will run three refreshes
-    back-to-back, not one shared refresh. Coalescing belongs to a future
-    cross-process mutex (issue #133); the in-class lock only guarantees that
-    refreshes are not interleaved.
+    both eager token reads (``token_provider``) and reactive refreshes
+    (``force_refresh``) — three concurrent 401s run three refreshes
+    back-to-back, not one shared refresh. Coalescing racing refreshes is
+    out of scope here; it's the responsibility of the refresh-token grant
+    path.
     """
 
     def __init__(
@@ -110,11 +111,9 @@ class RefreshableBearerAuth(Auth):
         yield request
 
     def _safe_force_refresh(self) -> str | None:
-        # Narrow on purpose: programming errors (AttributeError, TypeError, …)
-        # should surface, not collapse into a 401.
         try:
             return self._force_refresh()
-        except (RefreshError, RuntimeError):
+        except RefreshError:
             return None
 
 

--- a/packages/auth/src/pipefy_auth/bearer.py
+++ b/packages/auth/src/pipefy_auth/bearer.py
@@ -3,12 +3,9 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable, Generator
-from typing import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable, Generator
 
 from httpx import Auth, Request, Response
-
-from pipefy_auth.refresh import RefreshError
 
 
 class StaticBearerAuth(Auth):
@@ -54,9 +51,10 @@ class RefreshableBearerAuth(Auth):
     Pairs the per-request token rotation behaviour of :class:`CallableBearerAuth`
     with a 401 safety net: when an API call returns 401, ``force_refresh`` is
     invoked to obtain a new bearer and the request is retried exactly once. If
-    the refresh fails (raises) or returns ``None`` / the same token, the 401
-    propagates so callers surface a "session expired, re-login" error instead
-    of looping.
+    it returns ``None`` or the same token, the 401 propagates so callers surface
+    a "session expired, re-login" error instead of looping. ``force_refresh`` is
+    trusted to return ``str | None`` — translating an IdP failure (``RefreshError``)
+    into ``None`` is the wiring's job, not this class's.
 
     The eager refresh path (``token_provider`` calling
     :func:`pipefy_auth.refresh.ensure_fresh_session`) still handles the common
@@ -88,7 +86,7 @@ class RefreshableBearerAuth(Auth):
         response = yield request
         if response.status_code != 401:
             return
-        new_token = self._safe_force_refresh()
+        new_token = self._force_refresh()
         if new_token is None or new_token == token:
             return
         request.headers["Authorization"] = f"Bearer {new_token}"
@@ -104,17 +102,11 @@ class RefreshableBearerAuth(Auth):
         if response.status_code != 401:
             return
         async with self._async_lock:
-            new_token = await asyncio.to_thread(self._safe_force_refresh)
+            new_token = await asyncio.to_thread(self._force_refresh)
         if new_token is None or new_token == token:
             return
         request.headers["Authorization"] = f"Bearer {new_token}"
         yield request
-
-    def _safe_force_refresh(self) -> str | None:
-        try:
-            return self._force_refresh()
-        except RefreshError:
-            return None
 
 
 __all__ = [

--- a/packages/auth/src/pipefy_auth/refresh.py
+++ b/packages/auth/src/pipefy_auth/refresh.py
@@ -148,6 +148,7 @@ def ensure_fresh_session(
     issuer: str,
     client_id: str,
     leeway_s: int = _LEEWAY_S,
+    force: bool = False,
     http_client: httpx.Client | None = None,
 ) -> StoredSession | None:
     """Load the stored session; refresh it if the access token is near expiry.
@@ -155,6 +156,10 @@ def ensure_fresh_session(
     Returns ``None`` when no session is stored (or the keychain is unreachable
     — ``load_session`` already collapses those cases). Returns the (possibly
     refreshed) :class:`StoredSession` when one is usable.
+
+    ``force=True`` bypasses the deadline check and always refreshes when a
+    session is stored — used by the reactive 401-retry path to recover from
+    IdP-side revocation when the clock-side lifetime still looks fine.
 
     Concurrent ``pipefy`` processes near the leeway boundary are serialised
     via a cross-process filesystem lock; a re-load + re-check inside the
@@ -170,7 +175,7 @@ def ensure_fresh_session(
     session = load_session(issuer=issuer, client_id=client_id)
     if session is None:
         return None
-    if not _is_stale(session, leeway_s):
+    if not force and not _is_stale(session, leeway_s):
         return session
 
     try:
@@ -178,7 +183,7 @@ def ensure_fresh_session(
             session = load_session(issuer=issuer, client_id=client_id)
             if session is None:
                 return None
-            if not _is_stale(session, leeway_s):
+            if not force and not _is_stale(session, leeway_s):
                 return session
             return _refresh_and_store(
                 session,

--- a/packages/auth/src/pipefy_auth/resolver.py
+++ b/packages/auth/src/pipefy_auth/resolver.py
@@ -18,9 +18,13 @@ from dataclasses import dataclass
 from httpx import Auth
 from httpx_auth import OAuth2ClientCredentials
 
-from pipefy_auth.bearer import CallableBearerAuth, StaticBearerAuth
+from pipefy_auth.bearer import (
+    CallableBearerAuth,
+    RefreshableBearerAuth,
+    StaticBearerAuth,
+)
 from pipefy_auth.identity import OidcClient
-from pipefy_auth.refresh import ensure_fresh_session
+from pipefy_auth.refresh import RefreshError, ensure_fresh_session
 from pipefy_auth.storage import load_session
 
 STATIC_TOKEN_TIER = "static-token"
@@ -40,10 +44,13 @@ class ServiceAccount:
 # Maps each ``httpx.Auth`` implementation back to the resolver-tier name that
 # produced it. ``tier_for`` is the public lookup; the mapping itself is the
 # single source of truth so the wire-schema strings (e.g. ``"stored-session"``)
-# stay in one place.
+# stay in one place. ``CallableBearerAuth`` is listed alongside
+# ``RefreshableBearerAuth`` so consumers who build one directly still resolve
+# to the stored-session tier.
 _TIER_BY_AUTH_TYPE: dict[type[Auth], str] = {
     StaticBearerAuth: STATIC_TOKEN_TIER,
     OAuth2ClientCredentials: SERVICE_ACCOUNT_TIER,
+    RefreshableBearerAuth: STORED_SESSION_TIER,
     CallableBearerAuth: STORED_SESSION_TIER,
 }
 
@@ -64,8 +71,8 @@ def tier_for(auth: Auth) -> str:
     )
 
 
-def _stored_session_provider(oidc_client: OidcClient) -> CallableBearerAuth:
-    def _provider() -> str:
+def _stored_session_provider(oidc_client: OidcClient) -> RefreshableBearerAuth:
+    def _token() -> str:
         session = ensure_fresh_session(
             issuer=oidc_client.issuer_url, client_id=oidc_client.client_id
         )
@@ -75,7 +82,18 @@ def _stored_session_provider(oidc_client: OidcClient) -> CallableBearerAuth:
             )
         return session.access_token
 
-    return CallableBearerAuth(_provider)
+    def _force_refresh() -> str | None:
+        try:
+            session = ensure_fresh_session(
+                issuer=oidc_client.issuer_url,
+                client_id=oidc_client.client_id,
+                force=True,
+            )
+        except RefreshError:
+            return None
+        return session.access_token if session is not None else None
+
+    return RefreshableBearerAuth(token_provider=_token, force_refresh=_force_refresh)
 
 
 def _has_stored_session(oidc_client: OidcClient) -> bool:
@@ -108,7 +126,9 @@ def resolve_pipefy_auth(
         service_account: Service-account client-credentials inputs.
         oidc_client: OIDC client identity for the stored-session tier; the
             session is loaded from the keychain at detection time, and a fresh
-            access token is fetched per request via :class:`CallableBearerAuth`.
+            access token is fetched per request via
+            :class:`pipefy_auth.bearer.RefreshableBearerAuth`, which also
+            forces a refresh + retry on a 401 response.
     """
     if static_token and static_token.strip():
         return StaticBearerAuth(static_token.strip())

--- a/packages/auth/tests/test_bearer.py
+++ b/packages/auth/tests/test_bearer.py
@@ -116,7 +116,7 @@ class TestRefreshableBearerAuthSync:
         assert refresh_calls == []
 
     @pytest.mark.unit
-    def test_refresh_raises_lets_401_propagate(self) -> None:
+    def test_force_refresh_exception_is_not_swallowed(self) -> None:
         seen: list[str] = []
 
         def force_refresh() -> str | None:
@@ -129,9 +129,8 @@ class TestRefreshableBearerAuthSync:
             token_provider=lambda: "OLD", force_refresh=force_refresh
         )
 
-        response = client.get("https://example.test/", auth=auth)
-
-        assert response.status_code == 401
+        with pytest.raises(RefreshError):
+            client.get("https://example.test/", auth=auth)
         assert seen == ["Bearer OLD"]
 
     @pytest.mark.unit
@@ -202,7 +201,7 @@ class TestRefreshableBearerAuthAsync:
 
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_refresh_error_lets_401_propagate(self) -> None:
+    async def test_force_refresh_exception_is_not_swallowed(self) -> None:
         seen: list[str] = []
         transport = httpx.MockTransport(_scripted_handler([401], seen))
 
@@ -214,9 +213,8 @@ class TestRefreshableBearerAuthAsync:
         )
 
         async with httpx.AsyncClient(transport=transport) as client:
-            response = await client.get("https://example.test/", auth=auth)
-
-        assert response.status_code == 401
+            with pytest.raises(RefreshError):
+                await client.get("https://example.test/", auth=auth)
         assert seen == ["Bearer OLD"]
 
     @pytest.mark.unit

--- a/packages/auth/tests/test_bearer.py
+++ b/packages/auth/tests/test_bearer.py
@@ -1,13 +1,20 @@
-"""Unit tests for ``pipefy_auth.bearer`` (Static + Callable bearer adapters)."""
+"""Unit tests for ``pipefy_auth.bearer`` (Static, Callable, Refreshable adapters)."""
 
 from __future__ import annotations
 
 import asyncio
+import threading
+from collections.abc import Callable
 
 import httpx
 import pytest
 
-from pipefy_auth.bearer import CallableBearerAuth, StaticBearerAuth
+from pipefy_auth.bearer import (
+    CallableBearerAuth,
+    RefreshableBearerAuth,
+    StaticBearerAuth,
+)
+from pipefy_auth.refresh import RefreshError
 
 
 @pytest.mark.unit
@@ -54,3 +61,229 @@ async def test_callable_bearer_async_serializes_provider_calls():
     headers = await asyncio.gather(one_call(), one_call(), one_call())
     assert headers == ["Bearer TOK"] * 3
     assert len(call_order) == 3
+
+
+# --------------------------------------------------------------------------- #
+# RefreshableBearerAuth — reactive 401-refresh-retry safety net.              #
+# --------------------------------------------------------------------------- #
+
+
+def _scripted_handler(
+    statuses: list[int], seen: list[str]
+) -> Callable[[httpx.Request], httpx.Response]:
+    """Mock transport: returns ``statuses`` in order; records sent ``Authorization``."""
+    iterator = iter(statuses)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.headers.get("Authorization", ""))
+        return httpx.Response(next(iterator))
+
+    return handler
+
+
+class TestRefreshableBearerAuthSync:
+    @pytest.mark.unit
+    def test_happy_path_401_then_refresh_then_retry(self) -> None:
+        seen: list[str] = []
+        client = httpx.Client(
+            transport=httpx.MockTransport(_scripted_handler([401, 200], seen))
+        )
+        auth = RefreshableBearerAuth(
+            token_provider=lambda: "OLD",
+            force_refresh=lambda: "NEW",
+        )
+
+        response = client.get("https://example.test/", auth=auth)
+
+        assert response.status_code == 200
+        assert seen == ["Bearer OLD", "Bearer NEW"]
+
+    @pytest.mark.unit
+    def test_no_401_no_refresh_call(self) -> None:
+        seen: list[str] = []
+        refresh_calls: list[int] = []
+
+        def force_refresh() -> str:
+            refresh_calls.append(1)
+            return "NEW"
+
+        client = httpx.Client(
+            transport=httpx.MockTransport(_scripted_handler([200], seen))
+        )
+        auth = RefreshableBearerAuth(
+            token_provider=lambda: "OLD", force_refresh=force_refresh
+        )
+
+        response = client.get("https://example.test/", auth=auth)
+
+        assert response.status_code == 200
+        assert seen == ["Bearer OLD"]
+        assert refresh_calls == []
+
+    @pytest.mark.unit
+    def test_refresh_raises_lets_401_propagate(self) -> None:
+        seen: list[str] = []
+
+        def force_refresh() -> str | None:
+            raise RefreshError("invalid_grant", error_code="invalid_grant")
+
+        client = httpx.Client(
+            transport=httpx.MockTransport(_scripted_handler([401], seen))
+        )
+        auth = RefreshableBearerAuth(
+            token_provider=lambda: "OLD", force_refresh=force_refresh
+        )
+
+        response = client.get("https://example.test/", auth=auth)
+
+        assert response.status_code == 401
+        assert seen == ["Bearer OLD"]
+
+    @pytest.mark.unit
+    def test_refresh_returns_none_lets_401_propagate(self) -> None:
+        seen: list[str] = []
+        client = httpx.Client(
+            transport=httpx.MockTransport(_scripted_handler([401], seen))
+        )
+        auth = RefreshableBearerAuth(
+            token_provider=lambda: "OLD",
+            force_refresh=lambda: None,
+        )
+
+        response = client.get("https://example.test/", auth=auth)
+
+        assert response.status_code == 401
+        assert seen == ["Bearer OLD"]
+
+    @pytest.mark.unit
+    def test_refresh_returns_same_token_does_not_retry(self) -> None:
+        # A no-op refresh must not retry — same bearer would just 401 again.
+        seen: list[str] = []
+        client = httpx.Client(
+            transport=httpx.MockTransport(_scripted_handler([401], seen))
+        )
+        auth = RefreshableBearerAuth(
+            token_provider=lambda: "OLD",
+            force_refresh=lambda: "OLD",
+        )
+
+        response = client.get("https://example.test/", auth=auth)
+
+        assert response.status_code == 401
+        assert seen == ["Bearer OLD"]
+
+    @pytest.mark.unit
+    def test_retry_also_401_does_not_loop(self) -> None:
+        seen: list[str] = []
+        client = httpx.Client(
+            transport=httpx.MockTransport(_scripted_handler([401, 401], seen))
+        )
+        auth = RefreshableBearerAuth(
+            token_provider=lambda: "OLD",
+            force_refresh=lambda: "NEW",
+        )
+
+        response = client.get("https://example.test/", auth=auth)
+
+        # Only the retry runs once — the second 401 is the terminal answer.
+        assert response.status_code == 401
+        assert seen == ["Bearer OLD", "Bearer NEW"]
+
+
+class TestRefreshableBearerAuthAsync:
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_happy_path_401_then_refresh_then_retry(self) -> None:
+        seen: list[str] = []
+        transport = httpx.MockTransport(_scripted_handler([401, 200], seen))
+        auth = RefreshableBearerAuth(
+            token_provider=lambda: "OLD",
+            force_refresh=lambda: "NEW",
+        )
+
+        async with httpx.AsyncClient(transport=transport) as client:
+            response = await client.get("https://example.test/", auth=auth)
+
+        assert response.status_code == 200
+        assert seen == ["Bearer OLD", "Bearer NEW"]
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_refresh_error_lets_401_propagate(self) -> None:
+        seen: list[str] = []
+        transport = httpx.MockTransport(_scripted_handler([401], seen))
+
+        def force_refresh() -> str | None:
+            raise RefreshError("invalid_grant", error_code="invalid_grant")
+
+        auth = RefreshableBearerAuth(
+            token_provider=lambda: "OLD", force_refresh=force_refresh
+        )
+
+        async with httpx.AsyncClient(transport=transport) as client:
+            response = await client.get("https://example.test/", auth=auth)
+
+        assert response.status_code == 401
+        assert seen == ["Bearer OLD"]
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_concurrent_401s_serialize_under_async_lock(self) -> None:
+        """Under async fan-out, ``force_refresh`` runs serially — never two
+        threads inside it at once. Probed with ``threading.Barrier(parties=3)``:
+        without the lock all three threads rendezvous, with the lock only one
+        ever arrives and the barrier raises ``BrokenBarrierError``. Three
+        refresh calls (not one) pins the serialize-but-don't-coalesce contract;
+        coalescing belongs to the cross-process mutex in issue #133.
+        """
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.headers.get("Authorization") == "Bearer NEW":
+                return httpx.Response(200)
+            return httpx.Response(401)
+
+        barrier = threading.Barrier(parties=3, timeout=0.5)
+        state_lock = threading.Lock()
+        concurrent_rendezvous = 0
+        serialized_timeouts = 0
+        refresh_calls = 0
+
+        def force_refresh() -> str:
+            nonlocal concurrent_rendezvous, serialized_timeouts, refresh_calls
+            with state_lock:
+                refresh_calls += 1
+            try:
+                barrier.wait()
+            except threading.BrokenBarrierError:
+                with state_lock:
+                    serialized_timeouts += 1
+                return "NEW"
+            with state_lock:
+                concurrent_rendezvous += 1
+            return "NEW"
+
+        transport = httpx.MockTransport(handler)
+        auth = RefreshableBearerAuth(
+            token_provider=lambda: "OLD",
+            force_refresh=force_refresh,
+        )
+
+        async with httpx.AsyncClient(transport=transport) as client:
+            results = await asyncio.gather(
+                client.get("https://example.test/", auth=auth),
+                client.get("https://example.test/", auth=auth),
+                client.get("https://example.test/", auth=auth),
+            )
+
+        assert all(r.status_code == 200 for r in results)
+        assert concurrent_rendezvous == 0, (
+            "async lock must prevent concurrent force_refresh entry; "
+            f"{concurrent_rendezvous} thread(s) reached the barrier rendezvous"
+        )
+        assert serialized_timeouts == 3, (
+            "every force_refresh call must time out alone at the barrier — "
+            f"got {serialized_timeouts}"
+        )
+        assert refresh_calls == 3, (
+            "serialize-not-coalesce: three concurrent 401s drive three refreshes"
+        )

--- a/packages/auth/tests/test_bearer.py
+++ b/packages/auth/tests/test_bearer.py
@@ -222,8 +222,6 @@ class TestRefreshableBearerAuthAsync:
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_retry_also_401_does_not_loop(self) -> None:
-        # Async-generator yield semantics differ from sync; pin that the
-        # second ``yield request`` fires at most once even when it also 401s.
         seen: list[str] = []
         transport = httpx.MockTransport(_scripted_handler([401, 401], seen))
         auth = RefreshableBearerAuth(

--- a/packages/auth/tests/test_bearer.py
+++ b/packages/auth/tests/test_bearer.py
@@ -63,11 +63,6 @@ async def test_callable_bearer_async_serializes_provider_calls():
     assert len(call_order) == 3
 
 
-# --------------------------------------------------------------------------- #
-# RefreshableBearerAuth — reactive 401-refresh-retry safety net.              #
-# --------------------------------------------------------------------------- #
-
-
 def _scripted_handler(
     statuses: list[int], seen: list[str]
 ) -> Callable[[httpx.Request], httpx.Response]:
@@ -157,7 +152,6 @@ class TestRefreshableBearerAuthSync:
 
     @pytest.mark.unit
     def test_refresh_returns_same_token_does_not_retry(self) -> None:
-        # A no-op refresh must not retry — same bearer would just 401 again.
         seen: list[str] = []
         client = httpx.Client(
             transport=httpx.MockTransport(_scripted_handler([401], seen))
@@ -185,7 +179,6 @@ class TestRefreshableBearerAuthSync:
 
         response = client.get("https://example.test/", auth=auth)
 
-        # Only the retry runs once — the second 401 is the terminal answer.
         assert response.status_code == 401
         assert seen == ["Bearer OLD", "Bearer NEW"]
 
@@ -228,13 +221,31 @@ class TestRefreshableBearerAuthAsync:
 
     @pytest.mark.unit
     @pytest.mark.asyncio
+    async def test_retry_also_401_does_not_loop(self) -> None:
+        # Async-generator yield semantics differ from sync; pin that the
+        # second ``yield request`` fires at most once even when it also 401s.
+        seen: list[str] = []
+        transport = httpx.MockTransport(_scripted_handler([401, 401], seen))
+        auth = RefreshableBearerAuth(
+            token_provider=lambda: "OLD",
+            force_refresh=lambda: "NEW",
+        )
+
+        async with httpx.AsyncClient(transport=transport) as client:
+            response = await client.get("https://example.test/", auth=auth)
+
+        assert response.status_code == 401
+        assert seen == ["Bearer OLD", "Bearer NEW"]
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
     async def test_concurrent_401s_serialize_under_async_lock(self) -> None:
         """Under async fan-out, ``force_refresh`` runs serially — never two
         threads inside it at once. Probed with ``threading.Barrier(parties=3)``:
         without the lock all three threads rendezvous, with the lock only one
         ever arrives and the barrier raises ``BrokenBarrierError``. Three
         refresh calls (not one) pins the serialize-but-don't-coalesce contract;
-        coalescing belongs to the cross-process mutex in issue #133.
+        coalescing racing refreshes is out of scope for this class.
         """
 
         def handler(request: httpx.Request) -> httpx.Response:

--- a/packages/auth/tests/test_refresh.py
+++ b/packages/auth/tests/test_refresh.py
@@ -289,6 +289,92 @@ class TestEnsureFreshSession:
         # Session is still present (user can retry / re-login).
         assert storage.load_session(issuer=_ISSUER, client_id=_CLIENT_ID) is not None
 
+    def test_force_true_refreshes_even_when_fresh(
+        self,
+        fake_keyring: InMemoryKeyring,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _seed_session(monkeypatch, obtained_at=int(time.time()), expires_in=300)
+        client = httpx.Client(
+            transport=httpx.MockTransport(
+                _build_handler(
+                    token_payload={
+                        "access_token": "FORCED",
+                        "refresh_token": "FORCED_R",
+                    }
+                )
+            )
+        )
+        result = refresh.ensure_fresh_session(
+            issuer=_ISSUER,
+            client_id=_CLIENT_ID,
+            force=True,
+            http_client=client,
+        )
+        assert result is not None
+        assert result.access_token == "FORCED"
+        assert result.refresh_token == "FORCED_R"
+
+    def test_force_true_persists_rotated_session(
+        self,
+        fake_keyring: InMemoryKeyring,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _seed_session(monkeypatch, obtained_at=int(time.time()), expires_in=300)
+        client = httpx.Client(
+            transport=httpx.MockTransport(
+                _build_handler(
+                    token_payload={
+                        "access_token": "FORCED",
+                        "refresh_token": "FORCED_R",
+                    }
+                )
+            )
+        )
+        refresh.ensure_fresh_session(
+            issuer=_ISSUER,
+            client_id=_CLIENT_ID,
+            force=True,
+            http_client=client,
+        )
+        reloaded = storage.load_session(issuer=_ISSUER, client_id=_CLIENT_ID)
+        assert reloaded is not None
+        assert reloaded.access_token == "FORCED"
+        assert reloaded.refresh_token == "FORCED_R"
+
+    def test_force_true_returns_none_when_no_session_stored(
+        self, fake_keyring: InMemoryKeyring
+    ) -> None:
+        assert (
+            refresh.ensure_fresh_session(
+                issuer=_ISSUER, client_id=_CLIENT_ID, force=True
+            )
+            is None
+        )
+
+    def test_force_true_raises_refresh_error_on_idp_failure(
+        self,
+        fake_keyring: InMemoryKeyring,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _seed_session(monkeypatch, obtained_at=int(time.time()), expires_in=300)
+        client = httpx.Client(
+            transport=httpx.MockTransport(
+                _build_handler(
+                    token_status=400,
+                    token_payload={"error": "invalid_grant"},
+                )
+            )
+        )
+        with pytest.raises(refresh.RefreshError) as exc_info:
+            refresh.ensure_fresh_session(
+                issuer=_ISSUER,
+                client_id=_CLIENT_ID,
+                force=True,
+                http_client=client,
+            )
+        assert exc_info.value.error_code == "invalid_grant"
+
 
 # --------------------------------------------------------------------------- #
 # refresh_access_token (low-level)                                            #

--- a/packages/auth/tests/test_resolver.py
+++ b/packages/auth/tests/test_resolver.py
@@ -159,8 +159,6 @@ def test_tier_for_raises_on_foreign_auth_class():
 
 @pytest.mark.unit
 def test_tier_for_recognises_callable_bearer_auth_as_stored_session():
-    # Regression guard: ``CallableBearerAuth`` is still public — direct
-    # construction must keep resolving to the stored-session tier.
     auth = CallableBearerAuth(lambda: "TOKEN")
     assert tier_for(auth) == STORED_SESSION_TIER
 

--- a/packages/auth/tests/test_resolver.py
+++ b/packages/auth/tests/test_resolver.py
@@ -7,8 +7,13 @@ import time
 import pytest
 from httpx_auth import OAuth2ClientCredentials
 
-from pipefy_auth.bearer import CallableBearerAuth, StaticBearerAuth
+from pipefy_auth.bearer import (
+    CallableBearerAuth,
+    RefreshableBearerAuth,
+    StaticBearerAuth,
+)
 from pipefy_auth.identity import OidcClient
+from pipefy_auth.refresh import RefreshError
 from pipefy_auth.resolver import (
     SERVICE_ACCOUNT_TIER,
     STATIC_TOKEN_TIER,
@@ -92,7 +97,7 @@ def test_stored_session_wins_when_nothing_else_configured(monkeypatch):
         "pipefy_auth.resolver.load_session", lambda **_: _stored_session()
     )
     resolved = resolve_pipefy_auth(oidc_client=_oidc())
-    assert isinstance(resolved, CallableBearerAuth)
+    assert isinstance(resolved, RefreshableBearerAuth)
     assert tier_for(resolved) == STORED_SESSION_TIER
 
 
@@ -153,6 +158,14 @@ def test_tier_for_raises_on_foreign_auth_class():
 
 
 @pytest.mark.unit
+def test_tier_for_recognises_callable_bearer_auth_as_stored_session():
+    # Regression guard: ``CallableBearerAuth`` is still public — direct
+    # construction must keep resolving to the stored-session tier.
+    auth = CallableBearerAuth(lambda: "TOKEN")
+    assert tier_for(auth) == STORED_SESSION_TIER
+
+
+@pytest.mark.unit
 def test_stored_session_provider_raises_when_session_vanishes(monkeypatch):
     """The callable provider raises if the keychain entry disappears after detect."""
     monkeypatch.setattr(
@@ -160,10 +173,67 @@ def test_stored_session_provider_raises_when_session_vanishes(monkeypatch):
     )
     monkeypatch.setattr("pipefy_auth.resolver.ensure_fresh_session", lambda **_: None)
     resolved = resolve_pipefy_auth(oidc_client=_oidc())
-    assert isinstance(resolved, CallableBearerAuth)
+    assert isinstance(resolved, RefreshableBearerAuth)
     provider = resolved._token_provider  # type: ignore[attr-defined]
     with pytest.raises(RuntimeError, match="session was removed"):
         provider()
+
+
+@pytest.mark.unit
+def test_stored_session_force_refresh_calls_ensure_fresh_session_with_force(
+    monkeypatch,
+):
+    rotated = _stored_session()
+    monkeypatch.setattr("pipefy_auth.resolver.load_session", lambda **_: rotated)
+    captured: dict[str, object] = {}
+
+    def fake_ensure(**kwargs):
+        captured.update(kwargs)
+        return StoredSession(
+            issuer=rotated.issuer,
+            client_id=rotated.client_id,
+            access_token="ROTATED",
+            refresh_token="ROTATED_R",
+            token_type="Bearer",
+            obtained_at=int(time.time()),
+            expires_in=3600,
+            refresh_expires_in=None,
+            scope=None,
+            id_token=None,
+        )
+
+    monkeypatch.setattr("pipefy_auth.resolver.ensure_fresh_session", fake_ensure)
+    resolved = resolve_pipefy_auth(oidc_client=_oidc())
+    assert isinstance(resolved, RefreshableBearerAuth)
+    new_token = resolved._force_refresh()  # type: ignore[attr-defined]
+    assert new_token == "ROTATED"
+    assert captured.get("force") is True
+
+
+@pytest.mark.unit
+def test_stored_session_force_refresh_returns_none_on_refresh_error(monkeypatch):
+    monkeypatch.setattr(
+        "pipefy_auth.resolver.load_session", lambda **_: _stored_session()
+    )
+
+    def fake_ensure(**_: object) -> StoredSession:
+        raise RefreshError("invalid_grant", error_code="invalid_grant")
+
+    monkeypatch.setattr("pipefy_auth.resolver.ensure_fresh_session", fake_ensure)
+    resolved = resolve_pipefy_auth(oidc_client=_oidc())
+    assert isinstance(resolved, RefreshableBearerAuth)
+    assert resolved._force_refresh() is None  # type: ignore[attr-defined]
+
+
+@pytest.mark.unit
+def test_stored_session_force_refresh_returns_none_when_session_vanished(monkeypatch):
+    monkeypatch.setattr(
+        "pipefy_auth.resolver.load_session", lambda **_: _stored_session()
+    )
+    monkeypatch.setattr("pipefy_auth.resolver.ensure_fresh_session", lambda **_: None)
+    resolved = resolve_pipefy_auth(oidc_client=_oidc())
+    assert isinstance(resolved, RefreshableBearerAuth)
+    assert resolved._force_refresh() is None  # type: ignore[attr-defined]
 
 
 class MockCounter:

--- a/packages/cli/src/pipefy_cli/auth.py
+++ b/packages/cli/src/pipefy_cli/auth.py
@@ -160,8 +160,7 @@ def get_authenticated_client(
 
     # Stored-session: warm up eagerly so refresh failures surface as a clean
     # exit(2) with a "run `pipefy auth login` again" hint instead of leaking
-    # out as a transport error on the first GraphQL call. ``CallableBearerAuth``
-    # observes the rotated token on subsequent requests.
+    # out as a transport error on the first GraphQL call.
     if tier == STORED_SESSION_TIER:
         if auth.oidc_client is None:
             # Unreachable per the resolver contract; guard kept so the

--- a/packages/cli/tests/test_auth.py
+++ b/packages/cli/tests/test_auth.py
@@ -327,8 +327,7 @@ def test_refresh_error_exits_2_with_relogin_hint(clean_pipefy_env, capsys):
             side_effect=RefreshError("invalid_grant"),
         ),
     ):
-        # ``resolve_pipefy_auth`` now returns the ``httpx.Auth`` directly;
-        # use a real ``RefreshableBearerAuth`` so ``tier_for`` recognises it as
+        # Use a real ``RefreshableBearerAuth`` so ``tier_for`` recognises it as
         # the stored-session tier and triggers the eager warmup.
         mock_resolve.return_value = RefreshableBearerAuth(
             token_provider=lambda: "ACCESS",

--- a/packages/cli/tests/test_auth.py
+++ b/packages/cli/tests/test_auth.py
@@ -8,8 +8,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import typer
 from pipefy_auth import (
-    CallableBearerAuth,
     OidcClient,
+    RefreshableBearerAuth,
     ServiceAccount,
     StaticBearerAuth,
     StoredSession,
@@ -287,7 +287,7 @@ def test_stored_session_used_when_no_other_source(clean_pipefy_env):
             _public_only_auth(issuer_url=_ISSUER, client_id="pipefy-cli"),
         )
         mock_pc.assert_called_once()
-        assert isinstance(mock_pc.call_args.kwargs["auth"], CallableBearerAuth)
+        assert isinstance(mock_pc.call_args.kwargs["auth"], RefreshableBearerAuth)
 
 
 def test_cache_reuses_resolved_auth_for_stored_session(clean_pipefy_env):
@@ -328,9 +328,12 @@ def test_refresh_error_exits_2_with_relogin_hint(clean_pipefy_env, capsys):
         ),
     ):
         # ``resolve_pipefy_auth`` now returns the ``httpx.Auth`` directly;
-        # use a real ``CallableBearerAuth`` so ``tier_for`` recognises it as
+        # use a real ``RefreshableBearerAuth`` so ``tier_for`` recognises it as
         # the stored-session tier and triggers the eager warmup.
-        mock_resolve.return_value = CallableBearerAuth(lambda: "ACCESS")
+        mock_resolve.return_value = RefreshableBearerAuth(
+            token_provider=lambda: "ACCESS",
+            force_refresh=lambda: None,
+        )
         with pytest.raises(typer.Exit) as excinfo:
             get_authenticated_client(
                 settings,

--- a/packages/mcp/tests/core/test_container.py
+++ b/packages/mcp/tests/core/test_container.py
@@ -3,7 +3,12 @@ import time
 from unittest.mock import Mock, patch
 
 import pytest
-from pipefy_auth import AuthSettings, CallableBearerAuth, RefreshError, StaticBearerAuth
+from pipefy_auth import (
+    AuthSettings,
+    RefreshableBearerAuth,
+    RefreshError,
+    StaticBearerAuth,
+)
 from pipefy_auth.storage import StoredSession
 from pipefy_sdk import PipefyClient, PipefySettings
 
@@ -218,7 +223,7 @@ class TestServicesContainer:
             await ServicesContainer().initialize_services(settings)
 
         pc_auth = mock_pipefy_client_class.call_args.kwargs["auth"]
-        assert isinstance(pc_auth, CallableBearerAuth)
+        assert isinstance(pc_auth, RefreshableBearerAuth)
         mock_ensure_fresh_session.assert_called_once_with(
             issuer="https://signin.pipefy.com/realms/pipefy",
             client_id=settings.auth.auth_client_id,


### PR DESCRIPTION
## Summary

PR #131 wired **eager** refresh: `ensure_fresh_session` checks the access token's clock-side age before each request through `CallableBearerAuth._stored_session_provider`. It does not cover **IdP-side revocation**: an admin force-logs the user out, the token still looks fresh by our clock, the next API call 401s and surfaces as a generic transport error instead of a "session expired" prompt.

This adds the reactive safety net: when an API call returns 401, force a refresh, retry the request once if the bearer changed, persist any rotated tokens. Eager refresh stays the primary path.

## What's new

- **`ensure_fresh_session(force=True)`** — bypasses the freshness deadline; reuses the carry-forward + keychain persistence path. Failure semantics unchanged: `RefreshError` on IdP failure, `None` when no session is stored.
- **`RefreshableBearerAuth(httpx.Auth)`** — per-request bearer + 401-refresh-retry hook. Sync (`auth_flow`) and async (`async_auth_flow`). Refreshes serialized via `asyncio.Lock`. The class trusts its `force_refresh: Callable[[], str | None]` contract — translating an IdP `RefreshError` into `None` is the resolver's job (the imperative shell that does the keychain + IdP I/O), keeping the auth flow free of error handling.
- **Resolver wiring** — `_stored_session_provider` returns `RefreshableBearerAuth`; its `force_refresh` callable runs `ensure_fresh_session(force=True)` and maps `RefreshError`/no-session to `None`. `CallableBearerAuth` stays a public primitive and `tier_for(CallableBearerAuth())` still resolves to `STORED_SESSION_TIER` (regression test included).

## Concurrency model (serialize, don't coalesce)

Three concurrent 401s run **three** refresh POSTs back-to-back under the lock, not one shared refresh. Coalescing belongs to the cross-process mutex tracked in #133; the in-class lock only guarantees refreshes are not interleaved. `test_concurrent_401s_serialize_under_async_lock` probes the lock with `threading.Barrier(parties=3)` — deterministic, no sleep-based race-widening.

## Out of scope

- Concurrent-refresh race / filesystem mutex (#133).
- Replacing eager refresh — both coexist; reactive is the safety net.
- `StaticBearerAuth` / `OAuth2ClientCredentials` paths — untouched.

## Test plan

- [x] `uv run pytest packages/auth/tests -m "not integration"` — auth package green (65 tests; sync + async behavior matrix, deterministic barrier-based concurrency probe)
- [x] `uv run pytest packages/cli/tests/test_auth.py` + `packages/mcp/tests/core/test_container.py` — stored-session warm-up asserts `RefreshableBearerAuth`
- [x] `uv run pytest -m "not integration"` (whole repo) — green except `test_initialize_services_raises_when_no_auth_source_configured`, a pre-existing failure on `dev` too (repo `.env` leaks `PIPEFY_OAUTH_*` into `AuthSettings()`; passes hermetically and in CI, which has no `.env`)
- [x] `uv run ruff check` + `ruff format --check` on touched packages — clean
- [x] Manual E2E against piporacle — corrupted the stored access token, ran `pipefy pipe list`; wire log showed `POST /graphql 401 → GET /.well-known → POST /token 200 → POST /graphql 200`, keychain access_token rotated, real data returned

Closes #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)