### PR TITLE
feat: reduce Pipefy URL configuration surface area to PIPEFY_BASE_URL + PIPEFY_AUTH_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,15 +3,24 @@
 # Then fill in your Service Account credentials from Pipefy Admin Panel.
 # See docs/setup.md for first-time install, Pydantic precedence, and MCP client examples.
 
-PIPEFY_GRAPHQL_URL=https://app.pipefy.com/graphql
-PIPEFY_INTERNAL_API_URL=https://app.pipefy.com/internal_api
-# Optional: GraphQL endpoint for the Interfaces schema (portals, pages, elements).
-# PIPEFY_INTERFACES_GRAPHQL_URL=https://app.pipefy.com/graphql/interfaces
-PIPEFY_SERVICE_ACCOUNT_URL=https://app.pipefy.com/oauth/token
+# --- Service account (Tier 3) ---
 PIPEFY_SERVICE_ACCOUNT_CLIENT_ID=<YOUR_SERVICE_ACCOUNT_CLIENT_ID>
 PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET=<YOUR_SERVICE_ACCOUNT_CLIENT_SECRET>
-# Legacy names PIPEFY_OAUTH_URL / _CLIENT / _SECRET still work but emit a one-shot
+# Legacy names PIPEFY_OAUTH_CLIENT / _SECRET still work but emit a one-shot
 # stderr deprecation warning; they will be removed in a future beta. See docs/MIGRATION.md.
+
+# --- Non-prod environments only ---
+# PIPEFY_BASE_URL defaults to https://app.pipefy.com and drives the four
+# API endpoints (graphql, internal_api, interfaces, oauth/token). Set this
+# to a non-prod API host, a regional / proxy deployment, or local-dev mock.
+# PIPEFY_BASE_URL=
+# PIPEFY_AUTH_URL is the full OIDC issuer URL. Defaults to
+# https://signin.pipefy.com/realms/pipefy. Set this to the full issuer URL
+# for a non-prod IdP.
+# PIPEFY_AUTH_URL=
+
+# --- Other optional knobs ---
+# PIPEFY_AUTH_CLIENT_ID=pipefy-cli
 # Optional: default organization id for `pipefy org get` when you omit the positional id (numeric string).
 # PIPEFY_ORG_ID=
 # Optional (default false): allow http:// and internal hosts for GraphQL/OAuth/internal API/webhooks.
@@ -28,10 +37,3 @@ PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET=<YOUR_SERVICE_ACCOUNT_CLIENT_SECRET>
 # - Enables proactive membership checks in validate_ai_agent_behaviors (cross-pipe targets).
 # Discover IDs via get_pipe_members (emails like *@service-account.pipefy.com) or Pipefy Admin.
 # PIPEFY_SERVICE_ACCOUNT_IDS=
-#
-# --- Interactive user login (CLI only; `pipefy auth login`) ---
-# OIDC issuer URL for Pipefy authentication. The CLI appends
-# /.well-known/openid-configuration to discover the auth/token endpoints.
-# PIPEFY_AUTH_URL=https://signin.pipefy.com/realms/pipefy
-# Optional: override the OAuth client id registered for the CLI.
-# PIPEFY_AUTH_CLIENT_ID=pipefy-cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,22 +12,37 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **CLI**: `pipefy auth status [--json|-j]` — reports auth source, identity, session expiry, and exit codes.
 - **CLI**: `pipefy auth logout` — revokes the refresh token at the IdP and clears the stored session.
-- **Auth**: `AuthSettings.auth_url` now defaults to `https://signin.pipefy.com/realms/pipefy` (Pipefy production IdP) when `PIPEFY_AUTH_URL` is unset — removes the previous `PIPEFY_AUTH_URL is required` exit-2 friction on `pipefy auth login` / `pipefy auth logout` and wires the MCP stored-session tier automatically after `pipefy auth login`. Override by setting `PIPEFY_AUTH_URL=<url>` to a non-prod IdP; explicit-empty `PIPEFY_AUTH_URL=` disables the stored-session tier on hosts that need it. User-level `~/.config/pipefy/config.toml` `auth_url` keys still override the default via the existing TOML fallback. Closes #233.
+- **Auth**: `AuthSettings.auth_url` now defaults to the Pipefy production IdP when `PIPEFY_AUTH_URL` is unset — removes the previous `PIPEFY_AUTH_URL is required` exit-2 friction on `pipefy auth login` / `pipefy auth logout` and wires the MCP stored-session tier automatically after `pipefy auth login`. Override by setting `PIPEFY_AUTH_URL=<url>` to a non-prod IdP. Closes #233.
+- **SDK / Auth**: introduced `PIPEFY_BASE_URL` (default `https://app.pipefy.com`) that drives the four API endpoints (`graphql_url`, `internal_api_url`, `interfaces_graphql_url`, `service_account_url`) as pydantic `@computed_field` properties. Operators on non-prod environments set `PIPEFY_BASE_URL=<host>` once and all four endpoints follow. The OIDC issuer (`PIPEFY_AUTH_URL`, default `https://signin.pipefy.com/realms/pipefy`) remains a separate full-URL field because non-prod realm names don't follow a derivable convention. Closes #238.
 - **MCP**: stored-session tier wired into `ServicesContainer`; setting `PIPEFY_AUTH_URL` after `pipefy auth login` now lets the MCP server reuse the keychain-backed session, with the refresh pre-warmed at startup so a stale or revoked session surfaces before the first tool call.
 
 ### Changed
 
-- **SDK / MCP / CLI**: renamed the three service-account credential env vars for clarity and to remove the one-letter footgun against `PIPEFY_AUTH_URL` (interactive user-login issuer): `PIPEFY_OAUTH_URL` → `PIPEFY_SERVICE_ACCOUNT_URL`, `PIPEFY_OAUTH_CLIENT` → `PIPEFY_SERVICE_ACCOUNT_CLIENT_ID`, `PIPEFY_OAUTH_SECRET` → `PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET`. Closes #127.
+- **SDK / MCP / CLI**: renamed the two service-account credential env vars for clarity and to remove the one-letter footgun against `PIPEFY_AUTH_URL` (interactive user-login issuer): `PIPEFY_OAUTH_CLIENT` → `PIPEFY_SERVICE_ACCOUNT_CLIENT_ID`, `PIPEFY_OAUTH_SECRET` → `PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET`. `PIPEFY_OAUTH_URL` is dropped without a renamed counterpart — the OAuth token endpoint now derives from `PIPEFY_BASE_URL` (see the **Removed** section). Closes #127.
+- **Auth / SDK**: every `PIPEFY_*` env var is validated against a semantically meaningful pattern at settings construction. URL env vars (`PIPEFY_BASE_URL`, `PIPEFY_AUTH_URL`) require `https?://` plus non-whitespace; credential fields (`PIPEFY_TOKEN`, `PIPEFY_SERVICE_ACCOUNT_CLIENT_ID`, `PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET`, `PIPEFY_AUTH_CLIENT_ID`) reject leading / trailing whitespace; `PIPEFY_ORG_ID` must be an ASCII numeric string. There is no longer an empty-string opt-out for any tier — unset the variable to fall back to the default (kill-switch tracked separately in #237).
+- **SDK / MCP / CLI**: renamed `--graphql-url` CLI flag to `--base-url` to match the new env-var shape.
 
 ### Deprecated
 
-- **SDK**: legacy `PIPEFY_OAUTH_*` env vars and `oauth_*` keys in `~/.config/pipefy/config.toml` still resolve to the new `service_account_*` fields via an alias shim, with a one-shot stderr deprecation warning per legacy key. The aliases will be removed in a later `0.2.0-beta.x` release (carrying an explicit breaking-change callout). See [`docs/MIGRATION.md`](docs/MIGRATION.md#service-account-env-var-rename).
+- **SDK**: legacy `PIPEFY_OAUTH_*` env vars still resolve to the new `service_account_*` fields via an alias shim, with a one-shot stderr deprecation warning per legacy key. The aliases will be removed in a later `0.2.0-beta.x` release (carrying an explicit breaking-change callout). See [`docs/MIGRATION.md`](docs/MIGRATION.md#service-account-env-var-rename).
 
 ### Fixed
 
 - **CLI**: concurrent `pipefy` invocations near token expiry no longer surface `invalid_grant` errors; the refresh-token grant is now serialized across processes via a filesystem lock at `~/.config/pipefy/refresh.lock` (`%APPDATA%/pipefy/refresh.lock` on Windows). Closes #133.
 
 ### Removed
+
+- **HARD BREAK** — per-URL env vars dropped in favor of `PIPEFY_BASE_URL` + `PIPEFY_AUTH_URL`. The following env vars are no longer recognized; `PipefySettings` / `AuthSettings` are configured with `extra="ignore"`, so settings construction silently drops them with no exception or warning — stale `.env` keys look configured but the prod defaults still apply. Same wording as `docs/MIGRATION.md`. Audit `.env`, MCP client JSON, and CI secrets before upgrading:
+  - `PIPEFY_GRAPHQL_URL` — set `PIPEFY_BASE_URL` to your API host (graphql_url derives as `<base>/graphql`).
+  - `PIPEFY_INTERNAL_API_URL` — derives as `<base>/internal_api`.
+  - `PIPEFY_INTERFACES_GRAPHQL_URL` — derives as `<base>/graphql/interfaces`.
+  - `PIPEFY_SERVICE_ACCOUNT_URL` — derives as `<base>/oauth/token`.
+  - `PIPEFY_OAUTH_URL` (legacy alias for `PIPEFY_SERVICE_ACCOUNT_URL`) — no replacement; same derivation path.
+
+  Migration: replace the five per-URL env vars with a single `PIPEFY_BASE_URL` (default `https://app.pipefy.com`). If you need a non-prod OIDC issuer, also set `PIPEFY_AUTH_URL` to the full issuer URL.
+- **HARD BREAK** — user TOML config file `~/.config/pipefy/config.toml` is no longer read by either the CLI or the MCP server. Operators who relied on it must move credentials and `base_url` into shell environment variables, a `.env` file at the working directory, or their MCP client's `env` block. Two config surfaces (env + `.env`) instead of three; persistent global config is shell-rc territory.
+- `PIPEFY_TENANT` / `PIPEFY_AUTH_REALM` env vars (never shipped in a release; existed only on intermediate commits of this branch).
+- **Auth**: `pipefy_auth.DEFAULT_AUTH_URL` constant (and its re-export from the package root). Callers should consult the resolved `AuthSettings.auth_url` instead.
 
 ## [0.2.0-beta.1] - 2026-05-18
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -87,15 +87,17 @@ The three OAuth 2.0 client-credentials vars used by the service-account auth pat
 
 | Old | New |
 |---|---|
-| `PIPEFY_OAUTH_URL` | `PIPEFY_SERVICE_ACCOUNT_URL` |
+| `PIPEFY_OAUTH_URL` | _dropped_ — set `PIPEFY_BASE_URL` instead (the OAuth token endpoint derives from `<base>/oauth/token`) |
 | `PIPEFY_OAUTH_CLIENT` | `PIPEFY_SERVICE_ACCOUNT_CLIENT_ID` |
 | `PIPEFY_OAUTH_SECRET` | `PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET` |
 
-**No immediate action required.** The legacy names are still honored — `PIPEFY_OAUTH_*` env vars and `oauth_*` keys in `~/.config/pipefy/config.toml` both flow through an alias shim and populate the renamed fields. The first command run with a legacy name set prints a one-shot stderr deprecation warning per legacy key still in use; the message names the replacement.
+**No immediate action required for `_CLIENT` / `_SECRET`.** The legacy `PIPEFY_OAUTH_CLIENT` / `_SECRET` env vars flow through an alias shim and populate the renamed fields. The first command run with a legacy name set prints a one-shot stderr deprecation warning naming the replacement.
+
+**`PIPEFY_OAUTH_URL` is gone.** It has no alias. Operators with this env var set will see the OAuth token endpoint silently fall back to `<PIPEFY_BASE_URL>/oauth/token` (default `https://app.pipefy.com/oauth/token`). Set `PIPEFY_BASE_URL` to your API host root for non-prod environments.
 
 When you're ready to update:
 
-1. Search-and-replace your shell, `.env`, MCP client JSON, CI secrets, and any `~/.config/pipefy/config.toml` per the table above.
+1. Search-and-replace your shell, `.env`, MCP client JSON, and CI secrets per the table above.
 2. Optionally re-run any command (e.g. `pipefy org get --json`) to confirm the deprecation warning is gone.
 
 The legacy names will be removed in a later `0.2.0-beta.x` release; the change will carry an explicit breaking-change callout in the changelog at that time.
@@ -106,29 +108,34 @@ The legacy names will be removed in a later `0.2.0-beta.x` release; the change w
 
 ## Settings model split (library / script users only)
 
-End users of `pipefy-cli` and `pipefy-mcp-server` are unaffected — every `PIPEFY_*` env var, `.env` entry, and `~/.config/pipefy/config.toml` key keeps loading exactly as before. The split matters only if you construct settings types directly in Python code that depends on `pipefy-sdk`.
+End users of `pipefy-cli` and `pipefy-mcp-server` are unaffected — every `PIPEFY_*` env var and `.env` entry keeps loading exactly as before. The split matters only if you construct settings types directly in Python code that depends on `pipefy-sdk`.
 
-Auth-related fields have moved from `PipefySettings` (which now owns endpoint config only) to a new `pipefy_auth.AuthSettings`:
+Auth-related fields have moved from `PipefySettings` (which now owns endpoint config only) to `pipefy_auth.AuthSettings`. URL endpoints (graphql, internal_api, interfaces, service_account) are now `@computed_field` properties derived from `base_url`:
 
-| Was on `pipefy_sdk.PipefySettings` | Now on `pipefy_auth.AuthSettings` |
+| Was on `pipefy_sdk.PipefySettings` | Now |
 |---|---|
-| `service_account_url` | `service_account_url` |
-| `service_account_client_id` | `service_account_client_id` |
-| `service_account_client_secret` | `service_account_client_secret` |
-| (read from env only) | `auth_url`, `auth_client_id`, `static_token` |
+| `graphql_url` (settable) | `@computed_field` on `PipefySettings`, derived from `base_url` |
+| `internal_api_url` (settable) | `@computed_field` on `PipefySettings`, derived from `base_url` |
+| `interfaces_graphql_url` (settable) | `@computed_field` on `PipefySettings`, derived from `base_url` |
+| `service_account_url` (settable) | `@computed_field` on `AuthSettings`, derived from `base_url` |
+| `service_account_client_id` | `AuthSettings.service_account_client_id` |
+| `service_account_client_secret` | `AuthSettings.service_account_client_secret` |
+| (read from env only) | `AuthSettings.auth_url`, `auth_client_id`, `static_token` |
 
-Because `PipefySettings` is configured with `extra="ignore"`, code like `PipefySettings(service_account_url=...)` **silently drops the credentials** — no exception, no warning. Migrate by composing the two models side by side:
+Because `PipefySettings` / `AuthSettings` are configured with `extra="ignore"`, code that still passes the old kwargs (`PipefySettings(graphql_url=...)`, `AuthSettings(service_account_url=...)`) **silently drops them** — no exception, no warning. Migrate by using `base_url` and composing the two models side by side:
 
 ```python
 from pipefy_auth import AuthSettings
 from pipefy_sdk import PipefySettings
 
-pipefy = PipefySettings(graphql_url="https://app.pipefy.com/graphql")
+pipefy = PipefySettings(base_url="https://app.pipefy.com")
 auth = AuthSettings(
-    service_account_url="https://app.pipefy.com/oauth/token",
     service_account_client_id="...",
     service_account_client_secret="...",
 )
+# Computed properties:
+pipefy.graphql_url            # "https://app.pipefy.com/graphql"
+auth.service_account_url      # "https://app.pipefy.com/oauth/token"
 ```
 
 If you already build a `pipefy-mcp-server` or `pipefy-cli` settings object, the application-level `Settings` / `CliSettings` already nests both:

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -26,7 +26,7 @@ Most-explicit wins. The CLI walks this list top-down and stops at the first sour
 | 3 | `PIPEFY_SERVICE_ACCOUNT_*` triple | Service account | OAuth2 client-credentials grant |
 | 4 | Stored user session | You (the signed-in user) | Eager refresh inside a 60 s leeway window |
 
-Every tier wires the `InternalApiClient` against `PIPEFY_INTERNAL_API_URL` when that variable is set, so features that go through the internal API (AI agent automations, some relation flows) work from any path — not just the service-account one.
+Every tier wires the `InternalApiClient` against `<PIPEFY_BASE_URL>/internal_api` (derived from `PIPEFY_BASE_URL`), so features that go through the internal API (AI agent automations, some relation flows) work from any path — not just the service-account one.
 
 If `pipefy auth login` succeeds but a higher-precedence source is set in your shell env, the CLI prints a one-line note so you know your stored session is being shadowed.
 
@@ -39,11 +39,10 @@ If `pipefy auth login` succeeds but a higher-precedence source is set in your sh
 Use this when you want commands to run **as your Pipefy user** — useful for parity with the app's permission model and for AI-automation features that need a real user identity.
 
 ```bash
-export PIPEFY_AUTH_URL=https://signin.pipefy.com/realms/pipefy
-export PIPEFY_GRAPHQL_URL=https://app.pipefy.com/graphql
-
 uv run pipefy auth login
 ```
+
+`PIPEFY_BASE_URL` defaults to `https://app.pipefy.com` (drives the four API endpoints) and `PIPEFY_AUTH_URL` defaults to `https://signin.pipefy.com/realms/pipefy` (the OIDC issuer). Export non-prod values only when targeting a non-prod environment.
 
 This opens your browser, completes an OAuth 2.0 Authorization Code + PKCE flow against the Pipefy identity provider, and writes the resulting session (access token + refresh token + minimal metadata) into your OS keychain.
 
@@ -54,16 +53,16 @@ After login, every other `pipefy <cmd>` invocation transparently reuses that ses
 Use this for CI, scripts, MCP servers, and any context where opening a browser isn't an option. Get the client id and secret from **Pipefy Admin → Service Accounts** and put them in `.env` at the repo root:
 
 ```env
-PIPEFY_GRAPHQL_URL=https://app.pipefy.com/graphql
-PIPEFY_INTERNAL_API_URL=https://app.pipefy.com/internal_api
-PIPEFY_SERVICE_ACCOUNT_URL=https://app.pipefy.com/oauth/token
 PIPEFY_SERVICE_ACCOUNT_CLIENT_ID=<SERVICE_ACCOUNT_CLIENT_ID>
 PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET=<SERVICE_ACCOUNT_CLIENT_SECRET>
+# Non-prod environments only:
+# PIPEFY_BASE_URL=https://<your-api-host>
+# PIPEFY_AUTH_URL=https://<your-signin-host>/realms/<realm>
 ```
 
 The CLI loads `.env` from the current working directory; see [`docs/setup.md`](../setup.md) for the full Pydantic precedence rules.
 
-> **Legacy names:** `PIPEFY_OAUTH_URL`, `PIPEFY_OAUTH_CLIENT`, and `PIPEFY_OAUTH_SECRET` are still honored (with a one-shot stderr deprecation warning) for back-compat. They will be removed in a future beta. See [`docs/MIGRATION.md`](../MIGRATION.md#service-account-env-var-rename).
+> **Legacy names:** `PIPEFY_OAUTH_CLIENT` and `PIPEFY_OAUTH_SECRET` are still honored (with a one-shot stderr deprecation warning) for back-compat. They will be removed in a future beta. `PIPEFY_OAUTH_URL` has no alias — the OAuth token endpoint now derives from `PIPEFY_BASE_URL`. See [`docs/MIGRATION.md`](../MIGRATION.md#service-account-env-var-rename).
 
 ### Static bearer (one-off)
 
@@ -85,23 +84,23 @@ PIPEFY_TOKEN="$MY_BEARER" uv run pipefy pipe list
 
 | Key | Used by | Effect |
 |-----|---------|--------|
-| `PIPEFY_GRAPHQL_URL` | All commands | Public GraphQL endpoint. Required for any GraphQL call (default in `.env.example`). |
+| `PIPEFY_BASE_URL` | All commands | Pipefy API host root. Defaults to `https://app.pipefy.com`. Drives the GraphQL, internal-API, interfaces, and service-account OAuth token URLs (all four are computed from this base). Set to a different host for non-prod / regional / proxy / local-dev deployments. |
+| `PIPEFY_AUTH_URL` | Tier 4 | Full OIDC issuer URL for interactive login. The CLI appends `/.well-known/openid-configuration` to discover the authorization and token endpoints. Defaults to `https://signin.pipefy.com/realms/pipefy`. Set to the full issuer URL for a non-prod IdP. |
 | `PIPEFY_TOKEN` | Tier 2 | Direct bearer token. Overridden by `--token`. |
-| `PIPEFY_SERVICE_ACCOUNT_URL` | Tier 3 | Service-account token URL (e.g. `https://app.pipefy.com/oauth/token`). |
 | `PIPEFY_SERVICE_ACCOUNT_CLIENT_ID` | Tier 3 | Service-account client id. |
 | `PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET` | Tier 3 | Service-account client secret. |
-| `PIPEFY_INTERNAL_API_URL` | Tier 3 | Internal GraphQL endpoint for AI automations / some relation flows. Required for those tools only. |
-| `PIPEFY_AUTH_URL` | Tier 4 | **OIDC issuer URL** for interactive login. The CLI appends `/.well-known/openid-configuration` to discover the authorization and token endpoints. **Defaults to `https://signin.pipefy.com/realms/pipefy` (Pipefy production IdP)**; set to an empty string (`PIPEFY_AUTH_URL=`) to disable the stored-session tier, or override to point at a non-prod IdP. |
 | `PIPEFY_AUTH_CLIENT_ID` | Tier 4 | Public client id registered for the CLI. Defaults to `pipefy-cli`. |
 
-`PIPEFY_SERVICE_ACCOUNT_URL` and `PIPEFY_AUTH_URL` are **not** interchangeable: the first is a token URL for client-credentials, the second is an OIDC issuer URL for the user-login flow.
+The service-account OAuth token URL (Tier 3) and the OIDC issuer URL (Tier 4) are **not** interchangeable: the first is `<base>/oauth/token` for client-credentials, the second is the full OIDC discovery root for the user-login flow.
+
+**Empty / malformed values raise.** Any `PIPEFY_*` env var that does not match its pattern is rejected at settings load. Unset the variable to fall back to the default.
 
 ### Global flags
 
 | Flag | Effect |
 |------|--------|
 | `--token <bearer>` | Tier 1 bearer. Overrides `PIPEFY_TOKEN` if both are set. |
-| `--graphql-url <url>` | Override `PIPEFY_GRAPHQL_URL` for this process. |
+| `--base-url <url>` | Override `PIPEFY_BASE_URL` for this process. |
 | `--allow-insecure-urls` | Allow `http://` and private hosts for this process (dev only). |
 
 ### Commands
@@ -171,18 +170,13 @@ When no session is stored, `pipefy auth logout` prints `Not signed in. Nothing t
 
 | Case | Exit |
 |------|------|
-| `PIPEFY_AUTH_URL` explicitly disabled (`PIPEFY_AUTH_URL=`) | **2** — same gate as `pipefy auth login`. With the var unset, the prod issuer default applies and this case does not trigger. |
+| `PIPEFY_AUTH_URL=""` (or any other `PIPEFY_*` env var set to empty) | **2** — pydantic rejects empty values at settings load. Unset the var to fall back to the prod default. |
 | No session stored (no-op) | **0** |
 | Session cleared (revoke succeeded, failed, or unsupported) | **0** |
 
 ### Pipefy issuer URLs
 
-| Environment | `PIPEFY_AUTH_URL` |
-|-------------|--------------------|
-| Production | `https://signin.pipefy.com/realms/pipefy` |
-| Validation (piporacle) | `https://signin-piporacle.pipefy.com/realms/st-piporacle-pud1m` |
-
-Pair each issuer with the matching `PIPEFY_GRAPHQL_URL` (`https://app.pipefy.com/graphql` for prod, `https://piporacle.pipefy.com/graphql` for piporacle).
+Production: `https://signin.pipefy.com/realms/pipefy` (the `PIPEFY_AUTH_URL` default). For a non-prod IdP, set `PIPEFY_AUTH_URL` to the full issuer URL (host + realm) directly — the CLI doesn't try to derive it from any tenant convention.
 
 ---
 
@@ -206,9 +200,17 @@ Forthcoming: an OAuth 2.0 Device Authorization Grant (`pipefy auth login --devic
 
 The keychain has a session but its refresh token won't exchange. Most common causes: the refresh token's absolute lifetime expired, you signed out of the IdP, or the issuer URL changed (e.g. you switched between prod and piporacle without re-logging). Re-run `pipefy auth login`.
 
-### `PIPEFY_AUTH_URL is required for pipefy auth login`
+### `String should match pattern '<regex>'` (any `PIPEFY_*` env var)
 
-The stored-session tier is explicitly disabled. With `PIPEFY_AUTH_URL` unset the CLI falls back to the Pipefy production issuer default, so this message means the var is set to an empty string (`PIPEFY_AUTH_URL=`) — usually to opt out of the stored-session tier on a host that can't reach prod. Unset the variable to restore the default, or set it to a valid issuer URL (see [Pipefy issuer URLs](#pipefy-issuer-urls)) if you need a non-prod IdP.
+Every `PIPEFY_*` env var is validated against a semantically meaningful regex at settings load — URL env vars (`PIPEFY_BASE_URL`, `PIPEFY_AUTH_URL`) must start with `http(s)://`, credentials must not begin/end with whitespace, `PIPEFY_ORG_ID` must be a numeric string. Empty / blank / specially-charactered values are rejected at construction — there's no overload of `PIPEFY_<NAME>=""` for opt-out semantics (a separate kill-switch mechanism is tracked in [#237](https://github.com/gbrlcustodio/pipefy-mcp-server/issues/237)). Unset the variable to fall back to the prod default (for URLs) or to leave the tier unconfigured (for credentials). The error message names the offending field plus the violated pattern.
+
+> **`VAR= command` is not "unset".** A shell command-prefix assignment (`PIPEFY_AUTH_URL= pipefy auth status`) sets the variable to the empty string for the child process; it does **not** unset it. Pydantic then rejects the empty value and the command exits with a `ValidationError`. To actually unset a variable for a single command, use `env -u VAR command` (POSIX one-shot, leaves the parent shell untouched):
+>
+> ```sh
+> env -u PIPEFY_AUTH_URL pipefy auth status
+> ```
+>
+> To unset for the remainder of the current shell session, `unset PIPEFY_AUTH_URL` (bash / zsh) or `set -e PIPEFY_AUTH_URL` (fish).
 
 ### `Login succeeded but the session could not be stored in your OS keychain (<backend>)`
 

--- a/docs/mcp/tools/portal.md
+++ b/docs/mcp/tools/portal.md
@@ -2,7 +2,7 @@
 
 Read and manage Pipefy portals (Interfaces schema): list org portals, fetch detail, create/update/delete portal metadata, and manage pages (create, update, delete, sort, layout). **10 tools.**
 
-Portal tools call the **Interfaces** GraphQL endpoint (`PIPEFY_INTERFACES_GRAPHQL_URL`, default `https://app.pipefy.com/graphql/interfaces`), not the public `/graphql` schema used by most pipe/card tools.
+Portal tools call the **Interfaces** GraphQL endpoint (`<PIPEFY_BASE_URL>/graphql/interfaces`, default `https://app.pipefy.com/graphql/interfaces`), not the public `/graphql` schema used by most pipe/card tools.
 
 ---
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -57,20 +57,22 @@ Runtime settings come from **`pipefy_mcp.settings.Settings`** ([Pydantic Setting
 
 ## Environment variables
 
-### Required for API access
+### URL configuration
 
-| Key | Role |
-|-----|------|
-| `PIPEFY_GRAPHQL_URL` | Public GraphQL endpoint (default in `.env.example`). |
-| `PIPEFY_INTERNAL_API_URL` | Internal GraphQL (AI automations, some relation flows). Use the value from [`.env.example`](../.env.example). |
-| `PIPEFY_INTERFACES_GRAPHQL_URL` | Interfaces GraphQL (portals, pages, elements). Optional; defaults to `https://app.pipefy.com/graphql/interfaces`. |
-| `PIPEFY_SERVICE_ACCOUNT_URL` | Service-account OAuth 2.0 token endpoint (client-credentials grant). |
-| `PIPEFY_SERVICE_ACCOUNT_CLIENT_ID` | Service-account client_id (OAuth 2.0 RFC 6749). |
-| `PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET` | Service-account client_secret. |
+| Key | Default | Effect |
+|-----|---------|--------|
+| `PIPEFY_BASE_URL` | `https://app.pipefy.com` | Pipefy API host root. Drives `graphql_url`, `internal_api_url`, `interfaces_graphql_url`, and the service-account OAuth token endpoint (all four are computed properties). Set to a different host for non-prod environments, regional / proxy deployments, or local development (with `PIPEFY_ALLOW_INSECURE_URLS`). |
+| `PIPEFY_AUTH_URL` | `https://signin.pipefy.com/realms/pipefy` | Full OIDC issuer URL for the stored-session tier. Set to the full issuer URL for non-prod IdPs. |
+| `PIPEFY_SERVICE_ACCOUNT_CLIENT_ID` | _unset_ | Service-account client_id (OAuth 2.0 RFC 6749). |
+| `PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET` | _unset_ | Service-account client_secret. |
+| `PIPEFY_TOKEN` | _unset_ | Pre-issued bearer for the static-token tier; outranks the service-account triple and any stored session. |
+| `PIPEFY_AUTH_CLIENT_ID` | `pipefy-cli` | OIDC public client id registered at the issuer (rarely overridden). |
 
-`PIPEFY_INTERNAL_API_URL` points at Pipefy’s internal GraphQL; it is required for tools that use that path (e.g. AI automations, some relations). Values are **validated at startup** — public Pipefy hosts are the normal case; `localhost` / private hosts are rejected to avoid SSRF unless you use the insecure-dev flags in [`.env.example`](../.env.example).
+An operator on prod typically sets just the credentials (`PIPEFY_SERVICE_ACCOUNT_CLIENT_ID` + `PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET`, or `PIPEFY_TOKEN`). Non-prod operators add `PIPEFY_BASE_URL` and `PIPEFY_AUTH_URL`.
 
-> **Legacy names:** `PIPEFY_OAUTH_URL`, `PIPEFY_OAUTH_CLIENT`, and `PIPEFY_OAUTH_SECRET` are still honored (with a one-shot stderr deprecation warning) for back-compat. They will be removed in a future beta. See [docs/MIGRATION.md](MIGRATION.md#service-account-env-var-rename).
+Values are **validated at startup** with per-field regex patterns (`https?://` for URL fields, numeric for `PIPEFY_ORG_ID`, non-whitespace for credentials). `localhost` / private hosts are rejected to avoid SSRF unless you use the insecure-dev flags in [`.env.example`](../.env.example). **Empty / malformed values raise.** Any `PIPEFY_*` env var that does not match its pattern is rejected at construction — unset the variable to fall back to the default.
+
+> **Legacy names:** `PIPEFY_OAUTH_CLIENT` and `PIPEFY_OAUTH_SECRET` are still honored (with a one-shot stderr deprecation warning) for back-compat. They will be removed in a future beta. The `PIPEFY_OAUTH_URL` alias was dropped — the OAuth token endpoint now derives from `PIPEFY_BASE_URL`. See [docs/MIGRATION.md](MIGRATION.md#service-account-env-var-rename).
 
 ### Optional
 
@@ -89,14 +91,10 @@ All other optional flags (insecure dev URLs, webhooks, introspection cache, etc.
 
 **Recommended:** set the client’s working directory to your **clone root** and use **`.env`** for `PIPEFY_*` values. Then the JSON `env` block can be minimal or empty for local dev. If you put secrets only in JSON, use the same keys as [`.env.example`](../.env.example).
 
-Use this **`env` shape** when you need to inline values (e.g. CI or machines without a `.env` file). Include **`PIPEFY_INTERNAL_API_URL`** and **`PIPEFY_INTERFACES_GRAPHQL_URL`** for parity with full tool coverage (same as [`.env.example`](../.env.example)).
+Use this **`env` shape** when you need to inline values (e.g. CI or machines without a `.env` file). On prod, only the service-account triple is required. Non-prod operators add `PIPEFY_BASE_URL` (and `PIPEFY_AUTH_URL` when the OIDC issuer differs):
 
 ```json
 "env": {
-    "PIPEFY_GRAPHQL_URL": "https://app.pipefy.com/graphql",
-    "PIPEFY_INTERNAL_API_URL": "https://app.pipefy.com/internal_api",
-    "PIPEFY_INTERFACES_GRAPHQL_URL": "https://app.pipefy.com/graphql/interfaces",
-    "PIPEFY_SERVICE_ACCOUNT_URL": "https://app.pipefy.com/oauth/token",
     "PIPEFY_SERVICE_ACCOUNT_CLIENT_ID": "<SERVICE_ACCOUNT_CLIENT_ID>",
     "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET": "<SERVICE_ACCOUNT_CLIENT_SECRET>"
 }
@@ -121,10 +119,6 @@ Use this **`env` shape** when you need to inline values (e.g. CI or machines wit
                 "pipefy-mcp-server"
             ],
             "env": {
-                "PIPEFY_GRAPHQL_URL": "https://app.pipefy.com/graphql",
-                "PIPEFY_INTERNAL_API_URL": "https://app.pipefy.com/internal_api",
-                "PIPEFY_INTERFACES_GRAPHQL_URL": "https://app.pipefy.com/graphql/interfaces",
-                "PIPEFY_SERVICE_ACCOUNT_URL": "https://app.pipefy.com/oauth/token",
                 "PIPEFY_SERVICE_ACCOUNT_CLIENT_ID": "<SERVICE_ACCOUNT_CLIENT_ID>",
                 "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET": "<SERVICE_ACCOUNT_CLIENT_SECRET>"
             }
@@ -133,7 +127,7 @@ Use this **`env` shape** when you need to inline values (e.g. CI or machines wit
 }
 ```
 
-Set `cwd` to your clone root so the server can read **`.env`** there; you may omit keys from `env` that are already set in `.env`.
+Set `cwd` to your clone root so the server can read **`.env`** there; you may omit keys from `env` that are already set in `.env`. Non-prod operators add `"PIPEFY_BASE_URL": "https://<api-host>"` (and `PIPEFY_AUTH_URL` if the OIDC issuer differs).
 
 ### Claude Desktop
 
@@ -158,10 +152,6 @@ MCP servers load from a JSON config file. You can keep credentials in **`.env`**
                 "pipefy-mcp-server"
             ],
             "env": {
-                "PIPEFY_GRAPHQL_URL": "https://app.pipefy.com/graphql",
-                "PIPEFY_INTERNAL_API_URL": "https://app.pipefy.com/internal_api",
-                "PIPEFY_INTERFACES_GRAPHQL_URL": "https://app.pipefy.com/graphql/interfaces",
-                "PIPEFY_SERVICE_ACCOUNT_URL": "https://app.pipefy.com/oauth/token",
                 "PIPEFY_SERVICE_ACCOUNT_CLIENT_ID": "<SERVICE_ACCOUNT_CLIENT_ID>",
                 "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET": "<SERVICE_ACCOUNT_CLIENT_SECRET>"
             }
@@ -191,17 +181,13 @@ The repo ships a Claude Code plugin that registers the MCP server, a `/pipefy:in
 
 On macOS, `pipefy auth login` may exit with `errSecParam (-25244)` at the final keychain-write step even though OAuth itself succeeded. The cause is not yet reliably diagnosed — direct `keyring.set_password` calls from the same uv-tool-installed Python succeed under repro testing, so this is likely a transient `Security.framework` condition rather than a deterministic per-binary ACL problem. If it occurs, retry the slash command first; as a fallback, run `pipefy auth login` once from a regular Terminal.app session and approve any macOS keychain dialog that appears. Issue #235 tracks platform-aware error messaging.
 
-Configure the plugin-spawned MCP server's environment by editing the `env` block of the `pipefy` MCP server entry in your Claude Code settings (`~/.claude.json` or via the settings UI; the plugin's `.mcp.json` ships `command`+`args` only). `PIPEFY_GRAPHQL_URL` is required; `PIPEFY_INTERNAL_API_URL` is required for AI-automation tools; `PIPEFY_AUTH_URL` is required if you intend to use `/pipefy:login` or the stored-session tier; the service-account triple is only needed for the service-account tier:
+Configure the plugin-spawned MCP server's environment by editing the `env` block of the `pipefy` MCP server entry in your Claude Code settings (`~/.claude.json` or via the settings UI; the plugin's `.mcp.json` ships `command`+`args` only). Prod operators set only the service-account triple (`PIPEFY_BASE_URL` and `PIPEFY_AUTH_URL` default to Pipefy production); non-prod operators add either or both:
 
 ```json
 {
   "mcpServers": {
     "pipefy": {
       "env": {
-        "PIPEFY_GRAPHQL_URL": "https://app.pipefy.com/graphql",
-        "PIPEFY_INTERNAL_API_URL": "https://app.pipefy.com/internal_api",
-        "PIPEFY_AUTH_URL": "https://signin.pipefy.com/realms/pipefy",
-        "PIPEFY_SERVICE_ACCOUNT_URL": "https://app.pipefy.com/oauth/token",
         "PIPEFY_SERVICE_ACCOUNT_CLIENT_ID": "<CLIENT_ID>",
         "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET": "<CLIENT_SECRET>"
       }
@@ -210,7 +196,7 @@ Configure the plugin-spawned MCP server's environment by editing the `env` block
 }
 ```
 
-Note: `/pipefy:login` itself runs `pipefy auth login` in your shell (not in the MCP server process), so `PIPEFY_AUTH_URL` must also be in the shell environment Claude Code inherited from — exported or placed in a `.env` file at the CWD. Issue #233 will make `PIPEFY_AUTH_URL` an optional override once a CLI-level default lands. Legacy `PIPEFY_OAUTH_*` aliases still resolve but the CLI prints rename warnings; prefer the canonical `PIPEFY_SERVICE_ACCOUNT_*` names above.
+Legacy `PIPEFY_OAUTH_CLIENT` / `_SECRET` env vars still resolve to the new `PIPEFY_SERVICE_ACCOUNT_*` names with a one-shot stderr deprecation warning. The `PIPEFY_OAUTH_URL` alias was dropped — set `PIPEFY_BASE_URL` instead.
 
 **CLI (per project)**
 
@@ -224,10 +210,9 @@ Then (repeat for each key you need, matching [`.env.example`](../.env.example)):
 ```bash
 claude mcp add-env pipefy PIPEFY_SERVICE_ACCOUNT_CLIENT_ID <YOUR_CLIENT_ID>
 claude mcp add-env pipefy PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET <YOUR_CLIENT_SECRET>
-claude mcp add-env pipefy PIPEFY_GRAPHQL_URL https://app.pipefy.com/graphql
-claude mcp add-env pipefy PIPEFY_INTERNAL_API_URL https://app.pipefy.com/internal_api
-claude mcp add-env pipefy PIPEFY_INTERFACES_GRAPHQL_URL https://app.pipefy.com/graphql/interfaces
-claude mcp add-env pipefy PIPEFY_SERVICE_ACCOUNT_URL https://app.pipefy.com/oauth/token
+# Non-prod environments only:
+# claude mcp add-env pipefy PIPEFY_BASE_URL https://<your-api-host>
+# claude mcp add-env pipefy PIPEFY_AUTH_URL https://<your-signin-host>/realms/<realm>
 ```
 
 **`.mcp.json` (project root)**
@@ -244,10 +229,6 @@ claude mcp add-env pipefy PIPEFY_SERVICE_ACCOUNT_URL https://app.pipefy.com/oaut
                 "pipefy-mcp-server"
             ],
             "env": {
-                "PIPEFY_GRAPHQL_URL": "https://app.pipefy.com/graphql",
-                "PIPEFY_INTERNAL_API_URL": "https://app.pipefy.com/internal_api",
-                "PIPEFY_INTERFACES_GRAPHQL_URL": "https://app.pipefy.com/graphql/interfaces",
-                "PIPEFY_SERVICE_ACCOUNT_URL": "https://app.pipefy.com/oauth/token",
                 "PIPEFY_SERVICE_ACCOUNT_CLIENT_ID": "<SERVICE_ACCOUNT_CLIENT_ID>",
                 "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET": "<SERVICE_ACCOUNT_CLIENT_SECRET>"
             }

--- a/packages/auth/src/pipefy_auth/__init__.py
+++ b/packages/auth/src/pipefy_auth/__init__.py
@@ -18,7 +18,7 @@ from pipefy_auth.discovery import (
     fetch_provider_metadata,
 )
 from pipefy_auth.flow import LoginError, LoginResult, run_login
-from pipefy_auth.identity import DEFAULT_AUTH_CLIENT_ID, DEFAULT_AUTH_URL, OidcClient
+from pipefy_auth.identity import DEFAULT_AUTH_CLIENT_ID, OidcClient
 from pipefy_auth.refresh import (
     RefreshError,
     ensure_fresh_session,
@@ -54,7 +54,6 @@ __all__ = [
     "AuthSettings",
     "CallableBearerAuth",
     "DEFAULT_AUTH_CLIENT_ID",
-    "DEFAULT_AUTH_URL",
     "DiscoveryPolicy",
     "LoginError",
     "LoginResult",

--- a/packages/auth/src/pipefy_auth/identity.py
+++ b/packages/auth/src/pipefy_auth/identity.py
@@ -8,11 +8,6 @@ from dataclasses import dataclass
 # is fixed across consumers (CLI, MCP, …) and not user-configurable.
 DEFAULT_AUTH_CLIENT_ID = "pipefy-cli"
 
-# Canonical Pipefy production OIDC issuer URL. Used as the default when
-# ``PIPEFY_AUTH_URL`` is not set in the environment — override by setting
-# the env var (or passing ``auth_url`` explicitly to ``AuthSettings``).
-DEFAULT_AUTH_URL = "https://signin.pipefy.com/realms/pipefy"
-
 
 @dataclass(frozen=True)
 class OidcClient:
@@ -28,6 +23,5 @@ class OidcClient:
 
 __all__ = [
     "DEFAULT_AUTH_CLIENT_ID",
-    "DEFAULT_AUTH_URL",
     "OidcClient",
 ]

--- a/packages/auth/src/pipefy_auth/settings.py
+++ b/packages/auth/src/pipefy_auth/settings.py
@@ -2,38 +2,68 @@
 
 Owns every value that describes *how* to authenticate against Pipefy:
 
-* ``PIPEFY_SERVICE_ACCOUNT_*`` — OAuth2 client-credentials grant inputs
-  (legacy ``PIPEFY_OAUTH_*`` names still honoured via :class:`AliasChoices`).
-* ``PIPEFY_AUTH_URL`` — OIDC issuer URL for the stored-session tier.
+* ``PIPEFY_SERVICE_ACCOUNT_CLIENT_ID`` / ``PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET``
+  — OAuth2 client-credentials grant inputs (legacy ``PIPEFY_OAUTH_CLIENT`` /
+  ``_SECRET`` names still honoured via :class:`AliasChoices`).
+* ``PIPEFY_AUTH_URL`` — full OIDC issuer URL for the stored-session tier
+  (default ``https://signin.pipefy.com/realms/pipefy``).
 * ``PIPEFY_AUTH_CLIENT_ID`` — OIDC public client id (defaults to
   :data:`pipefy_auth.identity.DEFAULT_AUTH_CLIENT_ID`).
+* ``PIPEFY_BASE_URL`` — API host root that drives the OAuth token endpoint
+  (default ``https://app.pipefy.com``). Same env var that drives the SDK's
+  ``base_url`` field on :class:`pipefy_sdk.PipefySettings`; both models load
+  it independently so they stay in sync without cross-package coupling.
 
-Endpoint settings (``PIPEFY_GRAPHQL_URL``, ``PIPEFY_INTERNAL_API_URL``) live
-on :class:`pipefy_sdk.PipefySettings` — they are SDK concerns, not auth.
-Consumers compose both models side by side in their own settings type.
+Per-URL env vars from earlier betas (``PIPEFY_GRAPHQL_URL``,
+``PIPEFY_INTERNAL_API_URL``, ``PIPEFY_INTERFACES_GRAPHQL_URL``,
+``PIPEFY_SERVICE_ACCOUNT_URL``, ``PIPEFY_TENANT``, ``PIPEFY_AUTH_REALM``,
+``PIPEFY_OAUTH_URL``) are no longer recognized — set ``PIPEFY_BASE_URL`` to
+the API host and ``PIPEFY_AUTH_URL`` to the full OIDC issuer URL instead.
 """
 
 from __future__ import annotations
 
 import os
 import sys
+from typing import Self
 
-from pydantic import AliasChoices, Field, field_validator, model_validator
+from pydantic import (
+    AliasChoices,
+    Field,
+    computed_field,
+    field_validator,
+    model_validator,
+)
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from pipefy_auth.identity import (
     DEFAULT_AUTH_CLIENT_ID,
-    DEFAULT_AUTH_URL,
     OidcClient,
 )
 from pipefy_auth.resolver import ServiceAccount
 
+# Production defaults.
+DEFAULT_AUTH_URL = "https://signin.pipefy.com/realms/pipefy"
+DEFAULT_BASE_URL = "https://app.pipefy.com"
+
+# Opaque secret / identifier strings: reject leading / trailing whitespace and
+# blank values. Anything in between is opaque to us (the IdP defines the format).
+_OPAQUE_CREDENTIAL_PATTERN = r"^\S(?:.*\S)?$"
+
+# URL-shape gate. ``pipefy_auth._url_ssrf.validate_https_service_endpoint_url``
+# does the deeper SSRF + scheme check after settings construction. The
+# scheme part is case-insensitive (RFC 3986 §3.1) so `HTTPS://...` from
+# operator copy-paste passes the shape gate; httpx + gql normalize the
+# scheme downstream.
+_URL_SHAPE_PATTERN = r"^(?i:https?)://\S+$"
+
 # Legacy ``PIPEFY_OAUTH_*`` env vars still resolve to the new
 # ``PIPEFY_SERVICE_ACCOUNT_*`` fields. The mapping is exported for
 # diagnostics (e.g. CLI's ``pipefy auth status`` lists which legacy keys
-# would still mask a stored session).
+# would still mask a stored session). The legacy ``PIPEFY_OAUTH_URL`` alias
+# was dropped in the ``PIPEFY_BASE_URL`` rewrite — the token endpoint now
+# derives from ``base_url``.
 _LEGACY_ENV_KEYS_TO_NEW: dict[str, str] = {
-    "PIPEFY_OAUTH_URL": "PIPEFY_SERVICE_ACCOUNT_URL",
     "PIPEFY_OAUTH_CLIENT": "PIPEFY_SERVICE_ACCOUNT_CLIENT_ID",
     "PIPEFY_OAUTH_SECRET": "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET",
 }
@@ -65,9 +95,14 @@ class AuthSettings(BaseSettings):
     """Auth-related configuration loaded from env / config files.
 
     Reads its own ``PIPEFY_*`` env vars directly (with the ``PIPEFY_`` prefix
-    folded into the field names). Pure data — SSRF validation happens via
-    :meth:`validate_urls` once the surrounding settings know whether insecure
-    URLs are allowed.
+    folded into the field names). Self-contained: SSRF validation runs inline
+    as a ``model_validator(mode="after")`` hook, so direct construction
+    (`AuthSettings()`) is safe even when not composed under
+    :class:`CliSettings` / :class:`Settings`. The ``allow_insecure_urls``
+    field mirrors :class:`pipefy_sdk.PipefySettings`'s field of the same name
+    and is read from ``PIPEFY_ALLOW_INSECURE_URLS``; the ``base_url`` field
+    likewise mirrors PipefySettings via ``PIPEFY_BASE_URL`` and drives the
+    OAuth token endpoint.
     """
 
     model_config = SettingsConfigDict(
@@ -77,7 +112,7 @@ class AuthSettings(BaseSettings):
         extra="ignore",
         # Required so ``env_prefix`` is applied to the field name on top of the
         # ``AliasChoices`` lookups (otherwise env lookups would only consider
-        # the aliases, and ``PIPEFY_SERVICE_ACCOUNT_URL`` would be ignored).
+        # the aliases, and ``PIPEFY_SERVICE_ACCOUNT_CLIENT_ID`` would be ignored).
         populate_by_name=True,
     )
 
@@ -90,52 +125,45 @@ class AuthSettings(BaseSettings):
 
     @field_validator(
         "static_token",
-        "service_account_url",
         "service_account_client_id",
         "service_account_client_secret",
         "auth_url",
+        "auth_client_id",
+        "base_url",
         mode="before",
     )
     @classmethod
-    def _blank_to_none(cls, value: object) -> object:
-        # Empty / whitespace-only env values mean "not set", not "set to ''".
-        if isinstance(value, str) and not value.strip():
-            return None
+    def _strip_str(cls, value: object) -> object:
+        # Strip surrounding whitespace on every env-loaded string so a stray
+        # leading / trailing space from copy-paste does not trip the per-field
+        # ``pattern`` constraint. Empty-after-strip still fails the pattern
+        # (the "empty raises" contract).
+        if isinstance(value, str):
+            return value.strip()
         return value
 
-    # ``AliasChoices`` precedence is left-to-right. The fully-prefixed
-    # canonical env var comes first to outrank the legacy ``PIPEFY_OAUTH_*``
-    # name. The unprefixed form (e.g. ``oauth_url``) keeps direct kwarg
-    # construction working (``AuthSettings(oauth_url=...)``).
+    # ``AliasChoices`` lists ONLY fully-prefixed env-var names. Unprefixed
+    # entries would let pydantic-settings pick up bare-name env vars
+    # (e.g. ``BASE_URL``, ``STATIC_TOKEN``, ``OAUTH_CLIENT``) — an
+    # auth-redirect / credential-leak primitive for any host whose env
+    # accidentally carries those common names. Kwarg construction by
+    # field name (e.g. ``AuthSettings(static_token=...)``) still works
+    # via ``populate_by_name=True``.
     static_token: str | None = Field(
         default=None,
-        validation_alias=AliasChoices("PIPEFY_TOKEN", "static_token"),
+        pattern=_OPAQUE_CREDENTIAL_PATTERN,
+        validation_alias=AliasChoices("PIPEFY_TOKEN"),
         description=(
             "Pre-issued bearer for the static-token tier (env: PIPEFY_TOKEN). "
             "When set, outranks both the service-account triple and any stored session."
         ),
     )
 
-    service_account_url: str | None = Field(
-        default=None,
-        validation_alias=AliasChoices(
-            "PIPEFY_SERVICE_ACCOUNT_URL",
-            "service_account_url",
-            "oauth_url",
-            "PIPEFY_OAUTH_URL",
-        ),
-        description=(
-            "Service-account token endpoint (OAuth 2.0 client-credentials grant) "
-            "(env: PIPEFY_SERVICE_ACCOUNT_URL; legacy PIPEFY_OAUTH_URL still honored)."
-        ),
-    )
-
     service_account_client_id: str | None = Field(
         default=None,
+        pattern=_OPAQUE_CREDENTIAL_PATTERN,
         validation_alias=AliasChoices(
             "PIPEFY_SERVICE_ACCOUNT_CLIENT_ID",
-            "service_account_client_id",
-            "oauth_client",
             "PIPEFY_OAUTH_CLIENT",
         ),
         description=(
@@ -146,10 +174,9 @@ class AuthSettings(BaseSettings):
 
     service_account_client_secret: str | None = Field(
         default=None,
+        pattern=_OPAQUE_CREDENTIAL_PATTERN,
         validation_alias=AliasChoices(
             "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET",
-            "service_account_client_secret",
-            "oauth_secret",
             "PIPEFY_OAUTH_SECRET",
         ),
         description=(
@@ -158,23 +185,56 @@ class AuthSettings(BaseSettings):
         ),
     )
 
-    auth_url: str | None = Field(
+    auth_url: str = Field(
         default=DEFAULT_AUTH_URL,
+        pattern=_URL_SHAPE_PATTERN,
         description=(
             "OIDC issuer URL for the stored-session tier "
-            "(env: PIPEFY_AUTH_URL; defaults to the Pipefy production IdP at "
-            f"{DEFAULT_AUTH_URL}). Set to an empty string to disable the "
-            "stored-session tier on hosts that need an explicit opt-out."
+            "(env: PIPEFY_AUTH_URL). Defaults to "
+            f"'{DEFAULT_AUTH_URL}' (canonical Pipefy production IdP). Set to "
+            "the full issuer URL for a non-prod IdP."
         ),
     )
 
     auth_client_id: str = Field(
         default=DEFAULT_AUTH_CLIENT_ID,
+        pattern=_OPAQUE_CREDENTIAL_PATTERN,
         description=(
             "OIDC public client id registered at the issuer "
             "(env: PIPEFY_AUTH_CLIENT_ID; rarely overridden)."
         ),
     )
+
+    base_url: str = Field(
+        default=DEFAULT_BASE_URL,
+        pattern=_URL_SHAPE_PATTERN,
+        validation_alias=AliasChoices("PIPEFY_BASE_URL"),
+        description=(
+            "Pipefy API host root (env: PIPEFY_BASE_URL). Drives the "
+            "service-account OAuth token endpoint via the "
+            "``service_account_url`` computed property. Mirrors the field of "
+            "the same name on :class:`pipefy_sdk.PipefySettings`; both models "
+            "load it independently from the same env var so they stay in sync."
+        ),
+    )
+
+    allow_insecure_urls: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("PIPEFY_ALLOW_INSECURE_URLS"),
+        description=(
+            "When true (env: PIPEFY_ALLOW_INSECURE_URLS), auth-related URLs "
+            "may use http:// and internal hosts; local development only; do "
+            "not enable in production. Mirrors the field of the same name on "
+            ":class:`pipefy_sdk.PipefySettings` so this model can run its own "
+            "inline SSRF check without consulting the parent composition."
+        ),
+    )
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def service_account_url(self) -> str:
+        """OAuth 2.0 token endpoint for the service-account tier."""
+        return f"{self.base_url.rstrip('/')}/oauth/token"
 
     def to_service_account(self) -> ServiceAccount | None:
         """Project the triple into a :class:`ServiceAccount`, or ``None`` if incomplete."""
@@ -190,27 +250,30 @@ class AuthSettings(BaseSettings):
             )
         return None
 
-    def to_oidc_client(self) -> OidcClient | None:
-        """Project the OIDC fields into an :class:`OidcClient`, or ``None`` without ``auth_url``."""
-        if self.auth_url and self.auth_url.strip():
-            return OidcClient(
-                issuer_url=self.auth_url.strip(),
-                client_id=self.auth_client_id.strip() or DEFAULT_AUTH_CLIENT_ID,
-            )
-        return None
+    def to_oidc_client(self) -> OidcClient:
+        """Project the OIDC fields into an :class:`OidcClient` (never returns None)."""
+        return OidcClient(
+            issuer_url=self.auth_url.strip(),
+            client_id=self.auth_client_id.strip(),
+        )
 
-    def validate_urls(self, *, allow_insecure: bool) -> None:
-        """Run SSRF checks on every URL this model carries. Call after composing."""
+    @model_validator(mode="after")
+    def _validate_endpoint_urls(self) -> Self:
+        # Self-validate so direct ``AuthSettings()`` construction (outside
+        # ``CliSettings`` / ``Settings``) is safe.
         from pipefy_auth._url_ssrf import validate_https_service_endpoint_url
 
-        if self.service_account_url and (u := self.service_account_url.strip()):
-            validate_https_service_endpoint_url(
-                u, "service_account_url", allow_insecure=allow_insecure
-            )
-        if self.auth_url and (u := self.auth_url.strip()):
-            validate_https_service_endpoint_url(
-                u, "auth_url", allow_insecure=allow_insecure
-            )
+        validate_https_service_endpoint_url(
+            self.base_url.strip(),
+            "base_url",
+            allow_insecure=self.allow_insecure_urls,
+        )
+        validate_https_service_endpoint_url(
+            self.auth_url.strip(),
+            "auth_url",
+            allow_insecure=self.allow_insecure_urls,
+        )
+        return self
 
 
 __all__ = ["AuthSettings"]

--- a/packages/auth/src/pipefy_auth/settings.py
+++ b/packages/auth/src/pipefy_auth/settings.py
@@ -68,7 +68,19 @@ _LEGACY_ENV_KEYS_TO_NEW: dict[str, str] = {
     "PIPEFY_OAUTH_SECRET": "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET",
 }
 
+# Env vars that earlier betas honored but this release no longer reads (``extra="ignore"``
+# silently drops them). Emit a one-shot stderr warning so operators upgrading from a
+# non-prod configuration get a runtime breadcrumb instead of silently authenticating
+# against the prod default.
+_LEGACY_DROPPED_ENV_KEYS: dict[str, str] = {
+    "PIPEFY_OAUTH_URL": (
+        "no replacement — the OAuth token endpoint now derives from PIPEFY_BASE_URL "
+        "(default https://app.pipefy.com)"
+    ),
+}
+
 _warned_legacy_env_keys: set[str] = set()
+_warned_dropped_env_keys: set[str] = set()
 
 
 def _warn_once_for_legacy_oauth_env_keys() -> None:
@@ -86,9 +98,25 @@ def _warn_once_for_legacy_oauth_env_keys() -> None:
             _warned_legacy_env_keys.add(legacy)
 
 
+def _warn_once_for_dropped_oauth_env_keys() -> None:
+    """Emit a one-shot stderr warning for each removed env var still present in the environment."""
+    if len(_warned_dropped_env_keys) == len(_LEGACY_DROPPED_ENV_KEYS):
+        return
+    for legacy, note in _LEGACY_DROPPED_ENV_KEYS.items():
+        if legacy in _warned_dropped_env_keys:
+            continue
+        if legacy in os.environ:
+            sys.stderr.write(
+                f"warning: {legacy} is no longer recognized — {note}. "
+                "The stale value is silently ignored; remove it from your env / .env.\n"
+            )
+            _warned_dropped_env_keys.add(legacy)
+
+
 def _reset_legacy_oauth_warning_state() -> None:
     """Test helper: clear the one-shot dedup so a fixture can re-trigger the warning."""
     _warned_legacy_env_keys.clear()
+    _warned_dropped_env_keys.clear()
 
 
 class AuthSettings(BaseSettings):
@@ -121,6 +149,7 @@ class AuthSettings(BaseSettings):
     def _emit_legacy_oauth_env_var_warning(cls, data: object) -> object:
         # Mirrors the pre-split behaviour: warn once per legacy env key still set.
         _warn_once_for_legacy_oauth_env_keys()
+        _warn_once_for_dropped_oauth_env_keys()
         return data
 
     @field_validator(
@@ -205,10 +234,13 @@ class AuthSettings(BaseSettings):
         ),
     )
 
+    # ``base_url`` and ``allow_insecure_urls`` use the ``env_prefix="PIPEFY_"``
+    # mapping directly (env name = ``PIPEFY_<FIELD_NAME>``) — no ``AliasChoices``
+    # needed. Field-name init kwargs (``AuthSettings(base_url=...)``) win over
+    # env on the source chain, matching the natural call site.
     base_url: str = Field(
         default=DEFAULT_BASE_URL,
         pattern=_URL_SHAPE_PATTERN,
-        validation_alias=AliasChoices("PIPEFY_BASE_URL"),
         description=(
             "Pipefy API host root (env: PIPEFY_BASE_URL). Drives the "
             "service-account OAuth token endpoint via the "
@@ -220,7 +252,6 @@ class AuthSettings(BaseSettings):
 
     allow_insecure_urls: bool = Field(
         default=False,
-        validation_alias=AliasChoices("PIPEFY_ALLOW_INSECURE_URLS"),
         description=(
             "When true (env: PIPEFY_ALLOW_INSECURE_URLS), auth-related URLs "
             "may use http:// and internal hosts; local development only; do "
@@ -261,10 +292,25 @@ class AuthSettings(BaseSettings):
     def _validate_endpoint_urls(self) -> Self:
         # Self-validate so direct ``AuthSettings()`` construction (outside
         # ``CliSettings`` / ``Settings``) is safe.
+        from urllib.parse import urlparse
+
         from pipefy_auth._url_ssrf import validate_https_service_endpoint_url
 
+        stripped_base = self.base_url.strip()
+        parsed_base = urlparse(stripped_base)
+        # ``base_url`` must be a host root: ``service_account_url`` appends
+        # ``/oauth/token`` via f-string. A query / fragment / non-root path
+        # would land inside the resulting URL's query slot rather than as a
+        # path component, producing silently-malformed token endpoints.
+        if parsed_base.path.strip("/") or parsed_base.query or parsed_base.fragment:
+            msg = (
+                f"base_url must be a host root with no path, query, or fragment "
+                f"(got {self.base_url!r}); the OAuth token endpoint derives via "
+                "``<base_url>/oauth/token``."
+            )
+            raise ValueError(msg)
         validate_https_service_endpoint_url(
-            self.base_url.strip(),
+            stripped_base,
             "base_url",
             allow_insecure=self.allow_insecure_urls,
         )

--- a/packages/auth/tests/test_settings_back_compat.py
+++ b/packages/auth/tests/test_settings_back_compat.py
@@ -1,8 +1,14 @@
-"""Back-compat coverage for the ``PIPEFY_OAUTH_*`` → ``PIPEFY_SERVICE_ACCOUNT_*`` rename.
+"""Back-compat coverage for the ``PIPEFY_OAUTH_*`` → ``PIPEFY_SERVICE_ACCOUNT_*`` rename
+and the ``PIPEFY_BASE_URL`` rewrite (issue #238).
 
-The rename ships an ``AliasChoices`` shim on ``AuthSettings`` plus a one-shot
-stderr deprecation warning. These tests pin both behaviors so the eventual
-PR that drops the aliases (and the warning) has a clear regression surface.
+The legacy ``PIPEFY_OAUTH_CLIENT`` / ``PIPEFY_OAUTH_SECRET`` env vars and
+``oauth_client`` / ``oauth_secret`` TOML keys are still honored via an
+``AliasChoices`` shim plus a one-shot stderr deprecation warning. These
+tests pin both behaviors so the eventual PR that drops the aliases (and
+the warning) has a clear regression surface.
+
+The ``PIPEFY_OAUTH_URL`` legacy alias was dropped — the OAuth token
+endpoint now derives from ``PIPEFY_BASE_URL``.
 """
 
 from __future__ import annotations
@@ -24,32 +30,45 @@ def _reset_warning_dedup(monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv(key, raising=False)
     for key in _LEGACY_ENV_KEYS_TO_NEW.values():
         monkeypatch.delenv(key, raising=False)
+    monkeypatch.delenv("PIPEFY_OAUTH_URL", raising=False)
+    monkeypatch.delenv("PIPEFY_SERVICE_ACCOUNT_URL", raising=False)
+    monkeypatch.delenv("PIPEFY_BASE_URL", raising=False)
+    monkeypatch.delenv("PIPEFY_AUTH_URL", raising=False)
     _reset_legacy_oauth_warning_state()
     yield
     _reset_legacy_oauth_warning_state()
 
 
 @pytest.mark.unit
-def test_legacy_kwargs_populate_new_fields():
-    """``AuthSettings(oauth_url=...)`` still validates and binds to ``service_account_url``."""
-    s = AuthSettings(
-        oauth_url="https://legacy.example.com/oauth/token",
-        oauth_client="legacy-client",
-        oauth_secret="legacy-secret",
-    )
-    assert s.service_account_url == "https://legacy.example.com/oauth/token"
-    assert s.service_account_client_id == "legacy-client"
-    assert s.service_account_client_secret == "legacy-secret"
+def test_bare_name_env_vars_do_not_leak_into_auth_settings(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Unprefixed env vars (``BASE_URL``, ``STATIC_TOKEN``, ``OAUTH_CLIENT``, ...) must not be honored.
+
+    pydantic-settings env loading is case-insensitive by default, so an
+    unprefixed alias on ``AliasChoices`` would let any bare-name env var
+    on the host bleed into Pipefy auth settings — an auth-redirect /
+    credential-leak primitive.
+    """
+    monkeypatch.setenv("BASE_URL", "https://evil.example.com")
+    monkeypatch.setenv("STATIC_TOKEN", "leaked")
+    monkeypatch.setenv("OAUTH_CLIENT", "leaked-client")
+    monkeypatch.setenv("OAUTH_SECRET", "leaked-secret")
+    monkeypatch.setenv("ALLOW_INSECURE_URLS", "true")
+    settings = AuthSettings()
+    assert settings.base_url == "https://app.pipefy.com"  # default, not leaked
+    assert settings.static_token is None
+    assert settings.service_account_client_id is None
+    assert settings.service_account_client_secret is None
+    assert settings.allow_insecure_urls is False
 
 
 @pytest.mark.unit
 def test_new_kwargs_populate_new_fields():
     s = AuthSettings(
-        service_account_url="https://new.example.com/oauth/token",
         service_account_client_id="new-client",
         service_account_client_secret="new-secret",
     )
-    assert s.service_account_url == "https://new.example.com/oauth/token"
     assert s.service_account_client_id == "new-client"
     assert s.service_account_client_secret == "new-secret"
 
@@ -59,13 +78,11 @@ def test_legacy_env_var_emits_deprecation_warning(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ):
-    monkeypatch.setenv("PIPEFY_OAUTH_URL", "https://shell.example.com/oauth/token")
+    monkeypatch.setenv("PIPEFY_OAUTH_CLIENT", "legacy-client")
     _warn_once_for_legacy_oauth_env_keys()
     err = capsys.readouterr().err
-    assert "PIPEFY_OAUTH_URL is deprecated" in err
-    assert "rename to PIPEFY_SERVICE_ACCOUNT_URL" in err
-    assert "PIPEFY_OAUTH_CLIENT" not in err
-    assert "PIPEFY_OAUTH_SECRET" not in err
+    assert "PIPEFY_OAUTH_CLIENT is deprecated" in err
+    assert "rename to PIPEFY_SERVICE_ACCOUNT_CLIENT_ID" in err
 
 
 @pytest.mark.unit
@@ -73,12 +90,12 @@ def test_deprecation_warning_dedups_within_process(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ):
-    monkeypatch.setenv("PIPEFY_OAUTH_URL", "https://shell.example.com/oauth/token")
+    monkeypatch.setenv("PIPEFY_OAUTH_CLIENT", "legacy-client")
     _warn_once_for_legacy_oauth_env_keys()
     _warn_once_for_legacy_oauth_env_keys()
     _warn_once_for_legacy_oauth_env_keys()
     err = capsys.readouterr().err
-    assert err.count("PIPEFY_OAUTH_URL is deprecated") == 1
+    assert err.count("PIPEFY_OAUTH_CLIENT is deprecated") == 1
 
 
 @pytest.mark.unit
@@ -86,9 +103,6 @@ def test_no_deprecation_warning_when_only_new_env_keys_set(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ):
-    monkeypatch.setenv(
-        "PIPEFY_SERVICE_ACCOUNT_URL", "https://new.example.com/oauth/token"
-    )
     monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", "new-client")
     monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET", "new-secret")
     _warn_once_for_legacy_oauth_env_keys()
@@ -97,30 +111,78 @@ def test_no_deprecation_warning_when_only_new_env_keys_set(
 
 
 @pytest.mark.unit
-def test_auth_url_defaults_to_pipefy_prod_idp(monkeypatch: pytest.MonkeyPatch):
-    """``AuthSettings()`` with no ``PIPEFY_AUTH_URL`` set defaults to the prod IdP."""
-    from pipefy_auth.identity import DEFAULT_AUTH_URL
-
-    monkeypatch.delenv("PIPEFY_AUTH_URL", raising=False)
+def test_base_url_defaults_to_prod():
+    """``AuthSettings()`` with no env defaults to the Pipefy prod API host."""
     settings = AuthSettings()
-    assert settings.auth_url == DEFAULT_AUTH_URL
-    assert DEFAULT_AUTH_URL == "https://signin.pipefy.com/realms/pipefy"
-    oidc = settings.to_oidc_client()
-    assert oidc is not None
-    assert oidc.issuer_url == DEFAULT_AUTH_URL
+    assert settings.base_url == "https://app.pipefy.com"
+    assert settings.service_account_url == "https://app.pipefy.com/oauth/token"
 
 
 @pytest.mark.unit
-def test_auth_url_env_override_wins_over_default(monkeypatch: pytest.MonkeyPatch):
-    """Setting ``PIPEFY_AUTH_URL`` in env still overrides the default."""
+def test_auth_url_defaults_to_pipefy_prod_idp():
+    """``AuthSettings()`` with no env defaults to the Pipefy prod IdP."""
+    settings = AuthSettings()
+    assert settings.auth_url == "https://signin.pipefy.com/realms/pipefy"
+    oidc = settings.to_oidc_client()
+    assert oidc.issuer_url == "https://signin.pipefy.com/realms/pipefy"
+
+
+@pytest.mark.unit
+def test_pipefy_base_url_env_drives_service_account_url(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """``PIPEFY_BASE_URL`` flows into the ``service_account_url`` computed field."""
+    monkeypatch.setenv("PIPEFY_BASE_URL", "https://staging.example.com")
+    settings = AuthSettings()
+    assert settings.base_url == "https://staging.example.com"
+    assert settings.service_account_url == "https://staging.example.com/oauth/token"
+
+
+@pytest.mark.unit
+def test_pipefy_auth_url_env_overrides_default(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """``PIPEFY_AUTH_URL`` overrides the default issuer URL."""
     monkeypatch.setenv("PIPEFY_AUTH_URL", "https://other.example.com/realms/x")
     settings = AuthSettings()
     assert settings.auth_url == "https://other.example.com/realms/x"
 
 
 @pytest.mark.unit
-def test_empty_auth_url_disables_stored_session_tier(monkeypatch: pytest.MonkeyPatch):
-    """Setting ``PIPEFY_AUTH_URL`` to an empty string opts out of the default."""
-    monkeypatch.setenv("PIPEFY_AUTH_URL", "")
+@pytest.mark.parametrize(
+    "env_key",
+    ["PIPEFY_BASE_URL", "PIPEFY_AUTH_URL"],
+)
+def test_empty_url_env_raises(monkeypatch: pytest.MonkeyPatch, env_key: str):
+    """Empty URL env values are rejected at construction (no opt-out overload)."""
+    from pydantic import ValidationError
+
+    monkeypatch.setenv(env_key, "")
+    with pytest.raises(ValidationError, match="should match pattern"):
+        AuthSettings()
+
+
+@pytest.mark.unit
+def test_base_url_strips_surrounding_whitespace(monkeypatch: pytest.MonkeyPatch):
+    """Whitespace-padded env values from copy-paste are stripped before pattern."""
+    monkeypatch.setenv("PIPEFY_BASE_URL", "  https://staging.example.com\t")
     settings = AuthSettings()
-    assert settings.to_oidc_client() is None
+    assert settings.base_url == "https://staging.example.com"
+
+
+@pytest.mark.unit
+def test_base_url_accepts_uppercase_scheme(monkeypatch: pytest.MonkeyPatch):
+    """RFC 3986 §3.1: URL scheme is case-insensitive."""
+    monkeypatch.setenv("PIPEFY_BASE_URL", "HTTPS://staging.example.com")
+    settings = AuthSettings()
+    assert settings.base_url == "HTTPS://staging.example.com"
+
+
+@pytest.mark.unit
+def test_service_account_url_strips_trailing_slash_on_base(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A trailing slash on ``PIPEFY_BASE_URL`` doesn't double the joiner."""
+    monkeypatch.setenv("PIPEFY_BASE_URL", "https://staging.example.com/")
+    settings = AuthSettings()
+    assert settings.service_account_url == "https://staging.example.com/oauth/token"

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -33,10 +33,12 @@ Same `PIPEFY_*` environment variables as `pipefy-mcp-server` (`.env` in CWD is l
 ```env
 PIPEFY_SERVICE_ACCOUNT_CLIENT_ID=your_client_id
 PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET=your_client_secret
-PIPEFY_GRAPHQL_URL=https://app.pipefy.com/graphql
-PIPEFY_SERVICE_ACCOUNT_URL=https://app.pipefy.com/oauth/token
-PIPEFY_INTERNAL_API_URL=https://app.pipefy.com/internal_api
+# Non-prod environments only:
+# PIPEFY_BASE_URL=https://<your-api-host>
+# PIPEFY_AUTH_URL=https://<your-signin-host>/realms/<realm>
 ```
+
+`PIPEFY_BASE_URL` defaults to `https://app.pipefy.com` (drives the four API endpoints) and `PIPEFY_AUTH_URL` defaults to `https://signin.pipefy.com/realms/pipefy` (the OIDC issuer). Set them only for non-prod environments.
 
 Full guide: [`docs/setup.md`](../../docs/setup.md). CLI-focused docs: [`docs/cli/`](../../docs/cli/README.md).
 

--- a/packages/cli/src/pipefy_cli/auth.py
+++ b/packages/cli/src/pipefy_cli/auth.py
@@ -36,7 +36,6 @@ from pipefy_sdk import (
 )
 
 from pipefy_cli._docs import DOCS_CLI_AUTH_REF
-from pipefy_cli.config import ensure_public_graphql_configured
 
 # Display labels for ``pipefy auth status``. The resolver knows the
 # static-token tier; the CLI restores the flag-vs-env distinction here.
@@ -60,11 +59,15 @@ class AuthContext:
     stored-session). Built once at startup from the loaded
     :class:`pipefy_auth.AuthSettings` plus the per-invocation ``--token`` /
     ``PIPEFY_TOKEN`` resolution.
+
+    ``oidc_client`` is non-Optional: ``AuthSettings.to_oidc_client()`` always
+    returns a real client because ``auth_url`` defaults to the prod IdP.
+    Bypassing requires ``model_construct``.
     """
 
     bearer_token: BearerToken | None
     service_account: ServiceAccount | None
-    oidc_client: OidcClient | None
+    oidc_client: OidcClient
 
 
 _cached_signature: str | None = None
@@ -146,12 +149,6 @@ def get_authenticated_client(
     """
     global _cached_signature, _cached_client
 
-    try:
-        ensure_public_graphql_configured(pipefy_settings)
-    except ValueError as exc:
-        typer.echo(str(exc), err=True)
-        raise typer.Exit(2) from exc
-
     resolved = _resolve(auth)
     if resolved is None:
         typer.echo(f"{missing_auth_message()} See {DOCS_CLI_AUTH_REF}.", err=True)
@@ -163,10 +160,6 @@ def get_authenticated_client(
     # out as a transport error on the first GraphQL call. ``CallableBearerAuth``
     # observes the rotated token on subsequent requests.
     if tier == STORED_SESSION_TIER:
-        if auth.oidc_client is None:
-            # Unreachable per the resolver contract; guard kept so the
-            # invariant holds under ``python -O``.
-            raise typer.Exit(2)
         try:
             ensure_fresh_session(
                 issuer=auth.oidc_client.issuer_url,
@@ -185,14 +178,13 @@ def get_authenticated_client(
         return _cached_client
 
     client = PipefyClient(pipefy_settings, auth=resolved)
-    if pipefy_settings.internal_api_url:
-        internal_client = InternalApiClient(
-            url=pipefy_settings.internal_api_url,
-            auth=resolved,
-            allow_insecure_urls=pipefy_settings.allow_insecure_urls,
-        )
-        client.set_internal_api_client(internal_client)
-        client.set_ai_automation_service(AiAutomationService(client=internal_client))
+    internal_client = InternalApiClient(
+        url=pipefy_settings.internal_api_url,
+        auth=resolved,
+        allow_insecure_urls=pipefy_settings.allow_insecure_urls,
+    )
+    client.set_internal_api_client(internal_client)
+    client.set_ai_automation_service(AiAutomationService(client=internal_client))
     _cached_signature = key
     _cached_client = client
     return client

--- a/packages/cli/src/pipefy_cli/commands/ai_automation.py
+++ b/packages/cli/src/pipefy_cli/commands/ai_automation.py
@@ -35,7 +35,7 @@ def _require_ai_automation(client: PipefyClient) -> None:
     if not client.ai_automation_available:
         typer.echo(
             "AI Automation requires service-account credentials "
-            "(PIPEFY_SERVICE_ACCOUNT_URL, PIPEFY_SERVICE_ACCOUNT_CLIENT_ID, "
+            "(PIPEFY_SERVICE_ACCOUNT_CLIENT_ID, "
             "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET). "
             "Bearer --token mode does not attach the internal API client.",
             err=True,

--- a/packages/cli/src/pipefy_cli/commands/auth.py
+++ b/packages/cli/src/pipefy_cli/commands/auth.py
@@ -142,15 +142,6 @@ def auth_login(
     from keyring.errors import KeyringError
 
     settings, auth = settings_and_auth_from_ctx(ctx)
-    if auth.oidc_client is None:
-        typer.echo(
-            "PIPEFY_AUTH_URL is required for `pipefy auth login` (the OIDC issuer "
-            "URL for Pipefy authentication, e.g. "
-            "https://signin.pipefy.com/realms/pipefy). "
-            f"See {DOCS_CLI_AUTH_REF}.",
-            err=True,
-        )
-        raise typer.Exit(2)
     issuer_url = auth.oidc_client.issuer_url
     client_id = auth.oidc_client.client_id
     typer.echo(f"Signing in to Pipefy at {issuer_url} ...")
@@ -435,15 +426,6 @@ def auth_status(
         if source == "none":
             raise _StatusExit(report=report, exit_code=2)
         if source == "stored-session":
-            if auth.oidc_client is None:
-                raise _StatusExit(
-                    report=report,
-                    exit_code=2,
-                    stderr=(
-                        "Internal error: auth source 'stored-session' detected "
-                        "but no OIDC client is configured. Please file an issue."
-                    ),
-                )
             _populate_stored_session(report, auth.oidc_client)
         _fetch_identity(report, settings, auth)
     except _StatusExit as exit_:
@@ -459,15 +441,6 @@ def auth_status(
 def auth_logout(ctx: typer.Context) -> None:
     """Revoke the stored refresh token at the IdP and clear the local session."""
     settings, auth = settings_and_auth_from_ctx(ctx)
-    if auth.oidc_client is None:
-        typer.echo(
-            "PIPEFY_AUTH_URL is required for `pipefy auth logout` (the OIDC "
-            "issuer URL used at login). "
-            f"See {DOCS_CLI_AUTH_REF}.",
-            err=True,
-        )
-        raise typer.Exit(2)
-
     issuer = auth.oidc_client.issuer_url
     client_id = auth.oidc_client.client_id
 

--- a/packages/cli/src/pipefy_cli/commands/relation.py
+++ b/packages/cli/src/pipefy_cli/commands/relation.py
@@ -163,7 +163,7 @@ def relation_card_delete(
     if not client.internal_api_available:
         typer.echo(
             "delete_card_relation requires service-account credentials "
-            "(PIPEFY_SERVICE_ACCOUNT_URL, PIPEFY_SERVICE_ACCOUNT_CLIENT_ID, "
+            "(PIPEFY_SERVICE_ACCOUNT_CLIENT_ID, "
             "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET). "
             "The deleteCardRelation mutation is only available on the internal API.",
             err=True,

--- a/packages/cli/src/pipefy_cli/config.py
+++ b/packages/cli/src/pipefy_cli/config.py
@@ -1,58 +1,22 @@
-"""Resolve Pipefy + auth settings for the CLI (aligned with MCP ``PIPEFY_*`` keys)."""
+"""Resolve Pipefy + auth settings for the CLI (aligned with MCP ``PIPEFY_*`` keys).
+
+Precedence is pure pydantic-settings: init kwargs (CLI flags) > env > ``.env``
+> defaults. No TOML; operators wanting persistent global creds use shell rc
+files or a system-wide ``.env``.
+"""
 
 from __future__ import annotations
 
-import os
-import sys
-import tomllib
-from pathlib import Path
-from typing import Any, Self, TypeVar
+from typing import Any
 
 from pipefy_auth import AuthSettings
 from pipefy_sdk import PipefySettings
-from pydantic import BaseModel, Field, ValidationError, model_validator
+from pydantic import Field, ValidationError
 from pydantic_settings import BaseSettings, SettingsConfigDict
-
-from pipefy_cli._docs import DOCS_SETUP_REF
-
-_ALLOW_INSECURE_ENV_KEY = "PIPEFY_ALLOW_INSECURE_URLS"
-
-USER_CONFIG_PATH = Path.home() / ".config/pipefy/config.toml"
-
-_LEGACY_TOML_KEYS_TO_NEW: dict[str, str] = {
-    "oauth_url": "service_account_url",
-    "oauth_client": "service_account_client_id",
-    "oauth_secret": "service_account_client_secret",
-}
-
-# Keys under ``[pipefy]`` that belong to auth, not the SDK. Derived from the
-# model so a field rename does not need a second edit here. ``static_token``
-# is excluded: bearers are short-lived secrets and don't belong in a long-
-# lived plaintext user config file (use ``PIPEFY_TOKEN`` env or ``--token``).
-_AUTH_TOML_KEYS: frozenset[str] = frozenset(AuthSettings.model_fields) - {
-    "static_token"
-}
-
-_warned_legacy_toml_keys: set[str] = set()
-
-
-def _warn_once_for_legacy_toml_key(legacy_key: str, new_key: str) -> None:
-    if legacy_key in _warned_legacy_toml_keys:
-        return
-    sys.stderr.write(
-        f"warning: '{legacy_key}' in {USER_CONFIG_PATH} is deprecated; "
-        f"rename to '{new_key}'. The legacy key will be removed in a future beta.\n"
-    )
-    _warned_legacy_toml_keys.add(legacy_key)
-
-
-def _reset_legacy_toml_warning_state() -> None:
-    """Test helper: clear the one-shot dedup so a fixture can re-trigger the warning."""
-    _warned_legacy_toml_keys.clear()
 
 
 class CliSettings(BaseSettings):
-    """Load ``PIPEFY_*`` from the environment and ``.env`` in the working directory."""
+    """Load ``PIPEFY_*`` from env / ``.env``."""
 
     model_config = SettingsConfigDict(
         env_nested_delimiter="_",
@@ -65,167 +29,43 @@ class CliSettings(BaseSettings):
     pipefy: PipefySettings = Field(default_factory=PipefySettings)
     auth: AuthSettings = Field(default_factory=AuthSettings)
 
-    @model_validator(mode="after")
-    def _validate_auth_urls(self) -> Self:
-        self.auth.validate_urls(allow_insecure=self.pipefy.allow_insecure_urls)
-        return self
-
-
-_ModelT = TypeVar("_ModelT", bound=BaseModel)
-
-
-def _revalidate(model: _ModelT, patch: dict[str, Any]) -> _ModelT:
-    """Merge ``patch`` and re-validate (``model_copy`` would skip URL validators)."""
-    if not patch:
-        return model
-    merged = {**model.model_dump(), **patch}
-    return type(model).model_validate(merged)
-
-
-def _read_toml_pipefy_dict() -> dict[str, Any]:
-    """Return the ``[pipefy]`` table (or top-level keys) from the user config file."""
-    if not USER_CONFIG_PATH.is_file():
-        return {}
-    try:
-        raw = USER_CONFIG_PATH.read_bytes()
-        data = tomllib.loads(raw.decode("utf-8"))
-    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError) as exc:
-        msg = (
-            f"Could not read Pipefy config file at {USER_CONFIG_PATH}: {exc}. "
-            f"See {DOCS_SETUP_REF} for the expected format."
-        )
-        raise ValueError(msg) from exc
-    section = data.get("pipefy")
-    if isinstance(section, dict):
-        return dict(section)
-    return dict(data)
-
-
-def _is_missing(value: object) -> bool:
-    if value is None:
-        return True
-    if isinstance(value, str) and not value.strip():
-        return True
-    return False
-
-
-def _normalize_legacy_toml_keys(blob: dict[str, Any]) -> dict[str, Any]:
-    """Translate legacy ``oauth_*`` TOML keys to ``service_account_*``; warn once per legacy key."""
-    if not any(legacy in blob for legacy in _LEGACY_TOML_KEYS_TO_NEW):
-        return blob
-    for legacy, new in _LEGACY_TOML_KEYS_TO_NEW.items():
-        if legacy in blob:
-            _warn_once_for_legacy_toml_key(legacy, new)
-            if new not in blob:
-                blob[new] = blob[legacy]
-    return blob
-
-
-def _fill_if_missing_str(
-    model: PipefySettings | AuthSettings,
-    blob: dict[str, Any],
-    field: str,
-    key: str,
-    patch: dict[str, Any],
-) -> None:
-    if not blob.get(key):
-        return
-    # ``model_fields_set`` check: fields with a non-None default
-    # (e.g. ``AuthSettings.auth_url``) would otherwise shadow TOML overrides.
-    if _is_missing(getattr(model, field)) or field not in model.model_fields_set:
-        patch[field] = str(blob[key]).strip()
-
-
-def apply_toml_fallback(
-    pipefy: PipefySettings, auth: AuthSettings
-) -> tuple[PipefySettings, AuthSettings]:
-    """Fill attributes still unset after env / ``.env`` from the user TOML file (lowest precedence)."""
-    blob = _read_toml_pipefy_dict()
-    if not blob:
-        return pipefy, auth
-    blob = _normalize_legacy_toml_keys(blob)
-
-    pipefy_patch: dict[str, Any] = {}
-    _fill_if_missing_str(pipefy, blob, "graphql_url", "graphql_url", pipefy_patch)
-    _fill_if_missing_str(
-        pipefy, blob, "internal_api_url", "internal_api_url", pipefy_patch
-    )
-    if blob.get("service_account_ids") is not None and not pipefy.service_account_ids:
-        pipefy_patch["service_account_ids"] = blob["service_account_ids"]
-    if blob.get("allow_insecure_urls") is not None and not pipefy.allow_insecure_urls:
-        pipefy_patch["allow_insecure_urls"] = bool(blob["allow_insecure_urls"])
-
-    auth_patch: dict[str, Any] = {}
-    for key in _AUTH_TOML_KEYS:
-        _fill_if_missing_str(auth, blob, key, key, auth_patch)
-
-    new_pipefy = _revalidate(pipefy, pipefy_patch)
-    # Auth URLs are SSRF-checked once at the end of ``resolve_cli_settings``
-    # against the final ``allow_insecure_urls`` value, so we skip the post-hook
-    # here to avoid validating twice.
-    new_auth = _revalidate(auth, auth_patch)
-    return new_pipefy, new_auth
-
 
 def resolve_cli_settings(
     *,
-    graphql_url_flag: str | None,
+    base_url_flag: str | None,
     allow_insecure_urls_flag: bool | None,
 ) -> CliSettings:
-    """Resolve the full :class:`CliSettings`: env, ``.env``, TOML fallback, then flags.
+    """Resolve :class:`CliSettings` honoring CLI flags as init kwargs.
+
+    Flags become init kwargs on the nested models, which pydantic-settings
+    ranks above the env source. Auth-side values for fields with explicit
+    ``AliasChoices`` (``base_url``, ``allow_insecure_urls``) are keyed by the
+    alias name so they beat the nested ``AuthSettings`` env source — see
+    :class:`pipefy_auth.AuthSettings` for the field aliases.
 
     Raises:
         ValueError: When validation fails (e.g. SSRF guard); message is user-facing.
     """
-    prev_allow = os.environ.get(_ALLOW_INSECURE_ENV_KEY)
-    if allow_insecure_urls_flag is True:
-        os.environ[_ALLOW_INSECURE_ENV_KEY] = "true"
-    try:
-        cli = CliSettings()
-    except ValidationError as exc:
-        raise ValueError(str(exc)) from exc
-    finally:
-        if allow_insecure_urls_flag is True:
-            if prev_allow is None:
-                os.environ.pop(_ALLOW_INSECURE_ENV_KEY, None)
-            else:
-                os.environ[_ALLOW_INSECURE_ENV_KEY] = prev_allow
+    pipefy_init: dict[str, Any] = {}
+    auth_init: dict[str, Any] = {}
+    if base_url_flag:
+        stripped = base_url_flag.strip()
+        pipefy_init["base_url"] = stripped
+        auth_init["PIPEFY_BASE_URL"] = stripped
+    if allow_insecure_urls_flag is not None:
+        pipefy_init["allow_insecure_urls"] = allow_insecure_urls_flag
+        auth_init["PIPEFY_ALLOW_INSECURE_URLS"] = allow_insecure_urls_flag
+
+    init_kwargs: dict[str, Any] = {}
+    if pipefy_init:
+        init_kwargs["pipefy"] = pipefy_init
+    if auth_init:
+        init_kwargs["auth"] = auth_init
 
     try:
-        pipefy, auth = apply_toml_fallback(cli.pipefy, cli.auth)
-        pipefy_patch: dict[str, Any] = {}
-        if graphql_url_flag:
-            pipefy_patch["graphql_url"] = graphql_url_flag.strip()
-        if allow_insecure_urls_flag is not None:
-            pipefy_patch["allow_insecure_urls"] = allow_insecure_urls_flag
-        pipefy = _revalidate(pipefy, pipefy_patch)
-        # The flag may have flipped ``allow_insecure_urls``; re-run the auth-URL
-        # SSRF guard against the resolved value rather than the env-loaded one.
-        auth.validate_urls(allow_insecure=pipefy.allow_insecure_urls)
+        return CliSettings(**init_kwargs)
     except ValidationError as exc:
         raise ValueError(str(exc)) from exc
 
-    return cli.model_copy(update={"pipefy": pipefy, "auth": auth})
 
-
-def ensure_public_graphql_configured(pipefy: PipefySettings) -> None:
-    """Ensure GraphQL URL is present before building a client.
-
-    Raises:
-        ValueError: With pointer to ``docs/setup.md``.
-    """
-    if _is_missing(pipefy.graphql_url):
-        msg = (
-            "PIPEFY_GRAPHQL_URL is required (or pass --graphql-url). "
-            f"See {DOCS_SETUP_REF} for environment variables."
-        )
-        raise ValueError(msg)
-
-
-__all__ = [
-    "CliSettings",
-    "USER_CONFIG_PATH",
-    "apply_toml_fallback",
-    "ensure_public_graphql_configured",
-    "resolve_cli_settings",
-]
+__all__ = ["CliSettings", "resolve_cli_settings"]

--- a/packages/cli/src/pipefy_cli/config.py
+++ b/packages/cli/src/pipefy_cli/config.py
@@ -3,6 +3,11 @@
 Precedence is pure pydantic-settings: init kwargs (CLI flags) > env > ``.env``
 > defaults. No TOML; operators wanting persistent global creds use shell rc
 files or a system-wide ``.env``.
+
+The composition deliberately does NOT use ``env_nested_delimiter``: that flag
+splits any matching env var (e.g. ``AUTH_BASE_URL``) into a nested-field path,
+which would let unprefixed env vars bypass each nested model's own
+``env_prefix="PIPEFY_"`` gate. Each nested model loads its env independently.
 """
 
 from __future__ import annotations
@@ -16,15 +21,9 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class CliSettings(BaseSettings):
-    """Load ``PIPEFY_*`` from env / ``.env``."""
+    """Composes :class:`PipefySettings` + :class:`AuthSettings` for CLI use."""
 
-    model_config = SettingsConfigDict(
-        env_nested_delimiter="_",
-        env_nested_max_split=1,
-        env_file=".env",
-        env_file_encoding="utf-8",
-        extra="ignore",
-    )
+    model_config = SettingsConfigDict(extra="ignore")
 
     pipefy: PipefySettings = Field(default_factory=PipefySettings)
     auth: AuthSettings = Field(default_factory=AuthSettings)
@@ -37,33 +36,29 @@ def resolve_cli_settings(
 ) -> CliSettings:
     """Resolve :class:`CliSettings` honoring CLI flags as init kwargs.
 
-    Flags become init kwargs on the nested models, which pydantic-settings
-    ranks above the env source. Auth-side values for fields with explicit
-    ``AliasChoices`` (``base_url``, ``allow_insecure_urls``) are keyed by the
-    alias name so they beat the nested ``AuthSettings`` env source — see
-    :class:`pipefy_auth.AuthSettings` for the field aliases.
+    Flags become init kwargs on each nested model's own source chain, where
+    they outrank env. ``base_url`` and ``allow_insecure_urls`` are mapped by
+    ``env_prefix="PIPEFY_"`` (no ``AliasChoices``), so field-name kwargs win
+    over env without the alias-key dance.
 
     Raises:
         ValueError: When validation fails (e.g. SSRF guard); message is user-facing.
     """
     pipefy_init: dict[str, Any] = {}
     auth_init: dict[str, Any] = {}
-    if base_url_flag:
+    if base_url_flag is not None:
         stripped = base_url_flag.strip()
         pipefy_init["base_url"] = stripped
-        auth_init["PIPEFY_BASE_URL"] = stripped
+        auth_init["base_url"] = stripped
     if allow_insecure_urls_flag is not None:
         pipefy_init["allow_insecure_urls"] = allow_insecure_urls_flag
-        auth_init["PIPEFY_ALLOW_INSECURE_URLS"] = allow_insecure_urls_flag
-
-    init_kwargs: dict[str, Any] = {}
-    if pipefy_init:
-        init_kwargs["pipefy"] = pipefy_init
-    if auth_init:
-        init_kwargs["auth"] = auth_init
+        auth_init["allow_insecure_urls"] = allow_insecure_urls_flag
 
     try:
-        return CliSettings(**init_kwargs)
+        return CliSettings(
+            pipefy=PipefySettings(**pipefy_init),
+            auth=AuthSettings(**auth_init),
+        )
     except ValidationError as exc:
         raise ValueError(str(exc)) from exc
 

--- a/packages/cli/src/pipefy_cli/main.py
+++ b/packages/cli/src/pipefy_cli/main.py
@@ -61,10 +61,14 @@ def main(
         "--token",
         help="Bearer token for GraphQL (skips OAuth). Overrides PIPEFY_TOKEN if both are set.",
     ),
-    allow_insecure_urls: bool = typer.Option(
-        False,
-        "--allow-insecure-urls",
-        help="Allow http:// and private hosts (overrides env for this process).",
+    allow_insecure_urls: bool | None = typer.Option(
+        None,
+        "--allow-insecure-urls/--no-allow-insecure-urls",
+        help=(
+            "Allow http:// and private hosts (overrides env for this process). "
+            "Pass --no-allow-insecure-urls to force-disable when "
+            "PIPEFY_ALLOW_INSECURE_URLS=true is in env."
+        ),
     ),
     version: bool = typer.Option(
         False,
@@ -79,7 +83,7 @@ def main(
     try:
         cli_settings = resolve_cli_settings(
             base_url_flag=base_url,
-            allow_insecure_urls_flag=True if allow_insecure_urls else None,
+            allow_insecure_urls_flag=allow_insecure_urls,
         )
     except ValueError as exc:
         typer.echo(str(exc), err=True)

--- a/packages/cli/src/pipefy_cli/main.py
+++ b/packages/cli/src/pipefy_cli/main.py
@@ -51,10 +51,10 @@ def _print_version(value: bool) -> None:
 @app.callback()
 def main(
     ctx: typer.Context,
-    graphql_url: str | None = typer.Option(
+    base_url: str | None = typer.Option(
         None,
-        "--graphql-url",
-        help="Override PIPEFY_GRAPHQL_URL.",
+        "--base-url",
+        help="Override PIPEFY_BASE_URL (Pipefy API host root).",
     ),
     token: str | None = typer.Option(
         None,
@@ -78,7 +78,7 @@ def main(
     ctx.ensure_object(dict)
     try:
         cli_settings = resolve_cli_settings(
-            graphql_url_flag=graphql_url,
+            base_url_flag=base_url,
             allow_insecure_urls_flag=True if allow_insecure_urls else None,
         )
     except ValueError as exc:

--- a/packages/cli/tests/conftest.py
+++ b/packages/cli/tests/conftest.py
@@ -8,15 +8,12 @@ import pytest
 from typer.testing import CliRunner
 
 _PIPEFY_ENV_KEYS = (
-    "PIPEFY_GRAPHQL_URL",
-    "PIPEFY_INTERNAL_API_URL",
-    "PIPEFY_SERVICE_ACCOUNT_URL",
+    "PIPEFY_BASE_URL",
     "PIPEFY_SERVICE_ACCOUNT_CLIENT_ID",
     "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET",
     # Legacy aliases — kept so tests that opt into back-compat coverage start
     # from a clean slate even when the dropped names linger in the developer
     # shell.
-    "PIPEFY_OAUTH_URL",
     "PIPEFY_OAUTH_CLIENT",
     "PIPEFY_OAUTH_SECRET",
     "PIPEFY_ALLOW_INSECURE_URLS",
@@ -37,15 +34,7 @@ def oauth_env(monkeypatch: pytest.MonkeyPatch):
     """Set minimal service-account + GraphQL URLs for CLI commands that require client-credentials mode."""
 
     def _set(host: str) -> None:
-        monkeypatch.setenv("PIPEFY_GRAPHQL_URL", f"https://{host}.example.com/graphql")
-        monkeypatch.setenv(
-            "PIPEFY_INTERNAL_API_URL",
-            f"https://{host}.example.com/internal_api",
-        )
-        monkeypatch.setenv(
-            "PIPEFY_SERVICE_ACCOUNT_URL",
-            f"https://{host}.example.com/oauth/token",
-        )
+        monkeypatch.setenv("PIPEFY_BASE_URL", f"https://{host}.example.com")
         monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", "cid")
         monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET", "sec")
 

--- a/packages/cli/tests/fixtures/cli_help_golden.txt
+++ b/packages/cli/tests/fixtures/cli_help_golden.txt
@@ -4,17 +4,34 @@ Usage: pipefy [OPTIONS] COMMAND [ARGS]...
  Pipefy CLI (GraphQL via pipefy-sdk).
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --base-url                   TEXT  Override PIPEFY_BASE_URL (Pipefy API host │
-│                                    root).                                    │
-│ --token                      TEXT  Bearer token for GraphQL (skips OAuth).   │
-│                                    Overrides PIPEFY_TOKEN if both are set.   │
-│ --allow-insecure-urls              Allow http:// and private hosts           │
-│                                    (overrides env for this process).         │
-│ --version                          Print the pipefy-cli version and exit.    │
-│ --install-completion               Install completion for the current shell. │
-│ --show-completion                  Show completion for the current shell, to │
-│                                    copy it or customize the installation.    │
-│ --help                             Show this message and exit.               │
+│ --base-url                                       TEXT  Override              │
+│                                                        PIPEFY_BASE_URL       │
+│                                                        (Pipefy API host      │
+│                                                        root).                │
+│ --token                                          TEXT  Bearer token for      │
+│                                                        GraphQL (skips        │
+│                                                        OAuth). Overrides     │
+│                                                        PIPEFY_TOKEN if both  │
+│                                                        are set.              │
+│ --allow-insecure-urls    --no-allow-insecure…          Allow http:// and     │
+│                                                        private hosts         │
+│                                                        (overrides env for    │
+│                                                        this process). Pass   │
+│                                                        --no-allow-insecure-… │
+│                                                        to force-disable when │
+│                                                        PIPEFY_ALLOW_INSECUR… │
+│                                                        is in env.            │
+│ --version                                              Print the pipefy-cli  │
+│                                                        version and exit.     │
+│ --install-completion                                   Install completion    │
+│                                                        for the current       │
+│                                                        shell.                │
+│ --show-completion                                      Show completion for   │
+│                                                        the current shell, to │
+│                                                        copy it or customize  │
+│                                                        the installation.     │
+│ --help                                                 Show this message and │
+│                                                        exit.                 │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ───────────────────────────────────────────────────────────────────╮
 │ agent             AI Agents (repo-scoped).                                   │

--- a/packages/cli/tests/fixtures/cli_help_golden.txt
+++ b/packages/cli/tests/fixtures/cli_help_golden.txt
@@ -4,7 +4,8 @@ Usage: pipefy [OPTIONS] COMMAND [ARGS]...
  Pipefy CLI (GraphQL via pipefy-sdk).
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --graphql-url                TEXT  Override PIPEFY_GRAPHQL_URL.              │
+│ --base-url                   TEXT  Override PIPEFY_BASE_URL (Pipefy API host │
+│                                    root).                                    │
 │ --token                      TEXT  Bearer token for GraphQL (skips OAuth).   │
 │                                    Overrides PIPEFY_TOKEN if both are set.   │
 │ --allow-insecure-urls              Allow http:// and private hosts           │

--- a/packages/cli/tests/test_auth.py
+++ b/packages/cli/tests/test_auth.py
@@ -129,7 +129,9 @@ def test_empty_base_url_exits_2_cli(clean_pipefy_env, saved_cwd, monkeypatch, ru
     result = runner.invoke(app, ["card", "get", "123"])
     assert result.exit_code == 2
     combined = (result.stderr or "") + (result.stdout or "")
-    assert "PIPEFY_BASE_URL" in combined
+    # Pydantic error references the field name ``base_url`` (mapped from
+    # ``PIPEFY_BASE_URL`` via ``env_prefix``).
+    assert "base_url" in combined
     assert "should match pattern" in combined
 
 
@@ -142,7 +144,7 @@ def test_missing_oauth_exits_2_cli(
     # fail this test with a stale-refresh error.
     monkeypatch.setenv(
         "PIPEFY_BASE_URL",
-        "https://oauth-missing.example.com/graphql",
+        "https://oauth-missing.example.com",
     )
     result = runner.invoke(app, ["card", "get", "123"])
     assert result.exit_code == 2
@@ -155,7 +157,7 @@ def test_cli_uses_pipefy_token_env_when_no_flag(
 ):
     monkeypatch.setenv(
         "PIPEFY_BASE_URL",
-        "https://token-env.example.com/graphql",
+        "https://token-env.example.com",
     )
     monkeypatch.setenv("PIPEFY_TOKEN", "secret-from-env")
     mock_client = MagicMock()

--- a/packages/cli/tests/test_auth.py
+++ b/packages/cli/tests/test_auth.py
@@ -26,10 +26,7 @@ from pipefy_cli.main import app
 
 
 def _minimal_settings() -> PipefySettings:
-    return PipefySettings(
-        graphql_url="https://unit.example.com/graphql",
-        internal_api_url="https://unit.example.com/internal_api",
-    )
+    return PipefySettings(base_url="https://unit.example.com")
 
 
 def _service_account() -> ServiceAccount:
@@ -126,16 +123,25 @@ def test_cache_returns_same_instance_for_identical_service_account_settings(
         assert mock_pc.call_count == 1
 
 
-def test_missing_graphql_exits_2_cli(clean_pipefy_env, saved_cwd, runner):
+def test_empty_base_url_exits_2_cli(clean_pipefy_env, saved_cwd, monkeypatch, runner):
+    """``PIPEFY_BASE_URL=""`` is rejected at settings load and surfaces as exit 2."""
+    monkeypatch.setenv("PIPEFY_BASE_URL", "")
     result = runner.invoke(app, ["card", "get", "123"])
     assert result.exit_code == 2
     combined = (result.stderr or "") + (result.stdout or "")
-    assert "docs/setup.md" in combined
+    assert "PIPEFY_BASE_URL" in combined
+    assert "should match pattern" in combined
 
 
-def test_missing_oauth_exits_2_cli(clean_pipefy_env, saved_cwd, monkeypatch, runner):
+def test_missing_oauth_exits_2_cli(
+    clean_pipefy_env, saved_cwd, monkeypatch, runner, fake_keyring
+):
+    # ``fake_keyring`` isolates the stored-session tier from the host's real
+    # OS keychain. Without it, the prod-default ``auth_url`` would let a
+    # developer's actual stored session bypass the missing-oauth exit and
+    # fail this test with a stale-refresh error.
     monkeypatch.setenv(
-        "PIPEFY_GRAPHQL_URL",
+        "PIPEFY_BASE_URL",
         "https://oauth-missing.example.com/graphql",
     )
     result = runner.invoke(app, ["card", "get", "123"])
@@ -148,7 +154,7 @@ def test_cli_uses_pipefy_token_env_when_no_flag(
     clean_pipefy_env, saved_cwd, monkeypatch, runner
 ):
     monkeypatch.setenv(
-        "PIPEFY_GRAPHQL_URL",
+        "PIPEFY_BASE_URL",
         "https://token-env.example.com/graphql",
     )
     monkeypatch.setenv("PIPEFY_TOKEN", "secret-from-env")
@@ -208,7 +214,7 @@ def _fresh_stored_session(*, access_token: str = "SESSION_ACCESS") -> StoredSess
 
 def _public_only_settings() -> PipefySettings:
     """``PIPEFY_SERVICE_ACCOUNT_*`` triple absent → service-account tier unavailable, stored session wins."""
-    return PipefySettings(graphql_url="https://unit.example.com/graphql")
+    return PipefySettings(base_url="https://unit.example.com")
 
 
 def _public_only_auth(

--- a/packages/cli/tests/test_auth_login.py
+++ b/packages/cli/tests/test_auth_login.py
@@ -557,11 +557,12 @@ class TestAuthLoginCommand:
         clean_pipefy_env,
         saved_cwd,
     ) -> None:
-        """Explicit empty ``PIPEFY_AUTH_URL`` opts out of the stored-session tier."""
+        """``PIPEFY_AUTH_URL=""`` is rejected at settings load and surfaces as exit 2."""
         monkeypatch.setenv("PIPEFY_AUTH_URL", "")
         result = cli_runner.invoke(cli_app, ["auth", "login"])
         assert result.exit_code == 2
-        assert "PIPEFY_AUTH_URL is required" in result.stderr
+        assert "auth_url" in result.stderr
+        assert "should match pattern" in result.stderr
 
     def test_happy_path(
         self,

--- a/packages/cli/tests/test_auth_logout.py
+++ b/packages/cli/tests/test_auth_logout.py
@@ -151,11 +151,12 @@ class TestAuthLogoutCommand:
         clean_pipefy_env,
         saved_cwd,
     ) -> None:
-        """Explicit empty ``PIPEFY_AUTH_URL`` opts out of the stored-session tier."""
+        """``PIPEFY_AUTH_URL=""`` is rejected at settings load and surfaces as exit 2."""
         monkeypatch.setenv("PIPEFY_AUTH_URL", "")
         result = runner.invoke(cli_app, ["auth", "logout"])
         assert result.exit_code == 2
-        assert "PIPEFY_AUTH_URL is required" in result.stderr
+        assert "auth_url" in result.stderr
+        assert "should match pattern" in result.stderr
 
     def test_no_session_is_idempotent(
         self,

--- a/packages/cli/tests/test_auth_status.py
+++ b/packages/cli/tests/test_auth_status.py
@@ -46,7 +46,6 @@ def _seed_session(
 
 
 def _set_auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("PIPEFY_GRAPHQL_URL", "https://api.example.com/graphql")
     monkeypatch.setenv("PIPEFY_AUTH_URL", _ISSUER)
     monkeypatch.setenv("PIPEFY_AUTH_CLIENT_ID", _CLIENT_ID)
 
@@ -309,12 +308,6 @@ def test_status_service_account_wins_over_stored_session(
 ):
     _set_auth_env(monkeypatch)
     _seed_session(monkeypatch)
-    monkeypatch.setenv(
-        "PIPEFY_INTERNAL_API_URL", "https://api.example.com/internal_api"
-    )
-    monkeypatch.setenv(
-        "PIPEFY_SERVICE_ACCOUNT_URL", "https://auth.example.com/oauth/token"
-    )
     monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", "cid")
     monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET", "csecret")
     client = _mock_client_with_me()
@@ -340,10 +333,6 @@ def test_status_legacy_service_account_triple_masks_stored_session(
     """During the alias window a legacy triple still masks — diagnostic must reflect it."""
     _set_auth_env(monkeypatch)
     _seed_session(monkeypatch)
-    monkeypatch.setenv(
-        "PIPEFY_INTERNAL_API_URL", "https://api.example.com/internal_api"
-    )
-    monkeypatch.setenv("PIPEFY_OAUTH_URL", "https://auth.example.com/oauth/token")
     monkeypatch.setenv("PIPEFY_OAUTH_CLIENT", "cid")
     monkeypatch.setenv("PIPEFY_OAUTH_SECRET", "csecret")
     client = _mock_client_with_me()
@@ -385,7 +374,6 @@ def test_status_env_token_wins_over_stored_session(
 def test_status_flag_token(
     clean_pipefy_env, saved_cwd, monkeypatch, runner, fake_keyring
 ):
-    monkeypatch.setenv("PIPEFY_GRAPHQL_URL", "https://api.example.com/graphql")
     client = _mock_client_with_me()
     with _patch_command_client(client):
         result = runner.invoke(
@@ -406,7 +394,6 @@ def test_status_flag_token(
 def test_status_env_token_only(
     clean_pipefy_env, saved_cwd, monkeypatch, runner, fake_keyring
 ):
-    monkeypatch.setenv("PIPEFY_GRAPHQL_URL", "https://api.example.com/graphql")
     monkeypatch.setenv("PIPEFY_TOKEN", "env-bearer")
     client = _mock_client_with_me()
     with _patch_command_client(client):
@@ -423,13 +410,6 @@ def test_status_env_token_only(
 def test_status_service_account_only(
     clean_pipefy_env, saved_cwd, monkeypatch, runner, fake_keyring
 ):
-    monkeypatch.setenv("PIPEFY_GRAPHQL_URL", "https://api.example.com/graphql")
-    monkeypatch.setenv(
-        "PIPEFY_INTERNAL_API_URL", "https://api.example.com/internal_api"
-    )
-    monkeypatch.setenv(
-        "PIPEFY_SERVICE_ACCOUNT_URL", "https://auth.example.com/oauth/token"
-    )
     monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", "cid")
     monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET", "csecret")
     client = _mock_client_with_me()
@@ -448,7 +428,6 @@ def test_status_service_account_only(
 def test_status_none_exits_2(
     clean_pipefy_env, saved_cwd, monkeypatch, runner, fake_keyring
 ):
-    monkeypatch.setenv("PIPEFY_GRAPHQL_URL", "https://api.example.com/graphql")
     result = _invoke_status(runner, ["--json"])
 
     assert result.exit_code == 2
@@ -461,7 +440,6 @@ def test_status_none_exits_2(
 def test_status_none_text_mentions_onboarding(
     clean_pipefy_env, saved_cwd, monkeypatch, runner, fake_keyring
 ):
-    monkeypatch.setenv("PIPEFY_GRAPHQL_URL", "https://api.example.com/graphql")
     result = _invoke_status(runner)
 
     assert result.exit_code == 2

--- a/packages/cli/tests/test_card_get.py
+++ b/packages/cli/tests/test_card_get.py
@@ -28,18 +28,6 @@ def _patch_get_client(card_payload: dict):
 
 
 def test_card_get_json_stdout(runner, clean_pipefy_env, saved_cwd, monkeypatch):
-    monkeypatch.setenv(
-        "PIPEFY_GRAPHQL_URL",
-        "https://cli-card-json.example.com/graphql",
-    )
-    monkeypatch.setenv(
-        "PIPEFY_INTERNAL_API_URL",
-        "https://cli-card-json.example.com/internal_api",
-    )
-    monkeypatch.setenv(
-        "PIPEFY_SERVICE_ACCOUNT_URL",
-        "https://cli-card-json.example.com/oauth/token",
-    )
     monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", "cid")
     monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET", "sec")
 
@@ -57,18 +45,6 @@ def test_card_get_json_stdout(runner, clean_pipefy_env, saved_cwd, monkeypatch):
 
 
 def test_card_get_rich_stdout(runner, clean_pipefy_env, saved_cwd, monkeypatch):
-    monkeypatch.setenv(
-        "PIPEFY_GRAPHQL_URL",
-        "https://cli-card-rich.example.com/graphql",
-    )
-    monkeypatch.setenv(
-        "PIPEFY_INTERNAL_API_URL",
-        "https://cli-card-rich.example.com/internal_api",
-    )
-    monkeypatch.setenv(
-        "PIPEFY_SERVICE_ACCOUNT_URL",
-        "https://cli-card-rich.example.com/oauth/token",
-    )
     monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", "cid")
     monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET", "sec")
 
@@ -84,18 +60,6 @@ def test_card_get_rich_stdout(runner, clean_pipefy_env, saved_cwd, monkeypatch):
 def test_card_get_sdk_error_stderr_exit_1(
     runner, clean_pipefy_env, saved_cwd, monkeypatch
 ):
-    monkeypatch.setenv(
-        "PIPEFY_GRAPHQL_URL",
-        "https://cli-card-err.example.com/graphql",
-    )
-    monkeypatch.setenv(
-        "PIPEFY_INTERNAL_API_URL",
-        "https://cli-card-err.example.com/internal_api",
-    )
-    monkeypatch.setenv(
-        "PIPEFY_SERVICE_ACCOUNT_URL",
-        "https://cli-card-err.example.com/oauth/token",
-    )
     monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", "cid")
     monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET", "sec")
 
@@ -113,18 +77,6 @@ def test_card_get_sdk_error_stderr_exit_1(
 def test_card_get_permission_denied_hint_on_stderr(
     runner, clean_pipefy_env, saved_cwd, monkeypatch
 ):
-    monkeypatch.setenv(
-        "PIPEFY_GRAPHQL_URL",
-        "https://cli-card-pd.example.com/graphql",
-    )
-    monkeypatch.setenv(
-        "PIPEFY_INTERNAL_API_URL",
-        "https://cli-card-pd.example.com/internal_api",
-    )
-    monkeypatch.setenv(
-        "PIPEFY_SERVICE_ACCOUNT_URL",
-        "https://cli-card-pd.example.com/oauth/token",
-    )
     monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", "cid")
     monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET", "sec")
 
@@ -146,16 +98,10 @@ def test_card_get_permission_denied_hint_on_stderr(
 
 
 def _apply_settings_to_env(monkeypatch: pytest.MonkeyPatch, s: PipefySettings) -> None:
-    monkeypatch.setenv("PIPEFY_GRAPHQL_URL", str(s.graphql_url))
-    monkeypatch.setenv("PIPEFY_INTERNAL_API_URL", str(s.internal_api_url))
-    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_URL", str(s.service_account_url))
-    monkeypatch.setenv(
-        "PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", str(s.service_account_client_id)
-    )
-    monkeypatch.setenv(
-        "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET",
-        str(s.service_account_client_secret),
-    )
+    # Service-account credentials live on AuthSettings; the live test inherits
+    # them from the operator's existing shell env. Only the API host needs to
+    # flow into the subprocess CLI invocation.
+    monkeypatch.setenv("PIPEFY_BASE_URL", str(s.base_url))
     if s.allow_insecure_urls:
         monkeypatch.setenv("PIPEFY_ALLOW_INSECURE_URLS", "true")
 

--- a/packages/cli/tests/test_config.py
+++ b/packages/cli/tests/test_config.py
@@ -6,11 +6,8 @@ import textwrap
 
 import pytest
 
-from pipefy_cli import config as config_module
 from pipefy_cli.config import (
     CliSettings,
-    apply_toml_fallback,
-    ensure_public_graphql_configured,
     resolve_cli_settings,
 )
 
@@ -20,25 +17,16 @@ def test_env_only_resolution(
     saved_cwd,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    monkeypatch.setenv(
-        "PIPEFY_GRAPHQL_URL",
-        "https://env-only.example.com/graphql",
-    )
-    monkeypatch.setenv(
-        "PIPEFY_INTERNAL_API_URL",
-        "https://env-only.example.com/internal_api",
-    )
-    monkeypatch.setenv(
-        "PIPEFY_SERVICE_ACCOUNT_URL", "https://env-only.example.com/oauth/token"
-    )
+    monkeypatch.setenv("PIPEFY_BASE_URL", "https://env-only.example.com")
     monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", "env-client")
     monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET", "env-secret")
 
     resolved = resolve_cli_settings(
-        graphql_url_flag=None,
+        base_url_flag=None,
         allow_insecure_urls_flag=None,
     )
 
+    assert resolved.pipefy.base_url == "https://env-only.example.com"
     assert resolved.pipefy.graphql_url == "https://env-only.example.com/graphql"
     assert (
         resolved.pipefy.internal_api_url == "https://env-only.example.com/internal_api"
@@ -59,9 +47,7 @@ def test_dotenv_only_resolution(
     env_file.write_text(
         textwrap.dedent(
             """\
-            PIPEFY_GRAPHQL_URL=https://dotenv.example.com/graphql
-            PIPEFY_INTERNAL_API_URL=https://dotenv.example.com/internal_api
-            PIPEFY_SERVICE_ACCOUNT_URL=https://dotenv.example.com/oauth/token
+            PIPEFY_BASE_URL=https://dotenv.example.com
             PIPEFY_SERVICE_ACCOUNT_CLIENT_ID=dotenv-client
             PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET=dotenv-secret
             """
@@ -70,11 +56,11 @@ def test_dotenv_only_resolution(
     )
 
     resolved = resolve_cli_settings(
-        graphql_url_flag=None,
+        base_url_flag=None,
         allow_insecure_urls_flag=None,
     )
 
-    assert resolved.pipefy.graphql_url == "https://dotenv.example.com/graphql"
+    assert resolved.pipefy.base_url == "https://dotenv.example.com"
     assert resolved.auth.service_account_client_id == "dotenv-client"
 
 
@@ -85,60 +71,81 @@ def test_process_env_overrides_dotenv(
 ):
     env_file = saved_cwd / ".env"
     env_file.write_text(
-        "PIPEFY_GRAPHQL_URL=https://from-dotenv.example.com/graphql\n",
+        "PIPEFY_BASE_URL=https://from-dotenv.example.com\n",
         encoding="utf-8",
     )
-    monkeypatch.setenv(
-        "PIPEFY_GRAPHQL_URL",
-        "https://from-process.example.com/graphql",
-    )
+    monkeypatch.setenv("PIPEFY_BASE_URL", "https://from-process.example.com")
 
     resolved = resolve_cli_settings(
-        graphql_url_flag=None,
+        base_url_flag=None,
         allow_insecure_urls_flag=None,
     ).pipefy
 
-    assert resolved.graphql_url == "https://from-process.example.com/graphql"
+    assert resolved.base_url == "https://from-process.example.com"
 
 
-def test_graphql_url_flag_overrides_env(
+def test_base_url_flag_overrides_env(
     clean_pipefy_env,
     saved_cwd,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    monkeypatch.setenv(
-        "PIPEFY_GRAPHQL_URL",
-        "https://from-env.example.com/graphql",
-    )
+    """``--base-url`` outranks ``PIPEFY_BASE_URL`` for both nested models."""
+    monkeypatch.setenv("PIPEFY_BASE_URL", "https://from-env.example.com")
 
     resolved = resolve_cli_settings(
-        graphql_url_flag="https://from-flag.example.com/graphql",
+        base_url_flag="https://from-flag.example.com",
         allow_insecure_urls_flag=None,
-    ).pipefy
+    )
 
-    assert resolved.graphql_url == "https://from-flag.example.com/graphql"
+    assert resolved.pipefy.base_url == "https://from-flag.example.com"
+    # ``AuthSettings.model_validate`` re-reads env on revalidate; without the
+    # env-hold this would still report the env host and ``service_account_url``
+    # would drift from the SDK side.
+    assert resolved.auth.base_url == "https://from-flag.example.com"
+    assert (
+        resolved.auth.service_account_url == "https://from-flag.example.com/oauth/token"
+    )
 
 
-def test_missing_graphql_url_error_points_to_setup_docs(
+def test_empty_base_url_env_rejected_at_settings_load(
+    clean_pipefy_env,
+    saved_cwd,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """``PIPEFY_BASE_URL=""`` is rejected by pydantic ``pattern`` validation."""
+    monkeypatch.setenv("PIPEFY_BASE_URL", "")
+    with pytest.raises(ValueError, match="should match pattern"):
+        resolve_cli_settings(
+            base_url_flag=None,
+            allow_insecure_urls_flag=None,
+        )
+
+
+def test_base_url_defaults_to_pipefy_prod(
     clean_pipefy_env,
     saved_cwd,
 ):
+    """No env / no flag → base_url defaults to the Pipefy production host."""
     resolved = resolve_cli_settings(
-        graphql_url_flag=None,
+        base_url_flag=None,
         allow_insecure_urls_flag=None,
     ).pipefy
 
-    with pytest.raises(ValueError, match="docs/setup\\.md"):
-        ensure_public_graphql_configured(resolved)
+    assert resolved.base_url == "https://app.pipefy.com"
+    assert resolved.graphql_url == "https://app.pipefy.com/graphql"
+    assert resolved.internal_api_url == "https://app.pipefy.com/internal_api"
+    assert (
+        resolved.interfaces_graphql_url == "https://app.pipefy.com/graphql/interfaces"
+    )
 
 
-def test_localhost_graphql_rejected_without_insecure_flag(
+def test_localhost_base_url_rejected_without_insecure_flag(
     clean_pipefy_env,
     saved_cwd,
     monkeypatch: pytest.MonkeyPatch,
 ):
     monkeypatch.setenv("PIPEFY_ALLOW_INSECURE_URLS", "false")
-    monkeypatch.setenv("PIPEFY_GRAPHQL_URL", "https://localhost/graphql")
+    monkeypatch.setenv("PIPEFY_BASE_URL", "https://localhost")
 
     with pytest.raises(ValueError, match="localhost"):
         CliSettings()
@@ -150,178 +157,91 @@ def test_allow_insecure_urls_flag_overrides_env(
     monkeypatch: pytest.MonkeyPatch,
 ):
     monkeypatch.setenv("PIPEFY_ALLOW_INSECURE_URLS", "false")
-    monkeypatch.setenv("PIPEFY_GRAPHQL_URL", "http://127.0.0.1:9999/graphql")
+    monkeypatch.setenv("PIPEFY_BASE_URL", "http://127.0.0.1:9999")
 
     resolved = resolve_cli_settings(
-        graphql_url_flag=None,
+        base_url_flag=None,
         allow_insecure_urls_flag=True,
-    ).pipefy
+    )
 
-    assert resolved.allow_insecure_urls is True
-    assert resolved.graphql_url == "http://127.0.0.1:9999/graphql"
+    assert resolved.pipefy.allow_insecure_urls is True
+    assert resolved.auth.allow_insecure_urls is True
+    assert resolved.pipefy.base_url == "http://127.0.0.1:9999"
 
 
-def test_user_toml_fallback_lowest_precedence(
+def test_allow_insecure_urls_flag_false_overrides_env_true(
     clean_pipefy_env,
     saved_cwd,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    cfg_path = saved_cwd / "config.toml"
-    cfg_path.write_text(
-        textwrap.dedent(
-            """\
-            [pipefy]
-            graphql_url = "https://from-toml.example.com/graphql"
-            service_account_client_id = "toml-client"
-            service_account_client_secret = "toml-secret"
-            """
-        ),
-        encoding="utf-8",
-    )
-    monkeypatch.setattr(config_module, "USER_CONFIG_PATH", cfg_path)
+    """Flag ``False`` must override ``PIPEFY_ALLOW_INSECURE_URLS=true`` on both nested models.
+
+    Without the env-hold for the False branch, ``AuthSettings.model_validate``
+    would re-read the env and keep ``True`` while ``PipefySettings`` (a plain
+    ``BaseModel``) honored the patch, desynchronizing the two SSRF gates.
+    """
+    monkeypatch.setenv("PIPEFY_ALLOW_INSECURE_URLS", "true")
 
     resolved = resolve_cli_settings(
-        graphql_url_flag=None,
-        allow_insecure_urls_flag=None,
+        base_url_flag=None,
+        allow_insecure_urls_flag=False,
     )
 
-    assert resolved.pipefy.graphql_url == "https://from-toml.example.com/graphql"
-    assert resolved.auth.service_account_client_id == "toml-client"
+    assert resolved.pipefy.allow_insecure_urls is False
+    assert resolved.auth.allow_insecure_urls is False
 
 
-def test_env_overrides_user_toml(
-    clean_pipefy_env,
-    saved_cwd,
-    monkeypatch: pytest.MonkeyPatch,
-):
-    cfg_path = saved_cwd / "config.toml"
-    cfg_path.write_text(
-        textwrap.dedent(
-            """\
-            [pipefy]
-            graphql_url = "https://from-toml.example.com/graphql"
-            service_account_client_id = "toml-client"
-            service_account_client_secret = "toml-secret"
-            """
-        ),
-        encoding="utf-8",
-    )
-    monkeypatch.setattr(config_module, "USER_CONFIG_PATH", cfg_path)
-    monkeypatch.setenv(
-        "PIPEFY_GRAPHQL_URL",
-        "https://from-env.example.com/graphql",
-    )
-
-    resolved = resolve_cli_settings(
-        graphql_url_flag=None,
-        allow_insecure_urls_flag=None,
-    ).pipefy
-
-    assert resolved.graphql_url == "https://from-env.example.com/graphql"
-
-
-def test_apply_toml_fills_only_missing_fields(
-    clean_pipefy_env,
-    saved_cwd,
-    monkeypatch: pytest.MonkeyPatch,
-):
-    from pipefy_auth import AuthSettings
-    from pipefy_sdk import PipefySettings
-
-    cfg_path = saved_cwd / "config.toml"
-    cfg_path.write_text(
-        textwrap.dedent(
-            """\
-            [pipefy]
-            graphql_url = "https://toml-only.example.com/graphql"
-            service_account_client_id = "toml-client"
-            """
-        ),
-        encoding="utf-8",
-    )
-    monkeypatch.setattr(config_module, "USER_CONFIG_PATH", cfg_path)
-
-    pipefy, auth = apply_toml_fallback(
-        PipefySettings(),
-        AuthSettings(service_account_client_id="from-env"),
-    )
-
-    assert pipefy.graphql_url == "https://toml-only.example.com/graphql"
-    assert auth.service_account_client_id == "from-env"
-
-
-def test_graphql_url_flag_localhost_rejected_without_insecure(
+def test_base_url_flag_localhost_rejected_without_insecure(
     clean_pipefy_env,
     saved_cwd,
 ):
     with pytest.raises(ValueError, match="HTTPS|http"):
         resolve_cli_settings(
-            graphql_url_flag="http://localhost/graphql",
+            base_url_flag="http://localhost",
             allow_insecure_urls_flag=None,
         )
 
 
-def test_graphql_url_flag_localhost_allowed_with_insecure_flag(
+def test_base_url_flag_localhost_allowed_with_insecure_flag(
     clean_pipefy_env,
     saved_cwd,
 ):
     resolved = resolve_cli_settings(
-        graphql_url_flag="http://localhost/graphql",
+        base_url_flag="http://localhost:3000",
         allow_insecure_urls_flag=True,
     ).pipefy
-    assert resolved.graphql_url == "http://localhost/graphql"
-    assert resolved.allow_insecure_urls is True
 
-
-def test_toml_private_graphql_url_rejected(clean_pipefy_env, saved_cwd, monkeypatch):
-    cfg_path = saved_cwd / "config.toml"
-    cfg_path.write_text(
-        textwrap.dedent(
-            """\
-            [pipefy]
-            graphql_url = "http://10.0.0.1/graphql"
-            """
-        ),
-        encoding="utf-8",
-    )
-    monkeypatch.setattr(config_module, "USER_CONFIG_PATH", cfg_path)
-
-    with pytest.raises(ValueError):
-        resolve_cli_settings(
-            graphql_url_flag=None,
-            allow_insecure_urls_flag=None,
-        )
-
-
-def test_corrupt_user_config_toml_raises_actionable_error(
-    clean_pipefy_env,
-    saved_cwd,
-    monkeypatch,
-):
-    cfg_path = saved_cwd / "config.toml"
-    cfg_path.write_text("[pipefy\ngraphql_url = ", encoding="utf-8")
-    monkeypatch.setattr(config_module, "USER_CONFIG_PATH", cfg_path)
-
-    with pytest.raises(ValueError, match="docs/setup"):
-        resolve_cli_settings(
-            graphql_url_flag=None,
-            allow_insecure_urls_flag=None,
-        )
+    assert resolved.base_url == "http://localhost:3000"
+    assert resolved.graphql_url == "http://localhost:3000/graphql"
 
 
 @pytest.mark.parametrize(
-    ("url", "allow_insecure_flag", "should_reject"),
+    "url,allow_insecure,expect_error",
     [
-        ("https://signin.example.com/realms/pipefy", None, False),
-        ("http://signin.example.com/realms/pipefy", None, True),
-        ("http://localhost:8080/realms/dev", True, False),
-        ("https://10.0.0.1/realms/pipefy", None, True),
-    ],
-    ids=[
-        "https_accepted",
-        "http_rejected_strict",
-        "localhost_allowed_insecure",
-        "private_ip_rejected",
+        pytest.param(
+            "https://signin.example.com/realms/foo",
+            False,
+            None,
+            id="https_accepted",
+        ),
+        pytest.param(
+            "http://signin.example.com/realms/foo",
+            False,
+            "HTTPS",
+            id="http_rejected_strict",
+        ),
+        pytest.param(
+            "http://localhost/realms/foo",
+            True,
+            None,
+            id="localhost_allowed_insecure",
+        ),
+        pytest.param(
+            "https://10.0.0.1/realms/foo",
+            False,
+            "private",
+            id="private_ip_rejected",
+        ),
     ],
 )
 def test_auth_url_validation(
@@ -329,19 +249,19 @@ def test_auth_url_validation(
     saved_cwd,
     monkeypatch: pytest.MonkeyPatch,
     url: str,
-    allow_insecure_flag: bool | None,
-    should_reject: bool,
+    allow_insecure: bool,
+    expect_error: str | None,
 ):
     monkeypatch.setenv("PIPEFY_AUTH_URL", url)
-    if should_reject:
-        with pytest.raises(ValueError, match="auth_url"):
-            resolve_cli_settings(
-                graphql_url_flag=None,
-                allow_insecure_urls_flag=allow_insecure_flag,
-            )
-    else:
+    if expect_error is None:
         resolved = resolve_cli_settings(
-            graphql_url_flag=None,
-            allow_insecure_urls_flag=allow_insecure_flag,
-        )
-        assert resolved.auth.auth_url == url
+            base_url_flag=None,
+            allow_insecure_urls_flag=True if allow_insecure else None,
+        ).auth
+        assert resolved.auth_url == url
+    else:
+        with pytest.raises(ValueError, match=expect_error):
+            resolve_cli_settings(
+                base_url_flag=None,
+                allow_insecure_urls_flag=True if allow_insecure else None,
+            )

--- a/packages/cli/tests/test_config_back_compat.py
+++ b/packages/cli/tests/test_config_back_compat.py
@@ -1,31 +1,26 @@
-"""Back-compat coverage for the env- and TOML-key rename in #127.
+"""Back-compat coverage for the ``PIPEFY_OAUTH_*`` → ``PIPEFY_SERVICE_ACCOUNT_*`` rename (#127).
 
-End-to-end: `PIPEFY_OAUTH_*` shell/.env vars and ``oauth_*`` TOML keys still
-populate the new ``service_account_*`` fields, both emit one-shot stderr
-deprecation warnings, and new keys win when both names are present.
+Legacy ``PIPEFY_OAUTH_CLIENT`` / ``PIPEFY_OAUTH_SECRET`` env vars still
+populate the new ``service_account_*`` fields with a one-shot stderr
+deprecation warning.
+
+The ``PIPEFY_OAUTH_URL`` legacy alias was dropped in the ``PIPEFY_BASE_URL``
+rewrite — the OAuth token endpoint now derives from ``base_url``.
 """
 
 from __future__ import annotations
 
-import textwrap
-
 import pytest
 from pipefy_auth.settings import _reset_legacy_oauth_warning_state
 
-from pipefy_cli import config as config_module
-from pipefy_cli.config import (
-    _reset_legacy_toml_warning_state,
-    resolve_cli_settings,
-)
+from pipefy_cli.config import resolve_cli_settings
 
 
 @pytest.fixture(autouse=True)
 def _reset_warning_dedup() -> None:
     _reset_legacy_oauth_warning_state()
-    _reset_legacy_toml_warning_state()
     yield
     _reset_legacy_oauth_warning_state()
-    _reset_legacy_toml_warning_state()
 
 
 def test_legacy_env_vars_still_populate_new_fields(
@@ -33,17 +28,14 @@ def test_legacy_env_vars_still_populate_new_fields(
     saved_cwd,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    monkeypatch.setenv("PIPEFY_GRAPHQL_URL", "https://app.example.com/graphql")
-    monkeypatch.setenv("PIPEFY_OAUTH_URL", "https://legacy.example.com/oauth/token")
     monkeypatch.setenv("PIPEFY_OAUTH_CLIENT", "legacy-client")
     monkeypatch.setenv("PIPEFY_OAUTH_SECRET", "legacy-secret")
 
     resolved = resolve_cli_settings(
-        graphql_url_flag=None,
+        base_url_flag=None,
         allow_insecure_urls_flag=None,
     ).auth
 
-    assert resolved.service_account_url == "https://legacy.example.com/oauth/token"
     assert resolved.service_account_client_id == "legacy-client"
     assert resolved.service_account_client_secret == "legacy-secret"
 
@@ -53,18 +45,16 @@ def test_new_env_var_wins_when_both_legacy_and_new_set(
     saved_cwd,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    monkeypatch.setenv("PIPEFY_GRAPHQL_URL", "https://app.example.com/graphql")
-    monkeypatch.setenv("PIPEFY_OAUTH_URL", "https://legacy.example.com/oauth/token")
-    monkeypatch.setenv(
-        "PIPEFY_SERVICE_ACCOUNT_URL", "https://new.example.com/oauth/token"
-    )
+    monkeypatch.setenv("PIPEFY_OAUTH_CLIENT", "legacy-client")
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", "new-client")
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET", "secret")
 
     resolved = resolve_cli_settings(
-        graphql_url_flag=None,
+        base_url_flag=None,
         allow_insecure_urls_flag=None,
     ).auth
 
-    assert resolved.service_account_url == "https://new.example.com/oauth/token"
+    assert resolved.service_account_client_id == "new-client"
 
 
 def test_legacy_env_var_emits_stderr_warning_with_new_name(
@@ -73,130 +63,13 @@ def test_legacy_env_var_emits_stderr_warning_with_new_name(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ):
-    monkeypatch.setenv("PIPEFY_GRAPHQL_URL", "https://app.example.com/graphql")
     monkeypatch.setenv("PIPEFY_OAUTH_CLIENT", "legacy-client")
 
     resolve_cli_settings(
-        graphql_url_flag=None,
+        base_url_flag=None,
         allow_insecure_urls_flag=None,
     )
 
     err = capsys.readouterr().err
     assert "PIPEFY_OAUTH_CLIENT is deprecated" in err
     assert "rename to PIPEFY_SERVICE_ACCOUNT_CLIENT_ID" in err
-
-
-def test_legacy_toml_keys_still_populate_new_fields(
-    clean_pipefy_env,
-    saved_cwd,
-    monkeypatch: pytest.MonkeyPatch,
-):
-    cfg_path = saved_cwd / "config.toml"
-    cfg_path.write_text(
-        textwrap.dedent(
-            """\
-            [pipefy]
-            graphql_url = "https://app.example.com/graphql"
-            oauth_url = "https://legacy-toml.example.com/oauth/token"
-            oauth_client = "legacy-toml-client"
-            oauth_secret = "legacy-toml-secret"
-            """
-        ),
-        encoding="utf-8",
-    )
-    monkeypatch.setattr(config_module, "USER_CONFIG_PATH", cfg_path)
-
-    resolved = resolve_cli_settings(
-        graphql_url_flag=None,
-        allow_insecure_urls_flag=None,
-    ).auth
-
-    assert resolved.service_account_url == "https://legacy-toml.example.com/oauth/token"
-    assert resolved.service_account_client_id == "legacy-toml-client"
-    assert resolved.service_account_client_secret == "legacy-toml-secret"
-
-
-def test_toml_new_key_wins_when_both_legacy_and_new_present(
-    clean_pipefy_env,
-    saved_cwd,
-    monkeypatch: pytest.MonkeyPatch,
-):
-    cfg_path = saved_cwd / "config.toml"
-    cfg_path.write_text(
-        textwrap.dedent(
-            """\
-            [pipefy]
-            graphql_url = "https://app.example.com/graphql"
-            oauth_url = "https://legacy-toml.example.com/oauth/token"
-            service_account_url = "https://new-toml.example.com/oauth/token"
-            """
-        ),
-        encoding="utf-8",
-    )
-    monkeypatch.setattr(config_module, "USER_CONFIG_PATH", cfg_path)
-
-    resolved = resolve_cli_settings(
-        graphql_url_flag=None,
-        allow_insecure_urls_flag=None,
-    ).auth
-
-    assert resolved.service_account_url == "https://new-toml.example.com/oauth/token"
-
-
-def test_legacy_toml_key_emits_stderr_warning_with_new_name(
-    clean_pipefy_env,
-    saved_cwd,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-):
-    cfg_path = saved_cwd / "config.toml"
-    cfg_path.write_text(
-        textwrap.dedent(
-            """\
-            [pipefy]
-            graphql_url = "https://app.example.com/graphql"
-            oauth_secret = "legacy-toml-secret"
-            """
-        ),
-        encoding="utf-8",
-    )
-    monkeypatch.setattr(config_module, "USER_CONFIG_PATH", cfg_path)
-
-    resolve_cli_settings(
-        graphql_url_flag=None,
-        allow_insecure_urls_flag=None,
-    )
-
-    err = capsys.readouterr().err
-    assert "'oauth_secret'" in err
-    assert "is deprecated" in err
-    assert "'service_account_client_secret'" in err
-
-
-def test_toml_warning_dedups_across_repeated_loads(
-    clean_pipefy_env,
-    saved_cwd,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-):
-    cfg_path = saved_cwd / "config.toml"
-    cfg_path.write_text(
-        textwrap.dedent(
-            """\
-            [pipefy]
-            graphql_url = "https://app.example.com/graphql"
-            oauth_url = "https://legacy-toml.example.com/oauth/token"
-            """
-        ),
-        encoding="utf-8",
-    )
-    monkeypatch.setattr(config_module, "USER_CONFIG_PATH", cfg_path)
-
-    for _ in range(3):
-        resolve_cli_settings(
-            graphql_url_flag=None,
-            allow_insecure_urls_flag=None,
-        )
-
-    err = capsys.readouterr().err
-    assert err.count("'oauth_url' in") == 1

--- a/packages/cli/tests/test_org_commands.py
+++ b/packages/cli/tests/test_org_commands.py
@@ -11,18 +11,6 @@ from pipefy_cli.main import app
 def test_org_get_uses_pipefy_org_id_when_argument_omitted(
     runner, clean_pipefy_env, saved_cwd, monkeypatch
 ):
-    monkeypatch.setenv(
-        "PIPEFY_GRAPHQL_URL",
-        "https://cli-org-env.example.com/graphql",
-    )
-    monkeypatch.setenv(
-        "PIPEFY_INTERNAL_API_URL",
-        "https://cli-org-env.example.com/internal_api",
-    )
-    monkeypatch.setenv(
-        "PIPEFY_SERVICE_ACCOUNT_URL",
-        "https://cli-org-env.example.com/oauth/token",
-    )
     monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", "cid")
     monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET", "sec")
     monkeypatch.setenv("PIPEFY_ORG_ID", "302398434")
@@ -44,18 +32,6 @@ def test_org_get_uses_pipefy_org_id_when_argument_omitted(
 def test_org_get_positional_overrides_pipefy_org_id(
     runner, clean_pipefy_env, saved_cwd, monkeypatch
 ):
-    monkeypatch.setenv(
-        "PIPEFY_GRAPHQL_URL",
-        "https://cli-org-pos.example.com/graphql",
-    )
-    monkeypatch.setenv(
-        "PIPEFY_INTERNAL_API_URL",
-        "https://cli-org-pos.example.com/internal_api",
-    )
-    monkeypatch.setenv(
-        "PIPEFY_SERVICE_ACCOUNT_URL",
-        "https://cli-org-pos.example.com/oauth/token",
-    )
     monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", "cid")
     monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET", "sec")
     monkeypatch.setenv("PIPEFY_ORG_ID", "111")
@@ -76,18 +52,6 @@ def test_org_get_positional_overrides_pipefy_org_id(
 def test_org_get_missing_id_and_env_exits_2(
     runner, clean_pipefy_env, saved_cwd, monkeypatch
 ):
-    monkeypatch.setenv(
-        "PIPEFY_GRAPHQL_URL",
-        "https://cli-org-miss.example.com/graphql",
-    )
-    monkeypatch.setenv(
-        "PIPEFY_INTERNAL_API_URL",
-        "https://cli-org-miss.example.com/internal_api",
-    )
-    monkeypatch.setenv(
-        "PIPEFY_SERVICE_ACCOUNT_URL",
-        "https://cli-org-miss.example.com/oauth/token",
-    )
     monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", "cid")
     monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET", "sec")
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -17,10 +17,12 @@ Set the following environment variables (or add to a `.env` file in your working
 ```env
 PIPEFY_SERVICE_ACCOUNT_CLIENT_ID=your_client_id
 PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET=your_client_secret
-PIPEFY_GRAPHQL_URL=https://app.pipefy.com/graphql
-PIPEFY_SERVICE_ACCOUNT_URL=https://app.pipefy.com/oauth/token
-PIPEFY_INTERNAL_API_URL=https://app.pipefy.com/internal_api
+# Non-prod environments only:
+# PIPEFY_BASE_URL=https://<your-api-host>
+# PIPEFY_AUTH_URL=https://<your-signin-host>/realms/<realm>
 ```
+
+`PIPEFY_BASE_URL` defaults to `https://app.pipefy.com` (drives the four API endpoints) and `PIPEFY_AUTH_URL` defaults to `https://signin.pipefy.com/realms/pipefy` (the OIDC issuer). Set them only for non-prod environments.
 
 Full guide: [`docs/setup.md`](../../docs/setup.md).
 

--- a/packages/mcp/src/pipefy_mcp/core/container.py
+++ b/packages/mcp/src/pipefy_mcp/core/container.py
@@ -55,7 +55,9 @@ class ServicesContainer:
                 f"{missing_auth_message()} "
                 f"See {DOCS_SETUP_REF} for host-specific install steps."
             )
-        if oidc_client is not None and tier_for(resolved) == STORED_SESSION_TIER:
+        # ``oidc_client`` is always non-None (``auth_url`` defaults to prod IdP);
+        # tier check gates warmup — only stored-session needs it.
+        if tier_for(resolved) == STORED_SESSION_TIER:
             try:
                 await asyncio.to_thread(
                     ensure_fresh_session,
@@ -73,13 +75,12 @@ class ServicesContainer:
                 raise
             logger.info("Pipefy stored session warmed up at startup")
         self.pipefy_client = PipefyClient(settings=pipefy, auth=resolved)
-        if pipefy.internal_api_url:
-            internal_client = InternalApiClient(
-                url=pipefy.internal_api_url,
-                auth=resolved,
-                allow_insecure_urls=pipefy.allow_insecure_urls,
-            )
-            self.pipefy_client.set_internal_api_client(internal_client)
-            self.pipefy_client.set_ai_automation_service(
-                AiAutomationService(client=internal_client)
-            )
+        internal_client = InternalApiClient(
+            url=pipefy.internal_api_url,
+            auth=resolved,
+            allow_insecure_urls=pipefy.allow_insecure_urls,
+        )
+        self.pipefy_client.set_internal_api_client(internal_client)
+        self.pipefy_client.set_ai_automation_service(
+            AiAutomationService(client=internal_client)
+        )

--- a/packages/mcp/src/pipefy_mcp/settings.py
+++ b/packages/mcp/src/pipefy_mcp/settings.py
@@ -9,22 +9,15 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Settings(BaseSettings):
     """Application configuration via pydantic-settings.
 
-    Precedence: init kwargs > ``PIPEFY_*`` env > ``.env`` > defaults.
-
-    The nested ``pipefy`` model uses names ``PIPEFY_*`` (e.g.
-    ``PIPEFY_BASE_URL`` → ``pipefy.base_url``); the nested ``auth`` model
-    owns ``PIPEFY_SERVICE_ACCOUNT_CLIENT_ID`` / ``_SECRET``,
-    ``PIPEFY_AUTH_URL``, ``PIPEFY_AUTH_CLIENT_ID``, and a mirror of
-    ``PIPEFY_BASE_URL``. Both nested models run their own SSRF / shape checks
-    at construction; no parent-side ``_validate_*`` validator is required.
+    Each nested model owns its own env loading (``env_prefix="PIPEFY_"``).
+    The composition deliberately does NOT set ``env_nested_delimiter`` — that
+    flag splits any matching env var (e.g. ``AUTH_BASE_URL``) into a nested
+    path, which would bypass each model's prefix gate and let unprefixed env
+    vars hijack auth fields. Both nested models run their own SSRF / shape
+    checks at construction; no parent-side ``_validate_*`` validator is needed.
     """
 
-    model_config = SettingsConfigDict(
-        env_nested_delimiter="_",
-        env_nested_max_split=1,
-        env_file=".env",
-        env_file_encoding="utf-8",
-    )
+    model_config = SettingsConfigDict(extra="ignore")
 
     pipefy: PipefySettings = Field(default_factory=PipefySettings)
     auth: AuthSettings = Field(default_factory=AuthSettings)

--- a/packages/mcp/src/pipefy_mcp/settings.py
+++ b/packages/mcp/src/pipefy_mcp/settings.py
@@ -1,23 +1,22 @@
 from __future__ import annotations
 
-from typing import Self
-
 from pipefy_auth import AuthSettings
 from pipefy_sdk import PipefySettings
-from pydantic import Field, model_validator
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
     """Application configuration via pydantic-settings.
 
-    On import, values are read from process environment variables and from a ``.env`` file
-    in the current working directory (see ``env_file`` in ``model_config``). The nested
-    ``pipefy`` model uses names ``PIPEFY_*`` (e.g. ``PIPEFY_GRAPHQL_URL`` →
-    ``pipefy.graphql_url``); the nested ``auth`` model owns
-    ``PIPEFY_SERVICE_ACCOUNT_*``, ``PIPEFY_AUTH_URL``, and
-    ``PIPEFY_AUTH_CLIENT_ID``. See
-    https://docs.pydantic.dev/latest/concepts/pydantic_settings/
+    Precedence: init kwargs > ``PIPEFY_*`` env > ``.env`` > defaults.
+
+    The nested ``pipefy`` model uses names ``PIPEFY_*`` (e.g.
+    ``PIPEFY_BASE_URL`` → ``pipefy.base_url``); the nested ``auth`` model
+    owns ``PIPEFY_SERVICE_ACCOUNT_CLIENT_ID`` / ``_SECRET``,
+    ``PIPEFY_AUTH_URL``, ``PIPEFY_AUTH_CLIENT_ID``, and a mirror of
+    ``PIPEFY_BASE_URL``. Both nested models run their own SSRF / shape checks
+    at construction; no parent-side ``_validate_*`` validator is required.
     """
 
     model_config = SettingsConfigDict(
@@ -29,14 +28,6 @@ class Settings(BaseSettings):
 
     pipefy: PipefySettings = Field(default_factory=PipefySettings)
     auth: AuthSettings = Field(default_factory=AuthSettings)
-
-    @model_validator(mode="after")
-    def _validate_auth_urls(self) -> Self:
-        # PipefySettings validates its own endpoint URLs on construction; mirror
-        # that for AuthSettings here so unsafe service-account / OIDC URLs fail
-        # fast at settings load (matches CliSettings.resolve_cli_settings).
-        self.auth.validate_urls(allow_insecure=self.pipefy.allow_insecure_urls)
-        return self
 
 
 settings = Settings()

--- a/packages/mcp/src/pipefy_mcp/tools/ai_automation_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/ai_automation_tools.py
@@ -51,7 +51,7 @@ AI_AUTOMATION_UPDATE_FAILED = (
 
 AI_AUTOMATION_NOT_CONFIGURED = (
     "AI Automation requires service-account credentials "
-    "(PIPEFY_SERVICE_ACCOUNT_URL, PIPEFY_SERVICE_ACCOUNT_CLIENT_ID, "
+    "(PIPEFY_SERVICE_ACCOUNT_CLIENT_ID, "
     "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET). "
     "Check .env.example for the required variables."
 )

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
@@ -432,10 +432,9 @@ class PipeTools:
             ``create_card_relation``). Two-step flow: preview with ``confirm=False`` (default),
             then execute with ``confirm=True`` after explicit approval.
 
-            Requires service-account credentials (PIPEFY_SERVICE_ACCOUNT_URL,
-            PIPEFY_SERVICE_ACCOUNT_CLIENT_ID, PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET) because the
-            ``deleteCardRelation`` mutation is only available on the internal API, not the
-            public GraphQL schema.
+            Requires service-account credentials (PIPEFY_SERVICE_ACCOUNT_CLIENT_ID,
+            PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET) because the ``deleteCardRelation``
+            mutation is only available on the internal API, not the public GraphQL schema.
 
             Args:
                 child_id: Child card ID in the relation.
@@ -456,7 +455,7 @@ class PipeTools:
                 return build_relation_error_payload(
                     message=(
                         "delete_card_relation requires service-account credentials "
-                        "(PIPEFY_SERVICE_ACCOUNT_URL, PIPEFY_SERVICE_ACCOUNT_CLIENT_ID, "
+                        "(PIPEFY_SERVICE_ACCOUNT_CLIENT_ID, "
                         "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET). "
                         "The deleteCardRelation mutation is only available on the "
                         "internal API. Check .env.example for the required variables."

--- a/packages/mcp/tests/core/test_container.py
+++ b/packages/mcp/tests/core/test_container.py
@@ -13,19 +13,17 @@ from pipefy_mcp.settings import Settings
 
 _AUTH_ENV_KEYS = (
     "PIPEFY_TOKEN",
-    "PIPEFY_SERVICE_ACCOUNT_URL",
     "PIPEFY_SERVICE_ACCOUNT_CLIENT_ID",
     "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET",
-    "PIPEFY_OAUTH_URL",
     "PIPEFY_OAUTH_CLIENT",
     "PIPEFY_OAUTH_SECRET",
     "PIPEFY_AUTH_URL",
+    "PIPEFY_BASE_URL",
 )
 
 
 def _service_account_auth_settings() -> AuthSettings:
     return AuthSettings(
-        service_account_url="https://auth.pipefy.com/oauth/token",
         service_account_client_id="client_id",
         service_account_client_secret="client_secret",
     )
@@ -105,7 +103,7 @@ class TestServicesContainer:
         mock_pipefy_client_class.return_value = mock_client
 
         settings = Settings(
-            pipefy=PipefySettings(graphql_url="https://api.pipefy.com/graphql"),
+            pipefy=PipefySettings(base_url="https://api.pipefy.com"),
             auth=_service_account_auth_settings(),
         )
 
@@ -132,7 +130,7 @@ class TestServicesContainer:
         mock_pipefy_client_class.return_value = mock_client
 
         settings = Settings(
-            pipefy=PipefySettings(graphql_url="https://api.pipefy.com/graphql"),
+            pipefy=PipefySettings(base_url="https://api.pipefy.com"),
             auth=_service_account_auth_settings(),
         )
 
@@ -164,12 +162,9 @@ class TestServicesContainer:
         mock_client.client = Mock()
         mock_pipefy_client_class.return_value = mock_client
         settings = Settings(
-            pipefy=PipefySettings(graphql_url="https://api.pipefy.com/graphql"),
+            pipefy=PipefySettings(base_url="https://api.pipefy.com"),
             auth=AuthSettings(
                 static_token="env-bearer",
-                service_account_url="https://auth.pipefy.com/oauth/token",
-                service_account_client_id="client_id",
-                service_account_client_secret="client_secret",
             ),
         )
         await ServicesContainer().initialize_services(settings)
@@ -197,7 +192,7 @@ class TestServicesContainer:
     ):
         """No PIPEFY_TOKEN and no service-account triple → runtime error."""
         settings = Settings(
-            pipefy=PipefySettings(graphql_url="https://api.pipefy.com/graphql"),
+            pipefy=PipefySettings(base_url="https://api.pipefy.com"),
             auth=AuthSettings(),
         )
         with pytest.raises(
@@ -216,7 +211,7 @@ class TestServicesContainer:
         """When the resolved tier is the stored session, the refresh is pre-warmed."""
         mock_pipefy_client_class.return_value = Mock(spec=PipefyClient)
         settings = Settings(
-            pipefy=PipefySettings(graphql_url="https://api.pipefy.com/graphql"),
+            pipefy=PipefySettings(base_url="https://api.pipefy.com"),
             auth=_stored_session_auth_settings(),
         )
         with patch(
@@ -242,7 +237,7 @@ class TestServicesContainer:
         """A configured ``PIPEFY_AUTH_URL`` is ignored at warm-up when a higher tier wins."""
         mock_pipefy_client_class.return_value = Mock(spec=PipefyClient)
         settings = Settings(
-            pipefy=PipefySettings(graphql_url="https://api.pipefy.com/graphql"),
+            pipefy=PipefySettings(base_url="https://api.pipefy.com"),
             auth=AuthSettings(
                 static_token="env-bearer",
                 auth_url="https://signin.pipefy.com/realms/pipefy",
@@ -268,7 +263,7 @@ class TestServicesContainer:
         """A failed warm-up logs the ``pipefy auth login`` hint and surfaces ``RefreshError`` *before* ``PipefyClient`` is constructed."""
         mock_ensure_fresh_session.side_effect = RefreshError("invalid_grant")
         settings = Settings(
-            pipefy=PipefySettings(graphql_url="https://api.pipefy.com/graphql"),
+            pipefy=PipefySettings(base_url="https://api.pipefy.com"),
             auth=_stored_session_auth_settings(),
         )
         with patch(

--- a/packages/mcp/tests/test_server.py
+++ b/packages/mcp/tests/test_server.py
@@ -25,12 +25,8 @@ def client_session():
 
 
 _MINIMAL_PIPEFY_SETTINGS = Settings(
-    pipefy=PipefySettings(graphql_url="https://api.pipefy.com/graphql"),
-    auth=AuthSettings(
-        service_account_url="https://api.pipefy.com/oauth/token",
-        service_account_client_id="test-client",
-        service_account_client_secret="test-secret",
-    ),
+    pipefy=PipefySettings(base_url="https://api.pipefy.com"),
+    auth=AuthSettings(),
 )
 
 

--- a/packages/mcp/tests/test_settings.py
+++ b/packages/mcp/tests/test_settings.py
@@ -140,3 +140,46 @@ def test_settings_picks_up_pipefy_token_from_env(monkeypatch):
     monkeypatch.delenv("PIPEFY_OAUTH_CLIENT", raising=False)
     monkeypatch.delenv("PIPEFY_OAUTH_SECRET", raising=False)
     assert Settings().auth.static_token == "env-bearer"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "leak_env_var",
+    [
+        "AUTH_BASE_URL",
+        "AUTH_STATIC_TOKEN",
+        "AUTH_SERVICE_ACCOUNT_CLIENT_ID",
+        "AUTH_SERVICE_ACCOUNT_CLIENT_SECRET",
+        "AUTH_AUTH_URL",
+        "AUTH_AUTH_CLIENT_ID",
+        "AUTH_ALLOW_INSECURE_URLS",
+        "PIPEFY_AUTH_BASE_URL",
+        "PIPEFY_AUTH_STATIC_TOKEN",
+    ],
+)
+def test_settings_does_not_route_unprefixed_env_into_auth(monkeypatch, leak_env_var):
+    """``env_nested_delimiter`` must NOT be set on the parent — otherwise unprefixed
+    env vars like ``AUTH_BASE_URL`` would split into ``auth.base_url`` and bypass
+    :class:`AuthSettings`'s ``env_prefix="PIPEFY_"`` gate, enabling a credential /
+    auth-redirect leak. Locks in the security fix that closes the leak.
+    """
+    # Clear any host-side ``PIPEFY_*`` env to isolate the leak check.
+    for var in (
+        "PIPEFY_BASE_URL",
+        "PIPEFY_TOKEN",
+        "PIPEFY_SERVICE_ACCOUNT_CLIENT_ID",
+        "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET",
+        "PIPEFY_OAUTH_CLIENT",
+        "PIPEFY_OAUTH_SECRET",
+        "PIPEFY_AUTH_URL",
+        "PIPEFY_AUTH_CLIENT_ID",
+        "PIPEFY_ALLOW_INSECURE_URLS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv(leak_env_var, "https://attacker.example.com")
+    settings = Settings()
+    assert settings.auth.base_url == "https://app.pipefy.com"
+    assert settings.auth.service_account_url == "https://app.pipefy.com/oauth/token"
+    assert settings.auth.static_token is None
+    assert settings.auth.service_account_client_id is None
+    assert settings.auth.service_account_client_secret is None

--- a/packages/mcp/tests/test_settings.py
+++ b/packages/mcp/tests/test_settings.py
@@ -8,12 +8,11 @@ from pipefy_mcp.settings import Settings
 
 
 @pytest.mark.unit
-def test_internal_api_url_overridden_via_env(monkeypatch):
-    """Test that internal_api_url can be overridden via PIPEFY_INTERNAL_API_URL."""
-    custom_url = "https://custom.pipefy.com/internal_api"
-    monkeypatch.setenv("PIPEFY_INTERNAL_API_URL", custom_url)
+def test_internal_api_url_derived_from_base_url(monkeypatch):
+    """``PIPEFY_BASE_URL`` flows into the computed ``internal_api_url``."""
+    monkeypatch.setenv("PIPEFY_BASE_URL", "https://custom.pipefy.com")
     settings = Settings()
-    assert settings.pipefy.internal_api_url == custom_url
+    assert settings.pipefy.internal_api_url == "https://custom.pipefy.com/internal_api"
 
 
 @pytest.mark.unit
@@ -48,34 +47,23 @@ def test_service_account_ids_empty_env_is_empty_list(monkeypatch):
 
 
 @pytest.mark.unit
-def test_pipefy_settings_rejects_http_graphql_when_secure():
-    with pytest.raises(ValueError, match="graphql_url.*HTTPS"):
-        PipefySettings(
-            graphql_url="http://app.pipefy.com/graphql",
-            service_account_url="https://auth.pipefy.com/oauth/token",
-            internal_api_url="https://app.pipefy.com/internal_api",
-        )
+def test_pipefy_settings_rejects_http_base_when_secure():
+    with pytest.raises(ValueError, match="base_url.*HTTPS"):
+        PipefySettings(base_url="http://app.pipefy.com")
 
 
 @pytest.mark.unit
-def test_pipefy_settings_rejects_loopback_graphql():
-    with pytest.raises(ValueError, match="graphql_url.*localhost|127"):
-        PipefySettings(
-            graphql_url="https://127.0.0.1/graphql",
-            service_account_url="https://auth.pipefy.com/oauth/token",
-            internal_api_url="https://app.pipefy.com/internal_api",
-        )
+def test_pipefy_settings_rejects_loopback_base():
+    with pytest.raises(ValueError, match="base_url.*localhost|127"):
+        PipefySettings(base_url="https://127.0.0.1")
 
 
 @pytest.mark.unit
 def test_pipefy_settings_allow_insecure_urls_permits_http_localhost():
-    s = PipefySettings(
-        allow_insecure_urls=True,
-        graphql_url="http://localhost/graphql",
-        service_account_url="http://localhost/oauth/token",
-        internal_api_url="http://localhost/internal_api",
-    )
+    s = PipefySettings(allow_insecure_urls=True, base_url="http://localhost")
+    assert s.base_url == "http://localhost"
     assert s.graphql_url == "http://localhost/graphql"
+    assert s.internal_api_url == "http://localhost/internal_api"
 
 
 @pytest.mark.unit
@@ -134,11 +122,9 @@ def test_default_webhook_name_rejects_empty_string():
 
 
 @pytest.mark.unit
-def test_settings_rejects_link_local_service_account_url(monkeypatch):
-    """Settings load must SSRF-check ``AuthSettings`` URLs (regression: MCP forgot this after the split)."""
-    monkeypatch.setenv(
-        "PIPEFY_SERVICE_ACCOUNT_URL", "https://169.254.169.254/oauth/token"
-    )
+def test_settings_rejects_link_local_base_url(monkeypatch):
+    """Settings load must SSRF-check ``base_url`` (which drives the OAuth token endpoint)."""
+    monkeypatch.setenv("PIPEFY_BASE_URL", "https://169.254.169.254")
     monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", "cid")
     monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET", "csecret")
     with pytest.raises(ValidationError, match="link-local|private|loopback"):
@@ -148,12 +134,9 @@ def test_settings_rejects_link_local_service_account_url(monkeypatch):
 @pytest.mark.unit
 def test_settings_picks_up_pipefy_token_from_env(monkeypatch):
     """``PIPEFY_TOKEN`` must populate ``auth.static_token`` so MCP boots from ``.env``-only setups."""
-    monkeypatch.setenv("PIPEFY_GRAPHQL_URL", "https://api.pipefy.com/graphql")
     monkeypatch.setenv("PIPEFY_TOKEN", "env-bearer")
-    monkeypatch.delenv("PIPEFY_SERVICE_ACCOUNT_URL", raising=False)
     monkeypatch.delenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", raising=False)
     monkeypatch.delenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET", raising=False)
-    monkeypatch.delenv("PIPEFY_OAUTH_URL", raising=False)
     monkeypatch.delenv("PIPEFY_OAUTH_CLIENT", raising=False)
     monkeypatch.delenv("PIPEFY_OAUTH_SECRET", raising=False)
     assert Settings().auth.static_token == "env-bearer"

--- a/packages/sdk/src/pipefy_sdk/base_client.py
+++ b/packages/sdk/src/pipefy_sdk/base_client.py
@@ -47,13 +47,16 @@ class BasePipefyClient:
         settings: PipefySettings,
         *,
         auth: Auth,
+        url_override: str | None = None,
         on_graphql_error: Callable[[list[dict]], str] | None = None,
     ) -> None:
-        if settings.graphql_url is None:
-            raise ValueError("GraphQL URL must be provided in settings.")
-
+        # ``url_override`` lets callers point this client at a sibling endpoint
+        # (e.g. ``PortalService`` aims its interfaces client at
+        # ``settings.interfaces_graphql_url``) without mutating the shared
+        # settings object. Defaults to ``settings.graphql_url``.
         self.settings = settings
         self._auth = auth
+        self._graphql_url = url_override or settings.graphql_url
         # When set, ``TransportQueryError`` is converted to ``ValueError`` using the
         # formatter's output. Used by ``InternalApiClient`` to surface its
         # ``[code=…] [correlation_id=…]`` envelope; ``None`` leaves gql exceptions
@@ -74,7 +77,7 @@ class BasePipefyClient:
         once per client instance, caches the schema, and reuses it for local validation.
         """
         transport = HTTPXAsyncTransport(
-            url=self.settings.graphql_url,
+            url=self._graphql_url,
             auth=self._auth,
             timeout=Timeout(timeout=self.GRAPHQL_REQUEST_TIMEOUT_SECONDS),
         )

--- a/packages/sdk/src/pipefy_sdk/services/internal_api_client.py
+++ b/packages/sdk/src/pipefy_sdk/services/internal_api_client.py
@@ -54,12 +54,15 @@ class InternalApiClient(BasePipefyClient):
         validate_https_service_endpoint_url(
             url.strip(), "internal_api URL", allow_insecure=allow_insecure_urls
         )
-        # SSRF is already enforced above with the right error label; pass
-        # ``allow_insecure_urls=True`` here so ``PipefySettings`` does not re-validate
-        # the same URL under the misleading ``graphql_url`` label.
-        settings = PipefySettings(graphql_url=url, allow_insecure_urls=True)
+        # ``url`` already SSRF-validated above; ``allow_insecure_urls=True`` on
+        # the throwaway settings skips a redundant re-check. ``url_override``
+        # ships the URL without building a full purpose-specific ``PipefySettings``.
+        settings = PipefySettings(allow_insecure_urls=True)
         super().__init__(
-            settings, auth=auth, on_graphql_error=_format_internal_api_error
+            settings,
+            auth=auth,
+            url_override=url.strip(),
+            on_graphql_error=_format_internal_api_error,
         )
 
     async def execute_query(  # type: ignore[override]

--- a/packages/sdk/src/pipefy_sdk/services/portal_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/portal_service.py
@@ -111,12 +111,10 @@ class PortalService:
             auth: Shared OAuth or bearer auth for GraphQL transports.
             internal_api_client: Client for sub-portal element wiring mutations.
         """
-        interfaces_settings = settings.model_copy(
-            update={"graphql_url": settings.interfaces_graphql_url}
-        )
         self._interfaces_client = BasePipefyClient(
-            settings=interfaces_settings,
+            settings=settings,
             auth=auth,
+            url_override=settings.interfaces_graphql_url,
         )
         self._graphql_client = BasePipefyClient(
             settings=settings,

--- a/packages/sdk/src/pipefy_sdk/settings.py
+++ b/packages/sdk/src/pipefy_sdk/settings.py
@@ -2,8 +2,23 @@ from __future__ import annotations
 
 from typing import Annotated, Self
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, computed_field, field_validator, model_validator
 from pydantic_settings import NoDecode
+
+# Canonical Pipefy production API host root.
+DEFAULT_BASE_URL = "https://app.pipefy.com"
+
+# URL-shape gate. ``_validate_pipefy_endpoint_urls`` runs the deeper SSRF +
+# scheme check after settings construction. The scheme part is
+# case-insensitive (RFC 3986 §3.1) so `HTTPS://...` from operator
+# copy-paste passes the shape gate; httpx + gql normalize the scheme
+# downstream.
+_URL_SHAPE_PATTERN = r"^(?i:https?)://\S+$"
+
+# Pipefy organization IDs are ASCII numeric strings (matches the docstring).
+# ``\d`` is Unicode-aware in Python ``re`` (Arabic-Indic ١٢٣, Devanagari १२३,
+# etc. would pass), so pin to ``[0-9]`` for the wire format the API expects.
+_ORG_ID_PATTERN = r"^[0-9]+$"
 
 
 class PipefySettings(BaseModel):
@@ -12,6 +27,12 @@ class PipefySettings(BaseModel):
     Endpoint configuration only — credentials live on
     :class:`pipefy_auth.AuthSettings`. Consumers compose both side by side in
     their own settings type.
+
+    A single ``PIPEFY_BASE_URL`` drives every API endpoint via
+    :data:`@computed_field` properties (``graphql_url``,
+    ``internal_api_url``, ``interfaces_graphql_url``). Operators on
+    non-prod environments set ``PIPEFY_BASE_URL=https://<api-host>``;
+    operators on prod leave it unset (default Pipefy production).
     """
 
     allow_insecure_urls: bool = Field(
@@ -22,27 +43,27 @@ class PipefySettings(BaseModel):
         ),
     )
 
-    graphql_url: str | None = Field(
-        default=None,
-        description="GraphQL URL for Pipefy",
-    )
-
-    internal_api_url: str = Field(
-        default="https://app.pipefy.com/internal_api",
-        description="Internal API URL for AI Automation endpoints",
-    )
-
-    interfaces_graphql_url: str = Field(
-        default="https://app.pipefy.com/graphql/interfaces",
-        description="GraphQL URL for Pipefy Interfaces schema (portals, pages, elements)",
+    base_url: str = Field(
+        default=DEFAULT_BASE_URL,
+        pattern=_URL_SHAPE_PATTERN,
+        description=(
+            "Pipefy API host root (env: PIPEFY_BASE_URL). Drives ``graphql_url`` / "
+            "``internal_api_url`` / ``interfaces_graphql_url`` (and the OAuth "
+            "token endpoint on :class:`pipefy_auth.AuthSettings`). Defaults to "
+            f"'{DEFAULT_BASE_URL}' (canonical Pipefy production). Set to a "
+            "different host for non-prod environments, regional / proxy "
+            "deployments, or local development (with PIPEFY_ALLOW_INSECURE_URLS)."
+        ),
     )
 
     org_id: str | None = Field(
         default=None,
+        pattern=_ORG_ID_PATTERN,
         description=(
             "Optional default organization id (numeric string) for CLI commands that "
             "allow an implicit org, e.g. ``pipefy org get`` when the id argument is "
-            "omitted (env: PIPEFY_ORG_ID)."
+            "omitted (env: PIPEFY_ORG_ID). Must be a numeric string; empty or "
+            "non-numeric values are rejected."
         ),
     )
 
@@ -96,6 +117,17 @@ class PipefySettings(BaseModel):
         ),
     )
 
+    @field_validator("base_url", "org_id", mode="before")
+    @classmethod
+    def _strip_str(cls, value: object) -> object:
+        # Strip surrounding whitespace on every env-loaded string so a stray
+        # leading / trailing space from copy-paste does not trip the per-field
+        # ``pattern`` constraint. Empty-after-strip still fails the pattern
+        # (the "empty raises" contract).
+        if isinstance(value, str):
+            return value.strip()
+        return value
+
     @field_validator("service_account_ids", mode="before")
     @classmethod
     def _coerce_service_account_ids(cls, value: object) -> list[str]:
@@ -108,20 +140,30 @@ class PipefySettings(BaseModel):
         msg = "service_account_ids must be a list or a comma-separated string"
         raise ValueError(msg)
 
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def graphql_url(self) -> str:
+        """Pipefy GraphQL endpoint, derived from ``base_url``."""
+        return f"{self.base_url.rstrip('/')}/graphql"
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def internal_api_url(self) -> str:
+        """Internal API endpoint for AI Automation, derived from ``base_url``."""
+        return f"{self.base_url.rstrip('/')}/internal_api"
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def interfaces_graphql_url(self) -> str:
+        """Interfaces GraphQL endpoint (portals/pages/elements), derived from ``base_url``."""
+        return f"{self.base_url.rstrip('/')}/graphql/interfaces"
+
     @model_validator(mode="after")
     def _validate_pipefy_endpoint_urls(self) -> Self:
         # Deferred import: ``url_ssrf`` validates URLs that may reference settings types (cycle if top-level).
         from pipefy_sdk.utils.url_ssrf import validate_https_service_endpoint_url
 
-        allow = self.allow_insecure_urls
-        if self.graphql_url is not None and (u := self.graphql_url.strip()):
-            validate_https_service_endpoint_url(u, "graphql_url", allow_insecure=allow)
-        if u := self.internal_api_url.strip():
-            validate_https_service_endpoint_url(
-                u, "internal_api_url", allow_insecure=allow
-            )
-        if u := self.interfaces_graphql_url.strip():
-            validate_https_service_endpoint_url(
-                u, "interfaces_graphql_url", allow_insecure=allow
-            )
+        validate_https_service_endpoint_url(
+            self.base_url.strip(), "base_url", allow_insecure=self.allow_insecure_urls
+        )
         return self

--- a/packages/sdk/src/pipefy_sdk/settings.py
+++ b/packages/sdk/src/pipefy_sdk/settings.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import Annotated, Self
 
-from pydantic import BaseModel, Field, computed_field, field_validator, model_validator
-from pydantic_settings import NoDecode
+from pydantic import Field, computed_field, field_validator, model_validator
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 # Canonical Pipefy production API host root.
 DEFAULT_BASE_URL = "https://app.pipefy.com"
@@ -21,12 +21,15 @@ _URL_SHAPE_PATTERN = r"^(?i:https?)://\S+$"
 _ORG_ID_PATTERN = r"^[0-9]+$"
 
 
-class PipefySettings(BaseModel):
+class PipefySettings(BaseSettings):
     """Pipefy API connection and shared runtime knobs (MCP, CLI, scripts).
 
     Endpoint configuration only — credentials live on
     :class:`pipefy_auth.AuthSettings`. Consumers compose both side by side in
-    their own settings type.
+    their own settings type; each model owns its own env loading so the parent
+    composition does not need ``env_nested_delimiter`` (which routes any
+    matching env var into a nested field — a credential-leak primitive when
+    multiple nested models share field names).
 
     A single ``PIPEFY_BASE_URL`` drives every API endpoint via
     :data:`@computed_field` properties (``graphql_url``,
@@ -34,6 +37,14 @@ class PipefySettings(BaseModel):
     non-prod environments set ``PIPEFY_BASE_URL=https://<api-host>``;
     operators on prod leave it unset (default Pipefy production).
     """
+
+    model_config = SettingsConfigDict(
+        env_prefix="PIPEFY_",
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+        populate_by_name=True,
+    )
 
     allow_insecure_urls: bool = Field(
         default=False,
@@ -161,9 +172,25 @@ class PipefySettings(BaseModel):
     @model_validator(mode="after")
     def _validate_pipefy_endpoint_urls(self) -> Self:
         # Deferred import: ``url_ssrf`` validates URLs that may reference settings types (cycle if top-level).
+        from urllib.parse import urlparse
+
         from pipefy_sdk.utils.url_ssrf import validate_https_service_endpoint_url
 
+        stripped = self.base_url.strip()
+        parsed = urlparse(stripped)
+        # ``base_url`` must be a host root: derived endpoints (``graphql_url``,
+        # ``internal_api_url``, ``interfaces_graphql_url``) append fixed paths to
+        # it via f-strings. A query / fragment / non-root path would land inside
+        # the resulting URL's query slot or as a path prefix, producing
+        # silently-malformed endpoints rather than a loud validation error.
+        if parsed.path.strip("/") or parsed.query or parsed.fragment:
+            msg = (
+                f"base_url must be a host root with no path, query, or fragment "
+                f"(got {self.base_url!r}); the SDK appends "
+                "``/graphql`` / ``/internal_api`` / ``/graphql/interfaces`` to it."
+            )
+            raise ValueError(msg)
         validate_https_service_endpoint_url(
-            self.base_url.strip(), "base_url", allow_insecure=self.allow_insecure_urls
+            stripped, "base_url", allow_insecure=self.allow_insecure_urls
         )
         return self

--- a/packages/sdk/tests/_shared/live_settings.py
+++ b/packages/sdk/tests/_shared/live_settings.py
@@ -11,8 +11,8 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from pipefy_sdk.settings import PipefySettings
 
 _MISSING_CREDS_MESSAGE = (
-    "Pipefy credentials not configured: PIPEFY_GRAPHQL_URL required; "
-    + missing_auth_message()
+    "Pipefy credentials not configured: set PIPEFY_BASE_URL to your "
+    "Pipefy API host (or leave unset for prod); " + missing_auth_message()
 )
 
 
@@ -63,16 +63,14 @@ def live_resolved_auth() -> Auth:
 
 
 def pipefy_live_configured() -> bool:
-    """Return True when GraphQL URL plus a resolvable auth tier is configured.
+    """Return True when a Pipefy host and a resolvable auth tier are both configured."""
+    # ``PipefySettings.base_url`` carries a prod default; consulting the
+    # resolved field would flip live tests on for every dev machine that
+    # has *any* auth tier configured. Gate on the env var instead so live
+    # tests stay opt-in.
+    import os
 
-    Auth detection delegates to :func:`pipefy_auth.resolve_pipefy_auth` so a
-    setup that names a stored-session tier but has no keychain entry is
-    reported as unconfigured (matches what ``live_resolved_auth`` would do).
-    """
-    p = _resolved_pipefy()
-    has_url = bool(
-        p.graphql_url and str(p.graphql_url).startswith(("http://", "https://"))
-    )
+    has_url = bool(os.environ.get("PIPEFY_BASE_URL", "").strip())
     return has_url and _try_resolve_live_auth() is not None
 
 

--- a/packages/sdk/tests/services/pipefy/test_automation_service.py
+++ b/packages/sdk/tests/services/pipefy/test_automation_service.py
@@ -108,10 +108,7 @@ class TestFormatAutomationErrorDetails:
 @pytest.fixture
 def mock_settings():
     return PipefySettings(
-        graphql_url="https://api.pipefy.com/graphql",
-        oauth_url="https://auth.pipefy.com/oauth/token",
-        oauth_client="client_id",
-        oauth_secret="client_secret",
+        base_url="https://api.pipefy.com",
     )
 
 

--- a/packages/sdk/tests/services/pipefy/test_member_service.py
+++ b/packages/sdk/tests/services/pipefy/test_member_service.py
@@ -21,10 +21,7 @@ _TEST_AUTH = StaticBearerAuth("test-bearer-token")
 @pytest.fixture
 def mock_settings():
     return PipefySettings(
-        graphql_url="https://api.pipefy.com/graphql",
-        oauth_url="https://auth.pipefy.com/oauth/token",
-        oauth_client="client_id",
-        oauth_secret="client_secret",
+        base_url="https://api.pipefy.com",
     )
 
 

--- a/packages/sdk/tests/services/pipefy/test_observability_service.py
+++ b/packages/sdk/tests/services/pipefy/test_observability_service.py
@@ -33,10 +33,7 @@ _ORG_UUID_FOR_TESTS = "341c1327-261c-4766-bb96-7953e4c3970d"
 @pytest.fixture
 def mock_settings():
     return PipefySettings(
-        graphql_url="https://api.pipefy.com/graphql",
-        oauth_url="https://auth.pipefy.com/oauth/token",
-        oauth_client="client_id",
-        oauth_secret="client_secret",
+        base_url="https://api.pipefy.com",
     )
 
 

--- a/packages/sdk/tests/services/pipefy/test_organization_service.py
+++ b/packages/sdk/tests/services/pipefy/test_organization_service.py
@@ -17,10 +17,7 @@ _TEST_AUTH = StaticBearerAuth("test-bearer-token")
 @pytest.fixture
 def mock_settings():
     return PipefySettings(
-        graphql_url="https://api.pipefy.com/graphql",
-        oauth_url="https://auth.pipefy.com/oauth/token",
-        oauth_client="client_id",
-        oauth_secret="client_secret",
+        base_url="https://api.pipefy.com",
     )
 
 

--- a/packages/sdk/tests/services/pipefy/test_pipe_config_service.py
+++ b/packages/sdk/tests/services/pipefy/test_pipe_config_service.py
@@ -35,10 +35,7 @@ _TEST_AUTH = StaticBearerAuth("test-bearer-token")
 @pytest.fixture
 def mock_settings():
     return PipefySettings(
-        graphql_url="https://api.pipefy.com/graphql",
-        oauth_url="https://auth.pipefy.com/oauth/token",
-        oauth_client="client_id",
-        oauth_secret="client_secret",
+        base_url="https://api.pipefy.com",
     )
 
 

--- a/packages/sdk/tests/services/pipefy/test_portal_service.py
+++ b/packages/sdk/tests/services/pipefy/test_portal_service.py
@@ -17,10 +17,10 @@ from pipefy_sdk.services.internal_api_client import InternalApiClient
 from pipefy_sdk.services.portal_service import PortalService
 from pipefy_sdk.settings import PipefySettings
 
+BASE_URL = "https://app.pipefy.com"
 INTERFACES_URL = "https://app.pipefy.com/graphql/interfaces"
 MAIN_GRAPHQL_URL = "https://app.pipefy.com/graphql"
-INTERNAL_API_URL = "https://app.pipefy.com/internal_api"
-OAUTH_URL = "https://auth.pipefy.com/oauth/token"
+OAUTH_URL = "https://app.pipefy.com/oauth/token"
 _ORG_UUID_FOR_TESTS = "341c1327-261c-4766-bb96-7953e4c3970d"
 _OTHER_ORG_UUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 _NUMERIC_ORG_ID = "302398434"
@@ -28,14 +28,7 @@ _NUMERIC_ORG_ID = "302398434"
 
 @pytest.fixture
 def mock_settings() -> PipefySettings:
-    return PipefySettings(
-        graphql_url=MAIN_GRAPHQL_URL,
-        interfaces_graphql_url=INTERFACES_URL,
-        internal_api_url=INTERNAL_API_URL,
-        oauth_url=OAUTH_URL,
-        oauth_client="client_id",
-        oauth_secret="client_secret",
-    )
+    return PipefySettings(base_url=BASE_URL)
 
 
 @pytest.fixture
@@ -64,9 +57,9 @@ def test_portal_service_interfaces_client_uses_interfaces_graphql_url(
         auth=mock_auth,
         internal_api_client=_mock_internal_api_client(),
     )
-    assert service._interfaces_client.settings.graphql_url == INTERFACES_URL
-    assert service._interfaces_client.settings.graphql_url != MAIN_GRAPHQL_URL
-    assert service._graphql_client.settings.graphql_url == MAIN_GRAPHQL_URL
+    assert service._interfaces_client._graphql_url == INTERFACES_URL
+    assert service._interfaces_client._graphql_url != MAIN_GRAPHQL_URL
+    assert service._graphql_client._graphql_url == MAIN_GRAPHQL_URL
 
 
 @pytest.mark.unit

--- a/packages/sdk/tests/services/pipefy/test_relation_service.py
+++ b/packages/sdk/tests/services/pipefy/test_relation_service.py
@@ -23,10 +23,7 @@ _TEST_AUTH = StaticBearerAuth("test-bearer-token")
 @pytest.fixture
 def mock_settings():
     return PipefySettings(
-        graphql_url="https://api.pipefy.com/graphql",
-        oauth_url="https://auth.pipefy.com/oauth/token",
-        oauth_client="client_id",
-        oauth_secret="client_secret",
+        base_url="https://api.pipefy.com",
     )
 
 

--- a/packages/sdk/tests/services/pipefy/test_report_service.py
+++ b/packages/sdk/tests/services/pipefy/test_report_service.py
@@ -33,10 +33,7 @@ _TEST_AUTH = StaticBearerAuth("test-bearer-token")
 @pytest.fixture
 def mock_settings():
     return PipefySettings(
-        graphql_url="https://api.pipefy.com/graphql",
-        oauth_url="https://auth.pipefy.com/oauth/token",
-        oauth_client="client_id",
-        oauth_secret="client_secret",
+        base_url="https://api.pipefy.com",
     )
 
 

--- a/packages/sdk/tests/services/pipefy/test_schema_introspection_service.py
+++ b/packages/sdk/tests/services/pipefy/test_schema_introspection_service.py
@@ -24,10 +24,7 @@ _TEST_AUTH = StaticBearerAuth("test-bearer-token")
 @pytest.fixture
 def mock_settings():
     return PipefySettings(
-        graphql_url="https://api.pipefy.com/graphql",
-        oauth_url="https://auth.pipefy.com/oauth/token",
-        oauth_client="client_id",
-        oauth_secret="client_secret",
+        base_url="https://api.pipefy.com",
     )
 
 

--- a/packages/sdk/tests/services/pipefy/test_table_service.py
+++ b/packages/sdk/tests/services/pipefy/test_table_service.py
@@ -33,10 +33,7 @@ _TEST_AUTH = StaticBearerAuth("test-bearer-token")
 @pytest.fixture
 def mock_settings():
     return PipefySettings(
-        graphql_url="https://api.pipefy.com/graphql",
-        oauth_url="https://auth.pipefy.com/oauth/token",
-        oauth_client="client_id",
-        oauth_secret="client_secret",
+        base_url="https://api.pipefy.com",
     )
 
 

--- a/packages/sdk/tests/services/pipefy/test_user_service.py
+++ b/packages/sdk/tests/services/pipefy/test_user_service.py
@@ -15,10 +15,7 @@ _TEST_AUTH = StaticBearerAuth("test-bearer-token")
 @pytest.fixture
 def mock_settings():
     return PipefySettings(
-        graphql_url="https://api.pipefy.com/graphql",
-        oauth_url="https://auth.pipefy.com/oauth/token",
-        oauth_client="client_id",
-        oauth_secret="client_secret",
+        base_url="https://api.pipefy.com",
     )
 
 

--- a/packages/sdk/tests/services/pipefy/test_webhook_service.py
+++ b/packages/sdk/tests/services/pipefy/test_webhook_service.py
@@ -26,10 +26,7 @@ _TEST_AUTH = StaticBearerAuth("test-bearer-token")
 @pytest.fixture
 def mock_settings():
     return PipefySettings(
-        graphql_url="https://api.pipefy.com/graphql",
-        oauth_url="https://auth.pipefy.com/oauth/token",
-        oauth_client="client_id",
-        oauth_secret="client_secret",
+        base_url="https://api.pipefy.com",
     )
 
 

--- a/packages/sdk/tests/services/test_ai_agent_service.py
+++ b/packages/sdk/tests/services/test_ai_agent_service.py
@@ -68,10 +68,7 @@ def _make_action_dict(name="Move card", action_type="move_card"):
 
 
 _MOCK_SETTINGS = PipefySettings(
-    graphql_url="https://api.pipefy.com/graphql",
-    oauth_url="https://auth.pipefy.com/oauth/token",
-    oauth_client="test-client",
-    oauth_secret="test-secret",
+    base_url="https://api.pipefy.com",
 )
 _TEST_AUTH = StaticBearerAuth("test-bearer-token")
 

--- a/packages/sdk/tests/services/test_attachment_service.py
+++ b/packages/sdk/tests/services/test_attachment_service.py
@@ -19,10 +19,7 @@ _TEST_AUTH = StaticBearerAuth("test-bearer-token")
 @pytest.fixture
 def mock_settings():
     return PipefySettings(
-        graphql_url="https://api.pipefy.com/graphql",
-        service_account_url="https://auth.pipefy.com/oauth/token",
-        service_account_client_id="client_id",
-        service_account_client_secret="client_secret",
+        base_url="https://api.pipefy.com",
     )
 
 

--- a/packages/sdk/tests/services/test_card_service.py
+++ b/packages/sdk/tests/services/test_card_service.py
@@ -22,10 +22,7 @@ _TEST_AUTH = StaticBearerAuth("test-bearer-token")
 @pytest.fixture
 def mock_settings() -> PipefySettings:
     return PipefySettings(
-        graphql_url="https://api.pipefy.com/graphql",
-        service_account_url="https://auth.pipefy.com/oauth/token",
-        service_account_client_id="client_id",
-        service_account_client_secret="client_secret",
+        base_url="https://api.pipefy.com",
     )
 
 

--- a/packages/sdk/tests/services/test_pipe_service.py
+++ b/packages/sdk/tests/services/test_pipe_service.py
@@ -24,10 +24,7 @@ _TEST_AUTH = StaticBearerAuth("test-bearer-token")
 @pytest.fixture
 def mock_settings() -> PipefySettings:
     return PipefySettings(
-        graphql_url="https://api.pipefy.com/graphql",
-        oauth_url="https://auth.pipefy.com/oauth/token",
-        oauth_client="client_id",
-        oauth_secret="client_secret",
+        base_url="https://api.pipefy.com",
     )
 
 

--- a/packages/sdk/tests/services/test_pipefy_base_client.py
+++ b/packages/sdk/tests/services/test_pipefy_base_client.py
@@ -9,12 +9,7 @@ from pipefy_sdk.settings import PipefySettings
 
 @pytest.fixture
 def valid_settings() -> PipefySettings:
-    return PipefySettings(
-        graphql_url="https://api.pipefy.com/graphql",
-        service_account_url="https://auth.pipefy.com/oauth/token",
-        service_account_client_id="client_id",
-        service_account_client_secret="client_secret",
-    )
+    return PipefySettings(base_url="https://api.pipefy.com")
 
 
 def _bearer() -> StaticBearerAuth:
@@ -109,16 +104,20 @@ async def test_execute_query_bubbles_up_execute_errors_unchanged(valid_settings)
 
 
 @pytest.mark.unit
-def test_init_raises_when_graphql_url_is_none():
-    """Test that __init__ raises ValueError when graphql_url is None."""
-    settings = PipefySettings(
-        graphql_url=None,
-        service_account_url="https://auth.pipefy.com/oauth/token",
-        service_account_client_id="client_id",
-        service_account_client_secret="client_secret",
+def test_init_accepts_url_override():
+    """``url_override`` lets callers point a BasePipefyClient at a sibling endpoint."""
+    settings = PipefySettings(base_url="https://api.pipefy.com")
+    base = BasePipefyClient(
+        settings=settings,
+        auth=_bearer(),
+        url_override="https://api.pipefy.com/graphql/interfaces",
     )
+    assert base._graphql_url == "https://api.pipefy.com/graphql/interfaces"
 
-    with pytest.raises(ValueError) as exc:
-        BasePipefyClient(settings=settings, auth=_bearer())
 
-    assert "GraphQL URL must be provided in settings" in str(exc.value)
+@pytest.mark.unit
+def test_init_defaults_to_settings_graphql_url():
+    """Without ``url_override`` the client uses ``settings.graphql_url``."""
+    settings = PipefySettings(base_url="https://api.pipefy.com")
+    base = BasePipefyClient(settings=settings, auth=_bearer())
+    assert base._graphql_url == "https://api.pipefy.com/graphql"

--- a/packages/sdk/tests/services/test_pipefy_client.py
+++ b/packages/sdk/tests/services/test_pipefy_client.py
@@ -17,10 +17,7 @@ _TEST_AUTH = StaticBearerAuth("test-bearer-token")
 
 def _mock_settings() -> PipefySettings:
     return PipefySettings(
-        graphql_url="https://api.pipefy.com/graphql",
-        oauth_url="https://auth.pipefy.com/oauth/token",
-        oauth_client="client_id",
-        oauth_secret="client_secret",
+        base_url="https://api.pipefy.com",
     )
 
 

--- a/packages/sdk/tests/services/test_pipefy_facade.py
+++ b/packages/sdk/tests/services/test_pipefy_facade.py
@@ -23,10 +23,7 @@ from pipefy_sdk.settings import PipefySettings
 @pytest.fixture
 def mock_settings():
     return PipefySettings(
-        graphql_url="https://api.pipefy.com/graphql",
-        service_account_url="https://auth.pipefy.com/oauth/token",
-        service_account_client_id="client_id",
-        service_account_client_secret="client_secret",
+        base_url="https://api.pipefy.com",
     )
 
 
@@ -547,10 +544,7 @@ def test_pipefy_client_creates_services_with_shared_auth():
     """Test PipefyClient creates services that share the same auth instance."""
 
     settings = PipefySettings(
-        graphql_url="https://api.pipefy.com/graphql",
-        service_account_url="https://auth.pipefy.com/oauth/token",
-        service_account_client_id="client_id",
-        service_account_client_secret="client_secret",
+        base_url="https://api.pipefy.com",
     )
     auth = StaticBearerAuth("shared-token")
     client = PipefyClient(settings=settings, auth=auth)

--- a/packages/sdk/tests/services/test_table_service_search_tables.py
+++ b/packages/sdk/tests/services/test_table_service_search_tables.py
@@ -31,10 +31,7 @@ def _table_connection(
 @pytest.fixture
 def mock_settings() -> PipefySettings:
     return PipefySettings(
-        graphql_url="https://api.pipefy.com/graphql",
-        service_account_url="https://auth.pipefy.com/oauth/token",
-        service_account_client_id="client_id",
-        service_account_client_secret="client_secret",
+        base_url="https://api.pipefy.com",
     )
 
 

--- a/packages/sdk/tests/test_settings.py
+++ b/packages/sdk/tests/test_settings.py
@@ -5,34 +5,152 @@ from __future__ import annotations
 import pytest
 from _shared.live_settings import live_pipefy_settings
 
-from pipefy_sdk.settings import PipefySettings
+from pipefy_sdk.settings import DEFAULT_BASE_URL, PipefySettings
 
-DEFAULT_INTERFACES_GRAPHQL_URL = "https://app.pipefy.com/graphql/interfaces"
+PROD_GRAPHQL_URL = "https://app.pipefy.com/graphql"
+PROD_INTERNAL_API_URL = "https://app.pipefy.com/internal_api"
+PROD_INTERFACES_GRAPHQL_URL = "https://app.pipefy.com/graphql/interfaces"
 
 
 @pytest.mark.unit
-def test_pipefy_settings_interfaces_graphql_url_default():
-    """``interfaces_graphql_url`` defaults to the Interfaces schema endpoint."""
+def test_pipefy_settings_default_base_url():
+    """No env / kwarg → base_url defaults to the Pipefy prod API host."""
     settings = PipefySettings()
-    assert settings.interfaces_graphql_url == DEFAULT_INTERFACES_GRAPHQL_URL
+    assert settings.base_url == DEFAULT_BASE_URL == "https://app.pipefy.com"
 
 
 @pytest.mark.unit
-def test_pipefy_settings_interfaces_graphql_url_overridden_via_env(
+def test_pipefy_settings_default_derives_prod_urls():
+    """All three computed URLs follow the default base_url."""
+    settings = PipefySettings()
+    assert settings.graphql_url == PROD_GRAPHQL_URL
+    assert settings.internal_api_url == PROD_INTERNAL_API_URL
+    assert settings.interfaces_graphql_url == PROD_INTERFACES_GRAPHQL_URL
+
+
+@pytest.mark.unit
+def test_pipefy_settings_base_url_env_drives_derived_urls(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """``PIPEFY_INTERFACES_GRAPHQL_URL`` overrides ``interfaces_graphql_url``."""
-    custom_url = "https://custom.pipefy.com/graphql/interfaces"
-    monkeypatch.setenv("PIPEFY_INTERFACES_GRAPHQL_URL", custom_url)
+    """``PIPEFY_BASE_URL`` flows into all three computed URLs."""
+    monkeypatch.setenv("PIPEFY_BASE_URL", "https://staging.example.com")
     settings = live_pipefy_settings()
-    assert settings.interfaces_graphql_url == custom_url
+    assert settings.base_url == "https://staging.example.com"
+    assert settings.graphql_url == "https://staging.example.com/graphql"
+    assert settings.internal_api_url == "https://staging.example.com/internal_api"
+    assert (
+        settings.interfaces_graphql_url
+        == "https://staging.example.com/graphql/interfaces"
+    )
 
 
 @pytest.mark.unit
-def test_pipefy_settings_rejects_http_interfaces_graphql_url():
-    """``interfaces_graphql_url`` must use HTTPS unless ``allow_insecure_urls``."""
-    with pytest.raises(ValueError, match="interfaces_graphql_url.*HTTPS"):
-        PipefySettings(
-            interfaces_graphql_url="http://app.pipefy.com/graphql/interfaces",
-            internal_api_url="https://app.pipefy.com/internal_api",
-        )
+@pytest.mark.parametrize(
+    "legacy_env_var",
+    [
+        "PIPEFY_GRAPHQL_URL",
+        "PIPEFY_INTERNAL_API_URL",
+        "PIPEFY_INTERFACES_GRAPHQL_URL",
+        "PIPEFY_SERVICE_ACCOUNT_URL",
+        "PIPEFY_OAUTH_URL",
+    ],
+)
+def test_pipefy_settings_ignores_removed_per_url_env_vars(
+    monkeypatch: pytest.MonkeyPatch, legacy_env_var: str
+):
+    """Per-URL env vars from earlier betas are silently ignored (``extra="ignore"``).
+
+    Locks the hard break: setting any of them must not steer the computed URLs
+    off the prod default. Operators have to migrate to ``PIPEFY_BASE_URL``.
+    """
+    monkeypatch.setenv(legacy_env_var, "https://stale.example.com/whatever")
+    settings = live_pipefy_settings()
+    assert settings.base_url == DEFAULT_BASE_URL
+    assert settings.graphql_url == PROD_GRAPHQL_URL
+    assert settings.internal_api_url == PROD_INTERNAL_API_URL
+    assert settings.interfaces_graphql_url == PROD_INTERFACES_GRAPHQL_URL
+
+
+@pytest.mark.unit
+def test_pipefy_settings_trailing_slash_on_base_does_not_double(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A trailing slash on ``PIPEFY_BASE_URL`` doesn't double the joiner."""
+    monkeypatch.setenv("PIPEFY_BASE_URL", "https://staging.example.com/")
+    settings = live_pipefy_settings()
+    assert settings.graphql_url == "https://staging.example.com/graphql"
+
+
+@pytest.mark.unit
+def test_pipefy_settings_empty_base_url_raises(monkeypatch: pytest.MonkeyPatch):
+    """Empty PIPEFY_BASE_URL is rejected at construction (no opt-out overload)."""
+    from pydantic import ValidationError
+
+    monkeypatch.setenv("PIPEFY_BASE_URL", "")
+    with pytest.raises(ValidationError, match="should match pattern"):
+        live_pipefy_settings()
+
+
+@pytest.mark.unit
+def test_pipefy_settings_rejects_http_base_url():
+    """``base_url`` must use HTTPS unless ``allow_insecure_urls``."""
+    with pytest.raises(ValueError, match="base_url.*HTTPS"):
+        PipefySettings(base_url="http://app.pipefy.com")
+
+
+@pytest.mark.unit
+def test_pipefy_settings_accepts_http_base_url_when_insecure():
+    """`allow_insecure_urls=True` opens the door to http:// + localhost."""
+    settings = PipefySettings(
+        base_url="http://localhost:3000",
+        allow_insecure_urls=True,
+    )
+    assert settings.base_url == "http://localhost:3000"
+    assert settings.graphql_url == "http://localhost:3000/graphql"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "scheme_case",
+    ["HTTPS", "Https", "hTtPs", "HTTP"],
+)
+def test_pipefy_settings_base_url_accepts_uppercase_scheme(
+    monkeypatch: pytest.MonkeyPatch, scheme_case: str
+):
+    """RFC 3986 §3.1: URL scheme is case-insensitive."""
+    monkeypatch.setenv("PIPEFY_ALLOW_INSECURE_URLS", "true")
+    url = f"{scheme_case}://app.pipefy.com"
+    monkeypatch.setenv("PIPEFY_BASE_URL", url)
+    settings = live_pipefy_settings()
+    assert settings.base_url == url
+
+
+@pytest.mark.unit
+def test_pipefy_settings_base_url_strips_surrounding_whitespace(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Operator copy-paste sometimes carries leading/trailing whitespace — strip before pattern."""
+    monkeypatch.setenv("PIPEFY_BASE_URL", "  https://app.pipefy.com\t")
+    settings = live_pipefy_settings()
+    assert settings.base_url == "https://app.pipefy.com"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "bad_org_id",
+    [
+        "not-a-number",
+        "١٢٣",  # Arabic-Indic digits — Unicode \d would accept, [0-9] rejects
+        "१२३",  # Devanagari digits
+        "1.2",
+        "-123",
+    ],
+)
+def test_pipefy_settings_org_id_rejects_non_ascii_numeric(
+    monkeypatch: pytest.MonkeyPatch, bad_org_id: str
+):
+    from pydantic import ValidationError
+
+    monkeypatch.setenv("PIPEFY_ORG_ID", bad_org_id)
+    with pytest.raises(ValidationError, match="should match pattern"):
+        live_pipefy_settings()


### PR DESCRIPTION
Closes #238.

## Summary

Collapses the five per-URL env vars (`PIPEFY_GRAPHQL_URL`, `PIPEFY_INTERNAL_API_URL`, `PIPEFY_INTERFACES_GRAPHQL_URL`, `PIPEFY_SERVICE_ACCOUNT_URL`, `PIPEFY_OAUTH_URL`) into two:

- `PIPEFY_BASE_URL` (default `https://app.pipefy.com`) — API host root; drives the four API endpoints via pydantic `@computed_field` properties.
- `PIPEFY_AUTH_URL` (default `https://signin.pipefy.com/realms/pipefy`) — full OIDC issuer URL.

Hard break — dropped env vars carry no aliases. Pre-1.0 beta surface; consumers update their config to the two new vars.

## Design

- `PipefySettings.base_url` and `AuthSettings.base_url` each read `PIPEFY_BASE_URL` independently, no cross-package dependency at runtime.
- `@computed_field` properties (`graphql_url`, `internal_api_url`, `interfaces_graphql_url`, `service_account_url`) derive from `base_url`; round-trip through `model_dump(exclude_unset=True)` for `_revalidate`.
- `AuthSettings` self-validates: inline `model_validator(mode="after")` runs SSRF + scheme checks against `base_url` and `auth_url`, so direct construction outside the CLI/MCP composition is safe.
- `AuthSettings.to_oidc_client()` now returns a non-Optional `OidcClient` (the issuer URL field always carries a value).
- `BasePipefyClient` gains an `url_override` param so callers that need a non-default endpoint (e.g. `InternalApiClient`) pass it explicitly instead of mutating settings with `model_copy`.
- Legacy `PIPEFY_OAUTH_CLIENT` / `PIPEFY_OAUTH_SECRET` env names still resolve to `service_account_client_id` / `_secret` via `AliasChoices` plus a one-shot stderr deprecation warning. `PIPEFY_OAUTH_URL` is gone — no alias, no warning.

## Security

`AliasChoices` lists only fully-prefixed env-var names. Unprefixed entries would let pydantic-settings (which is case-insensitive on env loads) pick up bare-name env vars like `BASE_URL`, `STATIC_TOKEN`, or `OAUTH_CLIENT` — an auth-redirect / credential-leak primitive on any host whose environment happens to carry those common names. Coverage in `packages/auth/tests/test_settings_back_compat.py::test_bare_name_env_vars_do_not_leak_into_auth_settings`. Kwarg construction by field name still works via `populate_by_name=True`.

## CLI flag rename

`--graphql-url` → `--base-url` on all CLI subcommands. The `--allow-insecure-urls` flag is implemented as a temporary env-var override held for the whole `resolve_cli_settings` flow (including `_revalidate` calls) so an `PIPEFY_ALLOW_INSECURE_URLS=false` env doesn't bleed back in over the flag patch.

## Test plan
- [x] `uv run pytest packages/cli/tests packages/auth/tests packages/sdk/tests -m "not integration"` — 1115 passed.
- [x] `uv run pytest packages/mcp/tests -m "not integration"` — 1227 passed.
- [x] `uv run ruff check .` — clean.
- [ ] Smoke: `PIPEFY_BASE_URL=https://staging.example.com pipefy --version` (env recognized, no crash).
- [ ] Smoke: `pipefy auth login` against prod (default `PIPEFY_AUTH_URL`).