### PR TITLE
chore(140): point plugin manifest ownership at pipefy org

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,15 +1,17 @@
 {
   "name": "pipefy",
   "owner": {
-    "name": "Gabriel Custodio",
-    "url": "https://github.com/gbrlcustodio"
+    "name": "Pipefy",
+    "url": "https://github.com/pipefy"
   },
   "plugins": [
     {
       "name": "pipefy",
       "source": "./",
       "description": "Pipefy workflow integration for Claude Code.",
-      "version": "0.2.0-beta.1"
+      "version": "0.2.0-beta.1",
+      "homepage": "https://github.com/pipefy/ai-toolkit",
+      "repository": "https://github.com/pipefy/ai-toolkit"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "displayName": "Pipefy",
   "version": "0.2.0-beta.1",
   "description": "Pipefy workflow integration for Claude Code.",
-  "author": { "name": "Gabriel Custodio" },
+  "author": { "name": "Pipefy", "url": "https://github.com/pipefy" },
   "homepage": "https://github.com/pipefy/ai-toolkit",
   "repository": "https://github.com/pipefy/ai-toolkit",
   "license": "Apache-2.0"


### PR DESCRIPTION
## What

Repoint the two ownership fields in the plugin manifests at the Pipefy org and round out the marketplace plugin entry.

- `marketplace.json` `owner`: was `{ name: "Gabriel Custodio", url: https://github.com/gbrlcustodio }`, now `{ name: "Pipefy", url: https://github.com/pipefy }`.
- `plugin.json` `author`: set name to `Pipefy` and add `url: https://github.com/pipefy`, mirroring the marketplace owner.
- `marketplace.json` plugin entry: add `homepage` and `repository` (`https://github.com/pipefy/ai-toolkit`), matching the values already in `plugin.json`.

## Why

The repo URL repoint in #140 rewrote owner-path URLs but its scope was "URL paths only," so it left these ownership fields on the personal account. After the org transfer the marketplace owner is Pipefy, and a half-migrated `owner` (personal name + org URL) reads as inconsistent. `owner.name` and `owner.url` now describe the same entity.

Note the deliberate distinction: `owner`/`author` now attribute ownership to the org, which is correct post-transfer. Distribution package names are untouched, consistent with #140.

## Scope

Manifest fields only. The untracked `skills-lock.json` and the historical `CHANGELOG.md` references are left as-is.