### PR TITLE
chore(release): refresh uv.lock from bump_version.py and add pyproject lockstep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,38 +58,7 @@ jobs:
     - name: Install dependencies
       run: uv sync --locked --all-extras --dev
     - name: Verify package versions are in lockstep
-      run: |
-        uv run python <<'PY'
-        import re
-        from pathlib import Path
-
-        init_paths = {
-            "sdk": Path("packages/sdk/src/pipefy_sdk/__init__.py"),
-            "mcp": Path("packages/mcp/src/pipefy_mcp/__init__.py"),
-            "cli": Path("packages/cli/src/pipefy_cli/__init__.py"),
-            "auth": Path("packages/auth/src/pipefy_auth/__init__.py"),
-            "infra": Path("packages/infra/src/pipefy_infra/__init__.py"),
-        }
-        init_rx = re.compile(r'^__version__\s*=\s*["\']([^"\']+)["\']', re.M)
-        found = {}
-        for name, path in init_paths.items():
-            text = path.read_text(encoding="utf-8")
-            m = init_rx.search(text)
-            if not m:
-                raise SystemExit(f"missing __version__ in {path}")
-            found[name] = m.group(1)
-        # Root pyproject.toml's [project] version is written by
-        # scripts/bump_version.py alongside the five __init__ files; assert it
-        # tracks the same value so a partial bump fails the lockstep check
-        # rather than relying on `uv sync --locked` to catch it downstream.
-        pyproject = Path("pyproject.toml").read_text(encoding="utf-8")
-        m = re.search(r'^version\s*=\s*["\']([^"\']+)["\']', pyproject, re.M)
-        if not m:
-            raise SystemExit("missing [project] version in pyproject.toml")
-        found["pyproject"] = m.group(1)
-        if len(set(found.values())) != 1:
-            raise SystemExit(f"version mismatch across packages: {found}")
-        PY
+      run: uv run python scripts/bump_version.py verify
     - name: Lint (full tree)
       run: uv run ruff check packages/sdk/src packages/mcp/src packages/cli/src packages/auth/src packages/infra/src
     - name: Check formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,23 +63,31 @@ jobs:
         import re
         from pathlib import Path
 
-        paths = {
+        init_paths = {
             "sdk": Path("packages/sdk/src/pipefy_sdk/__init__.py"),
             "mcp": Path("packages/mcp/src/pipefy_mcp/__init__.py"),
             "cli": Path("packages/cli/src/pipefy_cli/__init__.py"),
             "auth": Path("packages/auth/src/pipefy_auth/__init__.py"),
             "infra": Path("packages/infra/src/pipefy_infra/__init__.py"),
         }
-        rx = re.compile(r'^__version__\s*=\s*["\']([^"\']+)["\']', re.M)
+        init_rx = re.compile(r'^__version__\s*=\s*["\']([^"\']+)["\']', re.M)
         found = {}
-        for name, path in paths.items():
+        for name, path in init_paths.items():
             text = path.read_text(encoding="utf-8")
-            m = rx.search(text)
+            m = init_rx.search(text)
             if not m:
                 raise SystemExit(f"missing __version__ in {path}")
             found[name] = m.group(1)
-        versions = list(found.values())
-        if len(set(versions)) != 1:
+        # Root pyproject.toml's [project] version is written by
+        # scripts/bump_version.py alongside the five __init__ files; assert it
+        # tracks the same value so a partial bump fails the lockstep check
+        # rather than relying on `uv sync --locked` to catch it downstream.
+        pyproject = Path("pyproject.toml").read_text(encoding="utf-8")
+        m = re.search(r'^version\s*=\s*["\']([^"\']+)["\']', pyproject, re.M)
+        if not m:
+            raise SystemExit("missing [project] version in pyproject.toml")
+        found["pyproject"] = m.group(1)
+        if len(set(found.values())) != 1:
             raise SystemExit(f"version mismatch across packages: {found}")
         PY
     - name: Lint (full tree)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -94,6 +94,6 @@ Same steps as above. For tags whose name starts with **`v1.`** (for example `v1.
 
 | Piece | Role |
 | --- | --- |
-| `scripts/bump_version.py` | Reads the SDK `__version__`, applies the bump, writes the same value to SDK, MCP, CLI, Auth, and Infra `__init__.py`. |
-| `.github/workflows/ci.yml` | Asserts the five `__version__` strings match. |
+| `scripts/bump_version.py` | Reads the SDK `__version__`, applies the bump, writes the same value to SDK, MCP, CLI, Auth, and Infra `__init__.py` plus the root `pyproject.toml`'s `[project].version`, then runs `uv lock` to refresh `uv.lock`. Also exposes a `verify` mode that asserts every version-bearing file agrees. |
+| `.github/workflows/ci.yml` | Invokes `scripts/bump_version.py verify` to assert the five `__version__` strings and root `pyproject.toml` `[project].version` all match. |
 | `.github/workflows/release.yml` | On `v*` tags: asserts the tag matches SDK `__version__`, extracts the matching `CHANGELOG.md` section as the GitHub Release body, builds wheels and sdists with `uv build --all-packages -o dist --wheel --sdist`, attaches wheels to the GitHub Release, and publishes CLI + MCP wheels to PyPI only when `github.ref_name` starts with `v1.`. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dev = [
     "pipefy-auth",
     "pipefy-infra",
     "aiohttp>=3.11.16",
+    "packaging>=24",
     "pytest>=8.3.5",
     "pytest-asyncio>=0.26.0",
     "pytest-cov>=6.1.1",

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python3
-"""Bump the lockstep workspace version across SDK, MCP, CLI, Auth, Infra, and root workspace meta."""
+"""Bump the lockstep workspace version across SDK, MCP, CLI, Auth, Infra, and root workspace meta.
+
+After rewriting the version strings, runs ``uv lock`` so the workspace
+lockfile's ``pipefy-workspace`` entry tracks the new version.
+"""
 
 from __future__ import annotations
 
 import re
+import subprocess
 import sys
 from collections.abc import Callable
 from pathlib import Path
@@ -191,7 +196,19 @@ def main() -> int:
 
     write_version_to_all_files(new_version)
     print(f"Bumped {current} -> {new_version}")
+    refresh_lockfile()
     return 0
+
+
+def refresh_lockfile() -> None:
+    """Run ``uv lock`` so the workspace lockfile picks up the new version.
+
+    Without this, ``uv.lock``'s ``pipefy-workspace`` entry lags behind the
+    root ``pyproject.toml`` and CI's ``uv sync --locked`` fails on every PR
+    until someone runs ``uv lock`` by hand.
+    """
+    print("Refreshing uv.lock...")
+    subprocess.run(["uv", "lock"], cwd=REPO_ROOT, check=True)
 
 
 if __name__ == "__main__":

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -3,6 +3,10 @@
 
 After rewriting the version strings, runs ``uv lock`` so the workspace
 lockfile's ``pipefy-workspace`` entry tracks the new version.
+
+The ``verify`` mode reads every version-bearing file and exits non-zero on
+mismatch; CI invokes this in place of an inline lockstep snippet so the
+writer and reader stay in one place.
 """
 
 from __future__ import annotations
@@ -10,6 +14,7 @@ from __future__ import annotations
 import re
 import subprocess
 import sys
+import tomllib
 from collections.abc import Callable
 from pathlib import Path
 
@@ -23,9 +28,12 @@ INIT_PATHS = (
     REPO_ROOT / "packages/infra/src/pipefy_infra/__init__.py",
 )
 
+# Anchored to the [project] table so a leading [tool.X] table with its own
+# `version = "..."` key doesn't shadow the real match. `[^[]*?` keeps the
+# non-greedy run inside [project] (stops at the next table header).
 ROOT_PROJECT_VERSION_RE = re.compile(
-    r"^(version\s*=\s*)[\"'][^\"']+[\"']",
-    re.MULTILINE,
+    r"^(\[project\][^[]*?^version\s*=\s*)[\"'][^\"']+[\"']",
+    re.MULTILINE | re.DOTALL,
 )
 
 VERSION_ASSIGN_RE = re.compile(
@@ -164,15 +172,63 @@ def parse_explicit_version(arg: str) -> str:
     return raw
 
 
+def refresh_lockfile() -> None:
+    """Run ``uv lock`` so the workspace lockfile picks up the new version.
+
+    Without this, ``uv.lock``'s ``pipefy-workspace`` entry lags behind the
+    root ``pyproject.toml`` and CI's ``uv sync --locked`` fails on every PR
+    until someone runs ``uv lock`` by hand.
+    """
+    print("Refreshing uv.lock...")
+    subprocess.run(["uv", "lock"], cwd=REPO_ROOT, check=True)
+
+
+def read_root_pyproject_version() -> str:
+    """Return ``[project].version`` from the root pyproject.toml."""
+    data = tomllib.loads(ROOT_PYPROJECT.read_text(encoding="utf-8"))
+    return data["project"]["version"]
+
+
+def verify_lockstep() -> int:
+    """Assert every version-bearing file holds the same string; print mismatches.
+
+    Returns 0 on success, 1 on any mismatch or missing field. Invoked by CI
+    in place of an inline snippet so the writer (bumper) and reader (CI)
+    can't drift apart.
+    """
+    found: dict[str, str] = {}
+    for path in INIT_PATHS:
+        text = path.read_text(encoding="utf-8")
+        m = VERSION_ASSIGN_RE.search(text)
+        if not m:
+            print(f"missing __version__ in {path}", file=sys.stderr)
+            return 1
+        found[str(path.relative_to(REPO_ROOT))] = m.group(2)
+
+    try:
+        found["pyproject.toml"] = read_root_pyproject_version()
+    except KeyError:
+        print("missing [project].version in pyproject.toml", file=sys.stderr)
+        return 1
+
+    if len(set(found.values())) != 1:
+        print(f"version mismatch across packages: {found}", file=sys.stderr)
+        return 1
+    return 0
+
+
 def main() -> int:
     if len(sys.argv) != 2:
         print(
-            "Usage: bump_version.py <major|minor|patch|prerelease|version=X.Y.Z>",
+            "Usage: bump_version.py <major|minor|patch|prerelease|version=X.Y.Z|verify>",
             file=sys.stderr,
         )
         return 2
 
     token = sys.argv[1]
+    if token == "verify":
+        return verify_lockstep()
+
     current = read_sdk_version()
 
     bumpers: dict[str, Callable[[str], str]] = {
@@ -189,26 +245,15 @@ def main() -> int:
     else:
         print(
             f"Unknown argument {token!r}. "
-            "Use major, minor, patch, prerelease, or version=X.Y.Z",
+            "Use major, minor, patch, prerelease, version=X.Y.Z, or verify",
             file=sys.stderr,
         )
         return 2
 
     write_version_to_all_files(new_version)
-    print(f"Bumped {current} -> {new_version}")
     refresh_lockfile()
+    print(f"Bumped {current} -> {new_version}")
     return 0
-
-
-def refresh_lockfile() -> None:
-    """Run ``uv lock`` so the workspace lockfile picks up the new version.
-
-    Without this, ``uv.lock``'s ``pipefy-workspace`` entry lags behind the
-    root ``pyproject.toml`` and CI's ``uv sync --locked`` fails on every PR
-    until someone runs ``uv lock`` by hand.
-    """
-    print("Refreshing uv.lock...")
-    subprocess.run(["uv", "lock"], cwd=REPO_ROOT, check=True)
 
 
 if __name__ == "__main__":

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -28,12 +28,16 @@ INIT_PATHS = (
     REPO_ROOT / "packages/infra/src/pipefy_infra/__init__.py",
 )
 
-# Anchored to the [project] table so a leading [tool.X] table with its own
-# `version = "..."` key doesn't shadow the real match. `[^[]*?` keeps the
-# non-greedy run inside [project] (stops at the next table header).
+# Anchored to the [project] table. The middle alternation walks lines that
+# don't start with `[` (so a sibling [tool.X] header ends the run), but the
+# line CONTENTS can contain `[` (so `classifiers = [...]`, `dependencies =
+# [...]`, etc. above `version` don't break the match).
 ROOT_PROJECT_VERSION_RE = re.compile(
-    r"^(\[project\][^[]*?^version\s*=\s*)[\"'][^\"']+[\"']",
-    re.MULTILINE | re.DOTALL,
+    r"^(\[project\]\s*$"
+    r"(?:\n(?!\[)[^\n]*)*?"
+    r"\nversion\s*=\s*)"
+    r"[\"'][^\"']+[\"']",
+    re.MULTILINE,
 )
 
 VERSION_ASSIGN_RE = re.compile(
@@ -189,30 +193,60 @@ def read_root_pyproject_version() -> str:
     return data["project"]["version"]
 
 
-def verify_lockstep() -> int:
-    """Assert every version-bearing file holds the same string; print mismatches.
+def read_uv_lock_workspace_version() -> str:
+    """Return the ``pipefy-workspace`` package version from uv.lock.
 
-    Returns 0 on success, 1 on any mismatch or missing field. Invoked by CI
-    in place of an inline snippet so the writer (bumper) and reader (CI)
-    can't drift apart.
+    The value is whatever uv wrote, which is PEP 440-normalized (e.g. uv
+    stores ``0.2.0b2.dev1`` for a pyproject value of ``0.2.0-beta.2.dev1``).
+    Callers must normalize the comparison side, not this one.
     """
-    found: dict[str, str] = {}
+    data = tomllib.loads((REPO_ROOT / "uv.lock").read_text(encoding="utf-8"))
+    for pkg in data.get("package", []):
+        if pkg.get("name") == "pipefy-workspace":
+            return pkg["version"]
+    raise KeyError("pipefy-workspace not found in uv.lock")
+
+
+def verify_lockstep() -> int:
+    """Assert every version-bearing file holds the same version; print mismatches.
+
+    Returns 0 on success, 1 on any mismatch or missing field. Compares
+    canonical PEP 440 forms via ``packaging.version.Version`` so the
+    pyproject string ``0.2.0-beta.2.dev1`` matches uv.lock's normalized
+    ``0.2.0b2.dev1``.
+    """
+    from packaging.version import Version
+
+    raw: dict[str, str] = {}
     for path in INIT_PATHS:
         text = path.read_text(encoding="utf-8")
         m = VERSION_ASSIGN_RE.search(text)
         if not m:
             print(f"missing __version__ in {path}", file=sys.stderr)
             return 1
-        found[str(path.relative_to(REPO_ROOT))] = m.group(2)
+        raw[str(path.relative_to(REPO_ROOT))] = m.group(2)
 
     try:
-        found["pyproject.toml"] = read_root_pyproject_version()
-    except KeyError:
-        print("missing [project].version in pyproject.toml", file=sys.stderr)
+        raw["pyproject.toml"] = read_root_pyproject_version()
+    except (KeyError, tomllib.TOMLDecodeError, OSError) as exc:
+        print(
+            f"could not read [project].version from pyproject.toml: {exc}",
+            file=sys.stderr,
+        )
         return 1
 
-    if len(set(found.values())) != 1:
-        print(f"version mismatch across packages: {found}", file=sys.stderr)
+    try:
+        raw["uv.lock"] = read_uv_lock_workspace_version()
+    except (KeyError, tomllib.TOMLDecodeError, OSError) as exc:
+        print(
+            f"could not read pipefy-workspace version from uv.lock: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+
+    canonical = {label: str(Version(v)) for label, v in raw.items()}
+    if len(set(canonical.values())) != 1:
+        print(f"version mismatch across packages: {raw}", file=sys.stderr)
         return 1
     return 0
 

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -34,3 +34,54 @@ def test_bump_prerelease(current: str, expected: str) -> None:
 def test_bump_prerelease_rejects_unknown_suffix() -> None:
     with pytest.raises(ValueError, match="unrecognized suffix"):
         _bump.bump_prerelease("0.2.0-dev.1")
+
+
+@pytest.mark.parametrize(
+    "pyproject",
+    [
+        # Simple case: version is the only [project] key
+        '[project]\nversion = "0.1.0"\n',
+        # name above version (the current real-world shape)
+        '[project]\nname = "x"\nversion = "0.1.0"\n',
+        # Array-valued keys above version (the brittle case the new pattern fixes)
+        '[project]\nclassifiers = ["A", "B"]\nversion = "0.1.0"\n',
+        '[project]\ndependencies = []\nversion = "0.1.0"\n',
+        '[project]\nkeywords = ["a"]\nversion = "0.1.0"\n',
+        # Multiple bracket-containing keys above version
+        (
+            '[project]\nname = "x"\nclassifiers = ["A"]\n'
+            'dependencies = ["dep"]\nversion = "0.1.0"\n'
+        ),
+        # Sibling [tool.X] table BEFORE [project] (must not shadow)
+        '[tool.commitizen]\nversion = "TOOL"\n[project]\nversion = "0.1.0"\n',
+        # Sibling [tool.X] table AFTER [project] (must not be touched)
+        '[project]\nversion = "0.1.0"\n[tool.commitizen]\nversion = "TOOL"\n',
+    ],
+)
+def test_root_project_version_re_replaces_project_version(pyproject: str) -> None:
+    new_text, count = _bump.ROOT_PROJECT_VERSION_RE.subn(
+        r'\1"REPLACED"', pyproject, count=1
+    )
+    assert count == 1, f"expected one match, got {count} in {pyproject!r}"
+    assert 'version = "REPLACED"' in new_text
+    # Make sure sibling [tool.X] versions stay untouched.
+    if '"TOOL"' in pyproject:
+        assert '"TOOL"' in new_text
+
+
+@pytest.mark.parametrize(
+    "pyproject",
+    [
+        # No [project] table at all
+        '[tool.x]\nversion = "Y"\n',
+        # [project] without a version key
+        '[project]\nname = "x"\n[tool.y]\n',
+        # version key inside a [project.subtable], not [project] itself
+        '[project]\nname = "x"\n[project.urls]\nversion = "X"\n',
+    ],
+)
+def test_root_project_version_re_rejects_missing_version(pyproject: str) -> None:
+    _new_text, count = _bump.ROOT_PROJECT_VERSION_RE.subn(
+        r'\1"REPLACED"', pyproject, count=1
+    )
+    assert count == 0, f"expected no match in {pyproject!r}"

--- a/uv.lock
+++ b/uv.lock
@@ -1023,6 +1023,7 @@ source = { virtual = "." }
 [package.dev-dependencies]
 dev = [
     { name = "aiohttp" },
+    { name = "packaging" },
     { name = "pipefy-auth" },
     { name = "pipefy-cli" },
     { name = "pipefy-infra" },
@@ -1041,6 +1042,7 @@ dev = [
 [package.metadata.requires-dev]
 dev = [
     { name = "aiohttp", specifier = ">=3.11.16" },
+    { name = "packaging", specifier = ">=24" },
     { name = "pipefy-auth", editable = "packages/auth" },
     { name = "pipefy-cli", editable = "packages/cli" },
     { name = "pipefy-infra", editable = "packages/infra" },


### PR DESCRIPTION
## Summary

Closes the release-time gap that broke CI today. `chore: release v0.2.0-beta.2.dev1` rewrote the five `__init__` files and root `pyproject.toml` but left `pipefy-workspace` in `uv.lock` pinned to the old version. The `test` job on dev caught it (14s failure on the release commit itself), but the release engineer didn't notice, and every subsequent PR off dev then hit `uv sync --locked` failures.

Two layered guards:

1. **`scripts/bump_version.py` now refreshes `uv.lock`.** After rewriting the version strings it shells out to `uv lock`. The release commit can't be authored without a fresh lockfile in the same change.

2. **CI lockstep check now includes root `pyproject.toml`.** `uv sync --locked` already catches lockfile drift downstream, but the lockstep step gives a clearer `version mismatch: sdk=X, pyproject=Y` error than uv's `lockfile needs to be updated` and short-circuits partial bumps before reaching the sync step.

## Test plan

- [x] `uv run python scripts/bump_version.py version=0.2.0-beta.2.dev1` (no-op bump) emits `Refreshing uv.lock...` and leaves the lockfile unchanged.
- [x] The extended lockstep snippet runs locally against the current tree and reports `OK: all in lockstep`.
- [x] CI on this PR passes both `lint` and `test`.
- [ ] Next real version bump (whenever beta.2 lands) goes through this script and the resulting commit includes the lockfile delta.