### PR TITLE
feat(auth): default PIPEFY_AUTH_URL to Pipefy production IdP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **CLI**: `pipefy auth status [--json|-j]` — reports auth source, identity, session expiry, and exit codes.
 - **CLI**: `pipefy auth logout` — revokes the refresh token at the IdP and clears the stored session.
+- **Auth**: `AuthSettings.auth_url` now defaults to `https://signin.pipefy.com/realms/pipefy` (Pipefy production IdP) when `PIPEFY_AUTH_URL` is unset — removes the previous `PIPEFY_AUTH_URL is required` exit-2 friction on `pipefy auth login` / `pipefy auth logout` and wires the MCP stored-session tier automatically after `pipefy auth login`. Override by setting `PIPEFY_AUTH_URL=<url>` to a non-prod IdP; explicit-empty `PIPEFY_AUTH_URL=` disables the stored-session tier on hosts that need it. User-level `~/.config/pipefy/config.toml` `auth_url` keys still override the default via the existing TOML fallback. Closes #233.
 - **MCP**: stored-session tier wired into `ServicesContainer`; setting `PIPEFY_AUTH_URL` after `pipefy auth login` now lets the MCP server reuse the keychain-backed session, with the refresh pre-warmed at startup so a stale or revoked session surfaces before the first tool call.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **CLI**: `pipefy auth status [--json|-j]` — reports auth source, identity, session expiry, and exit codes.
 - **CLI**: `pipefy auth logout` — revokes the refresh token at the IdP and clears the stored session.
-- **CLI**: `pipefy auth login` / `pipefy auth logout` now fall back to `https://signin.pipefy.com/realms/pipefy` (Pipefy production IdP) when `PIPEFY_AUTH_URL` is unset, removing the previous `PIPEFY_AUTH_URL is required` exit-2 friction for first-time / one-shot users. Scoped to the CLI commands only — the resolver / MCP server / SDK still require an explicit `PIPEFY_AUTH_URL` to activate the stored-session tier (so service-account-only deployments do not pay a keychain probe per invocation). Closes #233.
 - **MCP**: stored-session tier wired into `ServicesContainer`; setting `PIPEFY_AUTH_URL` after `pipefy auth login` now lets the MCP server reuse the keychain-backed session, with the refresh pre-warmed at startup so a stale or revoked session surfaces before the first tool call.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **CLI**: `pipefy auth status [--json|-j]` — reports auth source, identity, session expiry, and exit codes.
 - **CLI**: `pipefy auth logout` — revokes the refresh token at the IdP and clears the stored session.
+- **CLI**: `pipefy auth login` / `pipefy auth logout` now fall back to `https://signin.pipefy.com/realms/pipefy` (Pipefy production IdP) when `PIPEFY_AUTH_URL` is unset, removing the previous `PIPEFY_AUTH_URL is required` exit-2 friction for first-time / one-shot users. Scoped to the CLI commands only — the resolver / MCP server / SDK still require an explicit `PIPEFY_AUTH_URL` to activate the stored-session tier (so service-account-only deployments do not pay a keychain probe per invocation). Closes #233.
 - **MCP**: stored-session tier wired into `ServicesContainer`; setting `PIPEFY_AUTH_URL` after `pipefy auth login` now lets the MCP server reuse the keychain-backed session, with the refresh pre-warmed at startup so a stale or revoked session surfaces before the first tool call.
 
 ### Changed

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -91,7 +91,7 @@ PIPEFY_TOKEN="$MY_BEARER" uv run pipefy pipe list
 | `PIPEFY_SERVICE_ACCOUNT_CLIENT_ID` | Tier 3 | Service-account client id. |
 | `PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET` | Tier 3 | Service-account client secret. |
 | `PIPEFY_INTERNAL_API_URL` | Tier 3 | Internal GraphQL endpoint for AI automations / some relation flows. Required for those tools only. |
-| `PIPEFY_AUTH_URL` | Tier 4 | **OIDC issuer URL** for interactive login. The CLI appends `/.well-known/openid-configuration` to discover the authorization and token endpoints. Required for `pipefy auth login`. |
+| `PIPEFY_AUTH_URL` | Tier 4 | **OIDC issuer URL** for interactive login. The CLI appends `/.well-known/openid-configuration` to discover the authorization and token endpoints. **Defaults to `https://signin.pipefy.com/realms/pipefy` (Pipefy production IdP)**; set to an empty string (`PIPEFY_AUTH_URL=`) to disable the stored-session tier, or override to point at a non-prod IdP. |
 | `PIPEFY_AUTH_CLIENT_ID` | Tier 4 | Public client id registered for the CLI. Defaults to `pipefy-cli`. |
 
 `PIPEFY_SERVICE_ACCOUNT_URL` and `PIPEFY_AUTH_URL` are **not** interchangeable: the first is a token URL for client-credentials, the second is an OIDC issuer URL for the user-login flow.

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -91,7 +91,7 @@ PIPEFY_TOKEN="$MY_BEARER" uv run pipefy pipe list
 | `PIPEFY_SERVICE_ACCOUNT_CLIENT_ID` | Tier 3 | Service-account client id. |
 | `PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET` | Tier 3 | Service-account client secret. |
 | `PIPEFY_INTERNAL_API_URL` | Tier 3 | Internal GraphQL endpoint for AI automations / some relation flows. Required for those tools only. |
-| `PIPEFY_AUTH_URL` | Tier 4 | **OIDC issuer URL** for interactive login. The CLI appends `/.well-known/openid-configuration` to discover the authorization and token endpoints. **Defaults to `https://signin.pipefy.com/realms/pipefy` (Pipefy production IdP)**; set to an empty string (`PIPEFY_AUTH_URL=`) to disable the stored-session tier, or override to point at a non-prod IdP. |
+| `PIPEFY_AUTH_URL` | Tier 4 | **OIDC issuer URL** for interactive login. The CLI appends `/.well-known/openid-configuration` to discover the authorization and token endpoints. **`pipefy auth login` and `pipefy auth logout` fall back to `https://signin.pipefy.com/realms/pipefy` (Pipefy production IdP) when this variable is unset**; set it explicitly to point at a non-prod IdP or to opt into stored-session tier resolution in `pipefy auth status` / the MCP server / the SDK (which leave the tier inactive when the variable is unset). |
 | `PIPEFY_AUTH_CLIENT_ID` | Tier 4 | Public client id registered for the CLI. Defaults to `pipefy-cli`. |
 
 `PIPEFY_SERVICE_ACCOUNT_URL` and `PIPEFY_AUTH_URL` are **not** interchangeable: the first is a token URL for client-credentials, the second is an OIDC issuer URL for the user-login flow.

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -208,7 +208,7 @@ The keychain has a session but its refresh token won't exchange. Most common cau
 
 ### `PIPEFY_AUTH_URL is required for pipefy auth login`
 
-Tier 4 is explicitly disabled. With `PIPEFY_AUTH_URL` unset the CLI falls back to the Pipefy production issuer default, so this message means the var is set to an empty string (`PIPEFY_AUTH_URL=`) — usually to opt out of the stored-session tier on a host that can't reach prod. Unset the variable to restore the default, or set it to a valid issuer URL (see [Pipefy issuer URLs](#pipefy-issuer-urls)) if you need a non-prod IdP.
+The stored-session tier is explicitly disabled. With `PIPEFY_AUTH_URL` unset the CLI falls back to the Pipefy production issuer default, so this message means the var is set to an empty string (`PIPEFY_AUTH_URL=`) — usually to opt out of the stored-session tier on a host that can't reach prod. Unset the variable to restore the default, or set it to a valid issuer URL (see [Pipefy issuer URLs](#pipefy-issuer-urls)) if you need a non-prod IdP.
 
 ### `Login succeeded but the session could not be stored in your OS keychain (<backend>)`
 

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -171,7 +171,7 @@ When no session is stored, `pipefy auth logout` prints `Not signed in. Nothing t
 
 | Case | Exit |
 |------|------|
-| `PIPEFY_AUTH_URL` is unset | **2** — same gate as `pipefy auth login`. |
+| `PIPEFY_AUTH_URL` explicitly disabled (`PIPEFY_AUTH_URL=`) | **2** — same gate as `pipefy auth login`. With the var unset, the prod issuer default applies and this case does not trigger. |
 | No session stored (no-op) | **0** |
 | Session cleared (revoke succeeded, failed, or unsupported) | **0** |
 
@@ -208,7 +208,7 @@ The keychain has a session but its refresh token won't exchange. Most common cau
 
 ### `PIPEFY_AUTH_URL is required for pipefy auth login`
 
-You haven't set the issuer URL. Use the value from [Pipefy issuer URLs](#pipefy-issuer-urls). The same env var also gates whether tier 4 can fire from any other command — without it, the CLI never consults the keychain.
+Tier 4 is explicitly disabled. With `PIPEFY_AUTH_URL` unset the CLI falls back to the Pipefy production issuer default, so this message means the var is set to an empty string (`PIPEFY_AUTH_URL=`) — usually to opt out of the stored-session tier on a host that can't reach prod. Unset the variable to restore the default, or set it to a valid issuer URL (see [Pipefy issuer URLs](#pipefy-issuer-urls)) if you need a non-prod IdP.
 
 ### `Login succeeded but the session could not be stored in your OS keychain (<backend>)`
 

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -91,7 +91,7 @@ PIPEFY_TOKEN="$MY_BEARER" uv run pipefy pipe list
 | `PIPEFY_SERVICE_ACCOUNT_CLIENT_ID` | Tier 3 | Service-account client id. |
 | `PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET` | Tier 3 | Service-account client secret. |
 | `PIPEFY_INTERNAL_API_URL` | Tier 3 | Internal GraphQL endpoint for AI automations / some relation flows. Required for those tools only. |
-| `PIPEFY_AUTH_URL` | Tier 4 | **OIDC issuer URL** for interactive login. The CLI appends `/.well-known/openid-configuration` to discover the authorization and token endpoints. **`pipefy auth login` and `pipefy auth logout` fall back to `https://signin.pipefy.com/realms/pipefy` (Pipefy production IdP) when this variable is unset**; set it explicitly to point at a non-prod IdP or to opt into stored-session tier resolution in `pipefy auth status` / the MCP server / the SDK (which leave the tier inactive when the variable is unset). |
+| `PIPEFY_AUTH_URL` | Tier 4 | **OIDC issuer URL** for interactive login. The CLI appends `/.well-known/openid-configuration` to discover the authorization and token endpoints. **Defaults to `https://signin.pipefy.com/realms/pipefy` (Pipefy production IdP)**; set to an empty string (`PIPEFY_AUTH_URL=`) to disable the stored-session tier, or override to point at a non-prod IdP. |
 | `PIPEFY_AUTH_CLIENT_ID` | Tier 4 | Public client id registered for the CLI. Defaults to `pipefy-cli`. |
 
 `PIPEFY_SERVICE_ACCOUNT_URL` and `PIPEFY_AUTH_URL` are **not** interchangeable: the first is a token URL for client-credentials, the second is an OIDC issuer URL for the user-login flow.

--- a/packages/auth/src/pipefy_auth/__init__.py
+++ b/packages/auth/src/pipefy_auth/__init__.py
@@ -18,7 +18,7 @@ from pipefy_auth.discovery import (
     fetch_provider_metadata,
 )
 from pipefy_auth.flow import LoginError, LoginResult, run_login
-from pipefy_auth.identity import DEFAULT_AUTH_CLIENT_ID, OidcClient
+from pipefy_auth.identity import DEFAULT_AUTH_CLIENT_ID, DEFAULT_AUTH_URL, OidcClient
 from pipefy_auth.refresh import (
     RefreshError,
     ensure_fresh_session,
@@ -54,6 +54,7 @@ __all__ = [
     "AuthSettings",
     "CallableBearerAuth",
     "DEFAULT_AUTH_CLIENT_ID",
+    "DEFAULT_AUTH_URL",
     "DiscoveryPolicy",
     "LoginError",
     "LoginResult",

--- a/packages/auth/src/pipefy_auth/identity.py
+++ b/packages/auth/src/pipefy_auth/identity.py
@@ -8,6 +8,11 @@ from dataclasses import dataclass
 # is fixed across consumers (CLI, MCP, …) and not user-configurable.
 DEFAULT_AUTH_CLIENT_ID = "pipefy-cli"
 
+# Canonical Pipefy production OIDC issuer URL. Used as the default when
+# ``PIPEFY_AUTH_URL`` is not set in the environment — override by setting
+# the env var (or passing ``auth_url`` explicitly to ``AuthSettings``).
+DEFAULT_AUTH_URL = "https://signin.pipefy.com/realms/pipefy"
+
 
 @dataclass(frozen=True)
 class OidcClient:
@@ -23,5 +28,6 @@ class OidcClient:
 
 __all__ = [
     "DEFAULT_AUTH_CLIENT_ID",
+    "DEFAULT_AUTH_URL",
     "OidcClient",
 ]

--- a/packages/auth/src/pipefy_auth/settings.py
+++ b/packages/auth/src/pipefy_auth/settings.py
@@ -21,11 +21,7 @@ import sys
 from pydantic import AliasChoices, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from pipefy_auth.identity import (
-    DEFAULT_AUTH_CLIENT_ID,
-    DEFAULT_AUTH_URL,
-    OidcClient,
-)
+from pipefy_auth.identity import DEFAULT_AUTH_CLIENT_ID, OidcClient
 from pipefy_auth.resolver import ServiceAccount
 
 # Legacy ``PIPEFY_OAUTH_*`` env vars still resolve to the new
@@ -159,12 +155,14 @@ class AuthSettings(BaseSettings):
     )
 
     auth_url: str | None = Field(
-        default=DEFAULT_AUTH_URL,
+        default=None,
         description=(
             "OIDC issuer URL for the stored-session tier "
-            "(env: PIPEFY_AUTH_URL; defaults to the Pipefy production IdP at "
-            f"{DEFAULT_AUTH_URL}). Set to an empty string to disable the "
-            "stored-session tier on hosts that need an explicit opt-out."
+            "(env: PIPEFY_AUTH_URL, e.g. https://signin.pipefy.com/realms/pipefy). "
+            "Leave unset to disable stored-session detection in the resolver / "
+            "MCP startup; `pipefy auth login` / `pipefy auth logout` fall back "
+            "to `DEFAULT_AUTH_URL` (the Pipefy production IdP) at the CLI "
+            "layer when this is None."
         ),
     )
 

--- a/packages/auth/src/pipefy_auth/settings.py
+++ b/packages/auth/src/pipefy_auth/settings.py
@@ -21,7 +21,11 @@ import sys
 from pydantic import AliasChoices, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from pipefy_auth.identity import DEFAULT_AUTH_CLIENT_ID, OidcClient
+from pipefy_auth.identity import (
+    DEFAULT_AUTH_CLIENT_ID,
+    DEFAULT_AUTH_URL,
+    OidcClient,
+)
 from pipefy_auth.resolver import ServiceAccount
 
 # Legacy ``PIPEFY_OAUTH_*`` env vars still resolve to the new
@@ -155,10 +159,12 @@ class AuthSettings(BaseSettings):
     )
 
     auth_url: str | None = Field(
-        default=None,
+        default=DEFAULT_AUTH_URL,
         description=(
             "OIDC issuer URL for the stored-session tier "
-            "(env: PIPEFY_AUTH_URL, e.g. https://signin.pipefy.com/realms/pipefy)."
+            "(env: PIPEFY_AUTH_URL; defaults to the Pipefy production IdP at "
+            f"{DEFAULT_AUTH_URL}). Set to an empty string to disable the "
+            "stored-session tier on hosts that need an explicit opt-out."
         ),
     )
 

--- a/packages/auth/src/pipefy_auth/settings.py
+++ b/packages/auth/src/pipefy_auth/settings.py
@@ -21,7 +21,11 @@ import sys
 from pydantic import AliasChoices, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from pipefy_auth.identity import DEFAULT_AUTH_CLIENT_ID, OidcClient
+from pipefy_auth.identity import (
+    DEFAULT_AUTH_CLIENT_ID,
+    DEFAULT_AUTH_URL,
+    OidcClient,
+)
 from pipefy_auth.resolver import ServiceAccount
 
 # Legacy ``PIPEFY_OAUTH_*`` env vars still resolve to the new
@@ -155,14 +159,12 @@ class AuthSettings(BaseSettings):
     )
 
     auth_url: str | None = Field(
-        default=None,
+        default=DEFAULT_AUTH_URL,
         description=(
             "OIDC issuer URL for the stored-session tier "
-            "(env: PIPEFY_AUTH_URL, e.g. https://signin.pipefy.com/realms/pipefy). "
-            "Leave unset to disable stored-session detection in the resolver / "
-            "MCP startup; `pipefy auth login` / `pipefy auth logout` fall back "
-            "to `DEFAULT_AUTH_URL` (the Pipefy production IdP) at the CLI "
-            "layer when this is None."
+            "(env: PIPEFY_AUTH_URL; defaults to the Pipefy production IdP at "
+            f"{DEFAULT_AUTH_URL}). Set to an empty string to disable the "
+            "stored-session tier on hosts that need an explicit opt-out."
         ),
     )
 

--- a/packages/auth/tests/test_settings_back_compat.py
+++ b/packages/auth/tests/test_settings_back_compat.py
@@ -97,24 +97,30 @@ def test_no_deprecation_warning_when_only_new_env_keys_set(
 
 
 @pytest.mark.unit
-def test_auth_url_unset_yields_none_at_settings_layer(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    """``AuthSettings()`` does NOT default ``auth_url`` — the CLI commands fill in the
-    Pipefy prod IdP at the command layer when needed. Leaving the field as ``None``
-    preserves resolver / MCP / SDK semantics (stored-session tier only activates when
-    the user opts in by setting the env var)."""
+def test_auth_url_defaults_to_pipefy_prod_idp(monkeypatch: pytest.MonkeyPatch):
+    """``AuthSettings()`` with no ``PIPEFY_AUTH_URL`` set defaults to the prod IdP."""
+    from pipefy_auth.identity import DEFAULT_AUTH_URL
+
     monkeypatch.delenv("PIPEFY_AUTH_URL", raising=False)
     settings = AuthSettings()
-    assert settings.auth_url is None
-    assert settings.to_oidc_client() is None
+    assert settings.auth_url == DEFAULT_AUTH_URL
+    assert DEFAULT_AUTH_URL == "https://signin.pipefy.com/realms/pipefy"
+    oidc = settings.to_oidc_client()
+    assert oidc is not None
+    assert oidc.issuer_url == DEFAULT_AUTH_URL
 
 
 @pytest.mark.unit
-def test_auth_url_env_value_wins(monkeypatch: pytest.MonkeyPatch):
-    """Setting ``PIPEFY_AUTH_URL`` in env still populates the field."""
+def test_auth_url_env_override_wins_over_default(monkeypatch: pytest.MonkeyPatch):
+    """Setting ``PIPEFY_AUTH_URL`` in env still overrides the default."""
     monkeypatch.setenv("PIPEFY_AUTH_URL", "https://other.example.com/realms/x")
     settings = AuthSettings()
     assert settings.auth_url == "https://other.example.com/realms/x"
-    oidc = settings.to_oidc_client()
-    assert oidc is not None and oidc.issuer_url == "https://other.example.com/realms/x"
+
+
+@pytest.mark.unit
+def test_empty_auth_url_disables_stored_session_tier(monkeypatch: pytest.MonkeyPatch):
+    """Setting ``PIPEFY_AUTH_URL`` to an empty string opts out of the default."""
+    monkeypatch.setenv("PIPEFY_AUTH_URL", "")
+    settings = AuthSettings()
+    assert settings.to_oidc_client() is None

--- a/packages/auth/tests/test_settings_back_compat.py
+++ b/packages/auth/tests/test_settings_back_compat.py
@@ -94,3 +94,33 @@ def test_no_deprecation_warning_when_only_new_env_keys_set(
     _warn_once_for_legacy_oauth_env_keys()
     err = capsys.readouterr().err
     assert "deprecated" not in err
+
+
+@pytest.mark.unit
+def test_auth_url_defaults_to_pipefy_prod_idp(monkeypatch: pytest.MonkeyPatch):
+    """``AuthSettings()`` with no ``PIPEFY_AUTH_URL`` set defaults to the prod IdP."""
+    from pipefy_auth.identity import DEFAULT_AUTH_URL
+
+    monkeypatch.delenv("PIPEFY_AUTH_URL", raising=False)
+    settings = AuthSettings()
+    assert settings.auth_url == DEFAULT_AUTH_URL
+    assert DEFAULT_AUTH_URL == "https://signin.pipefy.com/realms/pipefy"
+    oidc = settings.to_oidc_client()
+    assert oidc is not None
+    assert oidc.issuer_url == DEFAULT_AUTH_URL
+
+
+@pytest.mark.unit
+def test_auth_url_env_override_wins_over_default(monkeypatch: pytest.MonkeyPatch):
+    """Setting ``PIPEFY_AUTH_URL`` in env still overrides the default."""
+    monkeypatch.setenv("PIPEFY_AUTH_URL", "https://other.example.com/realms/x")
+    settings = AuthSettings()
+    assert settings.auth_url == "https://other.example.com/realms/x"
+
+
+@pytest.mark.unit
+def test_empty_auth_url_disables_stored_session_tier(monkeypatch: pytest.MonkeyPatch):
+    """Setting ``PIPEFY_AUTH_URL`` to an empty string opts out of the default."""
+    monkeypatch.setenv("PIPEFY_AUTH_URL", "")
+    settings = AuthSettings()
+    assert settings.to_oidc_client() is None

--- a/packages/auth/tests/test_settings_back_compat.py
+++ b/packages/auth/tests/test_settings_back_compat.py
@@ -97,30 +97,24 @@ def test_no_deprecation_warning_when_only_new_env_keys_set(
 
 
 @pytest.mark.unit
-def test_auth_url_defaults_to_pipefy_prod_idp(monkeypatch: pytest.MonkeyPatch):
-    """``AuthSettings()`` with no ``PIPEFY_AUTH_URL`` set defaults to the prod IdP."""
-    from pipefy_auth.identity import DEFAULT_AUTH_URL
-
+def test_auth_url_unset_yields_none_at_settings_layer(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """``AuthSettings()`` does NOT default ``auth_url`` — the CLI commands fill in the
+    Pipefy prod IdP at the command layer when needed. Leaving the field as ``None``
+    preserves resolver / MCP / SDK semantics (stored-session tier only activates when
+    the user opts in by setting the env var)."""
     monkeypatch.delenv("PIPEFY_AUTH_URL", raising=False)
     settings = AuthSettings()
-    assert settings.auth_url == DEFAULT_AUTH_URL
-    assert DEFAULT_AUTH_URL == "https://signin.pipefy.com/realms/pipefy"
-    oidc = settings.to_oidc_client()
-    assert oidc is not None
-    assert oidc.issuer_url == DEFAULT_AUTH_URL
+    assert settings.auth_url is None
+    assert settings.to_oidc_client() is None
 
 
 @pytest.mark.unit
-def test_auth_url_env_override_wins_over_default(monkeypatch: pytest.MonkeyPatch):
-    """Setting ``PIPEFY_AUTH_URL`` in env still overrides the default."""
+def test_auth_url_env_value_wins(monkeypatch: pytest.MonkeyPatch):
+    """Setting ``PIPEFY_AUTH_URL`` in env still populates the field."""
     monkeypatch.setenv("PIPEFY_AUTH_URL", "https://other.example.com/realms/x")
     settings = AuthSettings()
     assert settings.auth_url == "https://other.example.com/realms/x"
-
-
-@pytest.mark.unit
-def test_empty_auth_url_disables_stored_session_tier(monkeypatch: pytest.MonkeyPatch):
-    """Setting ``PIPEFY_AUTH_URL`` to an empty string opts out of the default."""
-    monkeypatch.setenv("PIPEFY_AUTH_URL", "")
-    settings = AuthSettings()
-    assert settings.to_oidc_client() is None
+    oidc = settings.to_oidc_client()
+    assert oidc is not None and oidc.issuer_url == "https://other.example.com/realms/x"

--- a/packages/cli/src/pipefy_cli/commands/auth.py
+++ b/packages/cli/src/pipefy_cli/commands/auth.py
@@ -16,6 +16,8 @@ from gql.transport.exceptions import (
     TransportServerError,
 )
 from pipefy_auth import (
+    DEFAULT_AUTH_CLIENT_ID,
+    DEFAULT_AUTH_URL,
     DiscoveryPolicy,
     LoginError,
     OidcClient,
@@ -142,17 +144,11 @@ def auth_login(
     from keyring.errors import KeyringError
 
     settings, auth = settings_and_auth_from_ctx(ctx)
-    if auth.oidc_client is None:
-        typer.echo(
-            "PIPEFY_AUTH_URL is required for `pipefy auth login` (the OIDC issuer "
-            "URL for Pipefy authentication, e.g. "
-            "https://signin.pipefy.com/realms/pipefy). "
-            f"See {DOCS_CLI_AUTH_REF}.",
-            err=True,
-        )
-        raise typer.Exit(2)
-    issuer_url = auth.oidc_client.issuer_url
-    client_id = auth.oidc_client.client_id
+    oidc = auth.oidc_client or OidcClient(
+        issuer_url=DEFAULT_AUTH_URL, client_id=DEFAULT_AUTH_CLIENT_ID
+    )
+    issuer_url = oidc.issuer_url
+    client_id = oidc.client_id
     typer.echo(f"Signing in to Pipefy at {issuer_url} ...")
 
     def _print_url(url: str) -> None:
@@ -459,17 +455,12 @@ def auth_status(
 def auth_logout(ctx: typer.Context) -> None:
     """Revoke the stored refresh token at the IdP and clear the local session."""
     settings, auth = settings_and_auth_from_ctx(ctx)
-    if auth.oidc_client is None:
-        typer.echo(
-            "PIPEFY_AUTH_URL is required for `pipefy auth logout` (the OIDC "
-            "issuer URL used at login). "
-            f"See {DOCS_CLI_AUTH_REF}.",
-            err=True,
-        )
-        raise typer.Exit(2)
+    oidc = auth.oidc_client or OidcClient(
+        issuer_url=DEFAULT_AUTH_URL, client_id=DEFAULT_AUTH_CLIENT_ID
+    )
 
-    issuer = auth.oidc_client.issuer_url
-    client_id = auth.oidc_client.client_id
+    issuer = oidc.issuer_url
+    client_id = oidc.client_id
 
     session = load_session(issuer=issuer, client_id=client_id)
     if session is None:

--- a/packages/cli/src/pipefy_cli/commands/auth.py
+++ b/packages/cli/src/pipefy_cli/commands/auth.py
@@ -16,8 +16,6 @@ from gql.transport.exceptions import (
     TransportServerError,
 )
 from pipefy_auth import (
-    DEFAULT_AUTH_CLIENT_ID,
-    DEFAULT_AUTH_URL,
     DiscoveryPolicy,
     LoginError,
     OidcClient,
@@ -144,11 +142,17 @@ def auth_login(
     from keyring.errors import KeyringError
 
     settings, auth = settings_and_auth_from_ctx(ctx)
-    oidc = auth.oidc_client or OidcClient(
-        issuer_url=DEFAULT_AUTH_URL, client_id=DEFAULT_AUTH_CLIENT_ID
-    )
-    issuer_url = oidc.issuer_url
-    client_id = oidc.client_id
+    if auth.oidc_client is None:
+        typer.echo(
+            "PIPEFY_AUTH_URL is required for `pipefy auth login` (the OIDC issuer "
+            "URL for Pipefy authentication, e.g. "
+            "https://signin.pipefy.com/realms/pipefy). "
+            f"See {DOCS_CLI_AUTH_REF}.",
+            err=True,
+        )
+        raise typer.Exit(2)
+    issuer_url = auth.oidc_client.issuer_url
+    client_id = auth.oidc_client.client_id
     typer.echo(f"Signing in to Pipefy at {issuer_url} ...")
 
     def _print_url(url: str) -> None:
@@ -455,12 +459,17 @@ def auth_status(
 def auth_logout(ctx: typer.Context) -> None:
     """Revoke the stored refresh token at the IdP and clear the local session."""
     settings, auth = settings_and_auth_from_ctx(ctx)
-    oidc = auth.oidc_client or OidcClient(
-        issuer_url=DEFAULT_AUTH_URL, client_id=DEFAULT_AUTH_CLIENT_ID
-    )
+    if auth.oidc_client is None:
+        typer.echo(
+            "PIPEFY_AUTH_URL is required for `pipefy auth logout` (the OIDC "
+            "issuer URL used at login). "
+            f"See {DOCS_CLI_AUTH_REF}.",
+            err=True,
+        )
+        raise typer.Exit(2)
 
-    issuer = oidc.issuer_url
-    client_id = oidc.client_id
+    issuer = auth.oidc_client.issuer_url
+    client_id = auth.oidc_client.client_id
 
     session = load_session(issuer=issuer, client_id=client_id)
     if session is None:

--- a/packages/cli/src/pipefy_cli/config.py
+++ b/packages/cli/src/pipefy_cli/config.py
@@ -128,7 +128,17 @@ def _fill_if_missing_str(
     key: str,
     patch: dict[str, Any],
 ) -> None:
-    if _is_missing(getattr(model, field)) and blob.get(key):
+    """Fill ``field`` from ``blob`` when the model did not load a value for it.
+
+    "Did not load" means either the attribute is missing per :func:`_is_missing`
+    *or* the field was never explicitly set on the model (``model_fields_set``).
+    The latter check matters for fields that carry a non-``None`` default
+    (e.g. ``AuthSettings.auth_url`` defaults to the Pipefy production IdP) —
+    without it, the default would always win over the user's TOML override.
+    """
+    if not blob.get(key):
+        return
+    if _is_missing(getattr(model, field)) or field not in model.model_fields_set:
         patch[field] = str(blob[key]).strip()
 
 

--- a/packages/cli/src/pipefy_cli/config.py
+++ b/packages/cli/src/pipefy_cli/config.py
@@ -128,16 +128,10 @@ def _fill_if_missing_str(
     key: str,
     patch: dict[str, Any],
 ) -> None:
-    """Fill ``field`` from ``blob`` when the model did not load a value for it.
-
-    "Did not load" means either the attribute is missing per :func:`_is_missing`
-    *or* the field was never explicitly set on the model (``model_fields_set``).
-    The latter check matters for fields that carry a non-``None`` default
-    (e.g. ``AuthSettings.auth_url`` defaults to the Pipefy production IdP) —
-    without it, the default would always win over the user's TOML override.
-    """
     if not blob.get(key):
         return
+    # ``model_fields_set`` check: fields with a non-None default
+    # (e.g. ``AuthSettings.auth_url``) would otherwise shadow TOML overrides.
     if _is_missing(getattr(model, field)) or field not in model.model_fields_set:
         patch[field] = str(blob[key]).strip()
 

--- a/packages/cli/tests/test_auth_login.py
+++ b/packages/cli/tests/test_auth_login.py
@@ -550,18 +550,38 @@ def cli_runner():
 
 
 class TestAuthLoginCommand:
-    def test_empty_auth_url_exits_2(
+    def test_no_env_falls_back_to_default_idp(
         self,
         cli_runner,
         monkeypatch: pytest.MonkeyPatch,
+        fake_keyring: InMemoryKeyring,
         clean_pipefy_env,
         saved_cwd,
     ) -> None:
-        """Explicit empty ``PIPEFY_AUTH_URL`` opts out of the stored-session tier."""
-        monkeypatch.setenv("PIPEFY_AUTH_URL", "")
+        """With no ``PIPEFY_AUTH_URL`` set, the CLI falls back to the Pipefy production IdP."""
+        from pipefy_auth import DEFAULT_AUTH_URL
+
+        from pipefy_cli.commands import auth as auth_module
+
+        captured: dict[str, object] = {}
+
+        def _fake_run_login(**kwargs: object) -> flow.LoginResult:
+            captured.update(kwargs)
+            return flow.LoginResult(
+                issuer=DEFAULT_AUTH_URL,
+                token_response={
+                    "access_token": "AAA",
+                    "refresh_token": "RRR",
+                    "token_type": "Bearer",
+                    "expires_in": 300,
+                },
+            )
+
+        monkeypatch.setattr(auth_module, "run_login", _fake_run_login)
         result = cli_runner.invoke(cli_app, ["auth", "login"])
-        assert result.exit_code == 2
-        assert "PIPEFY_AUTH_URL is required" in result.stderr
+        assert result.exit_code == 0, result.stderr
+        assert captured["issuer_url"] == DEFAULT_AUTH_URL
+        assert DEFAULT_AUTH_URL in result.stdout
 
     def test_happy_path(
         self,

--- a/packages/cli/tests/test_auth_login.py
+++ b/packages/cli/tests/test_auth_login.py
@@ -550,13 +550,15 @@ def cli_runner():
 
 
 class TestAuthLoginCommand:
-    def test_missing_auth_url_exits_2(
+    def test_empty_auth_url_exits_2(
         self,
         cli_runner,
         monkeypatch: pytest.MonkeyPatch,
         clean_pipefy_env,
         saved_cwd,
     ) -> None:
+        """Explicit empty ``PIPEFY_AUTH_URL`` opts out of the stored-session tier."""
+        monkeypatch.setenv("PIPEFY_AUTH_URL", "")
         result = cli_runner.invoke(cli_app, ["auth", "login"])
         assert result.exit_code == 2
         assert "PIPEFY_AUTH_URL is required" in result.stderr

--- a/packages/cli/tests/test_auth_login.py
+++ b/packages/cli/tests/test_auth_login.py
@@ -550,38 +550,18 @@ def cli_runner():
 
 
 class TestAuthLoginCommand:
-    def test_no_env_falls_back_to_default_idp(
+    def test_empty_auth_url_exits_2(
         self,
         cli_runner,
         monkeypatch: pytest.MonkeyPatch,
-        fake_keyring: InMemoryKeyring,
         clean_pipefy_env,
         saved_cwd,
     ) -> None:
-        """With no ``PIPEFY_AUTH_URL`` set, the CLI falls back to the Pipefy production IdP."""
-        from pipefy_auth import DEFAULT_AUTH_URL
-
-        from pipefy_cli.commands import auth as auth_module
-
-        captured: dict[str, object] = {}
-
-        def _fake_run_login(**kwargs: object) -> flow.LoginResult:
-            captured.update(kwargs)
-            return flow.LoginResult(
-                issuer=DEFAULT_AUTH_URL,
-                token_response={
-                    "access_token": "AAA",
-                    "refresh_token": "RRR",
-                    "token_type": "Bearer",
-                    "expires_in": 300,
-                },
-            )
-
-        monkeypatch.setattr(auth_module, "run_login", _fake_run_login)
+        """Explicit empty ``PIPEFY_AUTH_URL`` opts out of the stored-session tier."""
+        monkeypatch.setenv("PIPEFY_AUTH_URL", "")
         result = cli_runner.invoke(cli_app, ["auth", "login"])
-        assert result.exit_code == 0, result.stderr
-        assert captured["issuer_url"] == DEFAULT_AUTH_URL
-        assert DEFAULT_AUTH_URL in result.stdout
+        assert result.exit_code == 2
+        assert "PIPEFY_AUTH_URL is required" in result.stderr
 
     def test_happy_path(
         self,

--- a/packages/cli/tests/test_auth_logout.py
+++ b/packages/cli/tests/test_auth_logout.py
@@ -144,17 +144,18 @@ def _store_test_session(issuer: str = _ISSUER, client_id: str = "pipefy-cli") ->
 
 
 class TestAuthLogoutCommand:
-    def test_no_env_falls_back_to_default_idp(
+    def test_empty_auth_url_exits_2(
         self,
         runner,
+        monkeypatch: pytest.MonkeyPatch,
         clean_pipefy_env,
         saved_cwd,
-        fake_keyring: InMemoryKeyring,
     ) -> None:
-        """With no ``PIPEFY_AUTH_URL`` set, logout targets the Pipefy production IdP."""
+        """Explicit empty ``PIPEFY_AUTH_URL`` opts out of the stored-session tier."""
+        monkeypatch.setenv("PIPEFY_AUTH_URL", "")
         result = runner.invoke(cli_app, ["auth", "logout"])
-        assert result.exit_code == 0
-        assert "Not signed in" in result.stdout
+        assert result.exit_code == 2
+        assert "PIPEFY_AUTH_URL is required" in result.stderr
 
     def test_no_session_is_idempotent(
         self,

--- a/packages/cli/tests/test_auth_logout.py
+++ b/packages/cli/tests/test_auth_logout.py
@@ -144,18 +144,17 @@ def _store_test_session(issuer: str = _ISSUER, client_id: str = "pipefy-cli") ->
 
 
 class TestAuthLogoutCommand:
-    def test_empty_auth_url_exits_2(
+    def test_no_env_falls_back_to_default_idp(
         self,
         runner,
-        monkeypatch: pytest.MonkeyPatch,
         clean_pipefy_env,
         saved_cwd,
+        fake_keyring: InMemoryKeyring,
     ) -> None:
-        """Explicit empty ``PIPEFY_AUTH_URL`` opts out of the stored-session tier."""
-        monkeypatch.setenv("PIPEFY_AUTH_URL", "")
+        """With no ``PIPEFY_AUTH_URL`` set, logout targets the Pipefy production IdP."""
         result = runner.invoke(cli_app, ["auth", "logout"])
-        assert result.exit_code == 2
-        assert "PIPEFY_AUTH_URL is required" in result.stderr
+        assert result.exit_code == 0
+        assert "Not signed in" in result.stdout
 
     def test_no_session_is_idempotent(
         self,

--- a/packages/cli/tests/test_auth_logout.py
+++ b/packages/cli/tests/test_auth_logout.py
@@ -144,12 +144,15 @@ def _store_test_session(issuer: str = _ISSUER, client_id: str = "pipefy-cli") ->
 
 
 class TestAuthLogoutCommand:
-    def test_missing_auth_url_exits_2(
+    def test_empty_auth_url_exits_2(
         self,
         runner,
+        monkeypatch: pytest.MonkeyPatch,
         clean_pipefy_env,
         saved_cwd,
     ) -> None:
+        """Explicit empty ``PIPEFY_AUTH_URL`` opts out of the stored-session tier."""
+        monkeypatch.setenv("PIPEFY_AUTH_URL", "")
         result = runner.invoke(cli_app, ["auth", "logout"])
         assert result.exit_code == 2
         assert "PIPEFY_AUTH_URL is required" in result.stderr

--- a/packages/mcp/tests/core/test_container.py
+++ b/packages/mcp/tests/core/test_container.py
@@ -181,6 +181,9 @@ class TestServicesContainer:
             mock_ai_automation_service_class.return_value
         )
 
+    # Patch ``load_session``: ``auth_url``'s prod default makes the stored-session
+    # tier always reachable, so a host with a real keychain entry would otherwise
+    # satisfy resolution and break the assertion.
     @patch("pipefy_auth.resolver.load_session", lambda **_: None)
     @patch("pipefy_mcp.core.container.AiAutomationService")
     @patch("pipefy_mcp.core.container.InternalApiClient")
@@ -191,15 +194,7 @@ class TestServicesContainer:
         mock_internal_api_client_class,
         mock_ai_automation_service_class,
     ):
-        """No PIPEFY_TOKEN and no service-account triple → runtime error.
-
-        ``AuthSettings.auth_url`` now defaults to the Pipefy prod IdP, so the
-        resolver's stored-session tier always carries a non-None ``OidcClient``
-        — the keychain probe inside ``_has_stored_session`` is patched to return
-        ``None`` so the test stays hermetic regardless of the host's OS keychain
-        state (a stray ``pipefy auth login`` against prod would otherwise leak
-        a real session into the test).
-        """
+        """No PIPEFY_TOKEN and no service-account triple → runtime error."""
         settings = Settings(
             pipefy=PipefySettings(graphql_url="https://api.pipefy.com/graphql"),
             auth=AuthSettings(),

--- a/packages/mcp/tests/core/test_container.py
+++ b/packages/mcp/tests/core/test_container.py
@@ -181,6 +181,7 @@ class TestServicesContainer:
             mock_ai_automation_service_class.return_value
         )
 
+    @patch("pipefy_auth.resolver.load_session", lambda **_: None)
     @patch("pipefy_mcp.core.container.AiAutomationService")
     @patch("pipefy_mcp.core.container.InternalApiClient")
     @patch("pipefy_mcp.core.container.PipefyClient")
@@ -190,7 +191,15 @@ class TestServicesContainer:
         mock_internal_api_client_class,
         mock_ai_automation_service_class,
     ):
-        """No PIPEFY_TOKEN and no service-account triple → runtime error."""
+        """No PIPEFY_TOKEN and no service-account triple → runtime error.
+
+        ``AuthSettings.auth_url`` now defaults to the Pipefy prod IdP, so the
+        resolver's stored-session tier always carries a non-None ``OidcClient``
+        — the keychain probe inside ``_has_stored_session`` is patched to return
+        ``None`` so the test stays hermetic regardless of the host's OS keychain
+        state (a stray ``pipefy auth login`` against prod would otherwise leak
+        a real session into the test).
+        """
         settings = Settings(
             pipefy=PipefySettings(graphql_url="https://api.pipefy.com/graphql"),
             auth=AuthSettings(),

--- a/packages/sdk/tests/_shared/live_settings.py
+++ b/packages/sdk/tests/_shared/live_settings.py
@@ -45,10 +45,16 @@ def live_auth_settings() -> AuthSettings:
 
 def _try_resolve_live_auth() -> Auth | None:
     a = live_auth_settings()
+    # Intentionally omit ``oidc_client``: live integration tests must authenticate
+    # via a service account or static bearer, never via a developer's personal
+    # stored OAuth session. After PIPEFY_AUTH_URL gained a default value, a stray
+    # ``pipefy auth login`` run on a developer machine would otherwise opt that
+    # developer's tests into the stored-session tier and fire real traffic against
+    # the prod Pipefy API under a personal user account.
     return resolve_pipefy_auth(
         static_token=a.static_token,
         service_account=a.to_service_account(),
-        oidc_client=a.to_oidc_client(),
+        oidc_client=None,
     )
 
 

--- a/packages/sdk/tests/_shared/live_settings.py
+++ b/packages/sdk/tests/_shared/live_settings.py
@@ -45,12 +45,8 @@ def live_auth_settings() -> AuthSettings:
 
 def _try_resolve_live_auth() -> Auth | None:
     a = live_auth_settings()
-    # Intentionally omit ``oidc_client``: live integration tests must authenticate
-    # via a service account or static bearer, never via a developer's personal
-    # stored OAuth session. After PIPEFY_AUTH_URL gained a default value, a stray
-    # ``pipefy auth login`` run on a developer machine would otherwise opt that
-    # developer's tests into the stored-session tier and fire real traffic against
-    # the prod Pipefy API under a personal user account.
+    # ``oidc_client=None``: a stray ``pipefy auth login`` on a dev machine would
+    # otherwise satisfy live-creds detection via the developer's personal session.
     return resolve_pipefy_auth(
         static_token=a.static_token,
         service_account=a.to_service_account(),


### PR DESCRIPTION
## Summary

- Adds `DEFAULT_AUTH_URL = \"https://signin.pipefy.com/realms/pipefy\"` to `pipefy_auth.identity` (sibling to the existing `DEFAULT_AUTH_CLIENT_ID`).
- `AuthSettings.auth_url` now defaults to that constant — `pipefy auth login` no longer exits 2 with `PIPEFY_AUTH_URL is required` when the env var is unset.
- Override path preserved: `PIPEFY_AUTH_URL=<custom>` still wins over the default; `PIPEFY_AUTH_URL=""` explicitly disables the stored-session tier (regression-tested).
- `docs/cli/auth.md` updated to document the new default + override shape.
- Existing `test_missing_auth_url_exits_2` tests in `packages/cli/tests/{test_auth_login,test_auth_logout}.py` renamed to `test_empty_auth_url_exits_2` and re-pointed at the explicit-empty case.

Surfaced during the workstream-C smoke test (PR #232): plugin / one-shot users following the documented `/pipefy:login` flow hit the missing-env exit because the canonical Pipefy production OIDC issuer URL was not baked in as a default. The URL is public, the only realm 99% of users would set, so requiring it as an env var introduced friction every install path had to pay through.

Closes #233.

## Test plan

- [x] `uv run pytest packages/auth/tests --no-cov` — 50/50 pass.
- [x] `uv run pytest packages/cli/tests -m \"not integration\" --no-cov` — 260/260 pass.
- [x] `uv run pytest packages/mcp/tests --no-cov` — 1203/1203 pass + 14 skipped (no regressions in MCP container's auth resolution).
- [x] `uv run ruff check .` + `uv run ruff format --check .` — clean.
- [x] `AuthSettings()` with no `PIPEFY_AUTH_URL` env returns `auth_url == DEFAULT_AUTH_URL` and a non-None `to_oidc_client()`.
- [x] `PIPEFY_AUTH_URL=https://other.example/realms/x` overrides the default.
- [x] `PIPEFY_AUTH_URL=""` opts out → `to_oidc_client()` returns None and `pipefy auth login` / `pipefy auth logout` exit 2 with the existing "PIPEFY_AUTH_URL is required" hint.