### PR TITLE
docs(portal): MCP reference, pipefy-portal-setup skill, and config cross-links

### DIFF
--- a/docs/mcp/tools/portal.md
+++ b/docs/mcp/tools/portal.md
@@ -234,9 +234,8 @@ Nested GraphQL/internal_api `success: false` → MCP top-level `{ success: false
 
 When changing portal SDK/MCP/CLI behavior:
 
-1. **Spec:** `.cursor/dev-planning/specs/portal-crud/` (PRD, `introspection-snapshot.md`, `tasks/tasks-portal-crud.md`).
-2. **TDD loop:** SDK unit tests → MCP tool tests → CLI tests; `uv run pytest -m "not integration" -k portal`; update [`docs/parity.md`](../../parity.md) in the same PR.
-3. **Live schema:** Portal mutations may live on Interfaces or internal_api (see [Endpoints](#endpoints) above), not the main GraphQL URL. Before adding SDK queries, verify shapes with [`skills/introspection/pipefy-introspection/SKILL.md`](../../../skills/introspection/pipefy-introspection/SKILL.md) (`introspect_mutation` / `pipefy introspect mutation`) or `gql-cli` against the derived URLs (set `PIPEFY_BASE_URL` and auth per [`docs/config.md`](../../config.md)):
+1. **TDD loop:** SDK unit tests → MCP tool tests → CLI tests; `uv run pytest -m "not integration" -k portal`; update [`docs/parity.md`](../../parity.md) in the same PR.
+2. **Live schema:** Portal mutations may live on Interfaces or internal_api (see [Endpoints](#endpoints) above), not the main GraphQL URL. Before adding SDK queries, verify shapes with [`skills/introspection/pipefy-introspection/SKILL.md`](../../../skills/introspection/pipefy-introspection/SKILL.md) (`introspect_mutation` / `pipefy introspect mutation`) or `gql-cli` against the derived URLs (set `PIPEFY_BASE_URL` and auth per [`docs/config.md`](../../config.md)):
 
    ```bash
    uv run gql-cli --headers "Authorization: Bearer $PIPEFY_ACCESS_TOKEN" \
@@ -250,4 +249,4 @@ When changing portal SDK/MCP/CLI behavior:
      -i "query { __type(name: \"Mutation\") { fields { name } } }"
    ```
 
-4. **Registry:** add tool names to `PIPEFY_TOOL_NAMES` in `packages/mcp/src/pipefy_mcp/tools/registry.py` and keep the **148** count in `docs/parity.md` in sync.
+3. **Registry:** add tool names to `PIPEFY_TOOL_NAMES` in `packages/mcp/src/pipefy_mcp/tools/registry.py` and keep the count in [`docs/parity.md`](../../parity.md) in sync.

--- a/docs/mcp/tools/portal.md
+++ b/docs/mcp/tools/portal.md
@@ -250,4 +250,4 @@ When changing portal SDK/MCP/CLI behavior:
      -i "query { __type(name: \"Mutation\") { fields { name } } }"
    ```
 
-4. **Registry:** add tool names to `PIPEFY_TOOL_NAMES` in `packages/mcp/src/pipefy_mcp/tools/registry.py` and keep the **149** count in `docs/parity.md` in sync.
+4. **Registry:** add tool names to `PIPEFY_TOOL_NAMES` in `packages/mcp/src/pipefy_mcp/tools/registry.py` and keep the **148** count in `docs/parity.md` in sync.

--- a/skills/portal-setup/pipefy-portal-setup/SKILL.md
+++ b/skills/portal-setup/pipefy-portal-setup/SKILL.md
@@ -31,7 +31,7 @@ Do **not** use for:
 
 ## Prerequisites
 
-- **Organization id:** UUID or **numeric org id** (e.g. `302398434` from `pipefy org get` / URL). SDK resolves numeric ids before Interfaces calls. The org you pass to **`list_portals`** / **`create_portal`** must be the same org your token can write on.
+- **Organization id:** UUID or **numeric org id** from `pipefy org get` / the Pipefy URL (examples below use fictional `123456789` per [`fixture_ids.py`](../../../packages/sdk/tests/_shared/fixture_ids.py)). SDK resolves numeric ids before Interfaces calls. The org you pass to **`list_portals`** / **`create_portal`** must be the same org your token can write on.
 - **Portal writes:** token needs **`create_portal`** and/or **`manage_portals`** on that org. Many service accounts only have pipe/card scope on their default org → `PERMISSION_DENIED` on portal mutations even when reads succeed elsewhere.
 - **One main portal per org** — `create_portal` is idempotent (second call returns the same portal UUID).
 - **Cursor MCP:** after changing `PIPEFY_*` in `.env`, restart the MCP server so tools pick up the new credentials.
@@ -121,20 +121,20 @@ Element `type` values (15): `text`, `table`, `field`, `embedLink`, `embedVideo`,
 
    MCP:
    ```
-   list_portals organization_uuid="302398434"
+   list_portals organization_uuid="123456789"
    ```
 
    Expect **at most one** main portal row. If none:
 
    MCP:
    ```
-   create_portal organization_uuid="302398434"
+   create_portal organization_uuid="123456789"
    ```
 
    CLI:
    ```bash
-   pipefy portal list --organization-uuid 302398434
-   pipefy portal create --organization-uuid 302398434
+   pipefy portal list --organization-uuid 123456789
+   pipefy portal create --organization-uuid 123456789
    ```
 
    Capture `uuid` where `subType` is the main portal.


### PR DESCRIPTION
## Summary

Follow-up on portal task 7.0 docs after **#269** landed the bulk of the work on `main` (`docs/mcp/tools/portal.md`, `pipefy-portal-setup` skill, `PIPEFY_PORTAL_ORG_UUID`, etc.).

This PR applies **review fixes** only:

- Remove maintainer links to gitignored `.cursor/` paths; keep tracked `skills/introspection/pipefy-introspection` + `gql-cli` examples.
- Drop hardcoded tool count in `portal.md` (canonical count stays in `docs/parity.md`).
- Use fictional org id `123456789` in skill examples (`fixture_ids.py`).

**Files changed (2):** `docs/mcp/tools/portal.md`, `skills/portal-setup/pipefy-portal-setup/SKILL.md`

Closes **Portal CRUD task 7.0** review items — **Issue:** #212

## Test plan

- [x] `uv run python .github/workflows/scripts/lint_skill_refs.py`
- [x] CI `lint` + `test` + skill frontmatter (green on branch)