### PR TITLE
chore: gitignore Ralph local state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,10 @@ env.bak/
 venv.bak/
 .mise.toml
 
+# Ralph Wiggum (local autonomous runs; state must not land in git)
+.ralph/
+RALPH_TASK.md
+
 # IDEs and editors
 .cursor/
 .claude/


### PR DESCRIPTION
## Summary

Ignore local Ralph Wiggum artifacts so autonomous runs do not pollute git:

- `.ralph/` — iteration state, logs, guardrails
- `RALPH_TASK.md` — symlinked per-issue task at repo root during runs

Harness docs and scripts live under `.cursor/` (already gitignored).

## Test plan

- [x] Diff is `.gitignore` only
- [x] Merge before Ralph pilot on `dev`