### PR TITLE
refactor(sdk): make InternalApiClient accept a gql DocumentNode

### DIFF
--- a/packages/sdk/src/pipefy_sdk/queries/card_queries.py
+++ b/packages/sdk/src/pipefy_sdk/queries/card_queries.py
@@ -265,16 +265,15 @@ UPDATE_FIELDS_VALUES_MUTATION = gql(
 )
 
 # ---------------------------------------------------------------------------
-# Internal API mutations (plain strings, not gql())
+# Internal API mutations
 #
 # ``deleteCardRelation`` is only available on the internal GraphQL schema
-# (core_api / internal_v1), not the public API. These are plain strings because
-# ``InternalApiClient.execute_query`` takes a raw string and parses it with
-# ``gql()`` itself before sending, unlike the public client which expects an
-# already-parsed ``DocumentNode``. Same pattern as ``portal_internal_queries.py``.
+# (core_api / internal_v1), not the public API. It runs through
+# ``InternalApiClient``, which accepts a ``gql()`` ``DocumentNode`` like every
+# other client.
 # ---------------------------------------------------------------------------
 
-INTERNAL_DELETE_CARD_RELATION_MUTATION = """
+INTERNAL_DELETE_CARD_RELATION_MUTATION = gql("""
 mutation deleteCardRelation(
   $childId: ID!,
   $parentId: ID!,
@@ -288,7 +287,7 @@ mutation deleteCardRelation(
     success
   }
 }
-"""
+""")
 
 __all__ = [
     "CREATE_CARD_MUTATION",

--- a/packages/sdk/src/pipefy_sdk/queries/portal_internal_queries.py
+++ b/packages/sdk/src/pipefy_sdk/queries/portal_internal_queries.py
@@ -1,36 +1,36 @@
-"""GraphQL mutation strings for portal sub-portals (internal_api endpoint).
+"""GraphQL mutations for portal sub-portals (internal_api endpoint).
 
-Mutations are plain strings (not ``gql()``) because
-``InternalApiClient.execute_query`` takes a raw string and parses it with
-``gql()`` itself before sending, unlike the public client which expects an
-already-parsed ``DocumentNode``.
+These run through ``InternalApiClient``, which accepts a ``gql()``
+``DocumentNode`` like every other client.
 """
 
 from __future__ import annotations
 
-UPDATE_SUB_PORTAL_ELEMENT_MUTATION = """
+from gql import gql
+
+UPDATE_SUB_PORTAL_ELEMENT_MUTATION = gql("""
 mutation UpdateSubPortalElement($input: UpdateSubPortalElementInput!) {
   updateSubPortalElement(input: $input) {
     success
   }
 }
-"""
+""")
 
-DELETE_SUB_PORTAL_ELEMENT_MUTATION = """
+DELETE_SUB_PORTAL_ELEMENT_MUTATION = gql("""
 mutation DeleteSubPortalElement($input: DeleteSubPortalElementInput!) {
   deleteSubPortalElement(input: $input) {
     success
   }
 }
-"""
+""")
 
-DELETE_SUB_PORTAL_INTERFACE_MUTATION = """
+DELETE_SUB_PORTAL_INTERFACE_MUTATION = gql("""
 mutation DeleteSubPortalInterface($input: DeleteSubPortalInterfaceInput!) {
   deleteSubPortalInterface(input: $input) {
     success
   }
 }
-"""
+""")
 
 __all__ = [
     "DELETE_SUB_PORTAL_ELEMENT_MUTATION",

--- a/packages/sdk/src/pipefy_sdk/services/internal_api_client.py
+++ b/packages/sdk/src/pipefy_sdk/services/internal_api_client.py
@@ -1,19 +1,13 @@
 """GraphQL client for Pipefy's internal_api endpoint.
 
-A thin :class:`pipefy_sdk.base_client.BasePipefyClient` subclass — the only
-real difference from the public-API client is the error envelope: each GraphQL
-error is decorated with ``[code=…]`` / ``[correlation_id=…]`` suffixes drawn
-from ``extensions``. AI-automation MCP tools strip those suffixes via
-``pipefy_mcp.tools.graphql_error_helpers.strip_internal_api_diagnostic_markers``
-before surfacing the message to end users; service-layer tests assert the
-fully suffixed text.
+A thin :class:`pipefy_sdk.base_client.BasePipefyClient` subclass. The only real
+difference from the public-API client is the error envelope: each GraphQL error
+is decorated with ``[code=...]`` / ``[correlation_id=...]`` suffixes drawn from
+``extensions``. Service-layer tests assert the fully suffixed text.
 """
 
 from __future__ import annotations
 
-from typing import Any
-
-from gql import gql as parse_gql
 from httpx import Auth
 from pipefy_infra import security
 
@@ -35,7 +29,14 @@ def _format_internal_api_error(errors: list[dict]) -> str:
 
 
 class InternalApiClient(BasePipefyClient):
-    """GraphQL client for Pipefy internal API (AI Automation mutations)."""
+    """GraphQL client for Pipefy's internal_api endpoint.
+
+    Used for mutations only available on the internal schema (card-relation
+    deletion, portal sub-portals). Accepts already-parsed ``gql()``
+    ``DocumentNode`` queries like every other client; the only behavioral
+    difference from the public-API client is the error envelope built by
+    ``_format_internal_api_error``.
+    """
 
     def __init__(
         self,
@@ -64,8 +65,3 @@ class InternalApiClient(BasePipefyClient):
             url_override=url.strip(),
             on_graphql_error=_format_internal_api_error,
         )
-
-    async def execute_query(  # type: ignore[override]
-        self, query: str, variables: dict[str, Any]
-    ) -> dict:
-        return await super().execute_query(parse_gql(query), variables)

--- a/packages/sdk/tests/services/test_internal_api_client.py
+++ b/packages/sdk/tests/services/test_internal_api_client.py
@@ -1,9 +1,8 @@
 """Unit tests for InternalApiClient and PipefySettings.internal_api_url.
 
-Service-layer tests intentionally assert the full GraphQL error text produced by
-``InternalApiClient`` (including ``[code=…]`` / ``[correlation_id=…]`` suffixes).
-MCP tools must not surface that raw text to users by default; see AI automation
-tool handlers and ``strip_internal_api_diagnostic_markers``.
+These tests intentionally assert the full GraphQL error text produced by
+``InternalApiClient`` (including ``[code=...]`` / ``[correlation_id=...]``
+suffixes).
 """
 
 import json
@@ -11,6 +10,7 @@ import json
 import httpx
 import pytest
 import respx
+from gql import gql
 from gql.transport.exceptions import TransportServerError
 from pipefy_auth import StaticBearerAuth
 
@@ -44,7 +44,7 @@ def test_pipefy_settings_internal_api_url_default():
 @respx.mock(assert_all_mocked=False, assert_all_called=False)
 async def test_execute_query_sends_post_with_correct_headers_and_body(respx_mock):
     """Test execute_query sends POST with Authorization, Content-Type, and JSON body."""
-    query_string = "mutation { test }"
+    query = gql("mutation { test }")
     variables = {"key": "value"}
     expected_json = {"data": {"automation": {"id": "123"}}}
 
@@ -53,7 +53,7 @@ async def test_execute_query_sends_post_with_correct_headers_and_body(respx_mock
     )
 
     client = _build_client()
-    result = await client.execute_query(query_string, variables)
+    result = await client.execute_query(query, variables)
 
     assert route.called
     request = route.calls.last.request
@@ -78,7 +78,7 @@ async def test_execute_query_returns_parsed_json_response(respx_mock):
         return_value=httpx.Response(200, json=api_response)
     )
 
-    result = await _build_client().execute_query("query { x }", {})
+    result = await _build_client().execute_query(gql("query { x }"), {})
     assert result == {"automation": {"id": "456"}}
 
 
@@ -94,7 +94,7 @@ async def test_execute_query_raises_on_non_2xx_response(respx_mock):
     # gql's HTTPXAsyncTransport wraps ``httpx.HTTPStatusError`` as
     # ``TransportServerError`` — same path as the public-API client.
     with pytest.raises(TransportServerError):
-        await _build_client().execute_query("query { x }", {})
+        await _build_client().execute_query(gql("query { x }"), {})
 
 
 @pytest.mark.unit
@@ -108,7 +108,7 @@ async def test_execute_query_raises_on_graphql_errors_in_body(respx_mock):
     )
 
     with pytest.raises(ValueError, match=r"^Something went wrong$"):
-        await _build_client().execute_query("query { x }", {})
+        await _build_client().execute_query(gql("query { x }"), {})
 
 
 @pytest.mark.unit
@@ -137,7 +137,7 @@ async def test_execute_query_error_includes_extensions_code_and_correlation_id(
         ValueError,
         match=r"Permission Denied \[code=PERMISSION_DENIED\] \[correlation_id=abc-123\]",
     ):
-        await _build_client().execute_query("query { x }", {})
+        await _build_client().execute_query(gql("query { x }"), {})
 
 
 @pytest.mark.unit
@@ -163,7 +163,7 @@ async def test_execute_query_error_includes_correlation_id_when_code_absent(
         ValueError,
         match=r"^Rate limited \[correlation_id=corr-only-99\]$",
     ):
-        await _build_client().execute_query("query { x }", {})
+        await _build_client().execute_query(gql("query { x }"), {})
 
 
 @pytest.mark.unit
@@ -185,7 +185,7 @@ async def test_execute_query_error_concatenates_multiple_errors(respx_mock):
         ValueError,
         match=r"^Error one; Error two \[code=BAD_INPUT\]$",
     ):
-        await _build_client().execute_query("query { x }", {})
+        await _build_client().execute_query(gql("query { x }"), {})
 
 
 @pytest.mark.unit
@@ -204,7 +204,7 @@ async def test_execute_query_error_without_message_uses_fallback(respx_mock):
         ValueError,
         match=r"^Unknown error \[code=UNKNOWN\]$",
     ):
-        await _build_client().execute_query("query { x }", {})
+        await _build_client().execute_query(gql("query { x }"), {})
 
 
 @pytest.mark.unit
@@ -217,7 +217,7 @@ async def test_execute_query_raises_on_timeout(respx_mock):
     )
 
     with pytest.raises(httpx.TimeoutException):
-        await _build_client().execute_query("query { x }", {})
+        await _build_client().execute_query(gql("query { x }"), {})
 
 
 @pytest.mark.unit

--- a/packages/sdk/tests/services/test_pipefy_facade.py
+++ b/packages/sdk/tests/services/test_pipefy_facade.py
@@ -722,6 +722,8 @@ async def test_pipefy_client_ai_agent_write_methods_delegate_to_ai_agent_service
 async def test_delete_card_relation_delegates_to_internal_api_client(mock_settings):
     """delete_card_relation uses InternalApiClient (not CardService) because the
     mutation is only on the internal GraphQL schema."""
+    from graphql import print_ast
+
     from pipefy_sdk.queries.card_queries import (
         INTERNAL_DELETE_CARD_RELATION_MUTATION,
     )
@@ -735,9 +737,10 @@ async def test_delete_card_relation_delegates_to_internal_api_client(mock_settin
     client.set_internal_api_client(internal)
 
     # Pin the snake_case input keys that the internal API expects
-    assert "child_id: $childId" in INTERNAL_DELETE_CARD_RELATION_MUTATION
-    assert "parent_id: $parentId" in INTERNAL_DELETE_CARD_RELATION_MUTATION
-    assert "source_id: $sourceId" in INTERNAL_DELETE_CARD_RELATION_MUTATION
+    rendered = print_ast(INTERNAL_DELETE_CARD_RELATION_MUTATION)
+    assert "child_id: $childId" in rendered
+    assert "parent_id: $parentId" in rendered
+    assert "source_id: $sourceId" in rendered
 
     result = await client.delete_card_relation("c1", "p2", "src-3")
 


### PR DESCRIPTION
Closes #273.

## Summary

`InternalApiClient.execute_query` was the only GraphQL client in the SDK that accepted a raw query **string** and parsed it with `gql()` internally, carrying a `# type: ignore[override]` that existed solely to accept `str`. Every other endpoint, including the portal interfaces client (a plain `BasePipefyClient`), already accepts an already-parsed `gql()` `DocumentNode`. This made the internal-API query modules store mutations as plain strings while every other module stored `gql(...)` constants.

This change makes `InternalApiClient` consistent with the rest of the SDK:

- Deletes the `execute_query` override. Once the `parse_gql()` call is dropped it is a pure pass-through to `BasePipefyClient.execute_query(query: Any, …)`, so inheriting it is equivalent and removes the `# type: ignore[override]` and the now-unused `parse_gql` / `typing.Any` imports.
- Wraps the internal mutation constants in `gql(...)` at module load: `INTERNAL_DELETE_CARD_RELATION_MUTATION` (`card_queries.py`) and the three sub-portal mutations (`portal_internal_queries.py`).
- Refreshes the docstrings/comments that described the old raw-string behavior (and the AI-automation rationale, which is removed by #274).

No behavior change: syntax errors now surface at import time, and tooling treats internal and public queries uniformly.

## Base branch

Opened against `fix/272-ai-automation-public-path` (PR #274). That PR deletes `ai_automation_queries.py` and `ai_automation_service.py`, removing the third internal-client caller that still passed plain strings, so this branch's scope is exactly the card-relation and portal sub-portal callers. Retarget to `dev` once #274 merges.

## Tests

- `test_pipefy_facade.py`: the three substring assertions now run against `print_ast(INTERNAL_DELETE_CARD_RELATION_MUTATION)` (the canonical pattern used across the test suite), preserving the intent of pinning the snake_case input keys.
- `test_internal_api_client.py`: its tests passed raw query strings to `execute_query`; they now wrap in `gql(...)`.

## Verification

- Import-time check: all four constants parse as `DocumentNode`.
- `uv run python -m pytest` (SDK): 873 passed, 17 skipped.
- `ruff check` and `ruff format --check`: clean.