### PR TITLE
feat: card-phase ergonomics (inventory, create_card phase_id, review fixes)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,15 +1,18 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
   "name": "pipefy",
   "owner": {
     "name": "Gabriel Custodio",
-    "url": "https://github.com/pipefy"
+    "url": "https://github.com/pipefy/ai-toolkit"
   },
   "plugins": [
     {
       "name": "pipefy",
       "source": "./",
       "description": "Pipefy workflow integration for Claude Code.",
-      "version": "0.2.0-beta.1"
+      "version": "0.2.0-beta.1",
+      "homepage": "https://github.com/pipefy/ai-toolkit",
+      "repository": "https://github.com/pipefy/ai-toolkit"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "pipefy",
   "owner": {
     "name": "Gabriel Custodio",
-    "url": "https://github.com/gbrlcustodio"
+    "url": "https://github.com/pipefy"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Releases are versioned in lockstep across workspace members (`pipefy-sdk`, `pipe
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+
+- **SDK / MCP / CLI**: `create_card` accepts optional `phase_id` and passes `title` on GraphQL `CreateCardInput` (mutation `createCard(input: $input)`). MCP: `phase_id` skips start-form elicitation; non-empty `fields` are validated against `get_phase_fields(phase_id)`; agent seeding should set `skip_elicitation=true`. CLI: `pipefy card create <pipe_id> --phase-id <id>` (optional `--title`).
+- **MCP / CLI**: `get_phase_allowed_move_targets` lists valid destination phases for `move_card_to_phase` (GraphQL `phase.cards_can_be_moved_to_phases`). MCP returns normalized `{phase_id, phase_name, allowed_phases}`; CLI: `pipefy phase allowed-moves <phase_id>`.
+- **SDK / MCP / CLI**: `get_phase_cards_count` reads native `Phase.cards_count` (MCP/CLI return `{phase_id, phase_name, cards_count}`; documents start-form count quirk). `get_phase_cards` lists cards in a phase via `Phase.cards` pagination (`first` default 50, `after`, optional fields). CLI: `pipefy phase cards-count <phase_id>`, `pipefy phase cards <phase_id> --first --after`.
+- **SDK / MCP / CLI**: `get_pipe` adds `start_form_phase` (`id`, `name`, `cards_count`) and `cards_count` on each workflow phase in `phases[]` (start form excluded from `phases`; same JSON shape on MCP and `pipefy pipe get --json`).
+- **SDK / MCP / CLI**: `create_pipe_report` and `update_pipe_report` preflight `filter` as nested `ReportCardsFilter` (`operator` + `queries`); reject naive top-level keys such as `current_phase` before GraphQL.
+
+### Changed
+
+- **Docs / install**: canonical GitHub repository is [`pipefy/ai-toolkit`](https://github.com/pipefy/ai-toolkit). Install snippets, `install.sh`, MCP setup links, Claude plugin metadata, and `.mcp.json` now point at `github.com/pipefy/ai-toolkit` (GitHub may still redirect older URLs).
+- **MCP / CLI (6.0 label color)**: `create_label` and `update_label` validate `color` as hex `#RRGGBB` before GraphQL (e.g. `red` is rejected with `expected #RRGGBB, received 'red'`).
+
 ## [0.2.0-beta.2] - 2026-06-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@
 
 # Pipefy AI Toolkit
 
-Official repository: **[github.com/pipefy/ai-toolkit](https://github.com/pipefy/ai-toolkit)** (MCP server, CLI, SDK, and agent skills). This monorepo is also referred to as **pipefy-labs** in internal docs.
-
 Open-source toolkit for **Pipefy** developers: a Model Context Protocol (MCP) server for AI agents, a **`pipefy`** CLI for terminals and automation, a shared GraphQL SDK, and a catalog of agent skill playbooks.
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License" /></a>
 </p>
 
-# pipefy-labs
+# Pipefy AI Toolkit
+
+Official repository: **[github.com/pipefy/ai-toolkit](https://github.com/pipefy/ai-toolkit)** (MCP server, CLI, SDK, and agent skills). This monorepo is also referred to as **pipefy-labs** in internal docs.
 
 Open-source toolkit for **Pipefy** developers: a Model Context Protocol (MCP) server for AI agents, a **`pipefy`** CLI for terminals and automation, a shared GraphQL SDK, and a catalog of agent skill playbooks.
 
@@ -36,7 +38,7 @@ Open-source toolkit for **Pipefy** developers: a Model Context Protocol (MCP) se
 
 | Component | Package / path | Purpose |
 |-----------|----------------|---------|
-| **MCP server** | `pipefy-mcp-server` | Exposes **149** tools to MCP clients (Cursor, Claude Desktop, Claude Code, and others). |
+| **MCP server** | `pipefy-mcp-server` | Exposes **152** tools to MCP clients (Cursor, Claude Desktop, Claude Code, and others). |
 | **CLI** | `pipefy-cli` | Terminal commands aligned with MCP capabilities; see [`docs/parity.md`](docs/parity.md). |
 | **SDK** | `pipefy-sdk` | Vendor GraphQL client, services, and models shared by MCP and CLI. |
 | **Skills** | [`skills/`](skills/) | Markdown playbooks (Anthropic Skills format) for common Pipefy workflows. |
@@ -148,7 +150,7 @@ Deprecation and semver (post-1.0): [`docs/DEPRECATION.md`](docs/DEPRECATION.md).
 
 ## MCP server
 
-The server registers **149 tools** across ten domains. Canonical names: `PIPEFY_TOOL_NAMES` in [`packages/mcp/src/pipefy_mcp/tools/registry.py`](packages/mcp/src/pipefy_mcp/tools/registry.py).
+The server registers **152 tools** across ten domains. Canonical names: `PIPEFY_TOOL_NAMES` in [`packages/mcp/src/pipefy_mcp/tools/registry.py`](packages/mcp/src/pipefy_mcp/tools/registry.py).
 
 Tool descriptions and `Args:` blocks come from Python docstrings (what MCP clients show to models). Per-area reference docs cover parameters, edge cases, and cross-cutting behavior.
 
@@ -156,7 +158,7 @@ Tool descriptions and `Args:` blocks come from Python docstrings (what MCP clien
 
 | Domain | Tools | Summary | Reference |
 |--------|:-----:|---------|-----------|
-| **Pipes & cards** | 37 | Pipes, phases, fields, labels, cards, field conditions, attachments. | [docs](docs/mcp/tools/pipes-and-cards.md) |
+| **Pipes & cards** | 37 | Pipes, phases, fields, labels, cards, field conditions, attachments. Phase inventory (`get_phase_cards`, `get_phase_cards_count`), move discovery (`get_phase_allowed_move_targets`), and `create_card(phase_id=…)` reduce raw GraphQL for agent seeding. | [docs](docs/mcp/tools/pipes-and-cards.md) |
 | **Database tables** | 17 | Tables, records, schema, table-record attachments. | [docs](docs/mcp/tools/database-tables.md) |
 | **Relations** | 8 | Pipe and card relations. | [docs](docs/mcp/tools/relations.md) |
 | **Reports** | 17 | Pipe and organization reports, async exports. | [docs](docs/mcp/tools/reports.md) |
@@ -188,6 +190,8 @@ CLI-specific guides: **[`docs/cli/`](docs/cli/README.md)** (including [introspec
 The [`skills/`](skills/) directory holds workflow playbooks: prerequisites, tool tables (MCP + CLI), steps, and success criteria. Compatible with any agent that reads Markdown (Cursor, Claude Code, Codex, and others). Distribution is via [`skills.sh`](https://github.com/vercel-labs/skills) (55+ agent targets); install commands are under [Installation](#installation) above.
 
 Full catalog: [`skills/README.md`](skills/README.md). Authoring: [`skills/AGENTS.md`](skills/AGENTS.md). Contributions: [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+**Card & phase agent ergonomics:** use [`skills/pipes-and-cards/pipefy-pipes-and-cards/SKILL.md`](skills/pipes-and-cards/pipefy-pipes-and-cards/SKILL.md) (workflow *Seed pipe across phases*; prefer dedicated tools over `execute_graphql`). Manual smoke logs and replay payloads: [`.cursor/qa-tests-and-smoke/`](.cursor/qa-tests-and-smoke/).
 
 ---
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -64,11 +64,11 @@ After tagging a release, run the following on macOS and a Linux machine (or CI r
 
 ```bash
 # Install CLI from the tagged release
-uvx --from "git+https://github.com/<owner>/pipefy-labs.git@vX.Y.Z" --refresh pipefy-cli --version
+uvx --from "git+https://github.com/pipefy/ai-toolkit.git@vX.Y.Z" --refresh pipefy-cli --version
 # Expected: X.Y.Z
 
 # Verify MCP server starts
-uvx --from "git+https://github.com/<owner>/pipefy-labs.git@vX.Y.Z" --refresh pipefy-mcp-server --help
+uvx --from "git+https://github.com/pipefy/ai-toolkit.git@vX.Y.Z" --refresh pipefy-mcp-server --help
 # Expected: help text (server may block in stdio mode — Ctrl-C after banner)
 ```
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -11,7 +11,7 @@ Existing users of `pipefy-mcp-server`: this guide covers what changed and what t
 **Pre-launch (v0.1 → v0.5):** install from git to get the latest:
 
 ```sh
-uvx --from git+https://github.com/<owner>/pipefy-labs --refresh pipefy-mcp-server
+uvx --from git+https://github.com/pipefy/ai-toolkit@latest --refresh pipefy-mcp-server
 ```
 
 ---
@@ -43,12 +43,16 @@ All MCP tools keep the same names, parameters, and behavior as in the pre-monore
 
 ## Repo URL
 
-The repository was renamed from `pipefy-mcp-server` to `pipefy-labs` on GitHub. GitHub preserves redirects — your existing `git remote` URLs for the old repo keep working for `git fetch`, `git pull`, and `git push`.
-
-Update your remote at your convenience:
+The toolkit lives in the **Pipefy org** at **[github.com/pipefy/ai-toolkit](https://github.com/pipefy/ai-toolkit)**. Earlier community forks (`pipefy-mcp-server`, `pipefy-labs`) may still redirect on GitHub; update remotes and install URLs when you can.
 
 ```sh
-git remote set-url origin https://github.com/<owner>/pipefy-labs.git
+git remote set-url origin https://github.com/pipefy/ai-toolkit.git
+```
+
+Pre-1.0 installs from git:
+
+```sh
+uvx --from git+https://github.com/pipefy/ai-toolkit@latest --refresh pipefy-mcp-server
 ```
 
 ---
@@ -60,7 +64,7 @@ These are new additions — all optional to adopt:
 **`pipefy-cli`** — a terminal CLI with the same capabilities as the MCP server.
 
 ```sh
-uvx --from git+https://github.com/<owner>/pipefy-labs --refresh pipefy-cli
+uvx --from git+https://github.com/pipefy/ai-toolkit@latest --refresh pipefy-cli
 pipefy card get 12345
 ```
 
@@ -152,4 +156,4 @@ The legacy `PIPEFY_OAUTH_*` env-var aliases and the deprecation warning live on 
 
 ## Questions?
 
-Open an issue at [github.com/<owner>/pipefy-labs/issues](https://github.com/<owner>/pipefy-labs/issues) or email **dev@pipefy.com**.
+Open an issue at [github.com/pipefy/ai-toolkit/issues](https://github.com/pipefy/ai-toolkit/issues) or email **dev@pipefy.com**.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation index
 
-Human-facing guides for the **pipefy-labs** monorepo (`pipefy-mcp-server` on GitHub). Use the sections below to load only the surface you need.
+Human-facing guides for the **[pipefy/ai-toolkit](https://github.com/pipefy/ai-toolkit)** monorepo (packages: `pipefy-mcp-server`, `pipefy-cli`, `pipefy-sdk`). Use the sections below to load only the surface you need.
 
 ## By surface
 

--- a/docs/mcp/tools/pipes-and-cards.md
+++ b/docs/mcp/tools/pipes-and-cards.md
@@ -25,12 +25,14 @@ Pipefy’s GraphQL API uses **string** IDs for pipes, phases, cards, and most ot
 
 | Tool | Role |
 |------|------|
-| `get_pipe` | Load pipe metadata (phases, fields, settings). |
+| `get_pipe` | Load pipe metadata (phases, fields, settings). Response includes `start_form_phase` (`id`, `name`, `cards_count`) and per-phase `cards_count` on workflow phases (start form is not duplicated in `phases[]`). |
 | `get_start_form_fields` | Start-form fields for a pipe. |
 | `get_phase_fields` | Fields for a phase — each includes `id`, `internal_id`, `uuid`. |
 | `get_pipe_members` | List pipe members. |
 | `get_labels` | List labels configured on the pipe (`id`, `name`). |
 | `search_pipes` | Search pipes by name. |
+| `get_phase_cards_count` | Native `Phase.cards_count` for one phase (fast scalar). Start-form count may be **0** while cards exist — pair with `get_phase_cards`. |
+| `get_phase_cards` | Paginated cards in a phase (`Phase.cards`). Prefer over `get_cards` for phase-local inventory. |
 
 ## Card reads
 
@@ -46,6 +48,7 @@ Pipefy’s GraphQL API uses **string** IDs for pipes, phases, cards, and most ot
 |-------|-------|-------|
 | Pipe | `create_pipe`, `update_pipe`, `delete_pipe`, `clone_pipe` | `delete_pipe`: two-step — preview first, then `confirm=true`. |
 | Phase | `create_phase`, `update_phase`, `delete_phase` | Destructive deletes: confirm with the user. |
+| Phase transitions | `get_phase_allowed_move_targets` | Read-only; mirrors **Phase → Connections** (`cards_can_be_moved_to_phases`). Call before `move_card_to_phase`. Edges are configured in the Pipefy UI only. |
 | Phase field | `create_phase_field`, `update_phase_field`, `delete_phase_field` | `field_type` maps to API `type`; `field_id` may be a slug or numeric ID. |
 | Label | `create_label`, `update_label`, `delete_label` | `color` must be a hex string (e.g. `#FF0000`), not a name. |
 
@@ -53,7 +56,7 @@ Pipefy’s GraphQL API uses **string** IDs for pipes, phases, cards, and most ot
 
 | Tool | Role |
 |------|------|
-| `create_card` | Create a card; may use elicitation to ask the user for required fields mid-call. |
+| `create_card` | Create a card in the start form (default) or in a specific phase via optional `phase_id`; may use elicitation to ask the user for required fields mid-call. |
 | `fill_card_phase_fields` | Fill phase-specific fields on a card; may use elicitation when available. |
 | `add_card_comment` | Add a comment to a card. |
 | `update_comment` | Update an existing comment. |
@@ -80,9 +83,64 @@ Because non-editable keys are dropped without warning, agents should discover fi
 get_start_form_fields(pipe_id)   → learn field IDs, types, required flag
 create_card(pipe_id, fields={…}) → supply every required field ID
 
+get_pipe(pipe_id)                → start_form_phase + phases[].id / cards_count for inventory
+                                 → phases[].id when seeding a non-start-form phase
+create_card(
+  pipe_id,
+  phase_id="340012345",
+  skip_elicitation=true,
+  title="Seeded card",
+  fields={…},
+)                                → card created in that phase (fields validated via get_phase_fields)
+
 get_phase_fields(phase_id)                     → learn phase field IDs
 fill_card_phase_fields(card_id, phase_id, fields={…}) → supply values
 ```
+
+With `phase_id`, the start-form elicitation path is skipped. Use `skip_elicitation=true` for agent workflows. When `fields` is non-empty, keys are filtered against both `get_phase_fields(phase_id)` and `get_start_form_fields(pipe_id)` so pipes that still require start-form values on `CreateCardInput` receive them alongside phase fields. Optional `title` is sent on `CreateCardInput` (no separate `update_card` on the happy path).
+
+### `get_pipe` inventory fields (additive)
+
+MCP tool results use the standard envelope; inventory fields live under the `pipe` object:
+
+| JSON path | Meaning |
+|-----------|---------|
+| `pipe.start_form_phase.id` | Start-form phase ID (same as `pipe.startFormPhaseId`) |
+| `pipe.start_form_phase.name` | Start-form phase display name |
+| `pipe.start_form_phase.cards_count` | Native `Phase.cards_count` for the start form (may be **0** while cards exist — use `get_phase_cards`) |
+| `pipe.phases[].id` | Workflow phase IDs (start form excluded) |
+| `pipe.phases[].name` | Phase display name |
+| `pipe.phases[].cards_count` | Native card count for that workflow phase |
+
+CLI `pipefy pipe get <pipe_id> --json` returns the same SDK-normalized shape.
+
+### Phase inventory (`get_phase_cards_count` / `get_phase_cards`)
+
+Use these when you need per-phase totals or card lists without pipe-wide `CardSearch`:
+
+| Tool | CLI | When to use |
+|------|-----|-------------|
+| `get_phase_cards_count` | `pipefy phase cards-count <phase_id>` | Quick scalar; empty phases for seeding. |
+| `get_phase_cards` | `pipefy phase cards <phase_id> --first 50 --after <cursor>` | Verify cards after create/move; paginate with `pageInfo.endCursor`. |
+
+Discovery path: `get_pipe(pipe_id)` → `phases[].id` (workflow) or `start_form_phase.id` (start form).
+
+```
+get_phase_cards_count(phase_id="340012345")
+get_phase_cards(phase_id="340012345", first=50, include_fields=true)
+```
+
+### Phase transitions (`get_phase_allowed_move_targets`)
+
+Outbound moves are constrained by UI-configured connections — there is no API to add edges.
+
+1. Resolve source phase: `get_card(card_id).current_phase.id` (or known `phase_id` before move).
+2. `get_phase_allowed_move_targets(phase_id=<source>)` → `allowed_phases` (`{id, name}`).
+3. `move_card_to_phase(card_id, destination_phase_id=<allowed id>)`.
+
+CLI: `pipefy phase allowed-moves <phase_id> --json`.
+
+Empty `allowed_phases` means no outbound transitions are configured in the UI.
 
 ## Field condition tools
 

--- a/docs/mcp/tools/reports.md
+++ b/docs/mcp/tools/reports.md
@@ -5,6 +5,27 @@ Pipe reports and organization reports: discovery, CRUD, single pipe report fetch
 ## Cross-cutting patterns
 
 - Build `ReportCardsFilter` using `get_pipe_report_columns` and `get_pipe_report_filterable_fields`; use `introspect_type` for uncommon inputs.
+- **Filter shape:** nested `operator` (`and` | `or`) plus `queries` (and optional `groups`). Do **not** pass a top-level `current_phase` array — that is not valid GraphQL input. `create_pipe_report` / `update_pipe_report` (MCP and CLI) validate structure before calling the API.
+
+### Example phase filter (`create_pipe_report` / `update_pipe_report`)
+
+Discover the exact `field` string for your pipe via `get_pipe_report_filterable_fields`, then:
+
+```json
+{
+  "operator": "and",
+  "queries": [
+    {
+      "field": "current_phase",
+      "operator": "eq",
+      "type": "select",
+      "value": "<phase_id>"
+    }
+  ]
+}
+```
+
+Replace `field` / `value` when filterable-field metadata uses different names or option ids.
 - `get_pipe_reports` omits `cardCount` in the query (Pipefy can error when resolving it).
 - `debug=true` on writes like other mutation tools.
 - **Async export pattern:** trigger export -> poll the matching `get_*_report_export` until `state` is done -> use `fileURL`. `export_pipe_audit_logs` only returns `success` (no export ID to poll — the file is delivered to the requesting user).

--- a/docs/parity.md
+++ b/docs/parity.md
@@ -2,7 +2,7 @@
 
 This matrix is the source of truth for **MCP tool ↔ `pipefy` CLI** coverage. Update it whenever MCP tools or CLI commands are added, renamed, or removed.
 
-**Registry source:** `PIPEFY_TOOL_NAMES` in `packages/mcp/src/pipefy_mcp/tools/registry.py` (must stay in sync with this table: **149** tools).
+**Registry source:** `PIPEFY_TOOL_NAMES` in `packages/mcp/src/pipefy_mcp/tools/registry.py` (must stay in sync with this table: **152** tools).
 
 **Later CLI coverage:** areas such as attachments, field conditions, email, audit export, traditional automations, exports/usage, introspection, and raw GraphQL appear as **shipped** below when the matching Typer commands exist in `packages/cli`.
 
@@ -30,16 +30,16 @@ For **database records**, `find_records` result nodes may use **`fields`** while
 | `create_ai_agent` | `pipefy agent create` | shipped | AI Agents domain; post-v0.1 CLI unless explicitly rescoped. |
 | `create_ai_automation` | `pipefy ai-automation create` | shipped | AI Automations domain; post-v0.1 CLI unless explicitly rescoped. |
 | `create_automation` | `pipefy automation create` | shipped | (`--pipe`, `--name`, `--trigger-id`, `--action-id`, optional `--extra` JSON). |
-| `create_card` | `pipefy card create` | shipped | (`--fields` JSON, optional `--title`). |
+| `create_card` | `pipefy card create` | shipped | (`--fields` JSON, optional `--title`, optional `--phase-id` for `CreateCardInput.phase_id`). |
 | `create_card_relation` | `pipefy relation card create` | shipped | — |
 | `create_field_condition` | `pipefy field-condition create` | shipped | (`--phase`, `--name`, `--condition`, `--actions` JSON). |
-| `create_label` | `pipefy label create` | shipped | — |
+| `create_label` | `pipefy label create` | shipped | `color` must be hex `#RRGGBB` (validated before GraphQL). |
 | `create_organization_report` | `pipefy report-org create` | shipped | Organization reports; organization-level ops out of v0.1 parity. |
 | `create_phase` | `pipefy phase create` | shipped | — |
 | `create_phase_field` | `pipefy field create` | shipped | (phase fields). |
 | `create_pipe` | `pipefy pipe create` | shipped | (`--org`). |
 | `create_pipe_relation` | `pipefy relation pipe create` | shipped | — |
-| `create_pipe_report` | `pipefy report-pipe create` | shipped | Reports domain; deferred from v0.1 CLI parity. |
+| `create_pipe_report` | `pipefy report-pipe create` | shipped | Reports domain; `filter` preflight validates ReportCardsFilter shape (nested `operator` + `queries`). |
 | `create_portal` | `pipefy portal create` | shipped | `--organization-uuid`; idempotent (find-or-create main portal). |
 | `create_portal_page` | `pipefy portal page create` | shipped | `--portal-uuid`, `--title`; optional `--description`, `--index`. Empty main portal may bootstrap a templated page when the API omits `elements`. |
 | `create_portal_element` | `pipefy portal element create` | shipped | `--page-id`, `--type`, `--metadata` JSON; optional `--data-sources` JSON array. SDK validates metadata before GraphQL. |
@@ -111,8 +111,11 @@ For **database records**, `find_records` result nodes may use **`fields`** while
 | `get_organization_report` | `pipefy report-org get` | shipped | Organization reports. |
 | `get_organization_report_export` | (poll via `pipefy report-org export --format json`) | shipped | Organization reports + export-shaped. |
 | `get_organization_reports` | `pipefy report-org list` | shipped | Organization reports. |
+| `get_phase_allowed_move_targets` | `pipefy phase allowed-moves` | shipped | Read-only; mirrors Phase -> Connections (`cards_can_be_moved_to_phases`). |
+| `get_phase_cards_count` | `pipefy phase cards-count` | shipped | Native ``Phase.cards_count``; start-form caveat in tool docstring; pair with ``get_phase_cards`` to list. |
+| `get_phase_cards` | `pipefy phase cards` | shipped | ``Phase.cards`` pagination (``--first`` default 50, ``--after``, ``--include-fields``). Prefer over ``get_cards`` for phase-local inventory. |
 | `get_phase_fields` | `pipefy field list --phase` | shipped | ``pipefy phase get`` returns the same shape. |
-| `get_pipe` | `pipefy pipe get` | shipped | — |
+| `get_pipe` | `pipefy pipe get` | shipped | Additive `start_form_phase` + `phases[].cards_count` (start form not in `phases[]`). |
 | `get_pipe_members` | `pipefy member list` | shipped | — |
 | `get_pipe_relations` | `pipefy relation pipe list` | shipped | — |
 | `get_pipe_report` | `pipefy report-pipe get` | shipped | Reports domain. |
@@ -154,7 +157,7 @@ For **database records**, `find_records` result nodes may use **`fields`** while
 | `update_card_field` | `pipefy card update` | shipped | Use `--field-updates` JSON array (). |
 | `update_comment` | `pipefy card comment update` | shipped | — |
 | `update_field_condition` | `pipefy field-condition update` | shipped | (`--extra` JSON). |
-| `update_label` | `pipefy label update` | shipped | — |
+| `update_label` | `pipefy label update` | shipped | `color` must be hex `#RRGGBB` (validated before GraphQL). |
 | `update_organization_report` | `pipefy report-org update` | shipped | Organization reports. |
 | `update_phase` | `pipefy phase update` | shipped | — |
 | `update_phase_field` | `pipefy field update` | shipped | (``--extra`` JSON). Optional ``phase_id`` / ``pipe_id`` in ``--extra`` resolve slug ``field_id`` to ``internal_id`` when ``uuid`` is omitted. |
@@ -186,6 +189,6 @@ for n in m.body:
             print(len(v.args[0].elts))"
 ```
 
-Expect **149** tool names in `PIPEFY_TOOL_NAMES` and **149** data rows in the parity table (excluding the header rows).
+Expect **152** tool names in `PIPEFY_TOOL_NAMES` and **152** data rows in the parity table (excluding the header rows).
 
 When adding or removing an MCP tool, update **this file** and `PIPEFY_TOOL_NAMES` in the same change set.

--- a/packages/cli/src/pipefy_cli/commands/_common.py
+++ b/packages/cli/src/pipefy_cli/commands/_common.py
@@ -13,6 +13,7 @@ import typer
 from gql.transport.exceptions import TransportError, TransportQueryError
 from pipefy_sdk import PipefyClient, PipefySettings, stream_bytes
 from pipefy_sdk.exceptions import PipefyError
+from pipefy_sdk.report_filter_preflight import validate_report_cards_filter
 
 from pipefy_cli.auth import (
     AuthContext,
@@ -47,6 +48,40 @@ def validate_positional_id(value: str) -> str:
 def resource_id_argument(*, help: str) -> Any:
     """Typer ``Argument`` for resource ids when ``ignore_unknown_options`` is enabled."""
     return typer.Argument(..., help=help, callback=validate_positional_id)
+
+
+def validate_optional_resource_id(value: str | None, label: str) -> str | None:
+    if value is None:
+        return None
+    cleaned = value.strip()
+    if not cleaned:
+        raise typer.BadParameter(
+            f"Invalid '{label}': provide a non-empty string or positive integer."
+        )
+    if cleaned.startswith("-") and cleaned[1:].isdigit():
+        raise typer.BadParameter(f"Invalid '{label}': provide a positive integer.")
+    if cleaned.isdigit() and int(cleaned) <= 0:
+        raise typer.BadParameter(f"Invalid '{label}': provide a positive integer.")
+    return cleaned
+
+
+_CARDS_PAGE_SIZE_MIN = 1
+_CARDS_PAGE_SIZE_MAX = 500
+
+
+def validate_cards_page_size(first: int) -> int:
+    if first < _CARDS_PAGE_SIZE_MIN or first > _CARDS_PAGE_SIZE_MAX:
+        raise typer.BadParameter(
+            f"--first must be between {_CARDS_PAGE_SIZE_MIN} and "
+            f"{_CARDS_PAGE_SIZE_MAX} (inclusive)."
+        )
+    return first
+
+
+def validate_report_filter_cli(filter_obj: dict[str, Any] | None) -> None:
+    message = validate_report_cards_filter(filter_obj)
+    if message is not None:
+        raise typer.BadParameter(message)
 
 
 def export_poll_max_rounds(

--- a/packages/cli/src/pipefy_cli/commands/card.py
+++ b/packages/cli/src/pipefy_cli/commands/card.py
@@ -22,6 +22,8 @@ from pipefy_cli.commands._common import (
     parse_json_value,
     resource_id_argument,
     run_cli_command,
+    validate_cards_page_size,
+    validate_optional_resource_id,
 )
 
 card_app = typer.Typer(help="Card operations.", no_args_is_help=True)
@@ -36,20 +38,6 @@ def _parse_card_search_json(raw: str | None) -> CardSearch | None:
     if not isinstance(parsed, dict):
         raise typer.BadParameter("--search must be a JSON object")
     return copy_card_search(parsed)
-
-
-_CARDS_FIRST_MIN = 1
-_CARDS_FIRST_MAX = 500
-
-
-def _validate_cards_page_size(first: int | None) -> int | None:
-    if first is None:
-        return None
-    if first < _CARDS_FIRST_MIN or first > _CARDS_FIRST_MAX:
-        raise typer.BadParameter(
-            f"--first must be between {_CARDS_FIRST_MIN} and {_CARDS_FIRST_MAX} (inclusive)."
-        )
-    return first
 
 
 def _parse_fields_json(raw: str | None) -> dict[str, Any] | list[dict[str, Any]] | None:
@@ -137,7 +125,7 @@ def card_list(
     first: int | None = typer.Option(
         None,
         "--first",
-        help=f"Max cards per page ({_CARDS_FIRST_MIN}-{_CARDS_FIRST_MAX}).",
+        help="Max cards per page (1-500).",
     ),
     after: str | None = typer.Option(
         None,
@@ -161,7 +149,7 @@ def card_list(
     if title is not None and title.strip():
         merged["title"] = title.strip()
     effective_search: CardSearch | None = merged if merged else None
-    first_validated = _validate_cards_page_size(first)
+    first_validated = validate_cards_page_size(first) if first is not None else None
 
     async def factory(client: PipefyClient):
         return await client.get_cards(
@@ -259,6 +247,7 @@ def card_create(
     """Create a card in a pipe (start-form or phase fields via --fields JSON when required)."""
 
     fields = _parse_fields_json(fields_json)
+    phase_id = validate_optional_resource_id(phase_id, "phase_id")
 
     async def factory(client: PipefyClient):
         payload = fields if fields is not None else {}

--- a/packages/cli/src/pipefy_cli/commands/card.py
+++ b/packages/cli/src/pipefy_cli/commands/card.py
@@ -234,12 +234,20 @@ def card_create(
         None,
         "--title",
         "-t",
-        help="Optional title (applied via update after create).",
+        help="Optional title (sent on CreateCardInput when set).",
+    ),
+    phase_id: str | None = typer.Option(
+        None,
+        "--phase-id",
+        help=(
+            "Target phase id (CreateCardInput.phase_id). "
+            "Creates the card in that phase instead of the start form."
+        ),
     ),
     fields_json: str | None = typer.Option(
         None,
         "--fields",
-        help="JSON object or array: start-form field values for createCard.",
+        help="JSON object or array: field values for createCard.",
     ),
     json_out: bool = typer.Option(
         False,
@@ -248,19 +256,18 @@ def card_create(
         help="Print machine-readable JSON to stdout.",
     ),
 ) -> None:
-    """Create a card in a pipe (start-form fields via --fields JSON when required)."""
+    """Create a card in a pipe (start-form or phase fields via --fields JSON when required)."""
 
     fields = _parse_fields_json(fields_json)
 
     async def factory(client: PipefyClient):
         payload = fields if fields is not None else {}
-        result = await client.create_card(pipe_id, payload)
-        card_node = (result.get("createCard") or {}).get("card") or {}
-        cid = card_node.get("id")
-        if title and cid:
-            await client.update_card(str(cid), title=title)
-            card_node["title"] = title
-        return result
+        create_kwargs: dict[str, Any] = {}
+        if phase_id is not None:
+            create_kwargs["phase_id"] = phase_id
+        if title:
+            create_kwargs["title"] = title
+        return await client.create_card(pipe_id, payload, **create_kwargs)
 
     run_cli_command(ctx, json_out, factory)
 

--- a/packages/cli/src/pipefy_cli/commands/label.py
+++ b/packages/cli/src/pipefy_cli/commands/label.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import typer
 from pipefy_sdk import PipefyClient
+from pipefy_sdk.label_color import normalize_label_color
 
 from pipefy_cli.commands._common import (
     ID_POSITIONAL_CONTEXT_SETTINGS,
@@ -46,17 +47,27 @@ def label_create(
     pipe_id: str = typer.Option(..., "--pipe", help="Pipe id."),
     name: str = typer.Option(..., "--name", "-n", help="Label name."),
     color: str = typer.Option(
-        ..., "--color", "-c", help="Label color (per Pipefy API)."
+        ...,
+        "--color",
+        "-c",
+        help="Label color as hex #RRGGBB (e.g. #E50000, #FF0000).",
     ),
     json_out: bool = typer.Option(False, "--json", "-j"),
 ) -> None:
     """Create a label on a pipe."""
 
     nm = name.strip()
-    col = color.strip()
-    if not nm or not col:
-        typer.echo("--name and --color must be non-empty.", err=True)
+    if not nm:
+        typer.echo("--name must be non-empty.", err=True)
         raise typer.Exit(2)
+    if not color.strip():
+        typer.echo("--color must be non-empty.", err=True)
+        raise typer.Exit(2)
+    try:
+        col = normalize_label_color(color)
+    except ValueError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(2) from exc
 
     async def factory(client: PipefyClient):
         return await client.create_label(pipe_id, nm, col)
@@ -72,17 +83,27 @@ def label_update(
         ..., "--name", "-n", help="New label name (required by API)."
     ),
     color: str = typer.Option(
-        ..., "--color", "-c", help="New label color (required by API)."
+        ...,
+        "--color",
+        "-c",
+        help="New label color as hex #RRGGBB (required by API).",
     ),
     json_out: bool = typer.Option(False, "--json", "-j"),
 ) -> None:
     """Update a label (name and color are both required by Pipefy)."""
 
     nm = name.strip()
-    col = color.strip()
-    if not nm or not col:
-        typer.echo("--name and --color must be non-empty.", err=True)
+    if not nm:
+        typer.echo("--name must be non-empty.", err=True)
         raise typer.Exit(2)
+    if not color.strip():
+        typer.echo("--color must be non-empty.", err=True)
+        raise typer.Exit(2)
+    try:
+        col = normalize_label_color(color)
+    except ValueError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(2) from exc
 
     async def factory(client: PipefyClient):
         return await client.update_label(label_id, name=nm, color=col)

--- a/packages/cli/src/pipefy_cli/commands/phase.py
+++ b/packages/cli/src/pipefy_cli/commands/phase.py
@@ -13,6 +13,7 @@ from pipefy_cli.commands._common import (
     parse_json_object,
     resource_id_argument,
     run_cli_command,
+    validate_cards_page_size,
 )
 
 phase_app = typer.Typer(help="Pipe phase operations.", no_args_is_help=True)
@@ -119,6 +120,8 @@ def phase_cards(
     ),
 ) -> None:
     """List cards in a phase (``Phase.cards`` pagination)."""
+
+    first = validate_cards_page_size(first)
 
     async def factory(client: PipefyClient):
         return await client.get_phase_cards(

--- a/packages/cli/src/pipefy_cli/commands/phase.py
+++ b/packages/cli/src/pipefy_cli/commands/phase.py
@@ -42,6 +42,95 @@ def phase_get(
     run_cli_command(ctx, json_out, factory)
 
 
+@phase_app.command(
+    "allowed-moves",
+    context_settings=ID_POSITIONAL_CONTEXT_SETTINGS,
+)
+def phase_allowed_moves(
+    ctx: typer.Context,
+    phase_id: str = resource_id_argument(
+        help="Source phase id (card's current phase)."
+    ),
+    json_out: bool = typer.Option(
+        False,
+        "--json",
+        "-j",
+        help="Print machine-readable JSON to stdout.",
+    ),
+) -> None:
+    """List phases a card may move to from this phase (UI transition rules)."""
+
+    async def factory(client: PipefyClient):
+        return await client.get_phase_allowed_move_targets(phase_id)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@phase_app.command(
+    "cards-count",
+    context_settings=ID_POSITIONAL_CONTEXT_SETTINGS,
+)
+def phase_cards_count(
+    ctx: typer.Context,
+    phase_id: str = resource_id_argument(help="Phase id."),
+    json_out: bool = typer.Option(
+        False,
+        "--json",
+        "-j",
+        help="Print machine-readable JSON to stdout.",
+    ),
+) -> None:
+    """Return native ``Phase.cards_count`` for a phase (fast inventory).
+
+    On the start-form phase, ``cards_count`` may be 0 while cards still exist;
+    use ``pipefy phase cards`` to list cards when the count looks wrong.
+    """
+
+    async def factory(client: PipefyClient):
+        return await client.get_phase_cards_count_payload(phase_id)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@phase_app.command("cards", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
+def phase_cards(
+    ctx: typer.Context,
+    phase_id: str = resource_id_argument(help="Phase id."),
+    first: int = typer.Option(
+        50,
+        "--first",
+        help="Max cards per page (1-500).",
+    ),
+    after: str | None = typer.Option(
+        None,
+        "--after",
+        help="Cursor from pageInfo.endCursor of a previous call.",
+    ),
+    include_fields: bool = typer.Option(
+        False,
+        "--include-fields",
+        help="Include each card's custom fields in the response.",
+    ),
+    json_out: bool = typer.Option(
+        False,
+        "--json",
+        "-j",
+        help="Print machine-readable JSON to stdout.",
+    ),
+) -> None:
+    """List cards in a phase (``Phase.cards`` pagination)."""
+
+    async def factory(client: PipefyClient):
+        return await client.get_phase_cards(
+            phase_id,
+            first=first,
+            after=after,
+            include_fields=include_fields,
+        )
+
+    run_cli_command(ctx, json_out, factory)
+
+
 @phase_app.command("create")
 def phase_create(
     ctx: typer.Context,

--- a/packages/cli/src/pipefy_cli/commands/report_org.py
+++ b/packages/cli/src/pipefy_cli/commands/report_org.py
@@ -13,6 +13,7 @@ from pipefy_cli.commands._common import (
     resource_id_argument,
     run_cli_command,
     run_pipefy_client_coroutine,
+    validate_report_filter_cli,
     write_export_csv_to_stdout,
 )
 
@@ -78,6 +79,7 @@ def report_org_create(
     if fields_list is not None and not isinstance(fields_list, list):
         raise typer.BadParameter("--fields must be a JSON array")
     filt = parse_json_object(filter_json, "--filter")
+    validate_report_filter_cli(filt)
 
     async def factory(client: PipefyClient):
         return await client.create_organization_report(
@@ -111,6 +113,7 @@ def report_org_update(
     if fields_list is not None and not isinstance(fields_list, list):
         raise typer.BadParameter("--fields must be a JSON array")
     filt = parse_json_object(filter_json, "--filter")
+    validate_report_filter_cli(filt)
     pids = parse_json_value(pipe_ids, "--pipe-ids") if pipe_ids else None
     if pids is not None:
         if not isinstance(pids, list):
@@ -187,6 +190,7 @@ def report_org_export(
         )
     sort_obj = parse_json_object(sort_by, "--sort-by")
     filt = parse_json_object(filter_json, "--filter")
+    validate_report_filter_cli(filt)
     cols = parse_json_value(columns, "--columns") if columns else None
     if cols is not None and not isinstance(cols, list):
         raise typer.BadParameter("--columns must be a JSON array")

--- a/packages/cli/src/pipefy_cli/commands/report_pipe.py
+++ b/packages/cli/src/pipefy_cli/commands/report_pipe.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import typer
 from pipefy_sdk import PipefyClient
+from pipefy_sdk.report_filter_preflight import validate_report_cards_filter
 
 from pipefy_cli.commands._common import (
     ID_POSITIONAL_CONTEXT_SETTINGS,
@@ -19,6 +20,12 @@ from pipefy_cli.commands._common import (
 )
 
 report_pipe_app = typer.Typer(help="Pipe reports.", no_args_is_help=True)
+
+
+def _validate_report_filter_cli(filter_obj: dict[str, Any] | None) -> None:
+    message = validate_report_cards_filter(filter_obj)
+    if message is not None:
+        raise typer.BadParameter(message)
 
 
 def _parse_order(raw: str | None) -> dict[str, Any] | None:
@@ -139,6 +146,7 @@ def report_pipe_create(
     if fields_list is not None and not isinstance(fields_list, list):
         raise typer.BadParameter("--fields must be a JSON array")
     filt = parse_json_object(filter_json, "--filter")
+    _validate_report_filter_cli(filt)
     formulas_val = parse_json_value(formulas, "--formulas") if formulas else None
     if formulas_val is not None and not isinstance(formulas_val, list):
         raise typer.BadParameter("--formulas must be a JSON array")
@@ -174,6 +182,7 @@ def report_pipe_update(
     if fields_list is not None and not isinstance(fields_list, list):
         raise typer.BadParameter("--fields must be a JSON array")
     filt = parse_json_object(filter_json, "--filter")
+    _validate_report_filter_cli(filt)
     formulas_val = parse_json_value(formulas, "--formulas") if formulas else None
     if formulas_val is not None and not isinstance(formulas_val, list):
         raise typer.BadParameter("--formulas must be a JSON array")

--- a/packages/cli/src/pipefy_cli/commands/report_pipe.py
+++ b/packages/cli/src/pipefy_cli/commands/report_pipe.py
@@ -6,7 +6,6 @@ from typing import Any
 
 import typer
 from pipefy_sdk import PipefyClient
-from pipefy_sdk.report_filter_preflight import validate_report_cards_filter
 
 from pipefy_cli.commands._common import (
     ID_POSITIONAL_CONTEXT_SETTINGS,
@@ -16,16 +15,11 @@ from pipefy_cli.commands._common import (
     resource_id_argument,
     run_cli_command,
     run_pipefy_client_coroutine,
+    validate_report_filter_cli,
     write_export_csv_to_stdout,
 )
 
 report_pipe_app = typer.Typer(help="Pipe reports.", no_args_is_help=True)
-
-
-def _validate_report_filter_cli(filter_obj: dict[str, Any] | None) -> None:
-    message = validate_report_cards_filter(filter_obj)
-    if message is not None:
-        raise typer.BadParameter(message)
 
 
 def _parse_order(raw: str | None) -> dict[str, Any] | None:
@@ -146,7 +140,7 @@ def report_pipe_create(
     if fields_list is not None and not isinstance(fields_list, list):
         raise typer.BadParameter("--fields must be a JSON array")
     filt = parse_json_object(filter_json, "--filter")
-    _validate_report_filter_cli(filt)
+    validate_report_filter_cli(filt)
     formulas_val = parse_json_value(formulas, "--formulas") if formulas else None
     if formulas_val is not None and not isinstance(formulas_val, list):
         raise typer.BadParameter("--formulas must be a JSON array")
@@ -182,7 +176,7 @@ def report_pipe_update(
     if fields_list is not None and not isinstance(fields_list, list):
         raise typer.BadParameter("--fields must be a JSON array")
     filt = parse_json_object(filter_json, "--filter")
-    _validate_report_filter_cli(filt)
+    validate_report_filter_cli(filt)
     formulas_val = parse_json_value(formulas, "--formulas") if formulas else None
     if formulas_val is not None and not isinstance(formulas_val, list):
         raise typer.BadParameter("--formulas must be a JSON array")
@@ -255,6 +249,7 @@ def report_pipe_export(
         )
     sort_obj = parse_json_object(sort_by, "--sort-by")
     filt = parse_json_object(filter_json, "--filter")
+    validate_report_filter_cli(filt)
     cols = parse_json_value(columns, "--columns") if columns else None
     if cols is not None and not isinstance(cols, list):
         raise typer.BadParameter("--columns must be a JSON array")

--- a/packages/cli/tests/fixtures/cli_help_golden.txt
+++ b/packages/cli/tests/fixtures/cli_help_golden.txt
@@ -859,8 +859,8 @@ Usage: pipefy card [OPTIONS] COMMAND [ARGS]...
 │ get       Fetch a card by id.                                                │
 │ list      List cards in a pipe (get_cards): browse, filter, and paginate.    │
 │ find      Find cards in a pipe where a custom field equals a value.          │
-│ create    Create a card in a pipe (start-form fields via --fields JSON when  │
-│           required).                                                         │
+│ create    Create a card in a pipe (start-form or phase fields via --fields   │
+│           JSON when required).                                               │
 │ update    Update a card (title, assignees, labels, due date, and/or field    │
 │           updates).                                                          │
 │ delete    Delete a card permanently.                                         │
@@ -927,17 +927,20 @@ Usage: pipefy card comment update [OPTIONS] COMMENT_ID TEXT
 ### HELP card/create
 Usage: pipefy card create [OPTIONS] PIPE_ID
 
- Create a card in a pipe (start-form fields via --fields JSON when required).
+ Create a card in a pipe (start-form or phase fields via --fields JSON when
+ required).
 
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    pipe_id      TEXT  Pipe id. [required]                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --title   -t      TEXT  Optional title (applied via update after create).    │
-│ --fields          TEXT  JSON object or array: start-form field values for    │
-│                         createCard.                                          │
-│ --json    -j            Print machine-readable JSON to stdout.               │
-│ --help                  Show this message and exit.                          │
+│ --title     -t      TEXT  Optional title (sent on CreateCardInput when set). │
+│ --phase-id          TEXT  Target phase id (CreateCardInput.phase_id).        │
+│                           Creates the card in that phase instead of the      │
+│                           start form.                                        │
+│ --fields            TEXT  JSON object or array: field values for createCard. │
+│ --json      -j            Print machine-readable JSON to stdout.             │
+│ --help                    Show this message and exit.                        │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 
 ### HELP card/delete
@@ -1504,7 +1507,9 @@ Usage: pipefy label create [OPTIONS]
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ *  --pipe           TEXT  Pipe id. [required]                                │
 │ *  --name   -n      TEXT  Label name. [required]                             │
-│ *  --color  -c      TEXT  Label color (per Pipefy API). [required]           │
+│ *  --color  -c      TEXT  Label color as hex #RRGGBB (e.g. #E50000,          │
+│                           #FF0000).                                          │
+│                           [required]                                         │
 │    --json   -j                                                               │
 │    --help                 Show this message and exit.                        │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -1545,7 +1550,8 @@ Usage: pipefy label update [OPTIONS] LABEL_ID
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ *  --name   -n      TEXT  New label name (required by API). [required]       │
-│ *  --color  -c      TEXT  New label color (required by API). [required]      │
+│ *  --color  -c      TEXT  New label color as hex #RRGGBB (required by API).  │
+│                           [required]                                         │
 │    --json   -j                                                               │
 │    --help                 Show this message and exit.                        │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -1659,11 +1665,64 @@ Usage: pipefy phase [OPTIONS] COMMAND [ARGS]...
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ get      Load phase metadata and fields by id (via ``get_phase_fields``).    │
-│ create   Create a phase in a pipe.                                           │
-│ update   Update a phase (Pipefy ``UpdatePhaseInput``). Resolves current name │
-│          when omitted.                                                       │
-│ delete   Delete a phase permanently.                                         │
+│ get             Load phase metadata and fields by id (via                    │
+│                 ``get_phase_fields``).                                       │
+│ allowed-moves   List phases a card may move to from this phase (UI           │
+│                 transition rules).                                           │
+│ cards-count     Return native ``Phase.cards_count`` for a phase (fast        │
+│                 inventory).                                                  │
+│ cards           List cards in a phase (``Phase.cards`` pagination).          │
+│ create          Create a phase in a pipe.                                    │
+│ update          Update a phase (Pipefy ``UpdatePhaseInput``). Resolves       │
+│                 current name when omitted.                                   │
+│ delete          Delete a phase permanently.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP phase/allowed-moves
+Usage: pipefy phase allowed-moves [OPTIONS] PHASE_ID
+
+ List phases a card may move to from this phase (UI transition rules).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    phase_id      TEXT  Source phase id (card's current phase). [required]  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --json  -j        Print machine-readable JSON to stdout.                     │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP phase/cards
+Usage: pipefy phase cards [OPTIONS] PHASE_ID
+
+ List cards in a phase (``Phase.cards`` pagination).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    phase_id      TEXT  Phase id. [required]                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --first                   INTEGER  Max cards per page (1-500). [default: 50] │
+│ --after                   TEXT     Cursor from pageInfo.endCursor of a       │
+│                                    previous call.                            │
+│ --include-fields                   Include each card's custom fields in the  │
+│                                    response.                                 │
+│ --json            -j               Print machine-readable JSON to stdout.    │
+│ --help                             Show this message and exit.               │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP phase/cards-count
+Usage: pipefy phase cards-count [OPTIONS] PHASE_ID
+
+ Return native ``Phase.cards_count`` for a phase (fast inventory).
+
+ On the start-form phase, ``cards_count`` may be 0 while cards still exist; use
+ ``pipefy phase cards`` to list cards when the count looks wrong.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    phase_id      TEXT  Phase id. [required]                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --json  -j        Print machine-readable JSON to stdout.                     │
+│ --help            Show this message and exit.                                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 
 ### HELP phase/create

--- a/packages/cli/tests/test_card_commands.py
+++ b/packages/cli/tests/test_card_commands.py
@@ -129,10 +129,10 @@ def test_card_find_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
 
 def test_card_create_with_title_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
     oauth_env("create-card")
-    create_resp = {"createCard": {"card": {"id": "777", "title": "Draft"}}}
+    create_resp = {"createCard": {"card": {"id": "777", "title": "Hello"}}}
     mock_client = MagicMock()
     mock_client.create_card = AsyncMock(return_value=create_resp)
-    mock_client.update_card = AsyncMock(return_value={"updateCard": {"card": {}}})
+    mock_client.update_card = AsyncMock()
     with patch(
         "pipefy_cli.commands._common.get_authenticated_client",
         return_value=mock_client,
@@ -151,20 +151,79 @@ def test_card_create_with_title_json(runner, clean_pipefy_env, saved_cwd, oauth_
             ],
         )
     assert result.exit_code == 0, result.stdout + (result.stderr or "")
-    mock_client.create_card.assert_awaited_once_with("303", {"field_x": "y"})
-    mock_client.update_card.assert_awaited_once_with("777", title="Hello")
+    mock_client.create_card.assert_awaited_once_with(
+        "303", {"field_x": "y"}, title="Hello"
+    )
+    mock_client.update_card.assert_not_called()
 
 
-def test_card_create_title_update_failure_exit_1(
+def test_card_create_forwards_phase_id(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("create-card-phase")
+    create_resp = {"createCard": {"card": {"id": "888"}}}
+    mock_client = MagicMock()
+    mock_client.create_card = AsyncMock(return_value=create_resp)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "card",
+                "create",
+                "303",
+                "--phase-id",
+                "phase_42",
+                "--fields",
+                '{"status": "Open"}',
+                "--json",
+            ],
+        )
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+    mock_client.create_card.assert_awaited_once_with(
+        "303",
+        {"status": "Open"},
+        phase_id="phase_42",
+    )
+
+
+def test_card_create_phase_id_and_title(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("create-card-phase-title")
+    create_resp = {"createCard": {"card": {"id": "889", "title": "Seed"}}}
+    mock_client = MagicMock()
+    mock_client.create_card = AsyncMock(return_value=create_resp)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "card",
+                "create",
+                "303",
+                "--phase-id",
+                "999",
+                "--title",
+                "Seed",
+                "--json",
+            ],
+        )
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+    mock_client.create_card.assert_awaited_once_with(
+        "303", {}, phase_id="999", title="Seed"
+    )
+
+
+def test_card_create_title_failure_exit_1(
     runner, clean_pipefy_env, saved_cwd, oauth_env
 ):
     oauth_env("create-card-fail-title")
     from pipefy_sdk.exceptions import PipefyError
 
-    create_resp = {"createCard": {"card": {"id": "777", "title": "Draft"}}}
     mock_client = MagicMock()
-    mock_client.create_card = AsyncMock(return_value=create_resp)
-    mock_client.update_card = AsyncMock(side_effect=PipefyError("update failed"))
+    mock_client.create_card = AsyncMock(side_effect=PipefyError("create failed"))
+    mock_client.update_card = AsyncMock()
     with patch(
         "pipefy_cli.commands._common.get_authenticated_client",
         return_value=mock_client,
@@ -181,8 +240,8 @@ def test_card_create_title_update_failure_exit_1(
             ],
         )
     assert result.exit_code == 1
-    mock_client.create_card.assert_awaited_once()
-    mock_client.update_card.assert_awaited_once_with("777", title="Hello")
+    mock_client.create_card.assert_awaited_once_with("303", {}, title="Hello")
+    mock_client.update_card.assert_not_called()
 
 
 def test_card_create_invalid_fields_exit_2(

--- a/packages/cli/tests/test_label_webhook_commands.py
+++ b/packages/cli/tests/test_label_webhook_commands.py
@@ -26,6 +26,87 @@ def test_label_list_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
     assert out["labels"] == [{"id": "1", "name": "Bug"}]
 
 
+def test_label_create_rejects_color_name_before_api(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("lbl-create-hex")
+    mock_client = MagicMock()
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "label",
+                "create",
+                "--pipe",
+                "8",
+                "--name",
+                "Bug",
+                "--color",
+                "red",
+            ],
+        )
+    assert result.exit_code == 2
+    assert "expected #RRGGBB, received 'red'" in result.stderr
+    mock_client.create_label.assert_not_called()
+
+
+def test_label_create_passes_normalized_hex(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("lbl-create-ok")
+    mock_client = MagicMock()
+    mock_client.create_label = AsyncMock(return_value={"createLabel": {}})
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "label",
+                "create",
+                "--pipe",
+                "8",
+                "--name",
+                "Bug",
+                "--color",
+                "#ff0000",
+                "--json",
+            ],
+        )
+    assert result.exit_code == 0
+    mock_client.create_label.assert_awaited_once_with("8", "Bug", "#FF0000")
+
+
+def test_label_update_rejects_color_name_before_api(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("lbl-update-hex")
+    mock_client = MagicMock()
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "label",
+                "update",
+                "3",
+                "--name",
+                "Story",
+                "--color",
+                "blue",
+            ],
+        )
+    assert result.exit_code == 2
+    assert "expected #RRGGBB, received 'blue'" in result.stderr
+    mock_client.update_label.assert_not_called()
+
+
 def test_label_list_pipe_denied_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
     oauth_env("lbl-denied")
     mock_client = MagicMock()

--- a/packages/cli/tests/test_label_webhook_commands.py
+++ b/packages/cli/tests/test_label_webhook_commands.py
@@ -49,7 +49,7 @@ def test_label_create_rejects_color_name_before_api(
             ],
         )
     assert result.exit_code == 2
-    assert "expected #RRGGBB, received 'red'" in result.stderr
+    assert "expected #RGB or #RRGGBB hex color, received 'red'" in result.stderr
     mock_client.create_label.assert_not_called()
 
 
@@ -103,7 +103,7 @@ def test_label_update_rejects_color_name_before_api(
             ],
         )
     assert result.exit_code == 2
-    assert "expected #RRGGBB, received 'blue'" in result.stderr
+    assert "expected #RGB or #RRGGBB hex color, received 'blue'" in result.stderr
     mock_client.update_label.assert_not_called()
 
 

--- a/packages/cli/tests/test_pipe_commands.py
+++ b/packages/cli/tests/test_pipe_commands.py
@@ -319,3 +319,23 @@ def test_phase_cards_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
         after="c1",
         include_fields=False,
     )
+
+
+def test_phase_cards_first_out_of_range_exit_2(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    # Help promises 1-500; the shared validate_cards_page_size clamp must reject
+    # an out-of-range --first before any API call (parity with `card list`).
+    oauth_env("ph-cards-bad-first")
+    mock_client = MagicMock()
+    mock_client.get_phase_cards = AsyncMock()
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["phase", "cards", "342182335", "--first", "501", "--json"],
+        )
+    assert result.exit_code == 2
+    mock_client.get_phase_cards.assert_not_called()

--- a/packages/cli/tests/test_pipe_commands.py
+++ b/packages/cli/tests/test_pipe_commands.py
@@ -57,6 +57,32 @@ def test_pipe_get_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
     mock_client.get_pipe.assert_awaited_once_with("10")
 
 
+def test_pipe_get_json_includes_phase_inventory_fields(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("pipe-get-inventory")
+    payload = {
+        "pipe": {
+            "id": "10",
+            "name": "P",
+            "startFormPhaseId": "100",
+            "start_form_phase": {"id": "100", "name": "Start", "cards_count": 1},
+            "phases": [{"id": "200", "name": "Done", "cards_count": 3}],
+        }
+    }
+    mock_client = MagicMock()
+    mock_client.get_pipe = AsyncMock(return_value=payload)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(app, ["pipe", "get", "10", "--json"])
+    assert result.exit_code == 0
+    body = json.loads(result.stdout)
+    assert body["pipe"]["start_form_phase"]["cards_count"] == 1
+    assert body["pipe"]["phases"][0]["cards_count"] == 3
+
+
 def test_pipe_list_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
     oauth_env("pipe-list")
     payload = {"organizations": []}
@@ -215,3 +241,81 @@ def test_pipe_update_preferences_empty_object_bad_parameter(
         )
     assert result.exit_code == 2
     mock_client.update_pipe.assert_not_called()
+
+
+def test_phase_allowed_moves_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("ph-allowed-moves")
+    payload = {
+        "phase": {
+            "id": "342182335",
+            "name": "Doing",
+            "cards_can_be_moved_to_phases": [{"id": "200", "name": "Done"}],
+        }
+    }
+    mock_client = MagicMock()
+    mock_client.get_phase_allowed_move_targets = AsyncMock(return_value=payload)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["phase", "allowed-moves", "342182335", "--json"],
+        )
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == payload
+    mock_client.get_phase_allowed_move_targets.assert_awaited_once_with("342182335")
+
+
+def test_phase_cards_count_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("ph-cards-count")
+    payload = {
+        "phase_id": "342182335",
+        "phase_name": "Doing",
+        "cards_count": 7,
+    }
+    mock_client = MagicMock()
+    mock_client.get_phase_cards_count_payload = AsyncMock(return_value=payload)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["phase", "cards-count", "342182335", "--json"],
+        )
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == payload
+    mock_client.get_phase_cards_count_payload.assert_awaited_once_with("342182335")
+
+
+def test_phase_cards_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("ph-cards-list")
+    payload = {
+        "phase": {
+            "id": "342182335",
+            "cards": {
+                "edges": [{"node": {"id": "1", "title": "A"}}],
+                "pageInfo": {"hasNextPage": False, "endCursor": None},
+                "totalCount": 1,
+            },
+        }
+    }
+    mock_client = MagicMock()
+    mock_client.get_phase_cards = AsyncMock(return_value=payload)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["phase", "cards", "342182335", "--first", "50", "--after", "c1", "--json"],
+        )
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == payload
+    mock_client.get_phase_cards.assert_awaited_once_with(
+        "342182335",
+        first=50,
+        after="c1",
+        include_fields=False,
+    )

--- a/packages/cli/tests/test_report_pipe_filter_commands.py
+++ b/packages/cli/tests/test_report_pipe_filter_commands.py
@@ -1,0 +1,100 @@
+"""CLI tests for report-pipe filter preflight."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pipefy_sdk.report_filter_preflight import EXAMPLE_PHASE_FILTER
+
+from pipefy_cli.main import app
+
+
+def test_report_pipe_create_rejects_naive_current_phase_filter(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("report-filter-bad")
+    mock_client = MagicMock()
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "report-pipe",
+                "create",
+                "--pipe",
+                "123",
+                "--name",
+                "R",
+                "--filter",
+                json.dumps({"current_phase": ["1"]}),
+            ],
+        )
+    assert result.exit_code == 2
+    mock_client.create_pipe_report.assert_not_called()
+    assert "top-level" in result.stderr
+
+
+def test_report_pipe_create_forwards_valid_filter(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("report-filter-ok")
+    filt = {
+        **EXAMPLE_PHASE_FILTER,
+        "queries": [{**EXAMPLE_PHASE_FILTER["queries"][0], "value": "99"}],
+    }
+    mock_client = MagicMock()
+    mock_client.create_pipe_report = AsyncMock(
+        return_value={"createPipeReport": {"pipeReport": {"id": "r1"}}}
+    )
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "report-pipe",
+                "create",
+                "--pipe",
+                "123",
+                "--name",
+                "R",
+                "--filter",
+                json.dumps(filt),
+                "--json",
+            ],
+        )
+    assert result.exit_code == 0, result.stderr
+    mock_client.create_pipe_report.assert_awaited_once_with(
+        "123",
+        "R",
+        fields=None,
+        filter=filt,
+        formulas=None,
+    )
+
+
+def test_report_pipe_update_rejects_invalid_filter_operator(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("report-filter-update-bad")
+    mock_client = MagicMock()
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "report-pipe",
+                "update",
+                "10",
+                "--filter",
+                json.dumps({"operator": "xor", "queries": []}),
+            ],
+        )
+    assert result.exit_code == 2
+    mock_client.update_pipe_report.assert_not_called()

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,6 +1,6 @@
 # pipefy-mcp-server
 
-MCP server for Pipefy — **149 tools** for AI agents (Cursor, Claude Desktop, Claude Code, Codex, and any MCP-compatible client). Depends on [`pipefy-sdk`](../sdk/README.md) for all GraphQL and API logic.
+MCP server for Pipefy — **152 tools** for AI agents (Cursor, Claude Desktop, Claude Code, Codex, and any MCP-compatible client). Depends on [`pipefy-sdk`](../sdk/README.md) for all GraphQL and API logic.
 
 ## Install (pre-launch, v0.1 → v0.5)
 
@@ -112,7 +112,7 @@ This form also works as a per-project `.mcp.json` if your team shares a clone. C
 
 ## Tools
 
-**149 tools** across ten domains (including **Portals**) — see the root [`README.md`](../../README.md#mcp-server) for the full table with per-area links. Deep reference: [`docs/mcp/tools/`](../../docs/mcp/tools/cross-cutting.md) (start with [`cross-cutting.md`](../../docs/mcp/tools/cross-cutting.md)); portals: [`portal.md`](../../docs/mcp/tools/portal.md).
+**152 tools** across ten domains (including **Portals**) — see the root [`README.md`](../../README.md#mcp-server) for the full table with per-area links. Deep reference: [`docs/mcp/tools/`](../../docs/mcp/tools/cross-cutting.md) (start with [`cross-cutting.md`](../../docs/mcp/tools/cross-cutting.md)); portals: [`portal.md`](../../docs/mcp/tools/portal.md).
 
 ## Development
 

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_config_tool_helpers.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_config_tool_helpers.py
@@ -562,6 +562,53 @@ async def resolve_phase_dependents(
     return out
 
 
+def normalize_phase_allowed_move_targets(
+    raw: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Map GraphQL ``phase`` payload to agent-friendly allowed-move targets.
+
+    Args:
+        raw: Response from ``PipefyClient.get_phase_allowed_move_targets``.
+
+    Returns:
+        ``{phase_id, phase_name, allowed_phases}`` or ``None`` when ``phase`` is missing.
+    """
+    phase = (raw or {}).get("phase")
+    if not isinstance(phase, dict):
+        return None
+    phase_id = phase.get("id")
+    if phase_id is None:
+        return None
+    allowed_raw = phase.get("cards_can_be_moved_to_phases") or []
+    allowed_phases: list[dict[str, str]] = []
+    if isinstance(allowed_raw, list):
+        for item in allowed_raw:
+            if not isinstance(item, dict):
+                continue
+            dest_id = item.get("id")
+            if dest_id is None:
+                continue
+            allowed_phases.append(
+                {
+                    "id": str(dest_id),
+                    "name": str(item.get("name") or ""),
+                }
+            )
+    return {
+        "phase_id": str(phase_id),
+        "phase_name": str(phase.get("name") or ""),
+        "allowed_phases": allowed_phases,
+    }
+
+
+def normalize_phase_cards_list(raw: dict[str, Any]) -> dict[str, Any] | None:
+    """Return ``phase`` payload when present, else ``None`` (not found)."""
+    phase = (raw or {}).get("phase")
+    if not isinstance(phase, dict) or phase.get("id") is None:
+        return None
+    return phase
+
+
 __all__ = [
     "DeletePipeErrorPayload",
     "DeletePipePayload",
@@ -584,6 +631,8 @@ __all__ = [
     "find_phase_field_dependents",
     "handle_pipe_config_tool_graphql_error",
     "map_delete_pipe_error_to_message",
+    "normalize_phase_allowed_move_targets",
+    "normalize_phase_cards_list",
     "resolve_phase_dependents",
     "resolve_phase_field_identifiers",
 ]

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_config_tool_helpers.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_config_tool_helpers.py
@@ -565,14 +565,6 @@ async def resolve_phase_dependents(
 def normalize_phase_allowed_move_targets(
     raw: dict[str, Any],
 ) -> dict[str, Any] | None:
-    """Map GraphQL ``phase`` payload to agent-friendly allowed-move targets.
-
-    Args:
-        raw: Response from ``PipefyClient.get_phase_allowed_move_targets``.
-
-    Returns:
-        ``{phase_id, phase_name, allowed_phases}`` or ``None`` when ``phase`` is missing.
-    """
     phase = (raw or {}).get("phase")
     if not isinstance(phase, dict):
         return None
@@ -602,7 +594,6 @@ def normalize_phase_allowed_move_targets(
 
 
 def normalize_phase_cards_list(raw: dict[str, Any]) -> dict[str, Any] | None:
-    """Return ``phase`` payload when present, else ``None`` (not found)."""
     phase = (raw or {}).get("phase")
     if not isinstance(phase, dict) or phase.get("id") is None:
         return None

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_config_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_config_tools.py
@@ -6,6 +6,7 @@ from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
 from mcp.types import ToolAnnotations
 from pipefy_sdk import PipefyClient, PipefyId
+from pipefy_sdk.label_color import normalize_label_color
 
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.graphql_error_helpers import (
@@ -13,6 +14,10 @@ from pipefy_mcp.tools.graphql_error_helpers import (
     extract_graphql_correlation_id,
     extract_graphql_error_codes,
     with_debug_suffix,
+)
+from pipefy_mcp.tools.pagination_helpers import (
+    build_pagination_info,
+    validate_page_size,
 )
 from pipefy_mcp.tools.pipe_config_tool_helpers import (
     build_delete_pipe_error_payload,
@@ -22,11 +27,17 @@ from pipefy_mcp.tools.pipe_config_tool_helpers import (
     find_phase_field_dependents,
     handle_pipe_config_tool_graphql_error,
     map_delete_pipe_error_to_message,
+    normalize_phase_allowed_move_targets,
+    normalize_phase_cards_list,
     resolve_phase_dependents,
     resolve_phase_field_identifiers,
 )
 from pipefy_mcp.tools.pipe_tool_helpers import find_label_dependents
-from pipefy_mcp.tools.tool_error_envelope import tool_error_message
+from pipefy_mcp.tools.tool_error_envelope import (
+    is_unified_envelope_enabled,
+    tool_error_message,
+    tool_success,
+)
 from pipefy_mcp.tools.validation_helpers import (
     validate_optional_tool_id,
     validate_tool_id,
@@ -342,6 +353,174 @@ class PipeConfigTools:
                 label="Pipe(s) cloned.",
                 data=raw,
             )
+
+        @mcp.tool(
+            annotations=ToolAnnotations(
+                readOnlyHint=True,
+            ),
+        )
+        async def get_phase_allowed_move_targets(
+            phase_id: PipefyId,
+            debug: bool = False,
+        ) -> dict[str, Any]:
+            """List phases a card may move to from a source phase (UI transition rules).
+
+            Read-only mirror of Pipefy **Phase -> Connections** (GraphQL
+            ``phase.cards_can_be_moved_to_phases``). Call before ``move_card_to_phase``
+            to avoid trial-and-error moves. New phases have no edges until configured
+            in the Pipefy UI.
+
+            Args:
+                phase_id: Source phase ID (typically the card's ``current_phase.id``).
+                    Discover via: ``get_card(card_id).current_phase.id`` or
+                    ``get_pipe(pipe_id).phases[].id``.
+                debug: When True, append GraphQL codes and correlation_id to errors.
+
+            Returns:
+                ``success: true`` with ``data`` containing ``phase_id``, ``phase_name``,
+                and ``allowed_phases`` (list of ``{id, name}``). Empty
+                ``allowed_phases`` means no outbound transitions are configured.
+            """
+            phase_id_str, err = validate_tool_id(phase_id, "phase_id")
+            if err is not None:
+                return err
+            try:
+                raw = await client.get_phase_allowed_move_targets(phase_id_str)
+            except Exception as exc:  # noqa: BLE001
+                return handle_pipe_config_tool_graphql_error(
+                    exc,
+                    "Get phase allowed move targets failed.",
+                    debug=debug,
+                    resource_kind="phase",
+                    resource_id=phase_id_str,
+                )
+            normalized = normalize_phase_allowed_move_targets(raw)
+            if normalized is None:
+                return build_pipe_tool_error_payload(
+                    message=f"Phase {phase_id_str} not found or access denied.",
+                    code="NOT_FOUND",
+                )
+            return tool_success(
+                data=normalized,
+                message="Allowed move targets loaded.",
+            )
+
+        @mcp.tool(
+            annotations=ToolAnnotations(
+                readOnlyHint=True,
+            ),
+        )
+        async def get_phase_cards_count(
+            phase_id: PipefyId,
+            debug: bool = False,
+        ) -> dict[str, Any]:
+            """Return the native ``Phase.cards_count`` for a phase (fast inventory).
+
+            Uses the schema scalar — no card enumeration. On the **start-form** phase,
+            ``cards_count`` may be **0** while cards still exist; use ``get_phase_cards``
+            to list or verify inventory when the count looks wrong.
+
+            Args:
+                phase_id: Phase ID. Discover via: ``get_pipe(pipe_id).phases[].id``.
+                debug: When True, append GraphQL codes and correlation_id to errors.
+
+            Returns:
+                ``success: true`` with ``data`` containing ``phase_id``, ``phase_name``,
+                and ``cards_count``.
+            """
+            phase_id_str, err = validate_tool_id(phase_id, "phase_id")
+            if err is not None:
+                return err
+            try:
+                payload = await client.get_phase_cards_count_payload(phase_id_str)
+            except Exception as exc:  # noqa: BLE001
+                return handle_pipe_config_tool_graphql_error(
+                    exc,
+                    "Get phase cards count failed.",
+                    debug=debug,
+                    resource_kind="phase",
+                    resource_id=phase_id_str,
+                )
+            return tool_success(
+                data=payload,
+                message="Phase cards count loaded.",
+            )
+
+        @mcp.tool(
+            annotations=ToolAnnotations(
+                readOnlyHint=True,
+            ),
+        )
+        async def get_phase_cards(
+            phase_id: PipefyId,
+            first: int = 50,
+            after: str | None = None,
+            include_fields: bool = False,
+            debug: bool = False,
+        ) -> dict[str, Any]:
+            """List cards currently in a phase (``Phase.cards`` pagination).
+
+            Prefer this over ``get_cards`` when you need every card in a specific phase;
+            pipe-level ``CardSearch`` has no phase filter. For a quick scalar total,
+            use ``get_phase_cards_count`` (see start-form ``cards_count`` caveat there).
+
+            Args:
+                phase_id: Phase ID. Discover via: ``get_pipe(pipe_id).phases[].id``.
+                first: Max cards per page (1-500). Default 50.
+                after: Cursor from ``pageInfo.endCursor`` of a previous call.
+                include_fields: When True, include each card's custom fields.
+                debug: When True, append GraphQL codes and correlation_id to errors.
+
+            Returns:
+                GraphQL ``phase`` object with ``cards`` connection (``edges``, ``pageInfo``,
+                ``totalCount``). When unified envelope is enabled, includes pagination hints.
+            """
+            phase_id_str, err = validate_tool_id(phase_id, "phase_id")
+            if err is not None:
+                return err
+            validated_first, page_err = validate_page_size(first)
+            if page_err is not None:
+                return page_err
+            try:
+                raw = await client.get_phase_cards(
+                    phase_id_str,
+                    first=validated_first,
+                    after=after,
+                    include_fields=include_fields,
+                )
+            except Exception as exc:  # noqa: BLE001
+                return handle_pipe_config_tool_graphql_error(
+                    exc,
+                    "Get phase cards failed.",
+                    debug=debug,
+                    resource_kind="phase",
+                    resource_id=phase_id_str,
+                )
+            phase_payload = normalize_phase_cards_list(raw)
+            if phase_payload is None:
+                return build_pipe_tool_error_payload(
+                    message=f"Phase {phase_id_str} not found or access denied.",
+                    code="NOT_FOUND",
+                )
+            if is_unified_envelope_enabled():
+                cards = (
+                    phase_payload.get("cards")
+                    if isinstance(phase_payload, dict)
+                    else None
+                )
+                page_info = (
+                    (cards or {}).get("pageInfo") if isinstance(cards, dict) else None
+                )
+                pagination = build_pagination_info(
+                    page_info=page_info,
+                    page_size=validated_first,
+                )
+                return tool_success(
+                    data=raw,
+                    message="Phase cards retrieved.",
+                    pagination=pagination,
+                )
+            return raw
 
         @mcp.tool(
             annotations=ToolAnnotations(
@@ -887,7 +1066,8 @@ class PipeConfigTools:
             Args:
                 pipe_id: Pipe that will receive the label.
                 name: Label name.
-                color: Label color (per Pipefy/API).
+                color: Label color as hex ``#RRGGBB`` (e.g. ``#E50000``, ``#FF0000``);
+                    color names such as ``red`` are rejected before GraphQL.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             pipe_id, err = validate_tool_id(pipe_id, "pipe_id")
@@ -904,10 +1084,17 @@ class PipeConfigTools:
                     code="INVALID_ARGUMENTS",
                 )
             try:
+                normalized_color = normalize_label_color(color)
+            except ValueError as exc:
+                return build_pipe_tool_error_payload(
+                    message=str(exc),
+                    code="INVALID_ARGUMENTS",
+                )
+            try:
                 raw = await client.create_label(
                     pipe_id,
                     name.strip(),
-                    color.strip(),
+                    normalized_color,
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
@@ -944,7 +1131,8 @@ class PipeConfigTools:
             Args:
                 label_id: Label ID to update.
                 name: New label name (non-empty).
-                color: New label color, hex string (non-empty).
+                color: New label color as hex ``#RRGGBB`` (e.g. ``#E50000``); color
+                    names are rejected before GraphQL.
                 extra_input: Additional UpdateLabelInput fields, if any.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
@@ -961,13 +1149,20 @@ class PipeConfigTools:
                     message="Invalid 'color': provide a non-empty string.",
                     code="INVALID_ARGUMENTS",
                 )
+            try:
+                normalized_color = normalize_label_color(color)
+            except ValueError as exc:
+                return build_pipe_tool_error_payload(
+                    message=str(exc),
+                    code="INVALID_ARGUMENTS",
+                )
             update_attrs: dict[str, Any] = {
                 k: v
                 for k, v in (extra_input or {}).items()
                 if k not in _UPDATE_LABEL_EXTRA_RESERVED
             }
             update_attrs["name"] = name.strip()
-            update_attrs["color"] = color.strip()
+            update_attrs["color"] = normalized_color
             try:
                 raw = await client.update_label(label_id, **update_attrs)
             except Exception as exc:  # noqa: BLE001

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_config_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_config_tools.py
@@ -421,7 +421,9 @@ class PipeConfigTools:
             to list or verify inventory when the count looks wrong.
 
             Args:
-                phase_id: Phase ID. Discover via: ``get_pipe(pipe_id).phases[].id``.
+                phase_id: Phase ID. Discover via: ``get_pipe(pipe_id).phases[].id``
+                    for workflow phases, or ``get_pipe(pipe_id).start_form_phase.id``
+                    for the start-form phase.
                 debug: When True, append GraphQL codes and correlation_id to errors.
 
             Returns:
@@ -465,7 +467,9 @@ class PipeConfigTools:
             use ``get_phase_cards_count`` (see start-form ``cards_count`` caveat there).
 
             Args:
-                phase_id: Phase ID. Discover via: ``get_pipe(pipe_id).phases[].id``.
+                phase_id: Phase ID. Discover via: ``get_pipe(pipe_id).phases[].id``
+                    for workflow phases, or ``get_pipe(pipe_id).start_form_phase.id``
+                    for the start-form phase.
                 first: Max cards per page (1-500). Default 50.
                 after: Cursor from ``pageInfo.endCursor`` of a previous call.
                 include_fields: When True, include each card's custom fields.
@@ -503,14 +507,8 @@ class PipeConfigTools:
                     code="NOT_FOUND",
                 )
             if is_unified_envelope_enabled():
-                cards = (
-                    phase_payload.get("cards")
-                    if isinstance(phase_payload, dict)
-                    else None
-                )
-                page_info = (
-                    (cards or {}).get("pageInfo") if isinstance(cards, dict) else None
-                )
+                cards = phase_payload.get("cards") or {}
+                page_info = cards.get("pageInfo") if isinstance(cards, dict) else None
                 pagination = build_pagination_info(
                     page_info=page_info,
                     page_size=validated_first,

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_tool_helpers.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_tool_helpers.py
@@ -444,6 +444,20 @@ def _filter_fields_by_definitions(
     }
 
 
+def _merge_phase_and_start_form_field_values(
+    fields: dict[str, object] | None,
+    *,
+    phase_field_definitions: list[dict],
+    start_form_field_definitions: list[dict],
+) -> dict[str, object]:
+    """Filter ``fields`` against phase and start-form defs; keep both subsets."""
+    start_form_values = _filter_fields_by_definitions(
+        fields, start_form_field_definitions
+    )
+    phase_values = _filter_fields_by_definitions(fields, phase_field_definitions)
+    return {**start_form_values, **phase_values}
+
+
 def map_delete_card_error_to_message(
     *, card_id: str | int, card_title: str, codes: list[str]
 ) -> str:

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_tool_helpers.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_tool_helpers.py
@@ -450,7 +450,6 @@ def _merge_phase_and_start_form_field_values(
     phase_field_definitions: list[dict],
     start_form_field_definitions: list[dict],
 ) -> dict[str, object]:
-    """Filter ``fields`` against phase and start-form defs; keep both subsets."""
     start_form_values = _filter_fields_by_definitions(
         fields, start_form_field_definitions
     )

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
@@ -45,6 +45,7 @@ from pipefy_mcp.tools.pipe_tool_helpers import (
     UserCancelledError,
     _filter_editable_field_definitions,
     _filter_fields_by_definitions,
+    _merge_phase_and_start_form_field_values,
     build_add_card_comment_error_payload,
     build_add_card_comment_success_payload,
     build_delete_card_error_payload,
@@ -93,26 +94,35 @@ class PipeTools:
             fields: dict[str, Any] | None = None,
             required_fields_only: bool = False,
             skip_elicitation: bool = False,
+            phase_id: PipefyId | None = None,
         ) -> dict:
             """Create a card in the pipe.
 
             When ``skip_elicitation`` is True, field values from ``fields`` are
-            filtered to editable start-form field IDs and sent directly to the
-            API — no interactive form is shown. AI agents should set this to
-            True when they already know the field values.
+            filtered to editable field IDs and sent directly to the API — no
+            interactive form is shown. AI agents should set this to True when
+            they already know the field values.
 
             When ``skip_elicitation`` is False (default) and the client supports
             elicitation, an interactive form is presented even if ``fields``
             carries pre-filled values — the human can review and adjust them.
 
-            Discover fields first via ``get_start_form_fields`` and pass all
-            required values.
+            Without ``phase_id``, discover start-form fields via
+            ``get_start_form_fields`` and pass all required values.
 
-            The Pipefy ``createCard`` mutation does not accept a title directly.
-            If ``title`` is provided, the card is created first and then updated
-            via ``updateCard`` to set the title — this is especially useful when the
-            pipe has no start-form fields, which would otherwise leave the card
-            titled "Draft".
+            With ``phase_id``, the card is created in that phase (including orphan
+            phases that are not the start form). Use ``get_pipe(pipe_id).phases[].id``
+            to discover phase IDs. For agent seeding in a specific phase, set
+            ``phase_id`` and ``skip_elicitation=true``. When ``fields`` is non-empty,
+            keys are filtered against ``get_phase_fields(phase_id)`` and
+            ``get_start_form_fields(pipe_id)`` so pipes that still require start-form
+            values on ``CreateCardInput`` receive them alongside phase fields.
+
+            Before ``move_card_to_phase``, call ``get_phase_allowed_move_targets`` on
+            the card's current phase; transition rules are UI-only (Pipe settings ->
+            Phase -> Connections).
+
+            ``title`` is sent on ``CreateCardInput`` when provided.
 
             When the pipe uses Pipefy's default of deriving the card title from the
             first text-like start-form field, a later ``update_card_field`` on that
@@ -121,48 +131,114 @@ class PipeTools:
 
             Args:
                 pipe_id: The ID of the pipe where the card will be created.
-                title: Optional card title. Applied via updateCard after creation.
+                    Discover via: ``search_pipes`` or ``get_organization``.
+                title: Optional card title. Passed on CreateCardInput when set.
                 fields: A dictionary of fields that can be pre-filled on the card.
                     When ``skip_elicitation`` is False, these pre-fill the interactive
                     form. When True, they are sent directly to the API.
                 required_fields_only: If True, only elicit required fields. Default: False.
                 skip_elicitation: When True, bypass interactive elicitation and send
                     ``fields`` directly to the API. Recommended for AI agent workflows.
+                phase_id: Optional target phase ID. Skips start-form elicitation; when
+                    ``fields`` is non-empty, validates against phase and start-form
+                    field definitions. Discover via: ``get_pipe(pipe_id).phases[].id``.
             """
-            try:
-                form_fields = await client.get_start_form_fields(
-                    pipe_id, required_fields_only
-                )
-            except MalformedFieldDefinitionError as exc:
-                return tool_error(str(exc))
-
-            expected_fields = _filter_editable_field_definitions(
-                form_fields.get("start_form_fields", [])
-            )
-
-            await ctx.debug(f"Expected fields for pipe {pipe_id}: {expected_fields}")
-            await ctx.debug(f"Provided fields: {fields}")
-
             card_data = fields or {}
             can_elicit = supports_elicitation(ctx)
 
-            if can_elicit and not skip_elicitation:
+            if phase_id is not None:
+                expected_fields: list[dict] = []
+                start_form_expected_fields: list[dict] = []
+                if fields:
+                    try:
+                        phase_fields_result = await client.get_phase_fields(
+                            phase_id, required_fields_only
+                        )
+                    except MalformedFieldDefinitionError as exc:
+                        return tool_error(str(exc))
+                    expected_fields = _filter_editable_field_definitions(
+                        phase_fields_result.get("fields", [])
+                    )
+                    try:
+                        form_fields = await client.get_start_form_fields(
+                            pipe_id, required_fields_only
+                        )
+                    except MalformedFieldDefinitionError as exc:
+                        return tool_error(str(exc))
+                    start_form_expected_fields = _filter_editable_field_definitions(
+                        form_fields.get("start_form_fields", [])
+                    )
+                await ctx.debug(
+                    f"Expected fields for phase {phase_id}: {expected_fields}"
+                )
+                await ctx.debug(
+                    f"Expected start-form fields for pipe {pipe_id}: "
+                    f"{start_form_expected_fields}"
+                )
+                await ctx.debug(f"Provided fields: {fields}")
+
+                if can_elicit and expected_fields and not skip_elicitation:
+                    try:
+                        card_data = await PipeTools._elicit_field_details(
+                            message=(
+                                f"Creating a card in phase {phase_id} (pipe {pipe_id})"
+                            ),
+                            prefilled_fields=fields,
+                            expected_fields=expected_fields,
+                            ctx=ctx,
+                        )
+                    except MalformedFieldDefinitionError as exc:
+                        return tool_error(str(exc))
+                    except UserCancelledError:
+                        return tool_error("Card creation cancelled by user.")
+                elif expected_fields or start_form_expected_fields:
+                    card_data = _merge_phase_and_start_form_field_values(
+                        card_data,
+                        phase_field_definitions=expected_fields,
+                        start_form_field_definitions=start_form_expected_fields,
+                    )
+            else:
                 try:
-                    card_data = await PipeTools._elicit_field_details(
-                        message=f"Creating a card in pipe {pipe_id}",
-                        prefilled_fields=fields,
-                        expected_fields=expected_fields,
-                        ctx=ctx,
+                    form_fields = await client.get_start_form_fields(
+                        pipe_id, required_fields_only
                     )
                 except MalformedFieldDefinitionError as exc:
                     return tool_error(str(exc))
-                except UserCancelledError:
-                    return tool_error("Card creation cancelled by user.")
-            elif expected_fields:
-                card_data = _filter_fields_by_definitions(card_data, expected_fields)
+
+                expected_fields = _filter_editable_field_definitions(
+                    form_fields.get("start_form_fields", [])
+                )
+
+                await ctx.debug(
+                    f"Expected fields for pipe {pipe_id}: {expected_fields}"
+                )
+                await ctx.debug(f"Provided fields: {fields}")
+
+                if can_elicit and not skip_elicitation:
+                    try:
+                        card_data = await PipeTools._elicit_field_details(
+                            message=f"Creating a card in pipe {pipe_id}",
+                            prefilled_fields=fields,
+                            expected_fields=expected_fields,
+                            ctx=ctx,
+                        )
+                    except MalformedFieldDefinitionError as exc:
+                        return tool_error(str(exc))
+                    except UserCancelledError:
+                        return tool_error("Card creation cancelled by user.")
+                elif expected_fields:
+                    card_data = _filter_fields_by_definitions(
+                        card_data, expected_fields
+                    )
+
+            create_kwargs: dict[str, Any] = {}
+            if phase_id is not None:
+                create_kwargs["phase_id"] = phase_id
+            if title:
+                create_kwargs["title"] = title
 
             try:
-                result = await client.create_card(pipe_id, card_data)
+                result = await client.create_card(pipe_id, card_data, **create_kwargs)
             except Exception as exc:  # noqa: BLE001
                 perm_msg = await enrich_permission_denied_error(
                     exc, [str(pipe_id)], client
@@ -174,16 +250,15 @@ class PipeTools:
             card_id = result.get("createCard", {}).get("card", {}).get("id")
             if card_id:
                 if title:
-                    try:
-                        await client.update_card(card_id, title=title)
-                    except Exception as exc:  # noqa: BLE001
-                        result["title_warning"] = (
-                            f"Card created but title update failed: {exc}"
-                        )
-                    else:
-                        card_data_node = result.get("createCard", {}).get("card")
-                        if card_data_node is not None:
-                            card_data_node["title"] = title
+                    card_data_node = result.get("createCard", {}).get("card")
+                    if card_data_node is not None:
+                        if card_data_node.get("title") != title:
+                            result["title_warning"] = (
+                                "Card created but title was not applied as expected "
+                                f"(response title={card_data_node.get('title')!r}, "
+                                f"requested={title!r})."
+                            )
+                        card_data_node["title"] = title
                 card_url = f"https://app.pipefy.com/open-cards/{card_id}"
                 result["card_link"] = f"[{card_url}]({card_url})"
             return result
@@ -659,7 +734,13 @@ class PipeTools:
 
             Returns:
                 dict: GraphQL response containing a ``pipe`` object with ``id``, ``name``,
-                ``phases``, ``labels``, ``start_form_fields``, and related metadata from the API.
+                ``phases`` (workflow phases only; each includes ``cards_count``),
+                ``start_form_phase`` (``id``, ``name``, ``cards_count`` when
+                ``startFormPhaseId`` is set — not duplicated in ``phases``),
+                ``labels``, ``start_form_fields``, and related metadata from the API.
+
+                Start-form ``cards_count`` may be 0 while cards still exist; use
+                ``get_phase_cards`` for a full list in that phase.
             """
             await ctx.debug(f"get_pipe: pipe_id={pipe_id}")
             pipe_id_str, err = validate_tool_id(pipe_id, "pipe_id")
@@ -775,16 +856,16 @@ class PipeTools:
         ) -> dict:
             """Move a card to a target phase (Kanban column) within the same pipe.
 
-            Use this when the workflow should advance or regress a card; pair with ``get_pipe``
-            or ``get_card`` to resolve valid phase IDs. On failure, if the destination is not
-            among ``cards_can_be_moved_to_phases`` for the card's current phase, the tool may
+            Use this when the workflow should advance or regress a card. On failure, if the
+            destination is not among allowed targets for the card's current phase, the tool may
             return ``success: false`` with ``valid_destinations`` instead of only the raw API error.
 
             Args:
                 card_id: The card to move.
                     Discover via: ``find_cards`` or ``get_cards(pipe_id)``.
                 destination_phase_id: Target phase ID (must be allowed for the current phase).
-                    Discover via: ``get_pipe(pipe_id).phases[].id``.
+                    Discover via: ``get_phase_allowed_move_targets(current_phase_id)`` where
+                    ``current_phase_id`` comes from ``get_card(card_id).current_phase.id``.
 
             Returns:
                 dict: Pipefy move mutation response on success. On some validation failures,

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
@@ -111,8 +111,9 @@ class PipeTools:
             ``get_start_form_fields`` and pass all required values.
 
             With ``phase_id``, the card is created in that phase (including orphan
-            phases that are not the start form). Use ``get_pipe(pipe_id).phases[].id``
-            to discover phase IDs. For agent seeding in a specific phase, set
+            phases that are not the start form). Discover via:
+            ``get_pipe(pipe_id).phases[].id`` or ``get_pipe(pipe_id).start_form_phase.id``.
+            For agent seeding in a specific phase, set
             ``phase_id`` and ``skip_elicitation=true``. When ``fields`` is non-empty,
             keys are filtered against ``get_phase_fields(phase_id)`` and
             ``get_start_form_fields(pipe_id)`` so pipes that still require start-form
@@ -141,12 +142,17 @@ class PipeTools:
                     ``fields`` directly to the API. Recommended for AI agent workflows.
                 phase_id: Optional target phase ID. Skips start-form elicitation; when
                     ``fields`` is non-empty, validates against phase and start-form
-                    field definitions. Discover via: ``get_pipe(pipe_id).phases[].id``.
+                    field definitions. Discover via: ``get_pipe(pipe_id).phases[].id``
+                    or ``get_pipe(pipe_id).start_form_phase.id``.
             """
             card_data = fields or {}
             can_elicit = supports_elicitation(ctx)
 
             if phase_id is not None:
+                phase_id_str, phase_err = validate_tool_id(phase_id, "phase_id")
+                if phase_err is not None:
+                    return phase_err
+                phase_id = phase_id_str
                 expected_fields: list[dict] = []
                 start_form_expected_fields: list[dict] = []
                 if fields:
@@ -258,7 +264,6 @@ class PipeTools:
                                 f"(response title={card_data_node.get('title')!r}, "
                                 f"requested={title!r})."
                             )
-                        card_data_node["title"] = title
                 card_url = f"https://app.pipefy.com/open-cards/{card_id}"
                 result["card_link"] = f"[{card_url}]({card_url})"
             return result

--- a/packages/mcp/src/pipefy_mcp/tools/registry.py
+++ b/packages/mcp/src/pipefy_mcp/tools/registry.py
@@ -20,6 +20,7 @@ from pipefy_mcp.tools.report_tools import ReportTools
 from pipefy_mcp.tools.table_tools import TableTools
 from pipefy_mcp.tools.webhook_tools import WebhookTools
 
+# 152 tools — keep in sync with docs/parity.md row count and README MCP totals.
 PIPEFY_TOOL_NAMES = frozenset(
     {
         "add_card_comment",
@@ -108,6 +109,9 @@ PIPEFY_TOOL_NAMES = frozenset(
         "get_organization_report",
         "get_organization_report_export",
         "get_organization_reports",
+        "get_phase_allowed_move_targets",
+        "get_phase_cards",
+        "get_phase_cards_count",
         "get_phase_fields",
         "get_portal",
         "get_pipe",

--- a/packages/mcp/src/pipefy_mcp/tools/report_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/report_tools.py
@@ -8,6 +8,7 @@ from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
 from mcp.types import ToolAnnotations
 from pipefy_sdk import PipefyClient, PipefyId
+from pipefy_sdk.report_filter_preflight import validate_report_cards_filter
 
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.pagination_helpers import (
@@ -32,6 +33,16 @@ def _blank_field_error(value: str, field: str) -> dict[str, Any] | None:
     if not value.strip():
         return build_report_error_payload(message=f"'{field}' must be non-empty.")
     return None
+
+
+def _report_filter_preflight_error(
+    filter_obj: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Return an error payload when ``filter_obj`` fails ReportCardsFilter validation."""
+    message = validate_report_cards_filter(filter_obj)
+    if message is None:
+        return None
+    return build_report_error_payload(message=message)
 
 
 class ReportTools:
@@ -378,6 +389,13 @@ class ReportTools:
         ) -> dict[str, Any]:
             """Create a pipe report. Use column `name` in `fields`; filter field names from `get_pipe_report_filterable_fields`.
 
+            Do not pass a top-level ``current_phase`` key on ``filter`` — use nested
+            ``operator`` + ``queries`` (ReportCardsFilter). Example phase filter::
+
+                {"operator": "and", "queries": [{"field": "current_phase", "operator": "eq", "type": "select", "value": "<phase_id>"}]}
+
+            Discover the exact ``field`` string per pipe via ``get_pipe_report_filterable_fields``.
+
             Args:
                 pipe_id: Pipe ID (numeric string).
                 name: Report name.
@@ -390,6 +408,9 @@ class ReportTools:
             if err is not None:
                 return err
             err = _blank_field_error(name, "name")
+            if err is not None:
+                return err
+            err = _report_filter_preflight_error(filter)
             if err is not None:
                 return err
             try:
@@ -424,6 +445,9 @@ class ReportTools:
         ) -> dict[str, Any]:
             """Update a pipe report; omitted parameters are unchanged.
 
+            ``filter`` uses the same ReportCardsFilter nested shape as ``create_pipe_report``
+            (``operator`` + ``queries``; no top-level ``current_phase`` list).
+
             Args:
                 report_id: Pipe report ID.
                 name: New report name.
@@ -435,6 +459,9 @@ class ReportTools:
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             err = _blank_field_error(report_id, "report_id")
+            if err is not None:
+                return err
+            err = _report_filter_preflight_error(filter)
             if err is not None:
                 return err
             try:

--- a/packages/mcp/src/pipefy_mcp/tools/report_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/report_tools.py
@@ -38,7 +38,6 @@ def _blank_field_error(value: str, field: str) -> dict[str, Any] | None:
 def _report_filter_preflight_error(
     filter_obj: dict[str, Any] | None,
 ) -> dict[str, Any] | None:
-    """Return an error payload when ``filter_obj`` fails ReportCardsFilter validation."""
     message = validate_report_cards_filter(filter_obj)
     if message is None:
         return None
@@ -389,12 +388,9 @@ class ReportTools:
         ) -> dict[str, Any]:
             """Create a pipe report. Use column `name` in `fields`; filter field names from `get_pipe_report_filterable_fields`.
 
-            Do not pass a top-level ``current_phase`` key on ``filter`` — use nested
-            ``operator`` + ``queries`` (ReportCardsFilter). Example phase filter::
-
-                {"operator": "and", "queries": [{"field": "current_phase", "operator": "eq", "type": "select", "value": "<phase_id>"}]}
-
-            Discover the exact ``field`` string per pipe via ``get_pipe_report_filterable_fields``.
+            ``filter`` must use ReportCardsFilter shape (``operator`` + ``queries``), not a
+            top-level ``current_phase`` key; discover field names via
+            ``get_pipe_report_filterable_fields``.
 
             Args:
                 pipe_id: Pipe ID (numeric string).
@@ -564,6 +560,9 @@ class ReportTools:
             err = _blank_field_error(name, "name")
             if err is not None:
                 return err
+            err = _report_filter_preflight_error(filter)
+            if err is not None:
+                return err
             if not pipe_ids or not isinstance(pipe_ids, list):
                 return build_report_error_payload(
                     message="'pipe_ids' must be a non-empty list.",
@@ -609,6 +608,9 @@ class ReportTools:
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             err = _blank_field_error(report_id, "report_id")
+            if err is not None:
+                return err
+            err = _report_filter_preflight_error(filter)
             if err is not None:
                 return err
             try:
@@ -710,6 +712,9 @@ class ReportTools:
             err = _blank_field_error(pipe_report_id, "pipe_report_id")
             if err is not None:
                 return err
+            err = _report_filter_preflight_error(filter)
+            if err is not None:
+                return err
             try:
                 raw = await client.export_pipe_report(
                     pipe_id,
@@ -756,6 +761,9 @@ class ReportTools:
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             organization_id, err = validate_tool_id(organization_id, "organization_id")
+            if err is not None:
+                return err
+            err = _report_filter_preflight_error(filter)
             if err is not None:
                 return err
             try:

--- a/packages/mcp/tests/tools/test_docstring_discovery_hints.py
+++ b/packages/mcp/tests/tools/test_docstring_discovery_hints.py
@@ -54,7 +54,27 @@ AUDIT: list[tuple[str, str, list[str]]] = [
         "automation_tools.py",
         ["get_automation", "create_automation"],
     ),
-    ("move_card_to_phase", "pipe_tools.py", ["get_pipe"]),
+    ("move_card_to_phase", "pipe_tools.py", ["get_phase_allowed_move_targets"]),
+    (
+        "create_card",
+        "pipe_tools.py",
+        ["get_pipe", "get_phase_allowed_move_targets"],
+    ),
+    (
+        "get_phase_allowed_move_targets",
+        "pipe_config_tools.py",
+        ["get_card", "get_pipe"],
+    ),
+    (
+        "get_phase_cards_count",
+        "pipe_config_tools.py",
+        ["get_pipe", "get_phase_cards"],
+    ),
+    (
+        "get_phase_cards",
+        "pipe_config_tools.py",
+        ["get_pipe", "get_phase_cards_count"],
+    ),
     ("create_phase_field", "pipe_config_tools.py", ["get_pipe"]),
     ("update_phase_field", "pipe_config_tools.py", ["get_phase_fields"]),
     ("delete_phase_field", "pipe_config_tools.py", ["get_phase_fields"]),

--- a/packages/mcp/tests/tools/test_pipe_config_tools.py
+++ b/packages/mcp/tests/tools/test_pipe_config_tools.py
@@ -1859,7 +1859,7 @@ async def test_label_color_rejects_non_hex_before_graphql__no_integration(
     payload = extract_payload(result)
     assert payload["success"] is False
     assert payload["error"]["code"] == "INVALID_ARGUMENTS"
-    assert "expected #RRGGBB, received" in tool_error_message(payload)
+    assert "expected #RGB or #RRGGBB" in tool_error_message(payload)
 
 
 @pytest.mark.anyio

--- a/packages/mcp/tests/tools/test_pipe_config_tools.py
+++ b/packages/mcp/tests/tools/test_pipe_config_tools.py
@@ -20,6 +20,8 @@ from pipefy_mcp.tools.pipe_config_tool_helpers import (
     build_field_condition_delete_payload,
     build_field_condition_success_payload,
     field_condition_phase_field_id_looks_like_slug,
+    normalize_phase_allowed_move_targets,
+    normalize_phase_cards_list,
 )
 from pipefy_mcp.tools.pipe_config_tools import PipeConfigTools
 from pipefy_mcp.tools.tool_error_envelope import tool_error, tool_error_message
@@ -83,7 +85,10 @@ def mock_pipe_config_client():
     client.update_label = AsyncMock()
     client.delete_label = AsyncMock()
     client.get_cards = AsyncMock()
+    client.get_phase_allowed_move_targets = AsyncMock()
     client.get_phase_cards_count = AsyncMock()
+    client.get_phase_cards_count_payload = AsyncMock()
+    client.get_phase_cards = AsyncMock()
     client.create_field_condition = AsyncMock()
     client.update_field_condition = AsyncMock()
     client.delete_field_condition = AsyncMock()
@@ -1139,16 +1144,16 @@ async def test_create_label_success(
     pipe_config_session, mock_pipe_config_client, extract_payload
 ):
     mock_pipe_config_client.create_label.return_value = {
-        "createLabel": {"label": {"id": "1", "name": "Bug", "color": "red"}},
+        "createLabel": {"label": {"id": "1", "name": "Bug", "color": "#FF0000"}},
     }
 
     async with pipe_config_session as session:
         result = await session.call_tool(
             "create_label",
-            {"pipe_id": 2, "name": "Bug", "color": "red"},
+            {"pipe_id": 2, "name": "Bug", "color": "#FF0000"},
         )
 
-    mock_pipe_config_client.create_label.assert_awaited_once_with("2", "Bug", "red")
+    mock_pipe_config_client.create_label.assert_awaited_once_with("2", "Bug", "#FF0000")
     assert extract_payload(result)["success"] is True
 
 
@@ -1158,17 +1163,17 @@ async def test_update_label_success(
     pipe_config_session, mock_pipe_config_client, extract_payload
 ):
     mock_pipe_config_client.update_label.return_value = {
-        "updateLabel": {"label": {"id": "3", "name": "Story", "color": "blue"}},
+        "updateLabel": {"label": {"id": "3", "name": "Story", "color": "#0000FF"}},
     }
 
     async with pipe_config_session as session:
         result = await session.call_tool(
             "update_label",
-            {"label_id": 3, "name": "Story", "color": "blue"},
+            {"label_id": 3, "name": "Story", "color": "#0000FF"},
         )
 
     mock_pipe_config_client.update_label.assert_awaited_once_with(
-        "3", name="Story", color="blue"
+        "3", name="Story", color="#0000FF"
     )
     assert extract_payload(result)["success"] is True
 
@@ -1179,7 +1184,7 @@ async def test_update_label_strips_id_from_extra_input__no_integration(
     pipe_config_session, mock_pipe_config_client, extract_payload
 ):
     mock_pipe_config_client.update_label.return_value = {
-        "updateLabel": {"label": {"id": "3", "name": "X", "color": "blue"}},
+        "updateLabel": {"label": {"id": "3", "name": "X", "color": "#0000FF"}},
     }
     async with pipe_config_session as session:
         result = await session.call_tool(
@@ -1187,14 +1192,14 @@ async def test_update_label_strips_id_from_extra_input__no_integration(
             {
                 "label_id": 3,
                 "name": "X",
-                "color": "blue",
+                "color": "#0000FF",
                 "extra_input": {"id": 999},
             },
         )
     mock_pipe_config_client.update_label.assert_awaited_once_with(
         "3",
         name="X",
-        color="blue",
+        color="#0000FF",
     )
     assert extract_payload(result)["success"] is True
 
@@ -1721,7 +1726,7 @@ async def test_create_label_graphql_error_returns_failure__no_integration(
     async with pipe_config_session as session:
         result = await session.call_tool(
             "create_label",
-            {"pipe_id": 2, "name": "Bug", "color": "red"},
+            {"pipe_id": 2, "name": "Bug", "color": "#FF0000"},
         )
     payload = extract_payload(result)
     assert payload["success"] is False
@@ -1740,7 +1745,7 @@ async def test_update_label_graphql_error_returns_failure__no_integration(
     async with pipe_config_session as session:
         result = await session.call_tool(
             "update_label",
-            {"label_id": 3, "name": "Story", "color": "blue"},
+            {"label_id": 3, "name": "Story", "color": "#0000FF"},
         )
     payload = extract_payload(result)
     assert payload["success"] is False
@@ -1823,6 +1828,38 @@ async def test_create_label_rejects_blank_color__no_integration(
         )
     mock_pipe_config_client.create_label.assert_not_called()
     assert extract_payload(result)["success"] is False
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("tool_name", "arguments"),
+    [
+        (
+            "create_label",
+            {"pipe_id": 2, "name": "Bug", "color": "red"},
+        ),
+        (
+            "update_label",
+            {"label_id": 3, "name": "Story", "color": "blue"},
+        ),
+    ],
+)
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_label_color_rejects_non_hex_before_graphql__no_integration(
+    pipe_config_session,
+    mock_pipe_config_client,
+    extract_payload,
+    tool_name: str,
+    arguments: dict[str, object],
+):
+    async with pipe_config_session as session:
+        result = await session.call_tool(tool_name, arguments)
+    mock_pipe_config_client.create_label.assert_not_called()
+    mock_pipe_config_client.update_label.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert payload["error"]["code"] == "INVALID_ARGUMENTS"
+    assert "expected #RRGGBB, received" in tool_error_message(payload)
 
 
 @pytest.mark.anyio
@@ -2433,6 +2470,319 @@ async def test_delete_field_condition_error(
     payload = extract_payload(result)
     assert payload["success"] is False
     assert "Forbidden" in tool_error_message(payload)
+
+
+@pytest.mark.unit
+def test_normalize_phase_allowed_move_targets__no_integration():
+    raw = {
+        "phase": {
+            "id": "100",
+            "name": "Doing",
+            "cards_can_be_moved_to_phases": [
+                {"id": "200", "name": "Done"},
+                {"id": "201", "name": "Blocked"},
+            ],
+        }
+    }
+    assert normalize_phase_allowed_move_targets(raw) == {
+        "phase_id": "100",
+        "phase_name": "Doing",
+        "allowed_phases": [
+            {"id": "200", "name": "Done"},
+            {"id": "201", "name": "Blocked"},
+        ],
+    }
+
+
+@pytest.mark.unit
+def test_normalize_phase_allowed_move_targets_missing_phase__no_integration():
+    assert normalize_phase_allowed_move_targets({}) is None
+    assert normalize_phase_allowed_move_targets({"phase": None}) is None
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_get_phase_allowed_move_targets_success(
+    pipe_config_session, mock_pipe_config_client, extract_payload
+):
+    phase_id = 342182335
+    mock_pipe_config_client.get_phase_allowed_move_targets.return_value = {
+        "phase": {
+            "id": str(phase_id),
+            "name": "Doing",
+            "cards_can_be_moved_to_phases": [{"id": "200", "name": "Done"}],
+        }
+    }
+
+    async with pipe_config_session as session:
+        result = await session.call_tool(
+            "get_phase_allowed_move_targets",
+            {"phase_id": phase_id},
+        )
+
+    assert result.isError is False
+    mock_pipe_config_client.get_phase_allowed_move_targets.assert_awaited_once_with(
+        str(phase_id)
+    )
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    assert payload["data"] == {
+        "phase_id": str(phase_id),
+        "phase_name": "Doing",
+        "allowed_phases": [{"id": "200", "name": "Done"}],
+    }
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+@pytest.mark.parametrize("invalid_phase_id", [0, -1])
+async def test_get_phase_allowed_move_targets_rejects_invalid_phase_id(
+    pipe_config_session,
+    mock_pipe_config_client,
+    extract_payload,
+    invalid_phase_id,
+):
+    async with pipe_config_session as session:
+        result = await session.call_tool(
+            "get_phase_allowed_move_targets",
+            {"phase_id": invalid_phase_id},
+        )
+    mock_pipe_config_client.get_phase_allowed_move_targets.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_get_phase_allowed_move_targets_not_found(
+    pipe_config_session, mock_pipe_config_client, extract_payload
+):
+    mock_pipe_config_client.get_phase_allowed_move_targets.return_value = {
+        "phase": None
+    }
+
+    async with pipe_config_session as session:
+        result = await session.call_tool(
+            "get_phase_allowed_move_targets",
+            {"phase_id": 999},
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "not found" in tool_error_message(payload).lower()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_get_phase_allowed_move_targets_graphql_error(
+    pipe_config_session, mock_pipe_config_client, extract_payload
+):
+    mock_pipe_config_client.get_phase_allowed_move_targets.side_effect = (
+        TransportQueryError(
+            "GraphQL Error",
+            errors=[{"message": "Forbidden"}],
+        )
+    )
+
+    async with pipe_config_session as session:
+        result = await session.call_tool(
+            "get_phase_allowed_move_targets",
+            {"phase_id": 55},
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "Forbidden" in tool_error_message(payload)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_get_phase_allowed_move_targets_read_only_hint(pipe_config_session):
+    async with pipe_config_session as session:
+        listed = await session.list_tools()
+    matching = [t for t in listed.tools if t.name == "get_phase_allowed_move_targets"]
+    assert len(matching) == 1
+    tool = matching[0]
+    assert tool.annotations is not None
+    assert tool.annotations.readOnlyHint is True
+
+
+@pytest.mark.unit
+def test_normalize_phase_cards_list__no_integration():
+    raw = {
+        "phase": {
+            "id": "100",
+            "cards": {"edges": [], "pageInfo": {"hasNextPage": False}},
+        }
+    }
+    assert normalize_phase_cards_list(raw) == raw["phase"]
+
+
+@pytest.mark.unit
+def test_normalize_phase_cards_list_missing_phase__no_integration():
+    assert normalize_phase_cards_list({}) is None
+    assert normalize_phase_cards_list({"phase": None}) is None
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_get_phase_cards_count_success(
+    pipe_config_session, mock_pipe_config_client, extract_payload
+):
+    phase_id = 342182335
+    mock_pipe_config_client.get_phase_cards_count_payload.return_value = {
+        "phase_id": str(phase_id),
+        "phase_name": "Doing",
+        "cards_count": 7,
+    }
+
+    async with pipe_config_session as session:
+        result = await session.call_tool(
+            "get_phase_cards_count",
+            {"phase_id": phase_id},
+        )
+
+    assert result.isError is False
+    mock_pipe_config_client.get_phase_cards_count_payload.assert_awaited_once_with(
+        str(phase_id)
+    )
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    assert payload["data"] == {
+        "phase_id": str(phase_id),
+        "phase_name": "Doing",
+        "cards_count": 7,
+    }
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+@pytest.mark.parametrize("invalid_phase_id", [0, -1])
+async def test_get_phase_cards_count_rejects_invalid_phase_id(
+    pipe_config_session,
+    mock_pipe_config_client,
+    extract_payload,
+    invalid_phase_id,
+):
+    async with pipe_config_session as session:
+        result = await session.call_tool(
+            "get_phase_cards_count",
+            {"phase_id": invalid_phase_id},
+        )
+    mock_pipe_config_client.get_phase_cards_count_payload.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_get_phase_cards_count_graphql_error(
+    pipe_config_session, mock_pipe_config_client, extract_payload
+):
+    mock_pipe_config_client.get_phase_cards_count_payload.side_effect = (
+        TransportQueryError(
+            "GraphQL Error",
+            errors=[{"message": "Forbidden"}],
+        )
+    )
+
+    async with pipe_config_session as session:
+        result = await session.call_tool(
+            "get_phase_cards_count",
+            {"phase_id": 55},
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "Forbidden" in tool_error_message(payload)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_get_phase_cards_success(
+    pipe_config_session,
+    mock_pipe_config_client,
+    extract_payload,
+    legacy_envelope,
+):
+    phase_id = 342182335
+    raw = {
+        "phase": {
+            "id": str(phase_id),
+            "cards": {
+                "edges": [{"node": {"id": "1", "title": "A"}}],
+                "pageInfo": {"hasNextPage": False, "endCursor": None},
+                "totalCount": 1,
+            },
+        }
+    }
+    mock_pipe_config_client.get_phase_cards.return_value = raw
+
+    async with pipe_config_session as session:
+        result = await session.call_tool(
+            "get_phase_cards",
+            {"phase_id": phase_id, "first": 50, "after": "cursor-1"},
+        )
+
+    assert result.isError is False
+    mock_pipe_config_client.get_phase_cards.assert_awaited_once_with(
+        str(phase_id),
+        first=50,
+        after="cursor-1",
+        include_fields=False,
+    )
+    payload = extract_payload(result)
+    assert payload == raw
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_get_phase_cards_not_found(
+    pipe_config_session, mock_pipe_config_client, extract_payload
+):
+    mock_pipe_config_client.get_phase_cards.return_value = {"phase": None}
+
+    async with pipe_config_session as session:
+        result = await session.call_tool(
+            "get_phase_cards",
+            {"phase_id": 999},
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "not found" in tool_error_message(payload).lower()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+@pytest.mark.parametrize("invalid_phase_id", [0, -1])
+async def test_get_phase_cards_rejects_invalid_phase_id(
+    pipe_config_session,
+    mock_pipe_config_client,
+    extract_payload,
+    invalid_phase_id,
+):
+    async with pipe_config_session as session:
+        result = await session.call_tool(
+            "get_phase_cards",
+            {"phase_id": invalid_phase_id},
+        )
+    mock_pipe_config_client.get_phase_cards.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_get_phase_cards_read_only_hint(pipe_config_session):
+    async with pipe_config_session as session:
+        listed = await session.list_tools()
+    for name in ("get_phase_cards_count", "get_phase_cards"):
+        matching = [t for t in listed.tools if t.name == name]
+        assert len(matching) == 1
+        tool = matching[0]
+        assert tool.annotations is not None
+        assert tool.annotations.readOnlyHint is True
 
 
 @pytest.mark.anyio

--- a/packages/mcp/tests/tools/test_pipe_tool_helpers.py
+++ b/packages/mcp/tests/tools/test_pipe_tool_helpers.py
@@ -23,6 +23,7 @@ from pipefy_mcp.tools.pipe_tool_helpers import (
     UserCancelledError,
     _filter_editable_field_definitions,
     _filter_fields_by_definitions,
+    _merge_phase_and_start_form_field_values,
     build_add_card_comment_error_payload,
     build_add_card_comment_success_payload,
     build_delete_card_error_payload,
@@ -476,6 +477,18 @@ def test_filter_fields_by_definitions_empty_returns_empty():
 
 
 @pytest.mark.unit
+def test_merge_phase_and_start_form_field_values_keeps_both_subsets():
+    defs_sf = [{"id": "sf1", "editable": True}]
+    defs_pf = [{"id": "pf1", "editable": True}]
+    fields = {"sf1": "a", "pf1": "b", "noise": "x"}
+    result = _merge_phase_and_start_form_field_values(
+        fields,
+        phase_field_definitions=defs_pf,
+        start_form_field_definitions=defs_sf,
+    )
+    assert result == {"sf1": "a", "pf1": "b"}
+
+
 def test_filter_fields_by_definitions_keeps_only_editable_ids():
     """Only field IDs present in definitions are kept."""
     fields = {"a": 1, "b": 2, "c": 3}

--- a/packages/mcp/tests/tools/test_pipe_tools.py
+++ b/packages/mcp/tests/tools/test_pipe_tools.py
@@ -351,18 +351,18 @@ class TestCreateCardTool:
             assert "card_link" in response
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
-    async def test_title_warning_when_response_lacks_title(
+    async def test_title_warning_when_response_title_mismatches(
         self,
         client_session,
         mock_pipefy_client,
         pipe_id,
     ):
-        """When create succeeds but response omits title, return title_warning."""
+        """When API stores a different title than requested, return title_warning."""
         mock_pipefy_client.get_start_form_fields.return_value = {
             "start_form_fields": []
         }
         mock_pipefy_client.create_card.return_value = {
-            "createCard": {"card": {"id": "789"}}
+            "createCard": {"card": {"id": "789", "title": "Derived from field"}}
         }
 
         async with client_session as session:
@@ -376,10 +376,35 @@ class TestCreateCardTool:
             )
             mock_pipefy_client.update_card.assert_not_called()
             response = json.loads(result.content[0].text)
-            assert response["createCard"]["card"]["title"] == "My Title"
+            assert response["createCard"]["card"]["title"] == "Derived from field"
             assert "title_warning" in response
             assert "not applied as expected" in response["title_warning"]
             assert "card_link" in response
+
+    @pytest.mark.parametrize("client_session", [None], indirect=True)
+    async def test_no_title_warning_when_response_matches(
+        self,
+        client_session,
+        mock_pipefy_client,
+        pipe_id,
+    ):
+        """Titled create with matching API title must not emit title_warning."""
+        mock_pipefy_client.get_start_form_fields.return_value = {
+            "start_form_fields": []
+        }
+        mock_pipefy_client.create_card.return_value = {
+            "createCard": {"card": {"id": "789", "title": "My Title"}}
+        }
+
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_card",
+                {"pipe_id": pipe_id, "title": "My Title"},
+            )
+            assert result.isError is False
+            response = json.loads(result.content[0].text)
+            assert response["createCard"]["card"]["title"] == "My Title"
+            assert "title_warning" not in response
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
     async def test_no_title_skips_update_card(
@@ -436,6 +461,29 @@ class TestCreateCardTool:
         payload = extract_payload(result)
         assert payload["success"] is False
         assert "invite_members" in tool_error_message(payload)
+
+    @pytest.mark.parametrize("client_session", [None], indirect=True)
+    @pytest.mark.parametrize("invalid_phase_id", [0, -1])
+    async def test_create_card_rejects_invalid_phase_id(
+        self,
+        client_session,
+        mock_pipefy_client,
+        pipe_id,
+        invalid_phase_id,
+        extract_payload,
+    ):
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_card",
+                {
+                    "pipe_id": pipe_id,
+                    "phase_id": invalid_phase_id,
+                    "skip_elicitation": True,
+                },
+            )
+        mock_pipefy_client.create_card.assert_not_called()
+        payload = extract_payload(result)
+        assert payload["success"] is False
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
     async def test_create_card_forwards_phase_id_with_skip_elicitation(

--- a/packages/mcp/tests/tools/test_pipe_tools.py
+++ b/packages/mcp/tests/tools/test_pipe_tools.py
@@ -322,21 +322,18 @@ class TestCreateCardTool:
             )
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
-    async def test_title_sets_card_title_after_creation(
+    async def test_title_passed_to_create_card_on_create_card_input(
         self,
         client_session,
         mock_pipefy_client,
         pipe_id,
     ):
-        """When title is provided, create_card calls update_card to set the title."""
+        """When title is provided, create_card passes title on CreateCardInput."""
         mock_pipefy_client.get_start_form_fields.return_value = {
             "start_form_fields": []
         }
         mock_pipefy_client.create_card.return_value = {
-            "createCard": {"card": {"id": "789"}}
-        }
-        mock_pipefy_client.update_card.return_value = {
-            "updateCard": {"card": {"id": "789", "title": "Copa América"}}
+            "createCard": {"card": {"id": "789", "title": "Copa América"}}
         }
 
         async with client_session as session:
@@ -345,30 +342,28 @@ class TestCreateCardTool:
                 {"pipe_id": pipe_id, "title": "Copa América"},
             )
             assert result.isError is False
-            mock_pipefy_client.create_card.assert_called_once_with(str(pipe_id), {})
-            mock_pipefy_client.update_card.assert_called_once_with(
-                "789", title="Copa América"
+            mock_pipefy_client.create_card.assert_called_once_with(
+                str(pipe_id), {}, title="Copa América"
             )
+            mock_pipefy_client.update_card.assert_not_called()
             response = json.loads(result.content[0].text)
             assert response["createCard"]["card"]["title"] == "Copa América"
             assert "card_link" in response
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
-    async def test_title_update_failure_returns_warning(
+    async def test_title_warning_when_response_lacks_title(
         self,
         client_session,
         mock_pipefy_client,
         pipe_id,
     ):
-        """When update_card raises after a successful create_card, the card result
-        is still returned with a title_warning and no title set."""
+        """When create succeeds but response omits title, return title_warning."""
         mock_pipefy_client.get_start_form_fields.return_value = {
             "start_form_fields": []
         }
         mock_pipefy_client.create_card.return_value = {
             "createCard": {"card": {"id": "789"}}
         }
-        mock_pipefy_client.update_card.side_effect = RuntimeError("API timeout")
 
         async with client_session as session:
             result = await session.call_tool(
@@ -376,14 +371,14 @@ class TestCreateCardTool:
                 {"pipe_id": pipe_id, "title": "My Title"},
             )
             assert result.isError is False
-            mock_pipefy_client.create_card.assert_called_once_with(str(pipe_id), {})
-            mock_pipefy_client.update_card.assert_called_once_with(
-                "789", title="My Title"
+            mock_pipefy_client.create_card.assert_called_once_with(
+                str(pipe_id), {}, title="My Title"
             )
+            mock_pipefy_client.update_card.assert_not_called()
             response = json.loads(result.content[0].text)
-            assert "title" not in response.get("createCard", {}).get("card", {})
+            assert response["createCard"]["card"]["title"] == "My Title"
             assert "title_warning" in response
-            assert "API timeout" in response["title_warning"]
+            assert "not applied as expected" in response["title_warning"]
             assert "card_link" in response
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
@@ -441,6 +436,167 @@ class TestCreateCardTool:
         payload = extract_payload(result)
         assert payload["success"] is False
         assert "invite_members" in tool_error_message(payload)
+
+    @pytest.mark.parametrize("client_session", [None], indirect=True)
+    async def test_create_card_forwards_phase_id_with_skip_elicitation(
+        self,
+        client_session,
+        mock_pipefy_client,
+        pipe_id,
+    ):
+        """create_card with phase_id and skip_elicitation forwards phase_id to SDK."""
+        phase_id = 987654321
+        mock_pipefy_client.get_start_form_fields.return_value = {
+            "start_form_fields": []
+        }
+        mock_pipefy_client.create_card.return_value = {
+            "createCard": {"card": {"id": "42"}}
+        }
+
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_card",
+                {
+                    "pipe_id": pipe_id,
+                    "phase_id": phase_id,
+                    "skip_elicitation": True,
+                },
+            )
+
+        assert result.isError is False
+        mock_pipefy_client.create_card.assert_called_once_with(
+            str(pipe_id), {}, phase_id=str(phase_id)
+        )
+
+    @pytest.mark.parametrize("client_session", [None], indirect=True)
+    async def test_create_card_with_phase_id_filters_fields_via_get_phase_fields(
+        self,
+        client_session,
+        mock_pipefy_client,
+        pipe_id,
+    ):
+        """When phase_id is set, field keys are filtered via phase and start-form defs."""
+        phase_id = 555666777
+        mock_pipefy_client.get_start_form_fields.return_value = {
+            "start_form_fields": [
+                {
+                    "id": "sf1",
+                    "label": "SF1",
+                    "type": "short_text",
+                    "editable": True,
+                },
+                {
+                    "id": "sf_readonly",
+                    "label": "SF RO",
+                    "type": "short_text",
+                    "editable": False,
+                },
+            ]
+        }
+        mock_pipefy_client.get_phase_fields = AsyncMock(
+            return_value={
+                "phase_id": str(phase_id),
+                "phase_name": "Orphan",
+                "fields": [
+                    {
+                        "id": "pf1",
+                        "label": "PF1",
+                        "type": "short_text",
+                        "editable": True,
+                    },
+                    {
+                        "id": "pf2",
+                        "label": "PF2",
+                        "type": "short_text",
+                        "editable": False,
+                    },
+                ],
+            }
+        )
+        mock_pipefy_client.create_card.return_value = {
+            "createCard": {"card": {"id": "99"}}
+        }
+
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_card",
+                {
+                    "pipe_id": pipe_id,
+                    "phase_id": phase_id,
+                    "fields": {"pf1": "ok", "pf2": "ignored"},
+                    "skip_elicitation": True,
+                },
+            )
+
+        assert result.isError is False
+        mock_pipefy_client.get_start_form_fields.assert_called_once_with(
+            str(pipe_id), False
+        )
+        mock_pipefy_client.get_phase_fields.assert_called_once_with(
+            str(phase_id), False
+        )
+        mock_pipefy_client.create_card.assert_called_once_with(
+            str(pipe_id), {"pf1": "ok"}, phase_id=str(phase_id)
+        )
+
+    @pytest.mark.parametrize("client_session", [None], indirect=True)
+    async def test_create_card_with_phase_id_keeps_start_form_and_phase_fields(
+        self,
+        client_session,
+        mock_pipefy_client,
+        pipe_id,
+    ):
+        """phase_id path must not drop start-form keys required by CreateCardInput."""
+        phase_id = 555666778
+        mock_pipefy_client.get_start_form_fields.return_value = {
+            "start_form_fields": [
+                {
+                    "id": "objetivo",
+                    "label": "Objetivo",
+                    "type": "long_text",
+                    "editable": True,
+                },
+            ]
+        }
+        mock_pipefy_client.get_phase_fields = AsyncMock(
+            return_value={
+                "phase_id": str(phase_id),
+                "phase_name": "Zona MCP",
+                "fields": [
+                    {
+                        "id": "flag_de_teste",
+                        "label": "Flag",
+                        "type": "checklist_vertical",
+                        "editable": True,
+                    },
+                ],
+            }
+        )
+        mock_pipefy_client.create_card.return_value = {
+            "createCard": {"card": {"id": "100"}}
+        }
+
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_card",
+                {
+                    "pipe_id": pipe_id,
+                    "phase_id": phase_id,
+                    "fields": {
+                        "objetivo": "Smoke",
+                        "flag_de_teste": "A",
+                        "unknown": "drop",
+                    },
+                    "skip_elicitation": True,
+                },
+            )
+
+        assert result.isError is False
+        mock_pipefy_client.create_card.assert_called_once_with(
+            str(pipe_id),
+            {"objetivo": "Smoke", "flag_de_teste": "A"},
+            phase_id=str(phase_id),
+        )
 
 
 @pytest.mark.anyio
@@ -592,6 +748,44 @@ class TestDirectToolCalls:
         mock_pipefy_client.get_pipe.assert_called_once_with(str(pipe_id))
         payload = extract_payload(result)
         assert payload["pipe"]["name"] == "My Pipe"
+
+    @pytest.mark.parametrize("client_session", [None], indirect=True)
+    async def test_get_pipe_returns_enriched_inventory_fields(
+        self, client_session, mock_pipefy_client, extract_payload
+    ):
+        """get_pipe surfaces SDK start_form_phase and per-phase cards_count."""
+        pipe_id = "306996634"
+        mock_pipefy_client.get_pipe = AsyncMock(
+            return_value={
+                "pipe": {
+                    "id": pipe_id,
+                    "name": "Inventory Pipe",
+                    "startFormPhaseId": "100",
+                    "start_form_phase": {
+                        "id": "100",
+                        "name": "Start form",
+                        "cards_count": 0,
+                    },
+                    "phases": [
+                        {"id": "200", "name": "Doing", "cards_count": 4},
+                    ],
+                    "labels": [],
+                    "start_form_fields": [],
+                }
+            }
+        )
+        async with client_session as session:
+            result = await session.call_tool("get_pipe", {"pipe_id": pipe_id})
+        assert result.isError is False
+        payload = extract_payload(result)
+        pipe = payload["pipe"]
+        assert pipe["start_form_phase"] == {
+            "id": "100",
+            "name": "Start form",
+            "cards_count": 0,
+        }
+        assert pipe["phases"] == [{"id": "200", "name": "Doing", "cards_count": 4}]
+        assert all(p["id"] != "100" for p in pipe["phases"])
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
     async def test_move_card_to_phase_forwards_params_to_client(

--- a/packages/mcp/tests/tools/test_report_tools.py
+++ b/packages/mcp/tests/tools/test_report_tools.py
@@ -483,6 +483,27 @@ async def test_create_pipe_report_rejects_naive_current_phase_filter(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_export_pipe_report_rejects_naive_current_phase_filter(
+    report_session, mock_report_client, extract_payload
+):
+    async with report_session as session:
+        result = await session.call_tool(
+            "export_pipe_report",
+            {
+                "pipe_id": "123",
+                "pipe_report_id": "r1",
+                "filter": {"current_phase": ["987654321"]},
+            },
+        )
+
+    mock_report_client.export_pipe_report.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "top-level" in tool_error_message(payload)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
 async def test_update_pipe_report_rejects_invalid_report_filter(
     report_session, mock_report_client, extract_payload
 ):

--- a/packages/mcp/tests/tools/test_report_tools.py
+++ b/packages/mcp/tests/tools/test_report_tools.py
@@ -10,10 +10,21 @@ from mcp.shared.memory import (
     create_connected_server_and_client_session as create_client_session,
 )
 from pipefy_sdk import PipefyClient
+from pipefy_sdk.report_filter_preflight import EXAMPLE_PHASE_FILTER
 
 from pipefy_mcp.tools.report_tools import ReportTools
 from pipefy_mcp.tools.tool_error_envelope import tool_error_message
 from tools.conftest import assert_invalid_arguments_envelope
+
+GOLDEN_REPORT_PHASE_FILTER = {
+    **EXAMPLE_PHASE_FILTER,
+    "queries": [
+        {
+            **EXAMPLE_PHASE_FILTER["queries"][0],
+            "value": "987654321",
+        }
+    ],
+}
 
 
 @pytest.fixture
@@ -416,6 +427,75 @@ async def test_create_pipe_report_success(
     payload = extract_payload(result)
     assert payload["success"] is True
     assert payload["result"]["createPipeReport"]["pipeReport"]["id"] == "r10"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_create_pipe_report_forwards_golden_report_filter(
+    report_session, mock_report_client, extract_payload
+):
+    mock_report_client.create_pipe_report.return_value = {
+        "createPipeReport": {"pipeReport": {"id": "r10", "name": "Filtered"}}
+    }
+
+    async with report_session as session:
+        result = await session.call_tool(
+            "create_pipe_report",
+            {
+                "pipe_id": "123",
+                "name": "Filtered",
+                "filter": GOLDEN_REPORT_PHASE_FILTER,
+            },
+        )
+
+    assert result.isError is False
+    mock_report_client.create_pipe_report.assert_awaited_once_with(
+        "123",
+        "Filtered",
+        fields=None,
+        filter=GOLDEN_REPORT_PHASE_FILTER,
+        formulas=None,
+    )
+    payload = extract_payload(result)
+    assert payload["success"] is True
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_create_pipe_report_rejects_naive_current_phase_filter(
+    report_session, mock_report_client, extract_payload
+):
+    async with report_session as session:
+        result = await session.call_tool(
+            "create_pipe_report",
+            {
+                "pipe_id": "123",
+                "name": "Bad filter",
+                "filter": {"current_phase": ["987654321"]},
+            },
+        )
+
+    mock_report_client.create_pipe_report.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "top-level" in tool_error_message(payload)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_update_pipe_report_rejects_invalid_report_filter(
+    report_session, mock_report_client, extract_payload
+):
+    async with report_session as session:
+        result = await session.call_tool(
+            "update_pipe_report",
+            {"report_id": "r10", "filter": {"operator": "xor", "queries": []}},
+        )
+
+    mock_report_client.update_pipe_report.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "operator must be one of" in tool_error_message(payload)
 
 
 @pytest.mark.anyio

--- a/packages/sdk/src/pipefy_sdk/client.py
+++ b/packages/sdk/src/pipefy_sdk/client.py
@@ -828,10 +828,17 @@ class PipefyClient:
         return await self._pipe_service.get_pipe_members(pipe_id)
 
     async def create_card(
-        self, pipe_id: str | int, fields: dict[str, Any] | list[dict[str, Any]]
+        self,
+        pipe_id: str | int,
+        fields: dict[str, Any] | list[dict[str, Any]],
+        *,
+        phase_id: str | int | None = None,
+        title: str | None = None,
     ) -> dict:
         """Create a card in the specified pipe with the given fields."""
-        return await self._card_service.create_card(pipe_id, fields)
+        return await self._card_service.create_card(
+            pipe_id, fields, phase_id=phase_id, title=title
+        )
 
     async def add_card_comment(self, card_id: str | int, text: str) -> dict:
         """Add a text comment to a card by its ID."""
@@ -1007,6 +1014,26 @@ class PipefyClient:
     async def get_phase_cards_count(self, phase_id: str | int) -> int:
         """Total card count for ``phase_id`` via native ``Phase.cards_count``."""
         return await self._pipe_service.get_phase_cards_count(phase_id)
+
+    async def get_phase_cards_count_payload(self, phase_id: str | int) -> dict:
+        """Phase id, name, and native ``cards_count`` (for MCP/CLI inventory)."""
+        return await self._pipe_service.get_phase_cards_count_payload(phase_id)
+
+    async def get_phase_cards(
+        self,
+        phase_id: str | int,
+        *,
+        first: int | None = None,
+        after: str | None = None,
+        include_fields: bool = False,
+    ) -> dict:
+        """Paginated cards in ``phase_id`` via ``Phase.cards``."""
+        return await self._pipe_service.get_phase_cards(
+            phase_id,
+            first=first,
+            after=after,
+            include_fields=include_fields,
+        )
 
     async def get_pipe_reports(
         self,

--- a/packages/sdk/src/pipefy_sdk/label_color.py
+++ b/packages/sdk/src/pipefy_sdk/label_color.py
@@ -1,22 +1,19 @@
-"""Pure validation for Pipefy label ``color`` (hex ``#RRGGBB`` only)."""
+"""Pure validation for Pipefy label ``color`` (hex ``#RGB`` or ``#RRGGBB``)."""
 
 from __future__ import annotations
 
 import re
 
-_LABEL_COLOR_HEX_RE = re.compile(r"^#[0-9A-Fa-f]{6}$")
+_LABEL_COLOR_HEX_6_RE = re.compile(r"^#[0-9A-Fa-f]{6}$")
+_LABEL_COLOR_HEX_3_RE = re.compile(r"^#[0-9A-Fa-f]{3}$")
 
 
 def normalize_label_color(value: str) -> str:
-    """Return a normalized ``#RRGGBB`` color string for Pipefy label mutations.
-
-    Args:
-        value: Raw color from MCP/CLI (stripped before validation).
-
-    Raises:
-        ValueError: When ``value`` is not exactly ``#`` plus six hex digits.
-    """
+    """Normalize label color to ``#RRGGBB`` (accepts ``#RGB`` or ``#RRGGBB``)."""
     stripped = value.strip()
-    if not _LABEL_COLOR_HEX_RE.fullmatch(stripped):
-        raise ValueError(f"expected #RRGGBB, received {stripped!r}")
-    return f"#{stripped[1:].upper()}"
+    if _LABEL_COLOR_HEX_3_RE.fullmatch(stripped):
+        r, g, b = stripped[1], stripped[2], stripped[3]
+        return f"#{r}{r}{g}{g}{b}{b}".upper()
+    if _LABEL_COLOR_HEX_6_RE.fullmatch(stripped):
+        return f"#{stripped[1:].upper()}"
+    raise ValueError(f"expected #RGB or #RRGGBB hex color, received {stripped!r}")

--- a/packages/sdk/src/pipefy_sdk/label_color.py
+++ b/packages/sdk/src/pipefy_sdk/label_color.py
@@ -1,0 +1,22 @@
+"""Pure validation for Pipefy label ``color`` (hex ``#RRGGBB`` only)."""
+
+from __future__ import annotations
+
+import re
+
+_LABEL_COLOR_HEX_RE = re.compile(r"^#[0-9A-Fa-f]{6}$")
+
+
+def normalize_label_color(value: str) -> str:
+    """Return a normalized ``#RRGGBB`` color string for Pipefy label mutations.
+
+    Args:
+        value: Raw color from MCP/CLI (stripped before validation).
+
+    Raises:
+        ValueError: When ``value`` is not exactly ``#`` plus six hex digits.
+    """
+    stripped = value.strip()
+    if not _LABEL_COLOR_HEX_RE.fullmatch(stripped):
+        raise ValueError(f"expected #RRGGBB, received {stripped!r}")
+    return f"#{stripped[1:].upper()}"

--- a/packages/sdk/src/pipefy_sdk/pipe_inventory.py
+++ b/packages/sdk/src/pipefy_sdk/pipe_inventory.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+
+def enrich_pipe_get_pipe_inventory(
+    pipe: dict,
+    *,
+    start_form_phase_row: dict | None = None,
+) -> dict:
+    """Add ``start_form_phase`` and per-phase ``cards_count`` to a ``get_pipe`` pipe row.
+
+    The start-form phase is removed from ``phases`` when ``startFormPhaseId`` is set so
+    agents can iterate workflow phases without duplicating the start form.
+
+    Args:
+        pipe: Raw ``pipe`` object from ``GET_PIPE_QUERY``.
+        start_form_phase_row: Optional ``phase`` row when the start form is absent from
+            ``pipe["phases"]`` (typically from ``GET_PHASE_CARDS_COUNT_QUERY``).
+
+    Returns:
+        A shallow copy of ``pipe`` with enriched ``phases`` and optional
+        ``start_form_phase``.
+
+    Raises:
+        ValueError: A workflow phase or the start form is missing ``cards_count``.
+    """
+    out = dict(pipe)
+    phases_raw = list(out.get("phases") or [])
+    start_id = out.get("startFormPhaseId")
+    start_id_str = str(start_id) if start_id is not None else None
+
+    start_from_phases: dict | None = None
+    workflow_phases: list = []
+    for phase in phases_raw:
+        if not isinstance(phase, dict):
+            workflow_phases.append(phase)
+            continue
+        phase_id = phase.get("id")
+        if (
+            start_id_str is not None
+            and phase_id is not None
+            and str(phase_id) == start_id_str
+        ):
+            start_from_phases = phase
+            continue
+        workflow_phases.append(_phase_with_required_cards_count(phase))
+
+    if "phases" in pipe:
+        out["phases"] = workflow_phases
+
+    if start_id_str is None:
+        return out
+
+    start_source = start_from_phases or start_form_phase_row
+    if start_source is None:
+        raise ValueError(
+            f"start form phase {start_id_str!r} missing from pipe phases and "
+            "could not be loaded"
+        )
+    out["start_form_phase"] = _start_form_phase_summary(start_source)
+    return out
+
+
+def _phase_with_required_cards_count(phase: dict) -> dict:
+    phase_out = dict(phase)
+    count = phase_out.get("cards_count")
+    if count is None:
+        raise ValueError(
+            f"phase {phase_out.get('id')!r} cards_count missing from response"
+        )
+    phase_out["cards_count"] = int(count)
+    return phase_out
+
+
+def _start_form_phase_summary(phase: dict) -> dict[str, str | int]:
+    phase_id = phase.get("id")
+    if phase_id is None:
+        raise ValueError("start form phase id missing from response")
+    count = phase.get("cards_count")
+    if count is None:
+        raise ValueError("start form phase cards_count missing from response")
+    return {
+        "id": str(phase_id),
+        "name": str(phase.get("name") or ""),
+        "cards_count": int(count),
+    }

--- a/packages/sdk/src/pipefy_sdk/pipe_inventory.py
+++ b/packages/sdk/src/pipefy_sdk/pipe_inventory.py
@@ -6,23 +6,7 @@ def enrich_pipe_get_pipe_inventory(
     *,
     start_form_phase_row: dict | None = None,
 ) -> dict:
-    """Add ``start_form_phase`` and per-phase ``cards_count`` to a ``get_pipe`` pipe row.
-
-    The start-form phase is removed from ``phases`` when ``startFormPhaseId`` is set so
-    agents can iterate workflow phases without duplicating the start form.
-
-    Args:
-        pipe: Raw ``pipe`` object from ``GET_PIPE_QUERY``.
-        start_form_phase_row: Optional ``phase`` row when the start form is absent from
-            ``pipe["phases"]`` (typically from ``GET_PHASE_CARDS_COUNT_QUERY``).
-
-    Returns:
-        A shallow copy of ``pipe`` with enriched ``phases`` and optional
-        ``start_form_phase``.
-
-    Raises:
-        ValueError: A workflow phase or the start form is missing ``cards_count``.
-    """
+    """Add ``start_form_phase`` and ``cards_count`` on workflow phases for ``get_pipe``."""
     out = dict(pipe)
     phases_raw = list(out.get("phases") or [])
     start_id = out.get("startFormPhaseId")

--- a/packages/sdk/src/pipefy_sdk/queries/card_queries.py
+++ b/packages/sdk/src/pipefy_sdk/queries/card_queries.py
@@ -4,8 +4,8 @@ from gql import gql
 
 CREATE_CARD_MUTATION = gql(
     """
-    mutation ($pipe_id: ID!, $fields: [FieldValueInput!]!) {
-        createCard(input: {pipe_id: $pipe_id, fields_attributes: $fields}) {
+    mutation ($input: CreateCardInput!) {
+        createCard(input: $input) {
             card {
                 id
             }

--- a/packages/sdk/src/pipefy_sdk/queries/card_queries.py
+++ b/packages/sdk/src/pipefy_sdk/queries/card_queries.py
@@ -8,6 +8,7 @@ CREATE_CARD_MUTATION = gql(
         createCard(input: $input) {
             card {
                 id
+                title
             }
         }
     }

--- a/packages/sdk/src/pipefy_sdk/queries/pipe_queries.py
+++ b/packages/sdk/src/pipefy_sdk/queries/pipe_queries.py
@@ -13,6 +13,7 @@ GET_PIPE_QUERY = gql(
             phases {
                 id
                 name
+                cards_count
                 fields {
                     id
                     internal_id
@@ -133,7 +134,40 @@ GET_PHASE_CARDS_COUNT_QUERY = gql(
     query GetPhaseCardsCount($phase_id: ID!) {
         phase(id: $phase_id) {
             id
+            name
             cards_count
+        }
+    }
+    """
+)
+
+GET_PHASE_CARDS_QUERY = gql(
+    """
+    query GetPhaseCards(
+        $phase_id: ID!,
+        $first: Int,
+        $after: String,
+        $includeFields: Boolean!
+    ) {
+        phase(id: $phase_id) {
+            id
+            cards(first: $first, after: $after) {
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
+                edges {
+                    node {
+                        id
+                        title
+                        fields @include(if: $includeFields) {
+                            name
+                            value
+                        }
+                    }
+                }
+                totalCount
+            }
         }
     }
     """
@@ -176,6 +210,7 @@ GET_PIPE_WITH_PREFERENCES_QUERY = gql(
 __all__ = [
     "GET_PHASE_ALLOWED_MOVES_QUERY",
     "GET_PHASE_CARDS_COUNT_QUERY",
+    "GET_PHASE_CARDS_QUERY",
     "GET_PHASE_FIELDS_QUERY",
     "GET_PIPE_MEMBERS_QUERY",
     "GET_PIPE_QUERY",

--- a/packages/sdk/src/pipefy_sdk/report_filter_preflight.py
+++ b/packages/sdk/src/pipefy_sdk/report_filter_preflight.py
@@ -1,0 +1,150 @@
+"""Pure validation for GraphQL ``ReportCardsFilter`` JSON before report mutations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+REPORT_CARDS_FILTER_GROUP_KEYS = frozenset(
+    {"operator", "queries", "groups", "id", "lastId"}
+)
+REPORT_CARDS_FILTER_QUERY_KEYS = frozenset(
+    {"field", "operator", "value", "type", "label", "id"}
+)
+REPORT_CARDS_FILTER_GROUP_OPERATORS = frozenset({"and", "or"})
+
+REPORT_CARDS_FILTER_REJECTED_ROOT_KEYS = frozenset(
+    {
+        "current_phase",
+        "current_phase_id",
+        "phase_id",
+        "phase_ids",
+        "phases_ids",
+    }
+)
+
+EXAMPLE_PHASE_FILTER: dict[str, Any] = {
+    "operator": "and",
+    "queries": [
+        {
+            "field": "current_phase",
+            "operator": "eq",
+            "type": "select",
+            "value": "<phase_id>",
+        }
+    ],
+}
+
+
+def validate_report_cards_filter(filter_obj: dict[str, Any] | None) -> str | None:
+    """Return an error message when ``filter_obj`` is not a valid ``ReportCardsFilter`` shape.
+
+    Args:
+        filter_obj: Filter dict from MCP/CLI, or ``None`` to skip validation.
+
+    Returns:
+        ``None`` when valid; otherwise a user-visible error string.
+    """
+    if filter_obj is None:
+        return None
+    if not isinstance(filter_obj, dict):
+        return f"filter must be a JSON object (ReportCardsFilter), received {type(filter_obj).__name__}"
+    return _validate_filter_group(filter_obj, path="filter")
+
+
+def _validate_filter_group(node: dict[str, Any], *, path: str) -> str | None:
+    if path == "filter":
+        for rejected in REPORT_CARDS_FILTER_REJECTED_ROOT_KEYS:
+            if rejected in node:
+                return (
+                    f"filter must use ReportCardsFilter shape (operator + queries), not top-level "
+                    f"'{rejected}'. Discover the phase predicate field via "
+                    "get_pipe_report_filterable_fields; use field/operator/value inside queries."
+                )
+
+    unknown = set(node) - REPORT_CARDS_FILTER_GROUP_KEYS
+    if unknown:
+        keys = ", ".join(sorted(unknown))
+        return f"{path} has unknown key(s): {keys}. Allowed: {', '.join(sorted(REPORT_CARDS_FILTER_GROUP_KEYS))}."
+
+    operator = node.get("operator")
+    if operator is None:
+        return f"{path}.operator is required (and | or)."
+    if not isinstance(operator, str) or not operator.strip():
+        return f"{path}.operator must be a non-empty string, received {operator!r}."
+    if operator not in REPORT_CARDS_FILTER_GROUP_OPERATORS:
+        return (
+            f"{path}.operator must be one of {sorted(REPORT_CARDS_FILTER_GROUP_OPERATORS)!r}, "
+            f"received {operator!r}."
+        )
+
+    queries = node.get("queries")
+    if queries is not None:
+        if not isinstance(queries, list):
+            return f"{path}.queries must be a list, received {type(queries).__name__}."
+        for index, query in enumerate(queries):
+            err = _validate_filter_query(query, path=f"{path}.queries[{index}]")
+            if err is not None:
+                return err
+
+    groups = node.get("groups")
+    if groups is not None:
+        if not isinstance(groups, list):
+            return f"{path}.groups must be a list, received {type(groups).__name__}."
+        for index, group in enumerate(groups):
+            if not isinstance(group, dict):
+                return f"{path}.groups[{index}] must be an object, received {type(group).__name__}."
+            err = _validate_filter_group(group, path=f"{path}.groups[{index}]")
+            if err is not None:
+                return err
+
+    return None
+
+
+def _validate_filter_query(node: Any, *, path: str) -> str | None:
+    if not isinstance(node, dict):
+        return f"{path} must be an object, received {type(node).__name__}."
+
+    unknown = set(node) - REPORT_CARDS_FILTER_QUERY_KEYS
+    if unknown:
+        keys = ", ".join(sorted(unknown))
+        return (
+            f"{path} has unknown key(s): {keys}. Allowed: "
+            f"{', '.join(sorted(REPORT_CARDS_FILTER_QUERY_KEYS))}."
+        )
+
+    field = node.get("field")
+    if field is None:
+        return f"{path}.field is required (internal name from get_pipe_report_filterable_fields)."
+    if not isinstance(field, str) or not field.strip():
+        return f"{path}.field must be a non-empty string, received {field!r}."
+
+    op = node.get("operator")
+    if op is None:
+        return f"{path}.operator is required (eq, not_eq, contains, ...)."
+    if not isinstance(op, str) or not op.strip():
+        return f"{path}.operator must be a non-empty string, received {op!r}."
+
+    value = node.get("value")
+    if value is not None and not isinstance(value, str):
+        return (
+            f"{path}.value must be a string when set, received {type(value).__name__}."
+        )
+
+    field_type = node.get("type")
+    if field_type is not None and (
+        not isinstance(field_type, str) or not field_type.strip()
+    ):
+        return (
+            f"{path}.type must be a non-empty string when set, received {field_type!r}."
+        )
+
+    return None
+
+
+__all__ = [
+    "EXAMPLE_PHASE_FILTER",
+    "REPORT_CARDS_FILTER_GROUP_KEYS",
+    "REPORT_CARDS_FILTER_QUERY_KEYS",
+    "REPORT_CARDS_FILTER_REJECTED_ROOT_KEYS",
+    "validate_report_cards_filter",
+]

--- a/packages/sdk/src/pipefy_sdk/report_filter_preflight.py
+++ b/packages/sdk/src/pipefy_sdk/report_filter_preflight.py
@@ -36,14 +36,6 @@ EXAMPLE_PHASE_FILTER: dict[str, Any] = {
 
 
 def validate_report_cards_filter(filter_obj: dict[str, Any] | None) -> str | None:
-    """Return an error message when ``filter_obj`` is not a valid ``ReportCardsFilter`` shape.
-
-    Args:
-        filter_obj: Filter dict from MCP/CLI, or ``None`` to skip validation.
-
-    Returns:
-        ``None`` when valid; otherwise a user-visible error string.
-    """
     if filter_obj is None:
         return None
     if not isinstance(filter_obj, dict):

--- a/packages/sdk/src/pipefy_sdk/services/card_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/card_service.py
@@ -40,11 +40,30 @@ class CardService(BasePipefyClient):
         super().__init__(settings=settings, auth=auth)
 
     async def create_card(
-        self, pipe_id: str | int, fields: dict[str, Any] | list[dict[str, Any]]
+        self,
+        pipe_id: str | int,
+        fields: dict[str, Any] | list[dict[str, Any]],
+        *,
+        phase_id: str | int | None = None,
+        title: str | None = None,
     ) -> dict:
-        """Create a card in the specified pipe with the given fields."""
-        variables = {"pipe_id": str(pipe_id), "fields": convert_fields_to_array(fields)}
-        return await self.execute_query(CREATE_CARD_MUTATION, variables)
+        """Create a card in the specified pipe with the given fields.
+
+        Args:
+            pipe_id: Target pipe id.
+            fields: Field slug/id map or ``FieldValueInput`` list (→ ``fields_attributes``).
+            phase_id: Optional phase to create the card in (non–start-form seeding).
+            title: Optional card title on ``CreateCardInput`` (vs post-create update).
+        """
+        card_input: dict[str, Any] = {
+            "pipe_id": str(pipe_id),
+            "fields_attributes": convert_fields_to_array(fields),
+        }
+        if phase_id is not None:
+            card_input["phase_id"] = str(phase_id)
+        if title is not None:
+            card_input["title"] = title
+        return await self.execute_query(CREATE_CARD_MUTATION, {"input": card_input})
 
     async def create_comment(self, card_id: str | int, text: str) -> dict:
         """Create a text comment on the specified card."""

--- a/packages/sdk/src/pipefy_sdk/services/card_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/card_service.py
@@ -47,14 +47,7 @@ class CardService(BasePipefyClient):
         phase_id: str | int | None = None,
         title: str | None = None,
     ) -> dict:
-        """Create a card in the specified pipe with the given fields.
-
-        Args:
-            pipe_id: Target pipe id.
-            fields: Field slug/id map or ``FieldValueInput`` list (→ ``fields_attributes``).
-            phase_id: Optional phase to create the card in (non–start-form seeding).
-            title: Optional card title on ``CreateCardInput`` (vs post-create update).
-        """
+        """Create a card in the specified pipe with the given fields."""
         card_input: dict[str, Any] = {
             "pipe_id": str(pipe_id),
             "fields_attributes": convert_fields_to_array(fields),

--- a/packages/sdk/src/pipefy_sdk/services/pipe_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/pipe_service.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+from typing import Any
+
 from httpx import Auth
 from pipefy_infra.coerce import optional_int
 from rapidfuzz import fuzz
 
 from pipefy_sdk.base_client import BasePipefyClient
 from pipefy_sdk.models.field_definition import parse_field_definitions
+from pipefy_sdk.pipe_inventory import enrich_pipe_get_pipe_inventory
 from pipefy_sdk.queries.pipe_queries import (
     GET_PHASE_ALLOWED_MOVES_QUERY,
     GET_PHASE_CARDS_COUNT_QUERY,
+    GET_PHASE_CARDS_QUERY,
     GET_PHASE_FIELDS_QUERY,
     GET_PIPE_MEMBERS_QUERY,
     GET_PIPE_QUERY,
@@ -38,9 +42,32 @@ class PipeService(BasePipefyClient):
         super().__init__(settings=settings, auth=auth)
 
     async def get_pipe(self, pipe_id: str | int) -> dict:
-        """Get a pipe by its ID, including phases, labels, and start form fields."""
+        """Get a pipe by its ID, including phases, labels, and start form fields.
+
+        Normalizes inventory fields: ``start_form_phase`` (id, name, cards_count) when
+        ``startFormPhaseId`` is set, and ``cards_count`` on each workflow phase in
+        ``phases`` (start form excluded from ``phases``).
+        """
         variables = {"pipe_id": str(pipe_id)}
-        return await self.execute_query(GET_PIPE_QUERY, variables)
+        result = await self.execute_query(GET_PIPE_QUERY, variables)
+        pipe = result.get("pipe")
+        if not isinstance(pipe, dict):
+            return result
+        start_form_row: dict | None = None
+        start_id = pipe.get("startFormPhaseId")
+        if start_id is not None:
+            start_id_str = str(start_id)
+            phases = pipe.get("phases") or []
+            if not any(
+                isinstance(p, dict) and str(p.get("id")) == start_id_str for p in phases
+            ):
+                start_form_row = await self._fetch_phase_cards_count_row(start_id)
+        return {
+            **result,
+            "pipe": enrich_pipe_get_pipe_inventory(
+                pipe, start_form_phase_row=start_form_row
+            ),
+        }
 
     async def get_pipe_with_preferences(self, pipe_id: str | int) -> dict:
         """Get a pipe including AI preferences, phases with fields, and start form fields.
@@ -222,6 +249,16 @@ class PipeService(BasePipefyClient):
         variables = {"phase_id": str(phase_id)}
         return await self.execute_query(GET_PHASE_ALLOWED_MOVES_QUERY, variables)
 
+    async def _fetch_phase_cards_count_row(self, phase_id: str | int) -> dict:
+        variables = {"phase_id": str(phase_id)}
+        result = await self.execute_query(GET_PHASE_CARDS_COUNT_QUERY, variables)
+        phase = (result or {}).get("phase")
+        if not isinstance(phase, dict) or phase.get("cards_count") is None:
+            raise ValueError("phase.cards_count missing from response")
+        if phase.get("id") is None:
+            raise ValueError("phase id missing from response")
+        return phase
+
     async def get_phase_cards_count(self, phase_id: str | int) -> int:
         """Return the total card count for ``phase_id`` via ``Phase.cards_count``.
 
@@ -237,12 +274,46 @@ class PipeService(BasePipefyClient):
         Raises:
             ValueError: ``phase.cards_count`` is missing from the response.
         """
-        variables = {"phase_id": str(phase_id)}
-        result = await self.execute_query(GET_PHASE_CARDS_COUNT_QUERY, variables)
-        phase = (result or {}).get("phase")
-        if not isinstance(phase, dict) or phase.get("cards_count") is None:
-            raise ValueError("phase.cards_count missing from response")
+        phase = await self._fetch_phase_cards_count_row(phase_id)
         return int(phase["cards_count"])
+
+    async def get_phase_cards_count_payload(self, phase_id: str | int) -> dict:
+        """Return phase id, name, and native ``cards_count`` for agent inventory tools."""
+        phase = await self._fetch_phase_cards_count_row(phase_id)
+        return {
+            "phase_id": str(phase["id"]),
+            "phase_name": str(phase.get("name") or ""),
+            "cards_count": int(phase["cards_count"]),
+        }
+
+    async def get_phase_cards(
+        self,
+        phase_id: str | int,
+        *,
+        first: int | None = None,
+        after: str | None = None,
+        include_fields: bool = False,
+    ) -> dict:
+        """List cards currently in ``phase_id`` via ``Phase.cards`` (Relay pagination).
+
+        Args:
+            phase_id: Phase ID.
+            first: Max cards per page.
+            after: Cursor from ``pageInfo.endCursor``.
+            include_fields: When True, include each card's custom fields.
+
+        Returns:
+            Raw GraphQL payload (``phase`` key at top level).
+        """
+        variables: dict[str, Any] = {
+            "phase_id": str(phase_id),
+            "includeFields": include_fields,
+        }
+        if first is not None:
+            variables["first"] = first
+        if after is not None:
+            variables["after"] = after
+        return await self.execute_query(GET_PHASE_CARDS_QUERY, variables)
 
     async def get_phase_fields(
         self, phase_id: str | int, required_only: bool = False

--- a/packages/sdk/src/pipefy_sdk/services/pipe_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/pipe_service.py
@@ -42,12 +42,7 @@ class PipeService(BasePipefyClient):
         super().__init__(settings=settings, auth=auth)
 
     async def get_pipe(self, pipe_id: str | int) -> dict:
-        """Get a pipe by its ID, including phases, labels, and start form fields.
-
-        Normalizes inventory fields: ``start_form_phase`` (id, name, cards_count) when
-        ``startFormPhaseId`` is set, and ``cards_count`` on each workflow phase in
-        ``phases`` (start form excluded from ``phases``).
-        """
+        """Get a pipe by its ID, including phases, labels, and start form fields."""
         variables = {"pipe_id": str(pipe_id)}
         result = await self.execute_query(GET_PIPE_QUERY, variables)
         pipe = result.get("pipe")

--- a/packages/sdk/tests/services/pipefy/test_report_service.py
+++ b/packages/sdk/tests/services/pipefy/test_report_service.py
@@ -309,6 +309,28 @@ async def test_create_pipe_report_success(mock_settings):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_create_pipe_report_forwards_golden_phase_filter(mock_settings):
+    from pipefy_sdk.report_filter_preflight import EXAMPLE_PHASE_FILTER
+
+    golden_filter = {
+        **EXAMPLE_PHASE_FILTER,
+        "queries": [
+            {
+                **EXAMPLE_PHASE_FILTER["queries"][0],
+                "value": "987654321",
+            }
+        ],
+    }
+    payload = {"createPipeReport": {"pipeReport": {"id": "r10", "name": "Filtered"}}}
+    service = _make_service(mock_settings, payload)
+    await service.create_pipe_report("123", "Filtered", filter=golden_filter)
+
+    variables = service.execute_query.call_args[0][1]
+    assert variables["input"]["filter"] == golden_filter
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_create_pipe_report_minimal(mock_settings):
     payload = {"createPipeReport": {"pipeReport": {"id": "r11", "name": "Minimal"}}}
     service = _make_service(mock_settings, payload)

--- a/packages/sdk/tests/services/test_card_service.py
+++ b/packages/sdk/tests/services/test_card_service.py
@@ -9,6 +9,7 @@ import pytest
 from pipefy_auth import StaticBearerAuth
 
 from pipefy_sdk.queries.card_queries import (
+    CREATE_CARD_MUTATION,
     FIND_CARDS_QUERY,
     GET_CARD_RELATIONS_QUERY,
     GET_CARDS_QUERY,
@@ -43,13 +44,125 @@ async def test_create_card_converts_fields_and_sets_generated_by_ai(mock_setting
     result = await service.create_card(pipe_id, fields)
 
     variables = service.execute_query.call_args[0][1]
-    assert variables["pipe_id"] == str(pipe_id), "Expected pipe_id in variables"
-    assert variables["fields"] == [
-        {"field_id": "title", "field_value": "Teste-MCP", "generated_by_ai": True}
-    ], "Expected fields converted to array format"
+    assert variables == {
+        "input": {
+            "pipe_id": str(pipe_id),
+            "fields_attributes": [
+                {
+                    "field_id": "title",
+                    "field_value": "Teste-MCP",
+                    "generated_by_ai": True,
+                }
+            ],
+        }
+    }
     assert result == {"createCard": {"card": {"id": "12345"}}}, (
         "Expected createCard response"
     )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_card_with_phase_id_sends_create_card_input(mock_settings):
+    """create_card with phase_id uses CreateCardInput with phase_id and fields_attributes."""
+    pipe_id = 303181849
+    phase_id = 987654321
+    fields = {"title": "Orphan phase card"}
+
+    service = _make_service(mock_settings, {"createCard": {"card": {"id": "12345"}}})
+    await service.create_card(pipe_id, fields, phase_id=phase_id)
+
+    query_used = service.execute_query.call_args[0][0]
+    variables = service.execute_query.call_args[0][1]
+    assert query_used is CREATE_CARD_MUTATION
+    assert "CreateCardInput" in CREATE_CARD_MUTATION.loc.source.body
+    assert variables == {
+        "input": {
+            "pipe_id": str(pipe_id),
+            "phase_id": str(phase_id),
+            "fields_attributes": [
+                {
+                    "field_id": "title",
+                    "field_value": "Orphan phase card",
+                    "generated_by_ai": True,
+                }
+            ],
+        }
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_card_with_phase_id_and_title_sends_create_card_input(
+    mock_settings,
+):
+    """create_card passes optional title on CreateCardInput when provided."""
+    pipe_id = 303181849
+    phase_id = 987654321
+    card_title = "Seed card title"
+
+    service = _make_service(mock_settings, {"createCard": {"card": {"id": "12345"}}})
+    await service.create_card(pipe_id, {}, phase_id=phase_id, title=card_title)
+
+    variables = service.execute_query.call_args[0][1]
+    assert variables == {
+        "input": {
+            "pipe_id": str(pipe_id),
+            "phase_id": str(phase_id),
+            "title": card_title,
+            "fields_attributes": [],
+        }
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_card_without_phase_id_uses_create_card_input(mock_settings):
+    """create_card without phase_id still uses CreateCardInput (no phase_id key)."""
+    pipe_id = 303181849
+    fields = {"title": "Start form card"}
+
+    service = _make_service(mock_settings, {"createCard": {"card": {"id": "12345"}}})
+    await service.create_card(pipe_id, fields)
+
+    query_used = service.execute_query.call_args[0][0]
+    variables = service.execute_query.call_args[0][1]
+    assert query_used is CREATE_CARD_MUTATION
+    assert "CreateCardInput" in CREATE_CARD_MUTATION.loc.source.body
+    assert variables == {
+        "input": {
+            "pipe_id": str(pipe_id),
+            "fields_attributes": [
+                {
+                    "field_id": "title",
+                    "field_value": "Start form card",
+                    "generated_by_ai": True,
+                }
+            ],
+        }
+    }
+    assert "phase_id" not in variables["input"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_card_with_title_only_sends_create_card_input(mock_settings):
+    """create_card passes title on CreateCardInput without phase_id (MCP happy path)."""
+    pipe_id = 303181849
+    card_title = "Start form title"
+
+    service = _make_service(mock_settings, {"createCard": {"card": {"id": "12345"}}})
+    await service.create_card(pipe_id, {}, title=card_title)
+
+    variables = service.execute_query.call_args[0][1]
+    assert variables == {
+        "input": {
+            "pipe_id": str(pipe_id),
+            "title": card_title,
+            "fields_attributes": [],
+        }
+    }
+    assert "phase_id" not in variables["input"]
 
 
 @pytest.mark.unit
@@ -63,8 +176,12 @@ async def test_create_card_with_empty_dict_sends_empty_list(mock_settings):
     result = await service.create_card(pipe_id, fields)
 
     variables = service.execute_query.call_args[0][1]
-    assert variables["pipe_id"] == str(pipe_id), "Expected pipe_id in variables"
-    assert variables["fields"] == [], "Empty dict should result in empty list"
+    assert variables == {
+        "input": {
+            "pipe_id": str(pipe_id),
+            "fields_attributes": [],
+        }
+    }
     assert result == {"createCard": {"card": {"id": "12345"}}}, (
         "Expected createCard response"
     )

--- a/packages/sdk/tests/services/test_pipe_service.py
+++ b/packages/sdk/tests/services/test_pipe_service.py
@@ -106,6 +106,23 @@ async def test_get_pipe_enriches_start_form_and_workflow_phases(mock_settings):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_get_pipe_raises_when_workflow_phase_missing_cards_count(mock_settings):
+    # The inventory enrichment requires cards_count on every workflow phase, so
+    # get_pipe propagates a ValueError instead of returning a partial pipe.
+    # get_pipe now backs delete previews, AI validation context, and get_labels,
+    # so this locks the shared hard-fail surface: a defensive fallback would
+    # change this expectation deliberately.
+    api_pipe = {
+        "id": "10",
+        "phases": [{"id": "200", "name": "Doing"}],  # cards_count omitted
+    }
+    service = _make_service(mock_settings, {"pipe": api_pipe})
+    with pytest.raises(ValueError, match="cards_count"):
+        await service.get_pipe("10")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_get_pipe_members_returns_members(mock_settings):
     """Test get_pipe_members returns the list of members for a pipe."""
     pipe_id = 123

--- a/packages/sdk/tests/services/test_pipe_service.py
+++ b/packages/sdk/tests/services/test_pipe_service.py
@@ -12,7 +12,9 @@ from pipefy_auth import StaticBearerAuth
 from pipefy_sdk.queries.pipe_queries import (
     GET_PHASE_ALLOWED_MOVES_QUERY,
     GET_PHASE_CARDS_COUNT_QUERY,
+    GET_PHASE_CARDS_QUERY,
     GET_PHASE_FIELDS_QUERY,
+    GET_PIPE_QUERY,
     SEARCH_PIPES_QUERY,
 )
 from pipefy_sdk.services.pipe_service import PipeService
@@ -58,6 +60,48 @@ async def test_get_pipe_accepts_alphanumeric_id(mock_settings):
 
     variables = service.execute_query.call_args[0][1]
     assert variables == {"pipe_id": "Yr5RUVCi"}
+
+
+@pytest.mark.unit
+def test_get_pipe_query_selects_cards_count_on_phases():
+    printed = print_ast(GET_PIPE_QUERY)
+    assert "cards_count" in printed
+    assert printed.count("cards_count") >= 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_pipe_enriches_start_form_and_workflow_phases(mock_settings):
+    pipe_id = 10
+    api_pipe = {
+        "id": str(pipe_id),
+        "startFormPhaseId": "100",
+        "phases": [
+            {"id": "200", "name": "Doing", "cards_count": 5, "fields": []},
+        ],
+    }
+    service = PipeService(settings=mock_settings, auth=_TEST_AUTH)
+    service.execute_query = AsyncMock(
+        side_effect=[
+            {"pipe": api_pipe},
+            {"phase": {"id": "100", "name": "Start", "cards_count": 2}},
+        ]
+    )
+
+    result = await service.get_pipe(pipe_id)
+
+    assert service.execute_query.call_count == 2
+    assert service.execute_query.call_args_list[0][0][0] is GET_PIPE_QUERY
+    assert service.execute_query.call_args_list[1][0][0] is GET_PHASE_CARDS_COUNT_QUERY
+    pipe = result["pipe"]
+    assert pipe["start_form_phase"] == {
+        "id": "100",
+        "name": "Start",
+        "cards_count": 2,
+    }
+    assert pipe["phases"] == [
+        {"id": "200", "name": "Doing", "cards_count": 5, "fields": []}
+    ]
 
 
 @pytest.mark.unit
@@ -552,9 +596,83 @@ async def test_get_phase_cards_count_raises_when_missing(mock_settings):
 def test_get_phase_cards_count_query_selects_native_scalar():
     query_text = print_ast(GET_PHASE_CARDS_COUNT_QUERY)
     assert "cards_count" in query_text
+    assert "name" in query_text
     # No card enumeration — must not touch the CardConnection edges/nodes.
     assert "edges" not in query_text
     assert "nodes" not in query_text
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_phase_cards_count_payload_returns_normalized_shape(mock_settings):
+    phase_id = 342182334
+    api_response = {"phase": {"id": str(phase_id), "name": "Doing", "cards_count": 42}}
+    service = _make_service(mock_settings, api_response)
+
+    result = await service.get_phase_cards_count_payload(phase_id)
+
+    assert result == {
+        "phase_id": str(phase_id),
+        "phase_name": "Doing",
+        "cards_count": 42,
+    }
+
+
+@pytest.mark.unit
+def test_get_phase_cards_query_requests_pagination_and_fields():
+    query_text = print_ast(GET_PHASE_CARDS_QUERY)
+    assert "first" in query_text
+    assert "after" in query_text
+    assert "totalCount" in query_text
+    assert "includeFields" in query_text
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_phase_cards_sends_phase_id_first_after(mock_settings):
+    phase_id = 99
+    api_response = {
+        "phase": {
+            "id": str(phase_id),
+            "cards": {
+                "edges": [{"node": {"id": "1", "title": "A"}}],
+                "pageInfo": {"hasNextPage": False, "endCursor": None},
+                "totalCount": 1,
+            },
+        }
+    }
+    service = _make_service(mock_settings, api_response)
+
+    result = await service.get_phase_cards(
+        phase_id,
+        first=50,
+        after="cursor-1",
+        include_fields=True,
+    )
+
+    service.execute_query.assert_called_once()
+    assert service.execute_query.call_args[0][0] is GET_PHASE_CARDS_QUERY
+    assert service.execute_query.call_args[0][1] == {
+        "phase_id": str(phase_id),
+        "first": 50,
+        "after": "cursor-1",
+        "includeFields": True,
+    }
+    assert result == api_response
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_phase_cards_omits_optional_variables_when_unset(mock_settings):
+    phase_id = 10
+    service = _make_service(mock_settings, {"phase": {"id": "10", "cards": {}}})
+
+    await service.get_phase_cards(phase_id, include_fields=False)
+
+    variables = service.execute_query.call_args[0][1]
+    assert variables == {"phase_id": "10", "includeFields": False}
+    assert "first" not in variables
+    assert "after" not in variables
 
 
 @pytest.mark.unit

--- a/packages/sdk/tests/services/test_pipefy_client.py
+++ b/packages/sdk/tests/services/test_pipefy_client.py
@@ -58,18 +58,22 @@ async def test_create_card_with_dict_fields():
 
     mock_execute.assert_called_once()
     variables = mock_execute.call_args[0][1]
-    assert variables["pipe_id"] == str(pipe_id)
-    assert isinstance(variables["fields"], list)
-    assert len(variables["fields"]) == 2
-    assert variables["fields"][0] == {
-        "field_id": "title",
-        "field_value": "Teste-MCP",
-        "generated_by_ai": True,
-    }
-    assert variables["fields"][1] == {
-        "field_id": "description",
-        "field_value": "Test description",
-        "generated_by_ai": True,
+    assert variables == {
+        "input": {
+            "pipe_id": str(pipe_id),
+            "fields_attributes": [
+                {
+                    "field_id": "title",
+                    "field_value": "Teste-MCP",
+                    "generated_by_ai": True,
+                },
+                {
+                    "field_id": "description",
+                    "field_value": "Test description",
+                    "generated_by_ai": True,
+                },
+            ],
+        }
     }
     assert result == {"createCard": {"card": {"id": "12345"}}}
 
@@ -91,17 +95,22 @@ async def test_create_card_with_array_fields():
 
     mock_execute.assert_called_once()
     variables = mock_execute.call_args[0][1]
-    assert variables["pipe_id"] == str(pipe_id)
-    assert len(variables["fields"]) == 2
-    assert variables["fields"][0] == {
-        "field_id": "title",
-        "field_value": "Teste-MCP",
-        "generated_by_ai": True,
-    }
-    assert variables["fields"][1] == {
-        "field_id": "description",
-        "field_value": "Test description",
-        "generated_by_ai": True,
+    assert variables == {
+        "input": {
+            "pipe_id": str(pipe_id),
+            "fields_attributes": [
+                {
+                    "field_id": "title",
+                    "field_value": "Teste-MCP",
+                    "generated_by_ai": True,
+                },
+                {
+                    "field_id": "description",
+                    "field_value": "Test description",
+                    "generated_by_ai": True,
+                },
+            ],
+        }
     }
     assert result == {"createCard": {"card": {"id": "12345"}}}
 
@@ -119,8 +128,12 @@ async def test_create_card_with_empty_dict():
 
     mock_execute.assert_called_once()
     variables = mock_execute.call_args[0][1]
-    assert variables["pipe_id"] == str(pipe_id)
-    assert variables["fields"] == []
+    assert variables == {
+        "input": {
+            "pipe_id": str(pipe_id),
+            "fields_attributes": [],
+        }
+    }
     assert result == {"createCard": {"card": {"id": "12345"}}}
 
 
@@ -138,12 +151,17 @@ async def test_create_card_with_single_field():
 
     mock_execute.assert_called_once()
     variables = mock_execute.call_args[0][1]
-    assert variables["pipe_id"] == str(pipe_id)
-    assert len(variables["fields"]) == 1
-    assert variables["fields"][0] == {
-        "field_id": "title",
-        "field_value": "Teste-MCP",
-        "generated_by_ai": True,
+    assert variables == {
+        "input": {
+            "pipe_id": str(pipe_id),
+            "fields_attributes": [
+                {
+                    "field_id": "title",
+                    "field_value": "Teste-MCP",
+                    "generated_by_ai": True,
+                }
+            ],
+        }
     }
     assert result == {"createCard": {"card": {"id": "12345"}}}
 
@@ -839,6 +857,46 @@ async def test_get_phase_allowed_move_targets_delegates_to_pipe_service():
 
     mock_execute.assert_awaited()
     assert mock_execute.call_args[0][1] == {"phase_id": "5"}
+    assert result == expected
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_phase_cards_count_payload_delegates_to_pipe_service():
+    expected = {"phase_id": "5", "phase_name": "Doing", "cards_count": 3}
+    pipe_service = AsyncMock()
+    pipe_service.get_phase_cards_count_payload = AsyncMock(return_value=expected)
+    client = PipefyClient.__new__(PipefyClient)
+    client._pipe_service = pipe_service
+
+    result = await client.get_phase_cards_count_payload(5)
+
+    pipe_service.get_phase_cards_count_payload.assert_awaited_once_with(5)
+    assert result == expected
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_phase_cards_delegates_to_pipe_service():
+    expected = {"phase": {"id": "5", "cards": {"edges": []}}}
+    pipe_service = AsyncMock()
+    pipe_service.get_phase_cards = AsyncMock(return_value=expected)
+    client = PipefyClient.__new__(PipefyClient)
+    client._pipe_service = pipe_service
+
+    result = await client.get_phase_cards(
+        5,
+        first=50,
+        after="c1",
+        include_fields=True,
+    )
+
+    pipe_service.get_phase_cards.assert_awaited_once_with(
+        5,
+        first=50,
+        after="c1",
+        include_fields=True,
+    )
     assert result == expected
 
 

--- a/packages/sdk/tests/services/test_pipefy_facade.py
+++ b/packages/sdk/tests/services/test_pipefy_facade.py
@@ -37,6 +37,20 @@ def test_pipefy_client_forwards_caller_provided_auth(mock_settings):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_create_card_forwards_phase_id_and_title(mock_settings):
+    """PipefyClient.create_card passes optional phase_id and title to CardService."""
+    card_service = AsyncMock()
+    card_service.create_card = AsyncMock(return_value={"ok": "create"})
+    client = PipefyClient(mock_settings, auth=StaticBearerAuth("unit-token"))
+    client._card_service = card_service
+
+    await client.create_card(10, {}, phase_id=20, title="Seed")
+
+    card_service.create_card.assert_awaited_once_with(10, {}, phase_id=20, title="Seed")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_pipefy_client_facade_delegates_to_services_without_modifying_args_or_return():
     """Test PipefyClient is a pure facade: delegates calls unchanged to services."""
     pipe_service = AsyncMock()
@@ -206,7 +220,9 @@ async def test_pipefy_client_facade_delegates_to_services_without_modifying_args
     pipe_service.get_start_form_fields.assert_awaited_once_with(2, True)
 
     assert await client.create_card(3, {"a": 1}) == {"ok": "create"}
-    card_service.create_card.assert_awaited_once_with(3, {"a": 1})
+    card_service.create_card.assert_awaited_once_with(
+        3, {"a": 1}, phase_id=None, title=None
+    )
 
     assert await client.add_card_comment(33, "hello") == {"ok": "comment"}
     card_service.create_comment.assert_awaited_once_with(33, "hello")

--- a/packages/sdk/tests/test_ai_pipe_validation.py
+++ b/packages/sdk/tests/test_ai_pipe_validation.py
@@ -113,6 +113,43 @@ async def test_fetch_pipe_validation_context_surfaces_phase_fetch_warning() -> N
 
 
 @pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_pipe_validation_context_excludes_start_form_phase() -> None:
+    # get_pipe returns the enriched shape: workflow phases carry cards_count and
+    # the start form is a separate ``start_form_phase`` key, never in ``phases``.
+    # phase_ids must reflect only workflow phases (the start form is not a valid
+    # move target), so a behavior validated here is checked against the same set
+    # the public ``phases`` field already exposed before enrichment.
+    client = AsyncMock()
+    client.get_pipe = AsyncMock(
+        return_value={
+            "pipe": {
+                "startFormPhaseId": "100",
+                "start_form_phase": {
+                    "id": "100",
+                    "name": "Start form",
+                    "cards_count": 0,
+                },
+                "phases": [
+                    {"id": "200", "name": "Doing", "cards_count": 2},
+                    {"id": "300", "name": "Done", "cards_count": 5},
+                ],
+                "start_form_fields": [],
+            }
+        }
+    )
+    client.get_pipe_relations = AsyncMock(return_value={"children": [], "parents": []})
+    client.get_phase_fields = AsyncMock(return_value={"fields": []})
+
+    _, phase_ids, _, _ = await fetch_pipe_validation_context(
+        client, EXAMPLE_PIPE_ID, timeout=5
+    )
+
+    assert phase_ids == {"200", "300"}
+    assert "100" not in phase_ids
+
+
+@pytest.mark.unit
 def test_validate_behaviors_accepts_internal_id_when_in_pipe_field_set() -> None:
     behavior = {
         "name": "Update briefing",

--- a/packages/sdk/tests/test_label_color.py
+++ b/packages/sdk/tests/test_label_color.py
@@ -1,0 +1,37 @@
+"""Tests for label color hex validation planner."""
+
+from __future__ import annotations
+
+import pytest
+
+from pipefy_sdk.label_color import normalize_label_color
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("#FF0000", "#FF0000"),
+        ("#ff0000", "#FF0000"),
+        ("  #E50000  ", "#E50000"),
+    ],
+)
+def test_normalize_label_color_accepts_rrggbb(raw: str, expected: str) -> None:
+    assert normalize_label_color(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "red",
+        "blue",
+        "#FFF",
+        "#FF00000",
+        "FF0000",
+        "#GGGGGG",
+        "",
+        "   ",
+    ],
+)
+def test_normalize_label_color_rejects_non_hex(raw: str) -> None:
+    with pytest.raises(ValueError, match=r"expected #RRGGBB, received"):
+        normalize_label_color(raw)

--- a/packages/sdk/tests/test_label_color.py
+++ b/packages/sdk/tests/test_label_color.py
@@ -13,6 +13,8 @@ from pipefy_sdk.label_color import normalize_label_color
         ("#FF0000", "#FF0000"),
         ("#ff0000", "#FF0000"),
         ("  #E50000  ", "#E50000"),
+        ("#F00", "#FF0000"),
+        ("#fff", "#FFFFFF"),
     ],
 )
 def test_normalize_label_color_accepts_rrggbb(raw: str, expected: str) -> None:
@@ -24,7 +26,6 @@ def test_normalize_label_color_accepts_rrggbb(raw: str, expected: str) -> None:
     [
         "red",
         "blue",
-        "#FFF",
         "#FF00000",
         "FF0000",
         "#GGGGGG",
@@ -33,5 +34,5 @@ def test_normalize_label_color_accepts_rrggbb(raw: str, expected: str) -> None:
     ],
 )
 def test_normalize_label_color_rejects_non_hex(raw: str) -> None:
-    with pytest.raises(ValueError, match=r"expected #RRGGBB, received"):
+    with pytest.raises(ValueError, match=r"expected #RGB or #RRGGBB"):
         normalize_label_color(raw)

--- a/packages/sdk/tests/test_pipe_inventory.py
+++ b/packages/sdk/tests/test_pipe_inventory.py
@@ -1,0 +1,62 @@
+"""Unit tests for get_pipe inventory normalization."""
+
+from __future__ import annotations
+
+import pytest
+
+from pipefy_sdk.pipe_inventory import enrich_pipe_get_pipe_inventory
+
+
+@pytest.mark.unit
+def test_enrich_pipe_splits_start_form_from_phases():
+    pipe = {
+        "id": "10",
+        "startFormPhaseId": "100",
+        "phases": [
+            {"id": "100", "name": "Start", "cards_count": 3},
+            {"id": "200", "name": "Doing", "cards_count": 7},
+        ],
+    }
+    enriched = enrich_pipe_get_pipe_inventory(pipe)
+    assert enriched["start_form_phase"] == {
+        "id": "100",
+        "name": "Start",
+        "cards_count": 3,
+    }
+    assert enriched["phases"] == [{"id": "200", "name": "Doing", "cards_count": 7}]
+
+
+@pytest.mark.unit
+def test_enrich_pipe_uses_fetched_start_form_when_absent_from_phases():
+    pipe = {
+        "id": "10",
+        "startFormPhaseId": "100",
+        "phases": [{"id": "200", "name": "Doing", "cards_count": 1}],
+    }
+    enriched = enrich_pipe_get_pipe_inventory(
+        pipe,
+        start_form_phase_row={"id": "100", "name": "Start", "cards_count": 0},
+    )
+    assert enriched["start_form_phase"]["cards_count"] == 0
+    assert len(enriched["phases"]) == 1
+
+
+@pytest.mark.unit
+def test_enrich_pipe_without_start_form_id_leaves_phases_only():
+    pipe = {
+        "id": "10",
+        "phases": [{"id": "200", "name": "Doing", "cards_count": 2}],
+    }
+    enriched = enrich_pipe_get_pipe_inventory(pipe)
+    assert "start_form_phase" not in enriched
+    assert enriched["phases"][0]["cards_count"] == 2
+
+
+@pytest.mark.unit
+def test_enrich_pipe_raises_when_workflow_phase_missing_cards_count():
+    pipe = {"startFormPhaseId": "100", "phases": [{"id": "200", "name": "Doing"}]}
+    with pytest.raises(ValueError, match="cards_count"):
+        enrich_pipe_get_pipe_inventory(
+            pipe,
+            start_form_phase_row={"id": "100", "name": "Start", "cards_count": 0},
+        )

--- a/packages/sdk/tests/test_pipe_inventory.py
+++ b/packages/sdk/tests/test_pipe_inventory.py
@@ -60,3 +60,46 @@ def test_enrich_pipe_raises_when_workflow_phase_missing_cards_count():
             pipe,
             start_form_phase_row={"id": "100", "name": "Start", "cards_count": 0},
         )
+
+
+@pytest.mark.unit
+def test_enrich_pipe_preserves_non_dict_phase_entries():
+    pipe = {"phases": ["unexpected", {"id": "200", "name": "Doing", "cards_count": 2}]}
+    enriched = enrich_pipe_get_pipe_inventory(pipe)
+    assert enriched["phases"][0] == "unexpected"
+    assert enriched["phases"][1]["cards_count"] == 2
+
+
+@pytest.mark.unit
+def test_enrich_pipe_raises_when_start_form_unresolvable():
+    # start form id is set but neither present in phases nor supplied as a row.
+    pipe = {
+        "startFormPhaseId": "100",
+        "phases": [{"id": "200", "name": "Doing", "cards_count": 1}],
+    }
+    with pytest.raises(ValueError, match="missing from pipe phases"):
+        enrich_pipe_get_pipe_inventory(pipe)
+
+
+@pytest.mark.unit
+def test_enrich_pipe_raises_when_start_form_row_missing_id():
+    pipe = {
+        "startFormPhaseId": "100",
+        "phases": [{"id": "200", "name": "Doing", "cards_count": 1}],
+    }
+    with pytest.raises(ValueError, match="start form phase id missing"):
+        enrich_pipe_get_pipe_inventory(
+            pipe, start_form_phase_row={"name": "Start", "cards_count": 0}
+        )
+
+
+@pytest.mark.unit
+def test_enrich_pipe_raises_when_start_form_row_missing_cards_count():
+    pipe = {
+        "startFormPhaseId": "100",
+        "phases": [{"id": "200", "name": "Doing", "cards_count": 1}],
+    }
+    with pytest.raises(ValueError, match="start form phase cards_count missing"):
+        enrich_pipe_get_pipe_inventory(
+            pipe, start_form_phase_row={"id": "100", "name": "Start"}
+        )

--- a/packages/sdk/tests/test_report_filter_preflight.py
+++ b/packages/sdk/tests/test_report_filter_preflight.py
@@ -1,0 +1,84 @@
+"""Unit tests for ReportCardsFilter preflight validation."""
+
+from __future__ import annotations
+
+from pipefy_sdk.report_filter_preflight import (
+    EXAMPLE_PHASE_FILTER,
+    validate_report_cards_filter,
+)
+
+
+def test_validate_report_cards_filter_none_passes():
+    assert validate_report_cards_filter(None) is None
+
+
+def test_validate_report_cards_filter_valid_phase_skeleton_passes():
+    assert validate_report_cards_filter(EXAMPLE_PHASE_FILTER) is None
+
+
+def test_validate_report_cards_filter_nested_group_passes():
+    filt = {
+        "operator": "or",
+        "groups": [
+            {
+                "operator": "and",
+                "queries": [
+                    {"field": "current_phase", "operator": "eq", "value": "1"},
+                ],
+            }
+        ],
+    }
+    assert validate_report_cards_filter(filt) is None
+
+
+def test_validate_report_cards_filter_rejects_top_level_current_phase():
+    err = validate_report_cards_filter({"current_phase": ["123"]})
+    assert err is not None
+    assert "top-level" in err
+    assert "current_phase" in err
+    assert "get_pipe_report_filterable_fields" in err
+
+
+def test_validate_report_cards_filter_rejects_unknown_root_key():
+    err = validate_report_cards_filter({"operator": "and", "bogus": True})
+    assert err is not None
+    assert "unknown key" in err
+    assert "bogus" in err
+
+
+def test_validate_report_cards_filter_requires_operator():
+    err = validate_report_cards_filter({"queries": []})
+    assert err is not None
+    assert "operator is required" in err
+
+
+def test_validate_report_cards_filter_rejects_invalid_group_operator():
+    err = validate_report_cards_filter({"operator": "xor", "queries": []})
+    assert err is not None
+    assert "operator must be one of" in err
+
+
+def test_validate_report_cards_filter_query_requires_field_and_operator():
+    err = validate_report_cards_filter(
+        {"operator": "and", "queries": [{"operator": "eq", "value": "x"}]}
+    )
+    assert err is not None
+    assert ".field is required" in err
+
+
+def test_validate_report_cards_filter_query_rejects_unknown_keys():
+    err = validate_report_cards_filter(
+        {
+            "operator": "and",
+            "queries": [{"field": "current_phase", "operator": "eq", "phase_id": "1"}],
+        }
+    )
+    assert err is not None
+    assert "unknown key" in err
+    assert "phase_id" in err
+
+
+def test_validate_report_cards_filter_rejects_non_object_filter():
+    err = validate_report_cards_filter([])  # type: ignore[arg-type]
+    assert err is not None
+    assert "JSON object" in err

--- a/packages/sdk/tests/test_report_filter_preflight.py
+++ b/packages/sdk/tests/test_report_filter_preflight.py
@@ -82,3 +82,100 @@ def test_validate_report_cards_filter_rejects_non_object_filter():
     err = validate_report_cards_filter([])  # type: ignore[arg-type]
     assert err is not None
     assert "JSON object" in err
+
+
+def test_validate_report_cards_filter_rejects_non_string_group_operator():
+    err = validate_report_cards_filter({"operator": 123, "queries": []})
+    assert err is not None
+    assert "operator must be a non-empty string" in err
+
+
+def test_validate_report_cards_filter_rejects_non_list_queries():
+    err = validate_report_cards_filter({"operator": "and", "queries": "x"})
+    assert err is not None
+    assert "queries must be a list" in err
+
+
+def test_validate_report_cards_filter_rejects_non_list_groups():
+    err = validate_report_cards_filter({"operator": "and", "groups": "x"})
+    assert err is not None
+    assert "groups must be a list" in err
+
+
+def test_validate_report_cards_filter_rejects_non_object_group_entry():
+    err = validate_report_cards_filter({"operator": "and", "groups": ["x"]})
+    assert err is not None
+    assert "groups[0] must be an object" in err
+
+
+def test_validate_report_cards_filter_propagates_nested_group_error():
+    err = validate_report_cards_filter(
+        {"operator": "or", "groups": [{"operator": "xor", "queries": []}]}
+    )
+    assert err is not None
+    assert "groups[0].operator must be one of" in err
+
+
+def test_validate_report_cards_filter_rejects_non_object_query():
+    err = validate_report_cards_filter({"operator": "and", "queries": ["x"]})
+    assert err is not None
+    assert "queries[0] must be an object" in err
+
+
+def test_validate_report_cards_filter_rejects_blank_query_field():
+    err = validate_report_cards_filter(
+        {"operator": "and", "queries": [{"field": "  ", "operator": "eq"}]}
+    )
+    assert err is not None
+    assert "field must be a non-empty string" in err
+
+
+def test_validate_report_cards_filter_requires_query_operator():
+    err = validate_report_cards_filter(
+        {"operator": "and", "queries": [{"field": "current_phase"}]}
+    )
+    assert err is not None
+    assert ".operator is required" in err
+
+
+def test_validate_report_cards_filter_rejects_blank_query_operator():
+    err = validate_report_cards_filter(
+        {"operator": "and", "queries": [{"field": "current_phase", "operator": "  "}]}
+    )
+    assert err is not None
+    assert "operator must be a non-empty string" in err
+
+
+def test_validate_report_cards_filter_rejects_non_string_value():
+    err = validate_report_cards_filter(
+        {
+            "operator": "and",
+            "queries": [{"field": "current_phase", "operator": "eq", "value": 123}],
+        }
+    )
+    assert err is not None
+    assert "value must be a string" in err
+
+
+def test_validate_report_cards_filter_allows_omitted_value():
+    # exists / not_exists operators carry no value; an omitted value must pass.
+    assert (
+        validate_report_cards_filter(
+            {
+                "operator": "and",
+                "queries": [{"field": "due_date", "operator": "exists"}],
+            }
+        )
+        is None
+    )
+
+
+def test_validate_report_cards_filter_rejects_blank_query_type():
+    err = validate_report_cards_filter(
+        {
+            "operator": "and",
+            "queries": [{"field": "current_phase", "operator": "eq", "type": "  "}],
+        }
+    )
+    assert err is not None
+    assert "type must be a non-empty string" in err

--- a/skills/README.md
+++ b/skills/README.md
@@ -28,7 +28,7 @@ git clone https://github.com/pipefy/ai-toolkit.git
 
 | Domain | Skill | Description |
 |--------|-------|-------------|
-| **Pipes & Cards** | [pipefy-pipes-and-cards](pipes-and-cards/pipefy-pipes-and-cards/SKILL.md) | Pipes, phases, fields, labels, cards, field conditions. 37 MCP tools. |
+| **Pipes & Cards** | [pipefy-pipes-and-cards](pipes-and-cards/pipefy-pipes-and-cards/SKILL.md) | Pipes, phases, cards, labels; phase inventory/moves; `create_card(phase_id=…)`. Prefer over `execute_graphql` for seeding. |
 | **Database Tables** | [pipefy-database-tables](database-tables/pipefy-database-tables/SKILL.md) | Tables, records, schema, attachments. 17 MCP tools. |
 | **Relations** | [pipefy-relations](relations/pipefy-relations/SKILL.md) | Pipe and card relations. 8 MCP tools. |
 | **Reports** | [pipefy-reports](reports/pipefy-reports/SKILL.md) | Pipe and organization reports, async exports. 17 MCP tools. |

--- a/skills/api-troubleshoot/pipefy-api-fallback/SKILL.md
+++ b/skills/api-troubleshoot/pipefy-api-fallback/SKILL.md
@@ -20,7 +20,7 @@ This skill activates only after Tiers 1 and 2 have failed. Call the Pipefy Graph
 
 | Tier | Method | When |
 |------|--------|------|
-| **1** | Dedicated MCP tool (`create_card`, `update_pipe`, etc.) | Always try first. |
+| **1** | Dedicated MCP tool (`create_card`, `get_phase_cards`, `get_phase_allowed_move_targets`, `update_pipe`, etc.) | Always try first. For card/phase seeding and inventory, see the table in [pipefy-pipes-and-cards](../../pipes-and-cards/pipefy-pipes-and-cards/SKILL.md#avoid-execute_graphql-card--phase-workflows). |
 | **2** | Introspection + `execute_graphql` | When no dedicated tool exists or a tool fails unexpectedly. See [skills/introspection/pipefy-introspection/SKILL.md](../../introspection/pipefy-introspection/SKILL.md). |
 | **3** | Direct HTTP via curl / httpx (this skill) | When the MCP server itself is unavailable, or `execute_graphql` fails with an infrastructure error. |
 

--- a/skills/pipes-and-cards/pipefy-pipes-and-cards/SKILL.md
+++ b/skills/pipes-and-cards/pipefy-pipes-and-cards/SKILL.md
@@ -3,7 +3,8 @@ name: pipefy-pipes-and-cards
 description: >
   Use this skill when the user wants to read, create, update, or delete
   pipes, phases, phase fields, labels, cards, comments, or field conditions.
-  Covers 37 MCP tools for the core pipe and card lifecycle.
+  Covers 37 MCP tools for the core pipe and card lifecycle. Use the
+  seed-pipe-across-phases workflow when populating empty phases for demos or QA.
 tags: [pipefy, pipes, cards, phases, fields, labels, comments, field-conditions]
 ---
 
@@ -54,6 +55,72 @@ Read, create, update, and delete pipes, phases, phase fields, labels, cards, att
 | `create_phase` | `pipefy phase create` | No | Add a phase to a pipe. |
 | `update_phase` | `pipefy phase update <id>` | No | Rename, reorder, set done flag. |
 | `delete_phase` | `pipefy phase delete <id>` | No | **Two-step destructive.** |
+| `get_phase_allowed_move_targets` | `pipefy phase allowed-moves <id>` | Yes | Valid destination phases before `move_card_to_phase` (UI-configured edges only). |
+| `get_phase_cards_count` | `pipefy phase cards-count <id>` | Yes | Native per-phase card count (start-form count may be 0 while cards exist). |
+| `get_phase_cards` | `pipefy phase cards <id>` | Yes | Paginated cards in a phase (`--first`, `--after`, optional `--include-fields`). |
+
+---
+
+## Seed pipe across phases
+
+Use this workflow to place at least one card in each workflow phase (demos, QA checklists, chaos pipes) **without** `execute_graphql`. Transition edges must already exist in the Pipefy UI.
+
+### Tools needed
+
+| Tool (MCP) | CLI | Read-only |
+|------------|-----|-----------|
+| `get_pipe` | `pipefy pipe get <pipe_id>` | Yes |
+| `get_phase_cards_count` | `pipefy phase cards-count <phase_id>` | Yes |
+| `create_card` | `pipefy card create --pipe <id> --phase-id <id>` | No |
+| `get_phase_cards` | `pipefy phase cards <phase_id>` | Yes |
+| `get_phase_allowed_move_targets` | `pipefy phase allowed-moves <phase_id>` | Yes |
+| `move_card_to_phase` | `pipefy card move <card_id> --phase <id>` | No |
+
+### Steps
+
+1. **Load phase IDs** — `get_pipe(pipe_id)` → collect `phases[].id` and `start_form_phase.id` when seeding the start form.
+
+   MCP: `get_pipe pipe_id="306996634"`
+
+   CLI: `pipefy pipe get 306996634 --json`
+
+2. **Find empty phases** — for each candidate `phase_id`, call `get_phase_cards_count`. Target phases where `cards_count` is 0 (if the start form shows 0 but you suspect cards, call `get_phase_cards` before creating duplicates).
+
+   MCP: `get_phase_cards_count phase_id="340012345"`
+
+   CLI: `pipefy phase cards-count 340012345 --json`
+
+3. **Create cards in empty phases** — loop `create_card` with `phase_id` (and `skip_elicitation=true` when no start-form elicitation is wanted). Discover required fields with `get_phase_fields(phase_id)` when `fields` is non-empty.
+
+   MCP:
+   ```
+   create_card pipe_id="306996634" phase_id="340012345" skip_elicitation=true title="Seeded"
+   ```
+
+   CLI:
+   ```bash
+   pipefy card create --pipe 306996634 --phase-id 340012345 --title "Seeded"
+   ```
+
+4. **Verify inventory** — `get_phase_cards(phase_id, first=50)` and confirm expected card IDs/titles.
+
+   CLI: `pipefy phase cards 340012345 --json`
+
+5. **Before moves** — on the card's current phase, `get_phase_allowed_move_targets` then `move_card_to_phase` only to an `allowed_phases[].id`.
+
+   MCP: `get_phase_allowed_move_targets phase_id="<current_phase_id>"`
+
+   CLI: `pipefy phase allowed-moves <current_phase_id> --json`
+
+### Success criteria
+
+- Every targeted phase reports `cards_count >= 1` (or `get_phase_cards` lists the seeded cards).
+- Moves use only phases returned in `allowed_phases`.
+
+### Failure modes
+
+- **Empty `allowed_phases`:** configure **Phase → Connections** in the Pipefy UI; the API cannot add edges.
+- **Start-form `cards_count` is 0:** use `get_phase_cards` on `start_form_phase.id` before assuming the phase is empty.
 
 ---
 
@@ -82,9 +149,9 @@ This returns valid `type` enum values and their descriptions.
 | `get_card` | `pipefy card get <id>` | Yes | Card data, fields, and comments. |
 | `get_cards` | `pipefy card list --pipe <id>` | Yes | Paginated card list by pipe. |
 | `find_cards` | `pipefy card find --pipe <id>` | Yes | Filter by a single field value. |
-| `create_card` | `pipefy card create --pipe <id>` | No | **Always get start form fields first.** |
+| `create_card` | `pipefy card create --pipe <id>` | No | Default: start form. Optional `--phase-id` / `phase_id` skips start-form elicitation. |
 | `update_card` | `pipefy card update <id>` | No | Update title, assignee, due date, fields. |
-| `move_card_to_phase` | `pipefy card move <id>` | No | Move a card to a different phase. |
+| `move_card_to_phase` | `pipefy card move <id> --phase <id>` | No | Call `get_phase_allowed_move_targets` on the source phase first. |
 | `delete_card` | `pipefy card delete <id>` | No | **Two-step destructive.** |
 | `add_card_comment` | `pipefy card comment add <id>` | No | Add a text comment to a card. |
 

--- a/skills/reports/pipefy-reports/SKILL.md
+++ b/skills/reports/pipefy-reports/SKILL.md
@@ -83,9 +83,14 @@ Pipe reports and organization reports: discovery, CRUD, and async exports. **17 
 
    MCP: `get_pipe_report_filterable_fields pipe_id=67890`
 
-2. **Create the report with a filter:**
+2. **Create the report with a `ReportCardsFilter` shape** (not a top-level `current_phase` array):
 
-   MCP: `create_pipe_report pipe_id=67890 name="Overdue Cards" filter='{"status":["overdue"]}'`
+   MCP:
+   ```
+   create_pipe_report pipe_id=67890 name="Phase subset" filter='{"operator":"and","queries":[{"field":"current_phase","operator":"eq","type":"select","value":"<phase_id>"}]}'
+   ```
+
+   Use the exact `field` string from step 1. Invalid shapes are rejected before GraphQL with a message pointing at `get_pipe_report_filterable_fields`.
 
 ---
 
@@ -98,7 +103,8 @@ Pipe reports and organization reports: discovery, CRUD, and async exports. **17 
 
 - **Export stuck in `processing`:** large pipes with many cards can take minutes. Wait at least 60 seconds per poll. Retry the export trigger if still `processing` after several minutes.
 - **`get_pipe_reports` returns `null` for `cardCount`:** known Pipefy API behavior; the tool omits that field automatically.
-- **Filter not working:** use `get_pipe_report_filterable_fields` to confirm the exact filter key and value format.
+- **Filter rejected at tool boundary:** do not pass `{"current_phase":["id"]}` — use `operator` + `queries` (see step 2 above).
+- **Filter not working after create:** use `get_pipe_report_filterable_fields` to confirm the exact `field` string and `value` format.
 
 ## See also
 


### PR DESCRIPTION
This work closes gaps identified while **agent-seeding the Analytics pipe** (`306996636`) during the *chaos-pipe* exercise. Agents had to fall back to **`execute_graphql`**, and sometimes **`introspect_type` / `search_schema`**, because first-class MCP tools did not cover common card/phase workflows—even though the GraphQL API and parts of the SDK already supported them.

### What agents did with raw GraphQL (and why)

| Need | Typical escape hatch | Gap before this PR |
|------|----------------------|-------------------|
| Create a card in an orphan / non–start-form phase | `createCard` + `CreateCardInput.phase_id` via `execute_graphql`; `introspect_type("CreateCardInput")` | `create_card` had no `phase_id`; post-create `update_card` for title |
| Inventory cards per phase | `phase { cards_count }`, `phase { cards(first) }` | No MCP `get_phase_cards_count` / `get_phase_cards`; `get_cards` has no phase filter |
| Move cards safely | `move_card_to_phase` when destination ∈ allowed set | No proactive `get_phase_allowed_move_targets` tool (SDK existed; not exposed) |
| Pipe structure for seeding | Multiple `get_pipe` + ad-hoc phase queries | Start form not visible as `start_form_phase`; no `cards_count` on workflow phases |
| Labels | — | `create_label("red")` failed; API expects hex (`#RGB` / `#RRGGBB`) |
| Reports filtered by phase | Raw filter attempts | `ReportCardsFilter` shape easy to get wrong (top-level `current_phase` rejected by API) |

### What already worked without GraphQL

`create_phase`, field/condition setup, automations/AI agents (inactive), `move_card_to_phase` when the graph allowed it, `get_pipe` / `get_phase_fields`, and `create_card` on the start form with `skip_elicitation`.

### Goal

Let agents **seed, audit, and move cards on the happy path** using dedicated SDK + MCP + CLI surfaces (parity in `docs/parity.md`), without raw GraphQL for these flows. Phase transition **graph editing** stays UI-only (documented).

---

## Summary

- **SDK:** `get_pipe` inventory enrichment (`start_form_phase`, per-phase `cards_count`), phase card reads/counts, `create_card` with `phase_id`/`title`, `#RGB` label colors, and `ReportCardsFilter` preflight planner.
- **MCP:** `get_phase_cards`, `get_phase_cards_count`, `get_phase_allowed_move_targets`, `create_card(phase_id=…)`; report filter preflight on all filter-accepting mutations; docstring discovery hints for `start_form_phase.id`.
- **CLI:** Parity for phase inventory, `--phase-id` / `--first` validation, shared report-filter and page-size helpers.
- **Review follow-up (F1–F7):** Fix false `title_warning`, expand label hex and report preflight coverage, validate `phase_id`, clamp `phase cards --first`, service-level `get_pipe` hard-fail test, README/marketplace metadata for `pipefy/ai-toolkit`.
- **Docs/skills:** `docs/parity.md`, MCP reference, `pipefy-pipes-and-cards` skill workflow (*Seed pipe across phases*; prefer dedicated tools over `execute_graphql`).

## Test plan

- [x] `uv run ruff check .` / `ruff format --check .`
- [x] `uv run pytest packages/sdk/tests -m "not integration"` (936 passed)
- [x] `uv run pytest packages/mcp/tests -m "not integration"` (1361 passed, CI dummy `PIPEFY_*` env)
- [x] `uv run pytest packages/cli/tests -m "not integration"` (318 passed)
- [x] `uv run pytest tests/test_parity.py -m "not integration"` (154 passed)
- [x] `uv run python .github/workflows/scripts/lint_skill_refs.py`
- [ ] CI green on this PR
