### PR TITLE
ci: restore CLI wheel smoke on PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,13 +93,10 @@ jobs:
     - name: Lint infra (banned upward imports)
       run: cd packages/infra && uv run ruff check src
     - name: Build workspace wheels (packaging smoke)
-      run: |
-        mkdir -p dist-packaging-smoke
-        uv build --all-packages --wheel -o dist-packaging-smoke
+      run: uv build --all-packages --wheel -o dist-packaging-smoke
     - name: Smoke install CLI wheel (clean venv)
       run: |
         python -m venv .venv-cli-smoke
-        .venv-cli-smoke/bin/python -m pip install --upgrade pip
         .venv-cli-smoke/bin/pip install dist-packaging-smoke/pipefy_infra-*.whl \
           dist-packaging-smoke/pipefy_sdk-*.whl \
           dist-packaging-smoke/pipefy_auth-*.whl \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,18 @@ jobs:
       run: cd packages/auth && uv run ruff check src
     - name: Lint infra (banned upward imports)
       run: cd packages/infra && uv run ruff check src
-    - name: Build MCP wheel (packaging smoke)
-      run: uv build packages/mcp -o packages/mcp/dist
+    - name: Build workspace wheels (packaging smoke)
+      run: |
+        mkdir -p dist-packaging-smoke
+        uv build --all-packages --wheel -o dist-packaging-smoke
+    - name: Smoke install CLI wheel (clean venv)
+      run: |
+        python -m venv .venv-cli-smoke
+        .venv-cli-smoke/bin/python -m pip install --upgrade pip
+        .venv-cli-smoke/bin/pip install dist-packaging-smoke/pipefy_infra-*.whl \
+          dist-packaging-smoke/pipefy_sdk-*.whl \
+          dist-packaging-smoke/pipefy_auth-*.whl \
+          dist-packaging-smoke/pipefy_cli-*.whl
+        .venv-cli-smoke/bin/pipefy --help
     - name: Run tests
       run: uv run pytest -m "not integration"


### PR DESCRIPTION
## Summary
- Restore CLI packaging smoke in the PR `test` CI job.
- Build all workspace wheels (`uv build --all-packages --wheel`) and install CLI + deps in a clean venv.
- Invoke `pipefy --help` via the console script entry point (not src layout).

Closes #242. Removing `pipefy skills list` in #230 dropped the only PR-level entry-point check; `release.yml` smoke only runs on `v1.*` tags.