### PR TITLE
feat(mcp,cli): phase inventory tools and CLI parity

### DIFF
--- a/packages/cli/src/pipefy_cli/commands/_common.py
+++ b/packages/cli/src/pipefy_cli/commands/_common.py
@@ -69,7 +69,9 @@ _CARDS_PAGE_SIZE_MIN = 1
 _CARDS_PAGE_SIZE_MAX = 500
 
 
-def validate_cards_page_size(first: int) -> int:
+def validate_cards_page_size(first: int | None) -> int | None:
+    if first is None:
+        return None
     if first < _CARDS_PAGE_SIZE_MIN or first > _CARDS_PAGE_SIZE_MAX:
         raise typer.BadParameter(
             f"--first must be between {_CARDS_PAGE_SIZE_MIN} and "

--- a/packages/cli/src/pipefy_cli/commands/_common.py
+++ b/packages/cli/src/pipefy_cli/commands/_common.py
@@ -13,6 +13,7 @@ import typer
 from gql.transport.exceptions import TransportError, TransportQueryError
 from pipefy_sdk import PipefyClient, PipefySettings, stream_bytes
 from pipefy_sdk.exceptions import PipefyError
+from pipefy_sdk.report_filter_preflight import validate_report_cards_filter
 
 from pipefy_cli.auth import (
     AuthContext,
@@ -47,6 +48,40 @@ def validate_positional_id(value: str) -> str:
 def resource_id_argument(*, help: str) -> Any:
     """Typer ``Argument`` for resource ids when ``ignore_unknown_options`` is enabled."""
     return typer.Argument(..., help=help, callback=validate_positional_id)
+
+
+def validate_optional_resource_id(value: str | None, label: str) -> str | None:
+    if value is None:
+        return None
+    cleaned = value.strip()
+    if not cleaned:
+        raise typer.BadParameter(
+            f"Invalid '{label}': provide a non-empty string or positive integer."
+        )
+    if cleaned.startswith("-") and cleaned[1:].isdigit():
+        raise typer.BadParameter(f"Invalid '{label}': provide a positive integer.")
+    if cleaned.isdigit() and int(cleaned) <= 0:
+        raise typer.BadParameter(f"Invalid '{label}': provide a positive integer.")
+    return cleaned
+
+
+_CARDS_PAGE_SIZE_MIN = 1
+_CARDS_PAGE_SIZE_MAX = 500
+
+
+def validate_cards_page_size(first: int) -> int:
+    if first < _CARDS_PAGE_SIZE_MIN or first > _CARDS_PAGE_SIZE_MAX:
+        raise typer.BadParameter(
+            f"--first must be between {_CARDS_PAGE_SIZE_MIN} and "
+            f"{_CARDS_PAGE_SIZE_MAX} (inclusive)."
+        )
+    return first
+
+
+def validate_report_filter_cli(filter_obj: dict[str, Any] | None) -> None:
+    message = validate_report_cards_filter(filter_obj)
+    if message is not None:
+        raise typer.BadParameter(message)
 
 
 def export_poll_max_rounds(

--- a/packages/cli/src/pipefy_cli/commands/card.py
+++ b/packages/cli/src/pipefy_cli/commands/card.py
@@ -16,12 +16,15 @@ from pipefy_sdk import (
 from pydantic import ValidationError
 
 from pipefy_cli.commands._common import (
+    _CARDS_PAGE_SIZE_MAX,
+    _CARDS_PAGE_SIZE_MIN,
     ID_POSITIONAL_CONTEXT_SETTINGS,
     confirm_destructive,
     format_card_get_transport_query_error,
     parse_json_value,
     resource_id_argument,
     run_cli_command,
+    validate_cards_page_size,
 )
 
 card_app = typer.Typer(help="Card operations.", no_args_is_help=True)
@@ -36,20 +39,6 @@ def _parse_card_search_json(raw: str | None) -> CardSearch | None:
     if not isinstance(parsed, dict):
         raise typer.BadParameter("--search must be a JSON object")
     return copy_card_search(parsed)
-
-
-_CARDS_FIRST_MIN = 1
-_CARDS_FIRST_MAX = 500
-
-
-def _validate_cards_page_size(first: int | None) -> int | None:
-    if first is None:
-        return None
-    if first < _CARDS_FIRST_MIN or first > _CARDS_FIRST_MAX:
-        raise typer.BadParameter(
-            f"--first must be between {_CARDS_FIRST_MIN} and {_CARDS_FIRST_MAX} (inclusive)."
-        )
-    return first
 
 
 def _parse_fields_json(raw: str | None) -> dict[str, Any] | list[dict[str, Any]] | None:
@@ -137,7 +126,7 @@ def card_list(
     first: int | None = typer.Option(
         None,
         "--first",
-        help=f"Max cards per page ({_CARDS_FIRST_MIN}-{_CARDS_FIRST_MAX}).",
+        help=f"Max cards per page ({_CARDS_PAGE_SIZE_MIN}-{_CARDS_PAGE_SIZE_MAX}).",
     ),
     after: str | None = typer.Option(
         None,
@@ -161,7 +150,7 @@ def card_list(
     if title is not None and title.strip():
         merged["title"] = title.strip()
     effective_search: CardSearch | None = merged if merged else None
-    first_validated = _validate_cards_page_size(first)
+    first_validated = validate_cards_page_size(first)
 
     async def factory(client: PipefyClient):
         return await client.get_cards(

--- a/packages/cli/src/pipefy_cli/commands/phase.py
+++ b/packages/cli/src/pipefy_cli/commands/phase.py
@@ -44,10 +44,10 @@ def phase_get(
 
 
 @phase_app.command(
-    "allowed-moves",
+    "targets",
     context_settings=ID_POSITIONAL_CONTEXT_SETTINGS,
 )
-def phase_allowed_moves(
+def phase_targets(
     ctx: typer.Context,
     phase_id: str = resource_id_argument(
         help="Source phase id (card's current phase)."
@@ -68,10 +68,10 @@ def phase_allowed_moves(
 
 
 @phase_app.command(
-    "cards-count",
+    "count",
     context_settings=ID_POSITIONAL_CONTEXT_SETTINGS,
 )
-def phase_cards_count(
+def phase_count(
     ctx: typer.Context,
     phase_id: str = resource_id_argument(help="Phase id."),
     json_out: bool = typer.Option(

--- a/packages/cli/src/pipefy_cli/commands/phase.py
+++ b/packages/cli/src/pipefy_cli/commands/phase.py
@@ -88,7 +88,7 @@ def phase_cards_count(
     """
 
     async def factory(client: PipefyClient):
-        return await client.get_phase_cards_count_payload(phase_id)
+        return await client.get_phase(phase_id)
 
     run_cli_command(ctx, json_out, factory)
 

--- a/packages/cli/src/pipefy_cli/commands/phase.py
+++ b/packages/cli/src/pipefy_cli/commands/phase.py
@@ -6,6 +6,10 @@ from typing import Any
 
 import typer
 from pipefy_sdk import PipefyClient
+from pipefy_sdk.phase_inventory import (
+    get_phase_not_found_message,
+    is_get_phase_not_found_error,
+)
 
 from pipefy_cli.commands._common import (
     ID_POSITIONAL_CONTEXT_SETTINGS,
@@ -88,7 +92,12 @@ def phase_count(
     """
 
     async def factory(client: PipefyClient):
-        return await client.get_phase(phase_id)
+        try:
+            return await client.get_phase(phase_id)
+        except ValueError as exc:
+            if is_get_phase_not_found_error(exc):
+                raise ValueError(get_phase_not_found_message(phase_id)) from exc
+            raise
 
     run_cli_command(ctx, json_out, factory)
 

--- a/packages/cli/src/pipefy_cli/commands/phase.py
+++ b/packages/cli/src/pipefy_cli/commands/phase.py
@@ -13,6 +13,7 @@ from pipefy_cli.commands._common import (
     parse_json_object,
     resource_id_argument,
     run_cli_command,
+    validate_cards_page_size,
 )
 
 phase_app = typer.Typer(help="Pipe phase operations.", no_args_is_help=True)
@@ -38,6 +39,97 @@ def phase_get(
 
     async def factory(client: PipefyClient):
         return await client.get_phase_fields(phase_id, required_only=required_only)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@phase_app.command(
+    "allowed-moves",
+    context_settings=ID_POSITIONAL_CONTEXT_SETTINGS,
+)
+def phase_allowed_moves(
+    ctx: typer.Context,
+    phase_id: str = resource_id_argument(
+        help="Source phase id (card's current phase)."
+    ),
+    json_out: bool = typer.Option(
+        False,
+        "--json",
+        "-j",
+        help="Print machine-readable JSON to stdout.",
+    ),
+) -> None:
+    """List phases a card may move to from this phase (UI transition rules)."""
+
+    async def factory(client: PipefyClient):
+        return await client.get_phase_allowed_move_targets(phase_id)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@phase_app.command(
+    "cards-count",
+    context_settings=ID_POSITIONAL_CONTEXT_SETTINGS,
+)
+def phase_cards_count(
+    ctx: typer.Context,
+    phase_id: str = resource_id_argument(help="Phase id."),
+    json_out: bool = typer.Option(
+        False,
+        "--json",
+        "-j",
+        help="Print machine-readable JSON to stdout.",
+    ),
+) -> None:
+    """Return native ``Phase.cards_count`` for a phase (fast inventory).
+
+    On the start-form phase, ``cards_count`` may be 0 while cards still exist;
+    use ``pipefy phase cards`` to list cards when the count looks wrong.
+    """
+
+    async def factory(client: PipefyClient):
+        return await client.get_phase_cards_count_payload(phase_id)
+
+    run_cli_command(ctx, json_out, factory)
+
+
+@phase_app.command("cards", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
+def phase_cards(
+    ctx: typer.Context,
+    phase_id: str = resource_id_argument(help="Phase id."),
+    first: int = typer.Option(
+        50,
+        "--first",
+        help="Max cards per page (1-500).",
+    ),
+    after: str | None = typer.Option(
+        None,
+        "--after",
+        help="Cursor from pageInfo.endCursor of a previous call.",
+    ),
+    include_fields: bool = typer.Option(
+        False,
+        "--include-fields",
+        help="Include each card's custom fields in the response.",
+    ),
+    json_out: bool = typer.Option(
+        False,
+        "--json",
+        "-j",
+        help="Print machine-readable JSON to stdout.",
+    ),
+) -> None:
+    """List cards in a phase (``Phase.cards`` pagination)."""
+
+    first = validate_cards_page_size(first)
+
+    async def factory(client: PipefyClient):
+        return await client.get_phase_cards(
+            phase_id,
+            first=first,
+            after=after,
+            include_fields=include_fields,
+        )
 
     run_cli_command(ctx, json_out, factory)
 

--- a/packages/cli/tests/fixtures/cli_help_golden.txt
+++ b/packages/cli/tests/fixtures/cli_help_golden.txt
@@ -1667,9 +1667,9 @@ Usage: pipefy phase [OPTIONS] COMMAND [ARGS]...
 ╭─ Commands ───────────────────────────────────────────────────────────────────╮
 │ get             Load phase metadata and fields by id (via                    │
 │                 ``get_phase_fields``).                                       │
-│ allowed-moves   List phases a card may move to from this phase (UI           │
+│ targets         List phases a card may move to from this phase (UI           │
 │                 transition rules).                                           │
-│ cards-count     Return native ``Phase.cards_count`` for a phase (fast        │
+│ count           Return native ``Phase.cards_count`` for a phase (fast        │
 │                 inventory).                                                  │
 │ cards           List cards in a phase (``Phase.cards`` pagination).          │
 │ create          Create a phase in a pipe.                                    │
@@ -1678,8 +1678,8 @@ Usage: pipefy phase [OPTIONS] COMMAND [ARGS]...
 │ delete          Delete a phase permanently.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 
-### HELP phase/allowed-moves
-Usage: pipefy phase allowed-moves [OPTIONS] PHASE_ID
+### HELP phase/targets
+Usage: pipefy phase targets [OPTIONS] PHASE_ID
 
  List phases a card may move to from this phase (UI transition rules).
 
@@ -1709,8 +1709,8 @@ Usage: pipefy phase cards [OPTIONS] PHASE_ID
 │ --help                             Show this message and exit.               │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 
-### HELP phase/cards-count
-Usage: pipefy phase cards-count [OPTIONS] PHASE_ID
+### HELP phase/count
+Usage: pipefy phase count [OPTIONS] PHASE_ID
 
  Return native ``Phase.cards_count`` for a phase (fast inventory).
 

--- a/packages/cli/tests/fixtures/cli_help_golden.txt
+++ b/packages/cli/tests/fixtures/cli_help_golden.txt
@@ -859,8 +859,8 @@ Usage: pipefy card [OPTIONS] COMMAND [ARGS]...
 │ get       Fetch a card by id.                                                │
 │ list      List cards in a pipe (get_cards): browse, filter, and paginate.    │
 │ find      Find cards in a pipe where a custom field equals a value.          │
-│ create    Create a card in a pipe (start-form fields via --fields JSON when  │
-│           required).                                                         │
+│ create    Create a card in a pipe (start-form or phase fields via --fields   │
+│           JSON when required).                                               │
 │ update    Update a card (title, assignees, labels, due date, and/or field    │
 │           updates).                                                          │
 │ delete    Delete a card permanently.                                         │
@@ -927,17 +927,20 @@ Usage: pipefy card comment update [OPTIONS] COMMENT_ID TEXT
 ### HELP card/create
 Usage: pipefy card create [OPTIONS] PIPE_ID
 
- Create a card in a pipe (start-form fields via --fields JSON when required).
+ Create a card in a pipe (start-form or phase fields via --fields JSON when
+ required).
 
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    pipe_id      TEXT  Pipe id. [required]                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --title   -t      TEXT  Optional title (applied via update after create).    │
-│ --fields          TEXT  JSON object or array: start-form field values for    │
-│                         createCard.                                          │
-│ --json    -j            Print machine-readable JSON to stdout.               │
-│ --help                  Show this message and exit.                          │
+│ --title     -t      TEXT  Optional title (sent on CreateCardInput when set). │
+│ --phase-id          TEXT  Target phase id (CreateCardInput.phase_id).        │
+│                           Creates the card in that phase instead of the      │
+│                           start form.                                        │
+│ --fields            TEXT  JSON object or array: field values for createCard. │
+│ --json      -j            Print machine-readable JSON to stdout.             │
+│ --help                    Show this message and exit.                        │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 
 ### HELP card/delete
@@ -1504,7 +1507,9 @@ Usage: pipefy label create [OPTIONS]
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ *  --pipe           TEXT  Pipe id. [required]                                │
 │ *  --name   -n      TEXT  Label name. [required]                             │
-│ *  --color  -c      TEXT  Label color (per Pipefy API). [required]           │
+│ *  --color  -c      TEXT  Label color as hex #RRGGBB (e.g. #E50000,          │
+│                           #FF0000).                                          │
+│                           [required]                                         │
 │    --json   -j                                                               │
 │    --help                 Show this message and exit.                        │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -1545,7 +1550,8 @@ Usage: pipefy label update [OPTIONS] LABEL_ID
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ *  --name   -n      TEXT  New label name (required by API). [required]       │
-│ *  --color  -c      TEXT  New label color (required by API). [required]      │
+│ *  --color  -c      TEXT  New label color as hex #RRGGBB (required by API).  │
+│                           [required]                                         │
 │    --json   -j                                                               │
 │    --help                 Show this message and exit.                        │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -1659,11 +1665,64 @@ Usage: pipefy phase [OPTIONS] COMMAND [ARGS]...
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ get      Load phase metadata and fields by id (via ``get_phase_fields``).    │
-│ create   Create a phase in a pipe.                                           │
-│ update   Update a phase (Pipefy ``UpdatePhaseInput``). Resolves current name │
-│          when omitted.                                                       │
-│ delete   Delete a phase permanently.                                         │
+│ get             Load phase metadata and fields by id (via                    │
+│                 ``get_phase_fields``).                                       │
+│ allowed-moves   List phases a card may move to from this phase (UI           │
+│                 transition rules).                                           │
+│ cards-count     Return native ``Phase.cards_count`` for a phase (fast        │
+│                 inventory).                                                  │
+│ cards           List cards in a phase (``Phase.cards`` pagination).          │
+│ create          Create a phase in a pipe.                                    │
+│ update          Update a phase (Pipefy ``UpdatePhaseInput``). Resolves       │
+│                 current name when omitted.                                   │
+│ delete          Delete a phase permanently.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP phase/allowed-moves
+Usage: pipefy phase allowed-moves [OPTIONS] PHASE_ID
+
+ List phases a card may move to from this phase (UI transition rules).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    phase_id      TEXT  Source phase id (card's current phase). [required]  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --json  -j        Print machine-readable JSON to stdout.                     │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP phase/cards
+Usage: pipefy phase cards [OPTIONS] PHASE_ID
+
+ List cards in a phase (``Phase.cards`` pagination).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    phase_id      TEXT  Phase id. [required]                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --first                   INTEGER  Max cards per page (1-500). [default: 50] │
+│ --after                   TEXT     Cursor from pageInfo.endCursor of a       │
+│                                    previous call.                            │
+│ --include-fields                   Include each card's custom fields in the  │
+│                                    response.                                 │
+│ --json            -j               Print machine-readable JSON to stdout.    │
+│ --help                             Show this message and exit.               │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP phase/cards-count
+Usage: pipefy phase cards-count [OPTIONS] PHASE_ID
+
+ Return native ``Phase.cards_count`` for a phase (fast inventory).
+
+ On the start-form phase, ``cards_count`` may be 0 while cards still exist; use
+ ``pipefy phase cards`` to list cards when the count looks wrong.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    phase_id      TEXT  Phase id. [required]                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --json  -j        Print machine-readable JSON to stdout.                     │
+│ --help            Show this message and exit.                                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 
 ### HELP phase/create

--- a/packages/cli/tests/test_pipe_commands.py
+++ b/packages/cli/tests/test_pipe_commands.py
@@ -57,6 +57,32 @@ def test_pipe_get_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
     mock_client.get_pipe.assert_awaited_once_with("10")
 
 
+def test_pipe_get_json_includes_phase_inventory_fields(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("pipe-get-inventory")
+    payload = {
+        "pipe": {
+            "id": "10",
+            "name": "P",
+            "startFormPhaseId": "100",
+            "start_form_phase": {"id": "100", "name": "Start", "cards_count": 1},
+            "phases": [{"id": "200", "name": "Done", "cards_count": 3}],
+        }
+    }
+    mock_client = MagicMock()
+    mock_client.get_pipe = AsyncMock(return_value=payload)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(app, ["pipe", "get", "10", "--json"])
+    assert result.exit_code == 0
+    body = json.loads(result.stdout)
+    assert body["pipe"]["start_form_phase"]["cards_count"] == 1
+    assert body["pipe"]["phases"][0]["cards_count"] == 3
+
+
 def test_pipe_list_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
     oauth_env("pipe-list")
     payload = {"organizations": []}
@@ -215,3 +241,101 @@ def test_pipe_update_preferences_empty_object_bad_parameter(
         )
     assert result.exit_code == 2
     mock_client.update_pipe.assert_not_called()
+
+
+def test_phase_allowed_moves_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("ph-allowed-moves")
+    payload = {
+        "phase": {
+            "id": "342182335",
+            "name": "Doing",
+            "cards_can_be_moved_to_phases": [{"id": "200", "name": "Done"}],
+        }
+    }
+    mock_client = MagicMock()
+    mock_client.get_phase_allowed_move_targets = AsyncMock(return_value=payload)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["phase", "allowed-moves", "342182335", "--json"],
+        )
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == payload
+    mock_client.get_phase_allowed_move_targets.assert_awaited_once_with("342182335")
+
+
+def test_phase_cards_count_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("ph-cards-count")
+    payload = {
+        "phase_id": "342182335",
+        "phase_name": "Doing",
+        "cards_count": 7,
+    }
+    mock_client = MagicMock()
+    mock_client.get_phase_cards_count_payload = AsyncMock(return_value=payload)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["phase", "cards-count", "342182335", "--json"],
+        )
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == payload
+    mock_client.get_phase_cards_count_payload.assert_awaited_once_with("342182335")
+
+
+def test_phase_cards_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("ph-cards-list")
+    payload = {
+        "phase": {
+            "id": "342182335",
+            "cards": {
+                "edges": [{"node": {"id": "1", "title": "A"}}],
+                "pageInfo": {"hasNextPage": False, "endCursor": None},
+                "totalCount": 1,
+            },
+        }
+    }
+    mock_client = MagicMock()
+    mock_client.get_phase_cards = AsyncMock(return_value=payload)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["phase", "cards", "342182335", "--first", "50", "--after", "c1", "--json"],
+        )
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == payload
+    mock_client.get_phase_cards.assert_awaited_once_with(
+        "342182335",
+        first=50,
+        after="c1",
+        include_fields=False,
+    )
+
+
+def test_phase_cards_first_out_of_range_exit_2(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    # Help promises 1-500; the shared validate_cards_page_size clamp must reject
+    # an out-of-range --first before any API call (parity with `card list`).
+    oauth_env("ph-cards-bad-first")
+    mock_client = MagicMock()
+    mock_client.get_phase_cards = AsyncMock()
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["phase", "cards", "342182335", "--first", "501", "--json"],
+        )
+    assert result.exit_code == 2
+    mock_client.get_phase_cards.assert_not_called()

--- a/packages/cli/tests/test_pipe_commands.py
+++ b/packages/cli/tests/test_pipe_commands.py
@@ -57,7 +57,7 @@ def test_pipe_get_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
     mock_client.get_pipe.assert_awaited_once_with("10")
 
 
-def test_pipe_get_json_includes_phase_inventory_fields(
+def test_pipe_get_json_includes_phase_cards_count(
     runner, clean_pipefy_env, saved_cwd, oauth_env
 ):
     oauth_env("pipe-get-inventory")
@@ -66,7 +66,6 @@ def test_pipe_get_json_includes_phase_inventory_fields(
             "id": "10",
             "name": "P",
             "startFormPhaseId": "100",
-            "start_form_phase": {"id": "100", "name": "Start", "cards_count": 1},
             "phases": [{"id": "200", "name": "Done", "cards_count": 3}],
         }
     }
@@ -79,7 +78,6 @@ def test_pipe_get_json_includes_phase_inventory_fields(
         result = runner.invoke(app, ["pipe", "get", "10", "--json"])
     assert result.exit_code == 0
     body = json.loads(result.stdout)
-    assert body["pipe"]["start_form_phase"]["cards_count"] == 1
     assert body["pipe"]["phases"][0]["cards_count"] == 3
 
 
@@ -275,7 +273,7 @@ def test_phase_cards_count_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
         "cards_count": 7,
     }
     mock_client = MagicMock()
-    mock_client.get_phase_cards_count_payload = AsyncMock(return_value=payload)
+    mock_client.get_phase = AsyncMock(return_value=payload)
     with patch(
         "pipefy_cli.commands._common.get_authenticated_client",
         return_value=mock_client,
@@ -286,7 +284,7 @@ def test_phase_cards_count_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
         )
     assert result.exit_code == 0
     assert json.loads(result.stdout) == payload
-    mock_client.get_phase_cards_count_payload.assert_awaited_once_with("342182335")
+    mock_client.get_phase.assert_awaited_once_with("342182335")
 
 
 def test_phase_cards_json(runner, clean_pipefy_env, saved_cwd, oauth_env):

--- a/packages/cli/tests/test_pipe_commands.py
+++ b/packages/cli/tests/test_pipe_commands.py
@@ -241,8 +241,8 @@ def test_pipe_update_preferences_empty_object_bad_parameter(
     mock_client.update_pipe.assert_not_called()
 
 
-def test_phase_allowed_moves_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
-    oauth_env("ph-allowed-moves")
+def test_phase_targets_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("ph-targets")
     payload = {
         "phase": {
             "id": "342182335",
@@ -258,15 +258,15 @@ def test_phase_allowed_moves_json(runner, clean_pipefy_env, saved_cwd, oauth_env
     ):
         result = runner.invoke(
             app,
-            ["phase", "allowed-moves", "342182335", "--json"],
+            ["phase", "targets", "342182335", "--json"],
         )
     assert result.exit_code == 0
     assert json.loads(result.stdout) == payload
     mock_client.get_phase_allowed_move_targets.assert_awaited_once_with("342182335")
 
 
-def test_phase_cards_count_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
-    oauth_env("ph-cards-count")
+def test_phase_count_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("ph-count")
     payload = {
         "phase_id": "342182335",
         "phase_name": "Doing",
@@ -280,7 +280,7 @@ def test_phase_cards_count_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
     ):
         result = runner.invoke(
             app,
-            ["phase", "cards-count", "342182335", "--json"],
+            ["phase", "count", "342182335", "--json"],
         )
     assert result.exit_code == 0
     assert json.loads(result.stdout) == payload

--- a/packages/cli/tests/test_pipe_commands.py
+++ b/packages/cli/tests/test_pipe_commands.py
@@ -287,6 +287,25 @@ def test_phase_count_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
     mock_client.get_phase.assert_awaited_once_with("342182335")
 
 
+def test_phase_count_not_found_exit_2(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("ph-count-missing")
+    mock_client = MagicMock()
+    mock_client.get_phase = AsyncMock(
+        side_effect=ValueError("phase.cards_count missing from response")
+    )
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["phase", "count", "999", "--json"],
+        )
+    assert result.exit_code == 2
+    assert "not found" in result.stderr.lower()
+    mock_client.get_phase.assert_awaited_once_with("999")
+
+
 def test_phase_cards_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
     oauth_env("ph-cards-list")
     payload = {

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_config_tool_helpers.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_config_tool_helpers.py
@@ -562,6 +562,44 @@ async def resolve_phase_dependents(
     return out
 
 
+def normalize_phase_allowed_move_targets(
+    raw: dict[str, Any],
+) -> dict[str, Any] | None:
+    phase = (raw or {}).get("phase")
+    if not isinstance(phase, dict):
+        return None
+    phase_id = phase.get("id")
+    if phase_id is None:
+        return None
+    allowed_raw = phase.get("cards_can_be_moved_to_phases") or []
+    allowed_phases: list[dict[str, str]] = []
+    if isinstance(allowed_raw, list):
+        for item in allowed_raw:
+            if not isinstance(item, dict):
+                continue
+            dest_id = item.get("id")
+            if dest_id is None:
+                continue
+            allowed_phases.append(
+                {
+                    "id": str(dest_id),
+                    "name": str(item.get("name") or ""),
+                }
+            )
+    return {
+        "phase_id": str(phase_id),
+        "phase_name": str(phase.get("name") or ""),
+        "allowed_phases": allowed_phases,
+    }
+
+
+def normalize_phase_cards_list(raw: dict[str, Any]) -> dict[str, Any] | None:
+    phase = (raw or {}).get("phase")
+    if not isinstance(phase, dict) or phase.get("id") is None:
+        return None
+    return phase
+
+
 __all__ = [
     "DeletePipeErrorPayload",
     "DeletePipePayload",
@@ -584,6 +622,8 @@ __all__ = [
     "find_phase_field_dependents",
     "handle_pipe_config_tool_graphql_error",
     "map_delete_pipe_error_to_message",
+    "normalize_phase_allowed_move_targets",
+    "normalize_phase_cards_list",
     "resolve_phase_dependents",
     "resolve_phase_field_identifiers",
 ]

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_config_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_config_tools.py
@@ -7,6 +7,10 @@ from mcp.server.session import ServerSession
 from mcp.types import ToolAnnotations
 from pipefy_sdk import PipefyClient, PipefyId
 from pipefy_sdk.label_color import normalize_label_color
+from pipefy_sdk.phase_inventory import (
+    get_phase_not_found_message,
+    is_get_phase_not_found_error,
+)
 
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.graphql_error_helpers import (
@@ -416,7 +420,7 @@ class PipeConfigTools:
         ) -> dict[str, Any]:
             """Return the native ``Phase.cards_count`` for a phase (fast inventory).
 
-            Uses the schema scalar — no card enumeration. On the **start-form** phase,
+            Uses the schema scalar; no card enumeration. On the **start-form** phase,
             ``cards_count`` may be **0** while cards still exist; use ``get_phase_cards``
             to list or verify inventory when the count looks wrong.
 
@@ -435,6 +439,13 @@ class PipeConfigTools:
                 return err
             try:
                 payload = await client.get_phase(phase_id_str)
+            except ValueError as exc:
+                if is_get_phase_not_found_error(exc):
+                    return build_pipe_tool_error_payload(
+                        message=get_phase_not_found_message(phase_id_str),
+                        code="NOT_FOUND",
+                    )
+                raise
             except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
                     exc,
@@ -476,8 +487,9 @@ class PipeConfigTools:
                 debug: When True, append GraphQL codes and correlation_id to errors.
 
             Returns:
-                GraphQL ``phase`` object with ``cards`` connection (``edges``, ``pageInfo``,
-                ``totalCount``). When unified envelope is enabled, includes pagination hints.
+                Query-root dict ``{"phase": {...}}`` with a ``cards`` connection
+                (``edges``, ``pageInfo``, ``totalCount``). With unified envelope enabled,
+                that dict is under ``data`` and includes pagination hints.
             """
             phase_id_str, err = validate_tool_id(phase_id, "phase_id")
             if err is not None:
@@ -1064,8 +1076,8 @@ class PipeConfigTools:
             Args:
                 pipe_id: Pipe that will receive the label.
                 name: Label name.
-                color: Label color as hex ``#RRGGBB`` (e.g. ``#E50000``, ``#FF0000``);
-                    color names such as ``red`` are rejected before GraphQL.
+                color: Label color as hex ``#RGB`` or ``#RRGGBB`` (e.g. ``#F00``,
+                    ``#FF0000``); color names such as ``red`` are rejected before GraphQL.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             pipe_id, err = validate_tool_id(pipe_id, "pipe_id")
@@ -1129,8 +1141,8 @@ class PipeConfigTools:
             Args:
                 label_id: Label ID to update.
                 name: New label name (non-empty).
-                color: New label color as hex ``#RRGGBB`` (e.g. ``#E50000``); color
-                    names are rejected before GraphQL.
+                color: New label color as hex ``#RGB`` or ``#RRGGBB`` (e.g. ``#F00``);
+                    color names are rejected before GraphQL.
                 extra_input: Additional UpdateLabelInput fields, if any.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_config_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_config_tools.py
@@ -422,8 +422,8 @@ class PipeConfigTools:
 
             Args:
                 phase_id: Phase ID. Discover via: ``get_pipe(pipe_id).phases[].id``
-                    for workflow phases, or ``get_pipe(pipe_id).start_form_phase.id``
-                    for the start-form phase.
+                    for workflow phases, or ``get_pipe(pipe_id).startFormPhaseId``
+                    for the start-form phase (not listed in ``phases[]``).
                 debug: When True, append GraphQL codes and correlation_id to errors.
 
             Returns:
@@ -434,7 +434,7 @@ class PipeConfigTools:
             if err is not None:
                 return err
             try:
-                payload = await client.get_phase_cards_count_payload(phase_id_str)
+                payload = await client.get_phase(phase_id_str)
             except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
                     exc,
@@ -468,8 +468,8 @@ class PipeConfigTools:
 
             Args:
                 phase_id: Phase ID. Discover via: ``get_pipe(pipe_id).phases[].id``
-                    for workflow phases, or ``get_pipe(pipe_id).start_form_phase.id``
-                    for the start-form phase.
+                    for workflow phases, or ``get_pipe(pipe_id).startFormPhaseId``
+                    for the start-form phase (not listed in ``phases[]``).
                 first: Max cards per page (1-500). Default 50.
                 after: Cursor from ``pageInfo.endCursor`` of a previous call.
                 include_fields: When True, include each card's custom fields.

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_config_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_config_tools.py
@@ -6,6 +6,7 @@ from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
 from mcp.types import ToolAnnotations
 from pipefy_sdk import PipefyClient, PipefyId
+from pipefy_sdk.label_color import normalize_label_color
 
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.graphql_error_helpers import (
@@ -13,6 +14,10 @@ from pipefy_mcp.tools.graphql_error_helpers import (
     extract_graphql_correlation_id,
     extract_graphql_error_codes,
     with_debug_suffix,
+)
+from pipefy_mcp.tools.pagination_helpers import (
+    build_pagination_info,
+    validate_page_size,
 )
 from pipefy_mcp.tools.pipe_config_tool_helpers import (
     build_delete_pipe_error_payload,
@@ -22,11 +27,17 @@ from pipefy_mcp.tools.pipe_config_tool_helpers import (
     find_phase_field_dependents,
     handle_pipe_config_tool_graphql_error,
     map_delete_pipe_error_to_message,
+    normalize_phase_allowed_move_targets,
+    normalize_phase_cards_list,
     resolve_phase_dependents,
     resolve_phase_field_identifiers,
 )
 from pipefy_mcp.tools.pipe_tool_helpers import find_label_dependents
-from pipefy_mcp.tools.tool_error_envelope import tool_error_message
+from pipefy_mcp.tools.tool_error_envelope import (
+    is_unified_envelope_enabled,
+    tool_error_message,
+    tool_success,
+)
 from pipefy_mcp.tools.validation_helpers import (
     validate_optional_tool_id,
     validate_tool_id,
@@ -342,6 +353,172 @@ class PipeConfigTools:
                 label="Pipe(s) cloned.",
                 data=raw,
             )
+
+        @mcp.tool(
+            annotations=ToolAnnotations(
+                readOnlyHint=True,
+            ),
+        )
+        async def get_phase_allowed_move_targets(
+            phase_id: PipefyId,
+            debug: bool = False,
+        ) -> dict[str, Any]:
+            """List phases a card may move to from a source phase (UI transition rules).
+
+            Read-only mirror of Pipefy **Phase -> Connections** (GraphQL
+            ``phase.cards_can_be_moved_to_phases``). Call before ``move_card_to_phase``
+            to avoid trial-and-error moves. New phases have no edges until configured
+            in the Pipefy UI.
+
+            Args:
+                phase_id: Source phase ID (typically the card's ``current_phase.id``).
+                    Discover via: ``get_card(card_id).current_phase.id`` or
+                    ``get_pipe(pipe_id).phases[].id``.
+                debug: When True, append GraphQL codes and correlation_id to errors.
+
+            Returns:
+                ``success: true`` with ``data`` containing ``phase_id``, ``phase_name``,
+                and ``allowed_phases`` (list of ``{id, name}``). Empty
+                ``allowed_phases`` means no outbound transitions are configured.
+            """
+            phase_id_str, err = validate_tool_id(phase_id, "phase_id")
+            if err is not None:
+                return err
+            try:
+                raw = await client.get_phase_allowed_move_targets(phase_id_str)
+            except Exception as exc:  # noqa: BLE001
+                return handle_pipe_config_tool_graphql_error(
+                    exc,
+                    "Get phase allowed move targets failed.",
+                    debug=debug,
+                    resource_kind="phase",
+                    resource_id=phase_id_str,
+                )
+            normalized = normalize_phase_allowed_move_targets(raw)
+            if normalized is None:
+                return build_pipe_tool_error_payload(
+                    message=f"Phase {phase_id_str} not found or access denied.",
+                    code="NOT_FOUND",
+                )
+            return tool_success(
+                data=normalized,
+                message="Allowed move targets loaded.",
+            )
+
+        @mcp.tool(
+            annotations=ToolAnnotations(
+                readOnlyHint=True,
+            ),
+        )
+        async def get_phase_cards_count(
+            phase_id: PipefyId,
+            debug: bool = False,
+        ) -> dict[str, Any]:
+            """Return the native ``Phase.cards_count`` for a phase (fast inventory).
+
+            Uses the schema scalar — no card enumeration. On the **start-form** phase,
+            ``cards_count`` may be **0** while cards still exist; use ``get_phase_cards``
+            to list or verify inventory when the count looks wrong.
+
+            Args:
+                phase_id: Phase ID. Discover via: ``get_pipe(pipe_id).phases[].id``
+                    for workflow phases, or ``get_pipe(pipe_id).start_form_phase.id``
+                    for the start-form phase.
+                debug: When True, append GraphQL codes and correlation_id to errors.
+
+            Returns:
+                ``success: true`` with ``data`` containing ``phase_id``, ``phase_name``,
+                and ``cards_count``.
+            """
+            phase_id_str, err = validate_tool_id(phase_id, "phase_id")
+            if err is not None:
+                return err
+            try:
+                payload = await client.get_phase_cards_count_payload(phase_id_str)
+            except Exception as exc:  # noqa: BLE001
+                return handle_pipe_config_tool_graphql_error(
+                    exc,
+                    "Get phase cards count failed.",
+                    debug=debug,
+                    resource_kind="phase",
+                    resource_id=phase_id_str,
+                )
+            return tool_success(
+                data=payload,
+                message="Phase cards count loaded.",
+            )
+
+        @mcp.tool(
+            annotations=ToolAnnotations(
+                readOnlyHint=True,
+            ),
+        )
+        async def get_phase_cards(
+            phase_id: PipefyId,
+            first: int = 50,
+            after: str | None = None,
+            include_fields: bool = False,
+            debug: bool = False,
+        ) -> dict[str, Any]:
+            """List cards currently in a phase (``Phase.cards`` pagination).
+
+            Prefer this over ``get_cards`` when you need every card in a specific phase;
+            pipe-level ``CardSearch`` has no phase filter. For a quick scalar total,
+            use ``get_phase_cards_count`` (see start-form ``cards_count`` caveat there).
+
+            Args:
+                phase_id: Phase ID. Discover via: ``get_pipe(pipe_id).phases[].id``
+                    for workflow phases, or ``get_pipe(pipe_id).start_form_phase.id``
+                    for the start-form phase.
+                first: Max cards per page (1-500). Default 50.
+                after: Cursor from ``pageInfo.endCursor`` of a previous call.
+                include_fields: When True, include each card's custom fields.
+                debug: When True, append GraphQL codes and correlation_id to errors.
+
+            Returns:
+                GraphQL ``phase`` object with ``cards`` connection (``edges``, ``pageInfo``,
+                ``totalCount``). When unified envelope is enabled, includes pagination hints.
+            """
+            phase_id_str, err = validate_tool_id(phase_id, "phase_id")
+            if err is not None:
+                return err
+            validated_first, page_err = validate_page_size(first)
+            if page_err is not None:
+                return page_err
+            try:
+                raw = await client.get_phase_cards(
+                    phase_id_str,
+                    first=validated_first,
+                    after=after,
+                    include_fields=include_fields,
+                )
+            except Exception as exc:  # noqa: BLE001
+                return handle_pipe_config_tool_graphql_error(
+                    exc,
+                    "Get phase cards failed.",
+                    debug=debug,
+                    resource_kind="phase",
+                    resource_id=phase_id_str,
+                )
+            phase_payload = normalize_phase_cards_list(raw)
+            if phase_payload is None:
+                return build_pipe_tool_error_payload(
+                    message=f"Phase {phase_id_str} not found or access denied.",
+                    code="NOT_FOUND",
+                )
+            if is_unified_envelope_enabled():
+                cards = phase_payload.get("cards") or {}
+                page_info = cards.get("pageInfo") if isinstance(cards, dict) else None
+                pagination = build_pagination_info(
+                    page_info=page_info,
+                    page_size=validated_first,
+                )
+                return tool_success(
+                    data=raw,
+                    message="Phase cards retrieved.",
+                    pagination=pagination,
+                )
+            return raw
 
         @mcp.tool(
             annotations=ToolAnnotations(
@@ -887,7 +1064,8 @@ class PipeConfigTools:
             Args:
                 pipe_id: Pipe that will receive the label.
                 name: Label name.
-                color: Label color (per Pipefy/API).
+                color: Label color as hex ``#RRGGBB`` (e.g. ``#E50000``, ``#FF0000``);
+                    color names such as ``red`` are rejected before GraphQL.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             pipe_id, err = validate_tool_id(pipe_id, "pipe_id")
@@ -904,10 +1082,17 @@ class PipeConfigTools:
                     code="INVALID_ARGUMENTS",
                 )
             try:
+                normalized_color = normalize_label_color(color)
+            except ValueError as exc:
+                return build_pipe_tool_error_payload(
+                    message=str(exc),
+                    code="INVALID_ARGUMENTS",
+                )
+            try:
                 raw = await client.create_label(
                     pipe_id,
                     name.strip(),
-                    color.strip(),
+                    normalized_color,
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
@@ -944,7 +1129,8 @@ class PipeConfigTools:
             Args:
                 label_id: Label ID to update.
                 name: New label name (non-empty).
-                color: New label color, hex string (non-empty).
+                color: New label color as hex ``#RRGGBB`` (e.g. ``#E50000``); color
+                    names are rejected before GraphQL.
                 extra_input: Additional UpdateLabelInput fields, if any.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
@@ -961,13 +1147,20 @@ class PipeConfigTools:
                     message="Invalid 'color': provide a non-empty string.",
                     code="INVALID_ARGUMENTS",
                 )
+            try:
+                normalized_color = normalize_label_color(color)
+            except ValueError as exc:
+                return build_pipe_tool_error_payload(
+                    message=str(exc),
+                    code="INVALID_ARGUMENTS",
+                )
             update_attrs: dict[str, Any] = {
                 k: v
                 for k, v in (extra_input or {}).items()
                 if k not in _UPDATE_LABEL_EXTRA_RESERVED
             }
             update_attrs["name"] = name.strip()
-            update_attrs["color"] = color.strip()
+            update_attrs["color"] = normalized_color
             try:
                 raw = await client.update_label(label_id, **update_attrs)
             except Exception as exc:  # noqa: BLE001

--- a/packages/mcp/src/pipefy_mcp/tools/registry.py
+++ b/packages/mcp/src/pipefy_mcp/tools/registry.py
@@ -20,6 +20,7 @@ from pipefy_mcp.tools.report_tools import ReportTools
 from pipefy_mcp.tools.table_tools import TableTools
 from pipefy_mcp.tools.webhook_tools import WebhookTools
 
+# 152 tools — keep in sync with docs/parity.md row count and README MCP totals.
 PIPEFY_TOOL_NAMES = frozenset(
     {
         "add_card_comment",
@@ -108,6 +109,9 @@ PIPEFY_TOOL_NAMES = frozenset(
         "get_organization_report",
         "get_organization_report_export",
         "get_organization_reports",
+        "get_phase_allowed_move_targets",
+        "get_phase_cards",
+        "get_phase_cards_count",
         "get_phase_fields",
         "get_portal",
         "get_pipe",

--- a/packages/mcp/src/pipefy_mcp/tools/registry.py
+++ b/packages/mcp/src/pipefy_mcp/tools/registry.py
@@ -20,7 +20,7 @@ from pipefy_mcp.tools.report_tools import ReportTools
 from pipefy_mcp.tools.table_tools import TableTools
 from pipefy_mcp.tools.webhook_tools import WebhookTools
 
-# 152 tools — keep in sync with docs/parity.md row count and README MCP totals.
+# Keep PIPEFY_TOOL_NAMES in sync with docs/parity.md and README MCP totals.
 PIPEFY_TOOL_NAMES = frozenset(
     {
         "add_card_comment",

--- a/packages/mcp/tests/tools/test_docstring_discovery_hints.py
+++ b/packages/mcp/tests/tools/test_docstring_discovery_hints.py
@@ -54,7 +54,27 @@ AUDIT: list[tuple[str, str, list[str]]] = [
         "automation_tools.py",
         ["get_automation", "create_automation"],
     ),
-    ("move_card_to_phase", "pipe_tools.py", ["get_pipe"]),
+    ("move_card_to_phase", "pipe_tools.py", ["get_phase_allowed_move_targets"]),
+    (
+        "create_card",
+        "pipe_tools.py",
+        ["get_pipe", "get_phase_allowed_move_targets"],
+    ),
+    (
+        "get_phase_allowed_move_targets",
+        "pipe_config_tools.py",
+        ["get_card", "get_pipe"],
+    ),
+    (
+        "get_phase_cards_count",
+        "pipe_config_tools.py",
+        ["get_pipe", "get_phase_cards"],
+    ),
+    (
+        "get_phase_cards",
+        "pipe_config_tools.py",
+        ["get_pipe", "get_phase_cards_count"],
+    ),
     ("create_phase_field", "pipe_config_tools.py", ["get_pipe"]),
     ("update_phase_field", "pipe_config_tools.py", ["get_phase_fields"]),
     ("delete_phase_field", "pipe_config_tools.py", ["get_phase_fields"]),

--- a/packages/mcp/tests/tools/test_pipe_config_tools.py
+++ b/packages/mcp/tests/tools/test_pipe_config_tools.py
@@ -2674,6 +2674,26 @@ async def test_get_phase_cards_count_rejects_invalid_phase_id(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_get_phase_cards_count_not_found(
+    pipe_config_session, mock_pipe_config_client, extract_payload
+):
+    mock_pipe_config_client.get_phase.side_effect = ValueError(
+        "phase.cards_count missing from response"
+    )
+
+    async with pipe_config_session as session:
+        result = await session.call_tool(
+            "get_phase_cards_count",
+            {"phase_id": 999},
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "not found" in tool_error_message(payload).lower()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
 async def test_get_phase_cards_count_graphql_error(
     pipe_config_session, mock_pipe_config_client, extract_payload
 ):

--- a/packages/mcp/tests/tools/test_pipe_config_tools.py
+++ b/packages/mcp/tests/tools/test_pipe_config_tools.py
@@ -2677,11 +2677,9 @@ async def test_get_phase_cards_count_rejects_invalid_phase_id(
 async def test_get_phase_cards_count_graphql_error(
     pipe_config_session, mock_pipe_config_client, extract_payload
 ):
-    mock_pipe_config_client.get_phase.side_effect = (
-        TransportQueryError(
-            "GraphQL Error",
-            errors=[{"message": "Forbidden"}],
-        )
+    mock_pipe_config_client.get_phase.side_effect = TransportQueryError(
+        "GraphQL Error",
+        errors=[{"message": "Forbidden"}],
     )
 
     async with pipe_config_session as session:

--- a/packages/mcp/tests/tools/test_pipe_config_tools.py
+++ b/packages/mcp/tests/tools/test_pipe_config_tools.py
@@ -20,6 +20,8 @@ from pipefy_mcp.tools.pipe_config_tool_helpers import (
     build_field_condition_delete_payload,
     build_field_condition_success_payload,
     field_condition_phase_field_id_looks_like_slug,
+    normalize_phase_allowed_move_targets,
+    normalize_phase_cards_list,
 )
 from pipefy_mcp.tools.pipe_config_tools import PipeConfigTools
 from pipefy_mcp.tools.tool_error_envelope import tool_error, tool_error_message
@@ -83,7 +85,10 @@ def mock_pipe_config_client():
     client.update_label = AsyncMock()
     client.delete_label = AsyncMock()
     client.get_cards = AsyncMock()
+    client.get_phase_allowed_move_targets = AsyncMock()
     client.get_phase_cards_count = AsyncMock()
+    client.get_phase_cards_count_payload = AsyncMock()
+    client.get_phase_cards = AsyncMock()
     client.create_field_condition = AsyncMock()
     client.update_field_condition = AsyncMock()
     client.delete_field_condition = AsyncMock()
@@ -1139,16 +1144,16 @@ async def test_create_label_success(
     pipe_config_session, mock_pipe_config_client, extract_payload
 ):
     mock_pipe_config_client.create_label.return_value = {
-        "createLabel": {"label": {"id": "1", "name": "Bug", "color": "red"}},
+        "createLabel": {"label": {"id": "1", "name": "Bug", "color": "#FF0000"}},
     }
 
     async with pipe_config_session as session:
         result = await session.call_tool(
             "create_label",
-            {"pipe_id": 2, "name": "Bug", "color": "red"},
+            {"pipe_id": 2, "name": "Bug", "color": "#FF0000"},
         )
 
-    mock_pipe_config_client.create_label.assert_awaited_once_with("2", "Bug", "red")
+    mock_pipe_config_client.create_label.assert_awaited_once_with("2", "Bug", "#FF0000")
     assert extract_payload(result)["success"] is True
 
 
@@ -1158,17 +1163,17 @@ async def test_update_label_success(
     pipe_config_session, mock_pipe_config_client, extract_payload
 ):
     mock_pipe_config_client.update_label.return_value = {
-        "updateLabel": {"label": {"id": "3", "name": "Story", "color": "blue"}},
+        "updateLabel": {"label": {"id": "3", "name": "Story", "color": "#0000FF"}},
     }
 
     async with pipe_config_session as session:
         result = await session.call_tool(
             "update_label",
-            {"label_id": 3, "name": "Story", "color": "blue"},
+            {"label_id": 3, "name": "Story", "color": "#0000FF"},
         )
 
     mock_pipe_config_client.update_label.assert_awaited_once_with(
-        "3", name="Story", color="blue"
+        "3", name="Story", color="#0000FF"
     )
     assert extract_payload(result)["success"] is True
 
@@ -1179,7 +1184,7 @@ async def test_update_label_strips_id_from_extra_input__no_integration(
     pipe_config_session, mock_pipe_config_client, extract_payload
 ):
     mock_pipe_config_client.update_label.return_value = {
-        "updateLabel": {"label": {"id": "3", "name": "X", "color": "blue"}},
+        "updateLabel": {"label": {"id": "3", "name": "X", "color": "#0000FF"}},
     }
     async with pipe_config_session as session:
         result = await session.call_tool(
@@ -1187,14 +1192,14 @@ async def test_update_label_strips_id_from_extra_input__no_integration(
             {
                 "label_id": 3,
                 "name": "X",
-                "color": "blue",
+                "color": "#0000FF",
                 "extra_input": {"id": 999},
             },
         )
     mock_pipe_config_client.update_label.assert_awaited_once_with(
         "3",
         name="X",
-        color="blue",
+        color="#0000FF",
     )
     assert extract_payload(result)["success"] is True
 
@@ -1721,7 +1726,7 @@ async def test_create_label_graphql_error_returns_failure__no_integration(
     async with pipe_config_session as session:
         result = await session.call_tool(
             "create_label",
-            {"pipe_id": 2, "name": "Bug", "color": "red"},
+            {"pipe_id": 2, "name": "Bug", "color": "#FF0000"},
         )
     payload = extract_payload(result)
     assert payload["success"] is False
@@ -1740,7 +1745,7 @@ async def test_update_label_graphql_error_returns_failure__no_integration(
     async with pipe_config_session as session:
         result = await session.call_tool(
             "update_label",
-            {"label_id": 3, "name": "Story", "color": "blue"},
+            {"label_id": 3, "name": "Story", "color": "#0000FF"},
         )
     payload = extract_payload(result)
     assert payload["success"] is False
@@ -1823,6 +1828,38 @@ async def test_create_label_rejects_blank_color__no_integration(
         )
     mock_pipe_config_client.create_label.assert_not_called()
     assert extract_payload(result)["success"] is False
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("tool_name", "arguments"),
+    [
+        (
+            "create_label",
+            {"pipe_id": 2, "name": "Bug", "color": "red"},
+        ),
+        (
+            "update_label",
+            {"label_id": 3, "name": "Story", "color": "blue"},
+        ),
+    ],
+)
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_label_color_rejects_non_hex_before_graphql__no_integration(
+    pipe_config_session,
+    mock_pipe_config_client,
+    extract_payload,
+    tool_name: str,
+    arguments: dict[str, object],
+):
+    async with pipe_config_session as session:
+        result = await session.call_tool(tool_name, arguments)
+    mock_pipe_config_client.create_label.assert_not_called()
+    mock_pipe_config_client.update_label.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert payload["error"]["code"] == "INVALID_ARGUMENTS"
+    assert "expected #RGB or #RRGGBB" in tool_error_message(payload)
 
 
 @pytest.mark.anyio
@@ -2433,6 +2470,319 @@ async def test_delete_field_condition_error(
     payload = extract_payload(result)
     assert payload["success"] is False
     assert "Forbidden" in tool_error_message(payload)
+
+
+@pytest.mark.unit
+def test_normalize_phase_allowed_move_targets__no_integration():
+    raw = {
+        "phase": {
+            "id": "100",
+            "name": "Doing",
+            "cards_can_be_moved_to_phases": [
+                {"id": "200", "name": "Done"},
+                {"id": "201", "name": "Blocked"},
+            ],
+        }
+    }
+    assert normalize_phase_allowed_move_targets(raw) == {
+        "phase_id": "100",
+        "phase_name": "Doing",
+        "allowed_phases": [
+            {"id": "200", "name": "Done"},
+            {"id": "201", "name": "Blocked"},
+        ],
+    }
+
+
+@pytest.mark.unit
+def test_normalize_phase_allowed_move_targets_missing_phase__no_integration():
+    assert normalize_phase_allowed_move_targets({}) is None
+    assert normalize_phase_allowed_move_targets({"phase": None}) is None
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_get_phase_allowed_move_targets_success(
+    pipe_config_session, mock_pipe_config_client, extract_payload
+):
+    phase_id = 342182335
+    mock_pipe_config_client.get_phase_allowed_move_targets.return_value = {
+        "phase": {
+            "id": str(phase_id),
+            "name": "Doing",
+            "cards_can_be_moved_to_phases": [{"id": "200", "name": "Done"}],
+        }
+    }
+
+    async with pipe_config_session as session:
+        result = await session.call_tool(
+            "get_phase_allowed_move_targets",
+            {"phase_id": phase_id},
+        )
+
+    assert result.isError is False
+    mock_pipe_config_client.get_phase_allowed_move_targets.assert_awaited_once_with(
+        str(phase_id)
+    )
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    assert payload["data"] == {
+        "phase_id": str(phase_id),
+        "phase_name": "Doing",
+        "allowed_phases": [{"id": "200", "name": "Done"}],
+    }
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+@pytest.mark.parametrize("invalid_phase_id", [0, -1])
+async def test_get_phase_allowed_move_targets_rejects_invalid_phase_id(
+    pipe_config_session,
+    mock_pipe_config_client,
+    extract_payload,
+    invalid_phase_id,
+):
+    async with pipe_config_session as session:
+        result = await session.call_tool(
+            "get_phase_allowed_move_targets",
+            {"phase_id": invalid_phase_id},
+        )
+    mock_pipe_config_client.get_phase_allowed_move_targets.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_get_phase_allowed_move_targets_not_found(
+    pipe_config_session, mock_pipe_config_client, extract_payload
+):
+    mock_pipe_config_client.get_phase_allowed_move_targets.return_value = {
+        "phase": None
+    }
+
+    async with pipe_config_session as session:
+        result = await session.call_tool(
+            "get_phase_allowed_move_targets",
+            {"phase_id": 999},
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "not found" in tool_error_message(payload).lower()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_get_phase_allowed_move_targets_graphql_error(
+    pipe_config_session, mock_pipe_config_client, extract_payload
+):
+    mock_pipe_config_client.get_phase_allowed_move_targets.side_effect = (
+        TransportQueryError(
+            "GraphQL Error",
+            errors=[{"message": "Forbidden"}],
+        )
+    )
+
+    async with pipe_config_session as session:
+        result = await session.call_tool(
+            "get_phase_allowed_move_targets",
+            {"phase_id": 55},
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "Forbidden" in tool_error_message(payload)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_get_phase_allowed_move_targets_read_only_hint(pipe_config_session):
+    async with pipe_config_session as session:
+        listed = await session.list_tools()
+    matching = [t for t in listed.tools if t.name == "get_phase_allowed_move_targets"]
+    assert len(matching) == 1
+    tool = matching[0]
+    assert tool.annotations is not None
+    assert tool.annotations.readOnlyHint is True
+
+
+@pytest.mark.unit
+def test_normalize_phase_cards_list__no_integration():
+    raw = {
+        "phase": {
+            "id": "100",
+            "cards": {"edges": [], "pageInfo": {"hasNextPage": False}},
+        }
+    }
+    assert normalize_phase_cards_list(raw) == raw["phase"]
+
+
+@pytest.mark.unit
+def test_normalize_phase_cards_list_missing_phase__no_integration():
+    assert normalize_phase_cards_list({}) is None
+    assert normalize_phase_cards_list({"phase": None}) is None
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_get_phase_cards_count_success(
+    pipe_config_session, mock_pipe_config_client, extract_payload
+):
+    phase_id = 342182335
+    mock_pipe_config_client.get_phase_cards_count_payload.return_value = {
+        "phase_id": str(phase_id),
+        "phase_name": "Doing",
+        "cards_count": 7,
+    }
+
+    async with pipe_config_session as session:
+        result = await session.call_tool(
+            "get_phase_cards_count",
+            {"phase_id": phase_id},
+        )
+
+    assert result.isError is False
+    mock_pipe_config_client.get_phase_cards_count_payload.assert_awaited_once_with(
+        str(phase_id)
+    )
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    assert payload["data"] == {
+        "phase_id": str(phase_id),
+        "phase_name": "Doing",
+        "cards_count": 7,
+    }
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+@pytest.mark.parametrize("invalid_phase_id", [0, -1])
+async def test_get_phase_cards_count_rejects_invalid_phase_id(
+    pipe_config_session,
+    mock_pipe_config_client,
+    extract_payload,
+    invalid_phase_id,
+):
+    async with pipe_config_session as session:
+        result = await session.call_tool(
+            "get_phase_cards_count",
+            {"phase_id": invalid_phase_id},
+        )
+    mock_pipe_config_client.get_phase_cards_count_payload.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_get_phase_cards_count_graphql_error(
+    pipe_config_session, mock_pipe_config_client, extract_payload
+):
+    mock_pipe_config_client.get_phase_cards_count_payload.side_effect = (
+        TransportQueryError(
+            "GraphQL Error",
+            errors=[{"message": "Forbidden"}],
+        )
+    )
+
+    async with pipe_config_session as session:
+        result = await session.call_tool(
+            "get_phase_cards_count",
+            {"phase_id": 55},
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "Forbidden" in tool_error_message(payload)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_get_phase_cards_success(
+    pipe_config_session,
+    mock_pipe_config_client,
+    extract_payload,
+    legacy_envelope,
+):
+    phase_id = 342182335
+    raw = {
+        "phase": {
+            "id": str(phase_id),
+            "cards": {
+                "edges": [{"node": {"id": "1", "title": "A"}}],
+                "pageInfo": {"hasNextPage": False, "endCursor": None},
+                "totalCount": 1,
+            },
+        }
+    }
+    mock_pipe_config_client.get_phase_cards.return_value = raw
+
+    async with pipe_config_session as session:
+        result = await session.call_tool(
+            "get_phase_cards",
+            {"phase_id": phase_id, "first": 50, "after": "cursor-1"},
+        )
+
+    assert result.isError is False
+    mock_pipe_config_client.get_phase_cards.assert_awaited_once_with(
+        str(phase_id),
+        first=50,
+        after="cursor-1",
+        include_fields=False,
+    )
+    payload = extract_payload(result)
+    assert payload == raw
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_get_phase_cards_not_found(
+    pipe_config_session, mock_pipe_config_client, extract_payload
+):
+    mock_pipe_config_client.get_phase_cards.return_value = {"phase": None}
+
+    async with pipe_config_session as session:
+        result = await session.call_tool(
+            "get_phase_cards",
+            {"phase_id": 999},
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "not found" in tool_error_message(payload).lower()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+@pytest.mark.parametrize("invalid_phase_id", [0, -1])
+async def test_get_phase_cards_rejects_invalid_phase_id(
+    pipe_config_session,
+    mock_pipe_config_client,
+    extract_payload,
+    invalid_phase_id,
+):
+    async with pipe_config_session as session:
+        result = await session.call_tool(
+            "get_phase_cards",
+            {"phase_id": invalid_phase_id},
+        )
+    mock_pipe_config_client.get_phase_cards.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
+async def test_get_phase_cards_read_only_hint(pipe_config_session):
+    async with pipe_config_session as session:
+        listed = await session.list_tools()
+    for name in ("get_phase_cards_count", "get_phase_cards"):
+        matching = [t for t in listed.tools if t.name == name]
+        assert len(matching) == 1
+        tool = matching[0]
+        assert tool.annotations is not None
+        assert tool.annotations.readOnlyHint is True
 
 
 @pytest.mark.anyio

--- a/packages/mcp/tests/tools/test_pipe_config_tools.py
+++ b/packages/mcp/tests/tools/test_pipe_config_tools.py
@@ -87,7 +87,7 @@ def mock_pipe_config_client():
     client.get_cards = AsyncMock()
     client.get_phase_allowed_move_targets = AsyncMock()
     client.get_phase_cards_count = AsyncMock()
-    client.get_phase_cards_count_payload = AsyncMock()
+    client.get_phase = AsyncMock()
     client.get_phase_cards = AsyncMock()
     client.create_field_condition = AsyncMock()
     client.update_field_condition = AsyncMock()
@@ -2630,7 +2630,7 @@ async def test_get_phase_cards_count_success(
     pipe_config_session, mock_pipe_config_client, extract_payload
 ):
     phase_id = 342182335
-    mock_pipe_config_client.get_phase_cards_count_payload.return_value = {
+    mock_pipe_config_client.get_phase.return_value = {
         "phase_id": str(phase_id),
         "phase_name": "Doing",
         "cards_count": 7,
@@ -2643,9 +2643,7 @@ async def test_get_phase_cards_count_success(
         )
 
     assert result.isError is False
-    mock_pipe_config_client.get_phase_cards_count_payload.assert_awaited_once_with(
-        str(phase_id)
-    )
+    mock_pipe_config_client.get_phase.assert_awaited_once_with(str(phase_id))
     payload = extract_payload(result)
     assert payload["success"] is True
     assert payload["data"] == {
@@ -2669,7 +2667,7 @@ async def test_get_phase_cards_count_rejects_invalid_phase_id(
             "get_phase_cards_count",
             {"phase_id": invalid_phase_id},
         )
-    mock_pipe_config_client.get_phase_cards_count_payload.assert_not_called()
+    mock_pipe_config_client.get_phase.assert_not_called()
     payload = extract_payload(result)
     assert payload["success"] is False
 
@@ -2679,7 +2677,7 @@ async def test_get_phase_cards_count_rejects_invalid_phase_id(
 async def test_get_phase_cards_count_graphql_error(
     pipe_config_session, mock_pipe_config_client, extract_payload
 ):
-    mock_pipe_config_client.get_phase_cards_count_payload.side_effect = (
+    mock_pipe_config_client.get_phase.side_effect = (
         TransportQueryError(
             "GraphQL Error",
             errors=[{"message": "Forbidden"}],

--- a/packages/mcp/tests/tools/test_pipe_tool_helpers.py
+++ b/packages/mcp/tests/tools/test_pipe_tool_helpers.py
@@ -23,6 +23,7 @@ from pipefy_mcp.tools.pipe_tool_helpers import (
     UserCancelledError,
     _filter_editable_field_definitions,
     _filter_fields_by_definitions,
+    _merge_phase_and_start_form_field_values,
     build_add_card_comment_error_payload,
     build_add_card_comment_success_payload,
     build_delete_card_error_payload,
@@ -476,6 +477,18 @@ def test_filter_fields_by_definitions_empty_returns_empty():
 
 
 @pytest.mark.unit
+def test_merge_phase_and_start_form_field_values_keeps_both_subsets():
+    defs_sf = [{"id": "sf1", "editable": True}]
+    defs_pf = [{"id": "pf1", "editable": True}]
+    fields = {"sf1": "a", "pf1": "b", "noise": "x"}
+    result = _merge_phase_and_start_form_field_values(
+        fields,
+        phase_field_definitions=defs_pf,
+        start_form_field_definitions=defs_sf,
+    )
+    assert result == {"sf1": "a", "pf1": "b"}
+
+
 def test_filter_fields_by_definitions_keeps_only_editable_ids():
     """Only field IDs present in definitions are kept."""
     fields = {"a": 1, "b": 2, "c": 3}

--- a/packages/mcp/tests/tools/test_pipe_tool_helpers.py
+++ b/packages/mcp/tests/tools/test_pipe_tool_helpers.py
@@ -23,7 +23,6 @@ from pipefy_mcp.tools.pipe_tool_helpers import (
     UserCancelledError,
     _filter_editable_field_definitions,
     _filter_fields_by_definitions,
-    _merge_phase_and_start_form_field_values,
     build_add_card_comment_error_payload,
     build_add_card_comment_success_payload,
     build_delete_card_error_payload,
@@ -474,19 +473,6 @@ def test_filter_fields_by_definitions_empty_returns_empty():
     """Empty fields returns empty dict."""
     defs = [{"id": "a", "type": "short_text"}]
     assert _filter_fields_by_definitions({}, defs) == {}
-
-
-@pytest.mark.unit
-def test_merge_phase_and_start_form_field_values_keeps_both_subsets():
-    defs_sf = [{"id": "sf1", "editable": True}]
-    defs_pf = [{"id": "pf1", "editable": True}]
-    fields = {"sf1": "a", "pf1": "b", "noise": "x"}
-    result = _merge_phase_and_start_form_field_values(
-        fields,
-        phase_field_definitions=defs_pf,
-        start_form_field_definitions=defs_sf,
-    )
-    assert result == {"sf1": "a", "pf1": "b"}
 
 
 def test_filter_fields_by_definitions_keeps_only_editable_ids():

--- a/packages/sdk/src/pipefy_sdk/phase_inventory.py
+++ b/packages/sdk/src/pipefy_sdk/phase_inventory.py
@@ -1,0 +1,18 @@
+"""Pure helpers for phase inventory read error mapping."""
+
+from __future__ import annotations
+
+_GET_PHASE_NOT_FOUND_MARKERS = (
+    "phase.cards_count missing from response",
+    "phase id missing from response",
+)
+
+
+def get_phase_not_found_message(phase_id: str | int) -> str:
+    return f"Phase {phase_id} not found or access denied."
+
+
+def is_get_phase_not_found_error(exc: BaseException) -> bool:
+    return isinstance(exc, ValueError) and any(
+        marker in str(exc) for marker in _GET_PHASE_NOT_FOUND_MARKERS
+    )

--- a/packages/sdk/tests/test_phase_inventory.py
+++ b/packages/sdk/tests/test_phase_inventory.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+
+from pipefy_sdk.phase_inventory import (
+    get_phase_not_found_message,
+    is_get_phase_not_found_error,
+)
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        ValueError("phase.cards_count missing from response"),
+        ValueError("phase id missing from response"),
+    ],
+)
+def test_is_get_phase_not_found_error_matches_sdk_value_errors(exc: ValueError) -> None:
+    assert is_get_phase_not_found_error(exc) is True
+
+
+def test_is_get_phase_not_found_error_rejects_other_value_errors() -> None:
+    assert is_get_phase_not_found_error(ValueError("other")) is False
+
+
+def test_is_get_phase_not_found_error_rejects_non_value_errors() -> None:
+    assert (
+        is_get_phase_not_found_error(RuntimeError("phase.cards_count missing")) is False
+    )
+
+
+def test_get_phase_not_found_message() -> None:
+    assert get_phase_not_found_message(99) == "Phase 99 not found or access denied."


### PR DESCRIPTION
Analytics pipe seeding (`306996636`) required **`execute_graphql`** for phase inventory and phase-local creates. **Spec:** `.cursor/dev-planning/specs/archive/card-phase-ergonomics/` — **Stack** after [#277](https://github.com/pipefy/ai-toolkit/pull/277) (closed).

**Depends on:** https://github.com/pipefy/ai-toolkit/pull/281

---

## Objective

Expose SDK phase reads on MCP + CLI so agents can audit/move without GraphQL:

- MCP: `get_phase_cards`, `get_phase_cards_count`, `get_phase_allowed_move_targets`
- CLI: `pipefy phase cards`, `cards-count`, `allowed-moves`
- Clamp `phase cards --first` to 1–500 (F5)
- MCP `create_label` / `update_label` hex via planner (needs PR1)

## Improvements

- Discover allowed move targets **before** `move_card_to_phase` fails.
- Count/list cards in one phase without pipe-wide `get_cards` title search.
