### PR TITLE
feat(mcp,cli): create_card phase_id and title on CreateCardInput

### DIFF
--- a/packages/cli/src/pipefy_cli/commands/card.py
+++ b/packages/cli/src/pipefy_cli/commands/card.py
@@ -56,7 +56,7 @@ def _apply_create_card_title_warning(
 ) -> dict[str, Any]:
     if not requested_title:
         return result
-    card_node = result.get("createCard", {}).get("card")
+    card_node = (result.get("createCard") or {}).get("card")
     if not isinstance(card_node, dict):
         return result
     if card_node.get("title") == requested_title:

--- a/packages/cli/src/pipefy_cli/commands/card.py
+++ b/packages/cli/src/pipefy_cli/commands/card.py
@@ -51,6 +51,24 @@ def _parse_fields_json(raw: str | None) -> dict[str, Any] | list[dict[str, Any]]
     raise typer.BadParameter("--fields must be a JSON object or array")
 
 
+def _apply_create_card_title_warning(
+    result: dict[str, Any], *, requested_title: str | None
+) -> dict[str, Any]:
+    if not requested_title:
+        return result
+    card_node = result.get("createCard", {}).get("card")
+    if not isinstance(card_node, dict):
+        return result
+    if card_node.get("title") == requested_title:
+        return result
+    warned = dict(result)
+    warned["title_warning"] = (
+        "Card created but title was not applied as expected "
+        f"(response title={card_node.get('title')!r}, requested={requested_title!r})."
+    )
+    return warned
+
+
 def _parse_field_updates_json(raw: str | None) -> list[dict[str, Any]] | None:
     if raw is None or raw.strip() == "":
         return None
@@ -258,7 +276,8 @@ def card_create(
             create_kwargs["phase_id"] = phase_id
         if title:
             create_kwargs["title"] = title
-        return await client.create_card(pipe_id, payload, **create_kwargs)
+        result = await client.create_card(pipe_id, payload, **create_kwargs)
+        return _apply_create_card_title_warning(result, requested_title=title)
 
     run_cli_command(ctx, json_out, factory)
 

--- a/packages/cli/src/pipefy_cli/commands/card.py
+++ b/packages/cli/src/pipefy_cli/commands/card.py
@@ -25,6 +25,7 @@ from pipefy_cli.commands._common import (
     resource_id_argument,
     run_cli_command,
     validate_cards_page_size,
+    validate_optional_resource_id,
 )
 
 card_app = typer.Typer(help="Card operations.", no_args_is_help=True)
@@ -223,12 +224,20 @@ def card_create(
         None,
         "--title",
         "-t",
-        help="Optional title (applied via update after create).",
+        help="Optional title (sent on CreateCardInput when set).",
+    ),
+    phase_id: str | None = typer.Option(
+        None,
+        "--phase-id",
+        help=(
+            "Target phase id (CreateCardInput.phase_id). "
+            "Creates the card in that phase instead of the start form."
+        ),
     ),
     fields_json: str | None = typer.Option(
         None,
         "--fields",
-        help="JSON object or array: start-form field values for createCard.",
+        help="JSON object or array: field values for createCard.",
     ),
     json_out: bool = typer.Option(
         False,
@@ -237,19 +246,19 @@ def card_create(
         help="Print machine-readable JSON to stdout.",
     ),
 ) -> None:
-    """Create a card in a pipe (start-form fields via --fields JSON when required)."""
+    """Create a card in a pipe (start-form or phase fields via --fields JSON when required)."""
 
     fields = _parse_fields_json(fields_json)
+    phase_id = validate_optional_resource_id(phase_id, "phase_id")
 
     async def factory(client: PipefyClient):
         payload = fields if fields is not None else {}
-        result = await client.create_card(pipe_id, payload)
-        card_node = (result.get("createCard") or {}).get("card") or {}
-        cid = card_node.get("id")
-        if title and cid:
-            await client.update_card(str(cid), title=title)
-            card_node["title"] = title
-        return result
+        create_kwargs: dict[str, Any] = {}
+        if phase_id is not None:
+            create_kwargs["phase_id"] = phase_id
+        if title:
+            create_kwargs["title"] = title
+        return await client.create_card(pipe_id, payload, **create_kwargs)
 
     run_cli_command(ctx, json_out, factory)
 

--- a/packages/cli/tests/test_card_commands.py
+++ b/packages/cli/tests/test_card_commands.py
@@ -191,9 +191,7 @@ def test_card_create_title_warning_when_mismatch(
     runner, clean_pipefy_env, saved_cwd, oauth_env
 ):
     oauth_env("create-card-title-warn")
-    create_resp = {
-        "createCard": {"card": {"id": "890", "title": "Derived from field"}}
-    }
+    create_resp = {"createCard": {"card": {"id": "890", "title": "Derived from field"}}}
     mock_client = MagicMock()
     mock_client.create_card = AsyncMock(return_value=create_resp)
     with patch(

--- a/packages/cli/tests/test_card_commands.py
+++ b/packages/cli/tests/test_card_commands.py
@@ -187,6 +187,29 @@ def test_card_create_forwards_phase_id(runner, clean_pipefy_env, saved_cwd, oaut
     )
 
 
+def test_card_create_title_warning_when_mismatch(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("create-card-title-warn")
+    create_resp = {
+        "createCard": {"card": {"id": "890", "title": "Derived from field"}}
+    }
+    mock_client = MagicMock()
+    mock_client.create_card = AsyncMock(return_value=create_resp)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["card", "create", "303", "--title", "Requested", "--json"],
+        )
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+    payload = json.loads(result.stdout)
+    assert "title_warning" in payload
+    assert "Requested" in payload["title_warning"]
+
+
 def test_card_create_phase_id_and_title(runner, clean_pipefy_env, saved_cwd, oauth_env):
     oauth_env("create-card-phase-title")
     create_resp = {"createCard": {"card": {"id": "889", "title": "Seed"}}}

--- a/packages/cli/tests/test_card_commands.py
+++ b/packages/cli/tests/test_card_commands.py
@@ -187,6 +187,26 @@ def test_card_create_forwards_phase_id(runner, clean_pipefy_env, saved_cwd, oaut
     )
 
 
+def test_card_create_title_warning_skipped_when_create_card_null(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("create-card-null-response")
+    mock_client = MagicMock()
+    mock_client.create_card = AsyncMock(return_value={"createCard": None})
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            ["card", "create", "303", "--title", "Requested", "--json"],
+        )
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+    payload = json.loads(result.stdout)
+    assert payload == {"createCard": None}
+    assert "title_warning" not in payload
+
+
 def test_card_create_title_warning_when_mismatch(
     runner, clean_pipefy_env, saved_cwd, oauth_env
 ):

--- a/packages/cli/tests/test_card_commands.py
+++ b/packages/cli/tests/test_card_commands.py
@@ -129,10 +129,10 @@ def test_card_find_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
 
 def test_card_create_with_title_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
     oauth_env("create-card")
-    create_resp = {"createCard": {"card": {"id": "777", "title": "Draft"}}}
+    create_resp = {"createCard": {"card": {"id": "777", "title": "Hello"}}}
     mock_client = MagicMock()
     mock_client.create_card = AsyncMock(return_value=create_resp)
-    mock_client.update_card = AsyncMock(return_value={"updateCard": {"card": {}}})
+    mock_client.update_card = AsyncMock()
     with patch(
         "pipefy_cli.commands._common.get_authenticated_client",
         return_value=mock_client,
@@ -151,20 +151,79 @@ def test_card_create_with_title_json(runner, clean_pipefy_env, saved_cwd, oauth_
             ],
         )
     assert result.exit_code == 0, result.stdout + (result.stderr or "")
-    mock_client.create_card.assert_awaited_once_with("303", {"field_x": "y"})
-    mock_client.update_card.assert_awaited_once_with("777", title="Hello")
+    mock_client.create_card.assert_awaited_once_with(
+        "303", {"field_x": "y"}, title="Hello"
+    )
+    mock_client.update_card.assert_not_called()
 
 
-def test_card_create_title_update_failure_exit_1(
+def test_card_create_forwards_phase_id(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("create-card-phase")
+    create_resp = {"createCard": {"card": {"id": "888"}}}
+    mock_client = MagicMock()
+    mock_client.create_card = AsyncMock(return_value=create_resp)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "card",
+                "create",
+                "303",
+                "--phase-id",
+                "phase_42",
+                "--fields",
+                '{"status": "Open"}',
+                "--json",
+            ],
+        )
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+    mock_client.create_card.assert_awaited_once_with(
+        "303",
+        {"status": "Open"},
+        phase_id="phase_42",
+    )
+
+
+def test_card_create_phase_id_and_title(runner, clean_pipefy_env, saved_cwd, oauth_env):
+    oauth_env("create-card-phase-title")
+    create_resp = {"createCard": {"card": {"id": "889", "title": "Seed"}}}
+    mock_client = MagicMock()
+    mock_client.create_card = AsyncMock(return_value=create_resp)
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "card",
+                "create",
+                "303",
+                "--phase-id",
+                "999",
+                "--title",
+                "Seed",
+                "--json",
+            ],
+        )
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+    mock_client.create_card.assert_awaited_once_with(
+        "303", {}, phase_id="999", title="Seed"
+    )
+
+
+def test_card_create_title_failure_exit_1(
     runner, clean_pipefy_env, saved_cwd, oauth_env
 ):
     oauth_env("create-card-fail-title")
     from pipefy_sdk.exceptions import PipefyError
 
-    create_resp = {"createCard": {"card": {"id": "777", "title": "Draft"}}}
     mock_client = MagicMock()
-    mock_client.create_card = AsyncMock(return_value=create_resp)
-    mock_client.update_card = AsyncMock(side_effect=PipefyError("update failed"))
+    mock_client.create_card = AsyncMock(side_effect=PipefyError("create failed"))
+    mock_client.update_card = AsyncMock()
     with patch(
         "pipefy_cli.commands._common.get_authenticated_client",
         return_value=mock_client,
@@ -181,8 +240,8 @@ def test_card_create_title_update_failure_exit_1(
             ],
         )
     assert result.exit_code == 1
-    mock_client.create_card.assert_awaited_once()
-    mock_client.update_card.assert_awaited_once_with("777", title="Hello")
+    mock_client.create_card.assert_awaited_once_with("303", {}, title="Hello")
+    mock_client.update_card.assert_not_called()
 
 
 def test_card_create_invalid_fields_exit_2(

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_tool_helpers.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_tool_helpers.py
@@ -444,6 +444,19 @@ def _filter_fields_by_definitions(
     }
 
 
+def _merge_phase_and_start_form_field_values(
+    fields: dict[str, object] | None,
+    *,
+    phase_field_definitions: list[dict],
+    start_form_field_definitions: list[dict],
+) -> dict[str, object]:
+    start_form_values = _filter_fields_by_definitions(
+        fields, start_form_field_definitions
+    )
+    phase_values = _filter_fields_by_definitions(fields, phase_field_definitions)
+    return {**start_form_values, **phase_values}
+
+
 def map_delete_card_error_to_message(
     *, card_id: str | int, card_title: str, codes: list[str]
 ) -> str:

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
@@ -111,9 +111,8 @@ class PipeTools:
             ``get_start_form_fields`` and pass all required values.
 
             With ``phase_id``, the card is created in that phase (including orphan
-            phases that are not the start form). Discover via:
-            ``get_pipe(pipe_id).phases[].id`` or ``get_pipe(pipe_id).startFormPhaseId``.
-            For agent seeding in a specific phase, set
+            phases that are not the start form). Discover workflow phase IDs via
+            ``get_pipe(pipe_id).phases[].id``. For agent seeding in a specific phase, set
             ``phase_id`` and ``skip_elicitation=true``. When ``fields`` is non-empty,
             keys are filtered against ``get_phase_fields(phase_id)`` and
             ``get_start_form_fields(pipe_id)`` so pipes that still require start-form
@@ -140,10 +139,10 @@ class PipeTools:
                 required_fields_only: If True, only elicit required fields. Default: False.
                 skip_elicitation: When True, bypass interactive elicitation and send
                     ``fields`` directly to the API. Recommended for AI agent workflows.
-                phase_id: Optional target phase ID. Skips start-form elicitation; when
-                    ``fields`` is non-empty, validates against phase and start-form
-                    field definitions. Discover via: ``get_pipe(pipe_id).phases[].id``
-                    or ``get_pipe(pipe_id).startFormPhaseId``.
+                phase_id: Optional target phase ID. Interactive elicitation prompts
+                    start-form fields (matching the Pipefy UI); phase field values are
+                    merged from ``fields`` when provided. For agent seeding, set
+                    ``skip_elicitation=true``. Discover via: ``get_pipe(pipe_id).phases[].id``.
             """
             card_data = fields or {}
             can_elicit = supports_elicitation(ctx)
@@ -153,55 +152,58 @@ class PipeTools:
                 if phase_err is not None:
                     return phase_err
                 phase_id = phase_id_str
-                expected_fields: list[dict] = []
-                start_form_expected_fields: list[dict] = []
-                if fields:
-                    try:
-                        phase_fields_result = await client.get_phase_fields(
-                            phase_id, required_fields_only
-                        )
-                    except MalformedFieldDefinitionError as exc:
-                        return tool_error(str(exc))
-                    expected_fields = _filter_editable_field_definitions(
-                        phase_fields_result.get("fields", [])
+                try:
+                    phase_fields_result = await client.get_phase_fields(
+                        phase_id, required_fields_only
                     )
-                    try:
-                        form_fields = await client.get_start_form_fields(
-                            pipe_id, required_fields_only
-                        )
-                    except MalformedFieldDefinitionError as exc:
-                        return tool_error(str(exc))
-                    start_form_expected_fields = _filter_editable_field_definitions(
-                        form_fields.get("start_form_fields", [])
+                except MalformedFieldDefinitionError as exc:
+                    return tool_error(str(exc))
+                phase_field_defs = _filter_editable_field_definitions(
+                    phase_fields_result.get("fields", [])
+                )
+                try:
+                    form_fields = await client.get_start_form_fields(
+                        pipe_id, required_fields_only
                     )
+                except MalformedFieldDefinitionError as exc:
+                    return tool_error(str(exc))
+                start_form_field_defs = _filter_editable_field_definitions(
+                    form_fields.get("start_form_fields", [])
+                )
                 await ctx.debug(
-                    f"Expected fields for phase {phase_id}: {expected_fields}"
+                    f"Expected phase fields for {phase_id}: {phase_field_defs}"
                 )
                 await ctx.debug(
                     f"Expected start-form fields for pipe {pipe_id}: "
-                    f"{start_form_expected_fields}"
+                    f"{start_form_field_defs}"
                 )
                 await ctx.debug(f"Provided fields: {fields}")
 
-                if can_elicit and expected_fields and not skip_elicitation:
+                if can_elicit and start_form_field_defs and not skip_elicitation:
                     try:
-                        card_data = await PipeTools._elicit_field_details(
+                        elicited = await PipeTools._elicit_field_details(
                             message=(
                                 f"Creating a card in phase {phase_id} (pipe {pipe_id})"
                             ),
                             prefilled_fields=fields,
-                            expected_fields=expected_fields,
+                            expected_fields=start_form_field_defs,
                             ctx=ctx,
                         )
                     except MalformedFieldDefinitionError as exc:
                         return tool_error(str(exc))
                     except UserCancelledError:
                         return tool_error("Card creation cancelled by user.")
-                elif expected_fields or start_form_expected_fields:
+                    merged_source = {**(fields or {}), **elicited}
+                    card_data = _merge_phase_and_start_form_field_values(
+                        merged_source,
+                        phase_field_definitions=phase_field_defs,
+                        start_form_field_definitions=start_form_field_defs,
+                    )
+                elif phase_field_defs or start_form_field_defs:
                     card_data = _merge_phase_and_start_form_field_values(
                         card_data,
-                        phase_field_definitions=expected_fields,
-                        start_form_field_definitions=start_form_expected_fields,
+                        phase_field_definitions=phase_field_defs,
+                        start_form_field_definitions=start_form_field_defs,
                     )
             else:
                 try:
@@ -739,12 +741,8 @@ class PipeTools:
 
             Returns:
                 dict: GraphQL response containing a ``pipe`` object with ``id``, ``name``,
-                ``phases`` (workflow phases only; each includes ``cards_count``),
-                ``startFormPhaseId`` (start form is not listed in ``phases``),
+                ``phases`` (workflow phases; each includes ``cards_count``),
                 ``labels``, ``start_form_fields``, and related metadata from the API.
-
-                For start-form inventory, use ``get_phase`` / ``get_phase_cards`` on
-                ``startFormPhaseId`` — native ``cards_count`` may be 0 while cards exist.
             """
             await ctx.debug(f"get_pipe: pipe_id={pipe_id}")
             pipe_id_str, err = validate_tool_id(pipe_id, "pipe_id")

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
@@ -118,9 +118,9 @@ class PipeTools:
             ``get_start_form_fields(pipe_id)`` so pipes that still require start-form
             values on ``CreateCardInput`` receive them alongside phase fields.
 
-            Before ``move_card_to_phase``, call ``get_phase_allowed_move_targets`` on
-            the card's current phase; transition rules are UI-only (Pipe settings ->
-            Phase -> Connections).
+            If you plan to move the card afterwards, call
+            ``get_phase_allowed_move_targets`` on the card's current phase before
+            ``move_card_to_phase`` — only phases allowed by the workflow can be used.
 
             ``title`` is sent on ``CreateCardInput`` when provided.
 
@@ -255,10 +255,12 @@ class PipeTools:
                 if perm_msg:
                     error_text = f"{perm_msg}\n{error_text}"
                 return tool_error(error_text)
-            card_id = result.get("createCard", {}).get("card", {}).get("id")
+            card_data_node = (result.get("createCard") or {}).get("card")
+            card_id = (
+                card_data_node.get("id") if isinstance(card_data_node, dict) else None
+            )
             if card_id:
                 if title:
-                    card_data_node = result.get("createCard", {}).get("card")
                     if card_data_node is not None:
                         if card_data_node.get("title") != title:
                             result["title_warning"] = (

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
@@ -112,7 +112,7 @@ class PipeTools:
 
             With ``phase_id``, the card is created in that phase (including orphan
             phases that are not the start form). Discover via:
-            ``get_pipe(pipe_id).phases[].id`` or ``get_pipe(pipe_id).start_form_phase.id``.
+            ``get_pipe(pipe_id).phases[].id`` or ``get_pipe(pipe_id).startFormPhaseId``.
             For agent seeding in a specific phase, set
             ``phase_id`` and ``skip_elicitation=true``. When ``fields`` is non-empty,
             keys are filtered against ``get_phase_fields(phase_id)`` and
@@ -143,7 +143,7 @@ class PipeTools:
                 phase_id: Optional target phase ID. Skips start-form elicitation; when
                     ``fields`` is non-empty, validates against phase and start-form
                     field definitions. Discover via: ``get_pipe(pipe_id).phases[].id``
-                    or ``get_pipe(pipe_id).start_form_phase.id``.
+                    or ``get_pipe(pipe_id).startFormPhaseId``.
             """
             card_data = fields or {}
             can_elicit = supports_elicitation(ctx)
@@ -740,12 +740,11 @@ class PipeTools:
             Returns:
                 dict: GraphQL response containing a ``pipe`` object with ``id``, ``name``,
                 ``phases`` (workflow phases only; each includes ``cards_count``),
-                ``start_form_phase`` (``id``, ``name``, ``cards_count`` when
-                ``startFormPhaseId`` is set — not duplicated in ``phases``),
+                ``startFormPhaseId`` (start form is not listed in ``phases``),
                 ``labels``, ``start_form_fields``, and related metadata from the API.
 
-                Start-form ``cards_count`` may be 0 while cards still exist; use
-                ``get_phase_cards`` for a full list in that phase.
+                For start-form inventory, use ``get_phase`` / ``get_phase_cards`` on
+                ``startFormPhaseId`` — native ``cards_count`` may be 0 while cards exist.
             """
             await ctx.debug(f"get_pipe: pipe_id={pipe_id}")
             pipe_id_str, err = validate_tool_id(pipe_id, "pipe_id")

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
@@ -45,6 +45,7 @@ from pipefy_mcp.tools.pipe_tool_helpers import (
     UserCancelledError,
     _filter_editable_field_definitions,
     _filter_fields_by_definitions,
+    _merge_phase_and_start_form_field_values,
     build_add_card_comment_error_payload,
     build_add_card_comment_success_payload,
     build_delete_card_error_payload,
@@ -93,26 +94,36 @@ class PipeTools:
             fields: dict[str, Any] | None = None,
             required_fields_only: bool = False,
             skip_elicitation: bool = False,
+            phase_id: PipefyId | None = None,
         ) -> dict:
             """Create a card in the pipe.
 
             When ``skip_elicitation`` is True, field values from ``fields`` are
-            filtered to editable start-form field IDs and sent directly to the
-            API — no interactive form is shown. AI agents should set this to
-            True when they already know the field values.
+            filtered to editable field IDs and sent directly to the API — no
+            interactive form is shown. AI agents should set this to True when
+            they already know the field values.
 
             When ``skip_elicitation`` is False (default) and the client supports
             elicitation, an interactive form is presented even if ``fields``
             carries pre-filled values — the human can review and adjust them.
 
-            Discover fields first via ``get_start_form_fields`` and pass all
-            required values.
+            Without ``phase_id``, discover start-form fields via
+            ``get_start_form_fields`` and pass all required values.
 
-            The Pipefy ``createCard`` mutation does not accept a title directly.
-            If ``title`` is provided, the card is created first and then updated
-            via ``updateCard`` to set the title — this is especially useful when the
-            pipe has no start-form fields, which would otherwise leave the card
-            titled "Draft".
+            With ``phase_id``, the card is created in that phase (including orphan
+            phases that are not the start form). Discover via:
+            ``get_pipe(pipe_id).phases[].id`` or ``get_pipe(pipe_id).start_form_phase.id``.
+            For agent seeding in a specific phase, set
+            ``phase_id`` and ``skip_elicitation=true``. When ``fields`` is non-empty,
+            keys are filtered against ``get_phase_fields(phase_id)`` and
+            ``get_start_form_fields(pipe_id)`` so pipes that still require start-form
+            values on ``CreateCardInput`` receive them alongside phase fields.
+
+            Before ``move_card_to_phase``, call ``get_phase_allowed_move_targets`` on
+            the card's current phase; transition rules are UI-only (Pipe settings ->
+            Phase -> Connections).
+
+            ``title`` is sent on ``CreateCardInput`` when provided.
 
             When the pipe uses Pipefy's default of deriving the card title from the
             first text-like start-form field, a later ``update_card_field`` on that
@@ -121,48 +132,119 @@ class PipeTools:
 
             Args:
                 pipe_id: The ID of the pipe where the card will be created.
-                title: Optional card title. Applied via updateCard after creation.
+                    Discover via: ``search_pipes`` or ``get_organization``.
+                title: Optional card title. Passed on CreateCardInput when set.
                 fields: A dictionary of fields that can be pre-filled on the card.
                     When ``skip_elicitation`` is False, these pre-fill the interactive
                     form. When True, they are sent directly to the API.
                 required_fields_only: If True, only elicit required fields. Default: False.
                 skip_elicitation: When True, bypass interactive elicitation and send
                     ``fields`` directly to the API. Recommended for AI agent workflows.
+                phase_id: Optional target phase ID. Skips start-form elicitation; when
+                    ``fields`` is non-empty, validates against phase and start-form
+                    field definitions. Discover via: ``get_pipe(pipe_id).phases[].id``
+                    or ``get_pipe(pipe_id).start_form_phase.id``.
             """
-            try:
-                form_fields = await client.get_start_form_fields(
-                    pipe_id, required_fields_only
-                )
-            except MalformedFieldDefinitionError as exc:
-                return tool_error(str(exc))
-
-            expected_fields = _filter_editable_field_definitions(
-                form_fields.get("start_form_fields", [])
-            )
-
-            await ctx.debug(f"Expected fields for pipe {pipe_id}: {expected_fields}")
-            await ctx.debug(f"Provided fields: {fields}")
-
             card_data = fields or {}
             can_elicit = supports_elicitation(ctx)
 
-            if can_elicit and not skip_elicitation:
+            if phase_id is not None:
+                phase_id_str, phase_err = validate_tool_id(phase_id, "phase_id")
+                if phase_err is not None:
+                    return phase_err
+                phase_id = phase_id_str
+                expected_fields: list[dict] = []
+                start_form_expected_fields: list[dict] = []
+                if fields:
+                    try:
+                        phase_fields_result = await client.get_phase_fields(
+                            phase_id, required_fields_only
+                        )
+                    except MalformedFieldDefinitionError as exc:
+                        return tool_error(str(exc))
+                    expected_fields = _filter_editable_field_definitions(
+                        phase_fields_result.get("fields", [])
+                    )
+                    try:
+                        form_fields = await client.get_start_form_fields(
+                            pipe_id, required_fields_only
+                        )
+                    except MalformedFieldDefinitionError as exc:
+                        return tool_error(str(exc))
+                    start_form_expected_fields = _filter_editable_field_definitions(
+                        form_fields.get("start_form_fields", [])
+                    )
+                await ctx.debug(
+                    f"Expected fields for phase {phase_id}: {expected_fields}"
+                )
+                await ctx.debug(
+                    f"Expected start-form fields for pipe {pipe_id}: "
+                    f"{start_form_expected_fields}"
+                )
+                await ctx.debug(f"Provided fields: {fields}")
+
+                if can_elicit and expected_fields and not skip_elicitation:
+                    try:
+                        card_data = await PipeTools._elicit_field_details(
+                            message=(
+                                f"Creating a card in phase {phase_id} (pipe {pipe_id})"
+                            ),
+                            prefilled_fields=fields,
+                            expected_fields=expected_fields,
+                            ctx=ctx,
+                        )
+                    except MalformedFieldDefinitionError as exc:
+                        return tool_error(str(exc))
+                    except UserCancelledError:
+                        return tool_error("Card creation cancelled by user.")
+                elif expected_fields or start_form_expected_fields:
+                    card_data = _merge_phase_and_start_form_field_values(
+                        card_data,
+                        phase_field_definitions=expected_fields,
+                        start_form_field_definitions=start_form_expected_fields,
+                    )
+            else:
                 try:
-                    card_data = await PipeTools._elicit_field_details(
-                        message=f"Creating a card in pipe {pipe_id}",
-                        prefilled_fields=fields,
-                        expected_fields=expected_fields,
-                        ctx=ctx,
+                    form_fields = await client.get_start_form_fields(
+                        pipe_id, required_fields_only
                     )
                 except MalformedFieldDefinitionError as exc:
                     return tool_error(str(exc))
-                except UserCancelledError:
-                    return tool_error("Card creation cancelled by user.")
-            elif expected_fields:
-                card_data = _filter_fields_by_definitions(card_data, expected_fields)
+
+                expected_fields = _filter_editable_field_definitions(
+                    form_fields.get("start_form_fields", [])
+                )
+
+                await ctx.debug(
+                    f"Expected fields for pipe {pipe_id}: {expected_fields}"
+                )
+                await ctx.debug(f"Provided fields: {fields}")
+
+                if can_elicit and not skip_elicitation:
+                    try:
+                        card_data = await PipeTools._elicit_field_details(
+                            message=f"Creating a card in pipe {pipe_id}",
+                            prefilled_fields=fields,
+                            expected_fields=expected_fields,
+                            ctx=ctx,
+                        )
+                    except MalformedFieldDefinitionError as exc:
+                        return tool_error(str(exc))
+                    except UserCancelledError:
+                        return tool_error("Card creation cancelled by user.")
+                elif expected_fields:
+                    card_data = _filter_fields_by_definitions(
+                        card_data, expected_fields
+                    )
+
+            create_kwargs: dict[str, Any] = {}
+            if phase_id is not None:
+                create_kwargs["phase_id"] = phase_id
+            if title:
+                create_kwargs["title"] = title
 
             try:
-                result = await client.create_card(pipe_id, card_data)
+                result = await client.create_card(pipe_id, card_data, **create_kwargs)
             except Exception as exc:  # noqa: BLE001
                 perm_msg = await enrich_permission_denied_error(
                     exc, [str(pipe_id)], client
@@ -174,16 +256,14 @@ class PipeTools:
             card_id = result.get("createCard", {}).get("card", {}).get("id")
             if card_id:
                 if title:
-                    try:
-                        await client.update_card(card_id, title=title)
-                    except Exception as exc:  # noqa: BLE001
-                        result["title_warning"] = (
-                            f"Card created but title update failed: {exc}"
-                        )
-                    else:
-                        card_data_node = result.get("createCard", {}).get("card")
-                        if card_data_node is not None:
-                            card_data_node["title"] = title
+                    card_data_node = result.get("createCard", {}).get("card")
+                    if card_data_node is not None:
+                        if card_data_node.get("title") != title:
+                            result["title_warning"] = (
+                                "Card created but title was not applied as expected "
+                                f"(response title={card_data_node.get('title')!r}, "
+                                f"requested={title!r})."
+                            )
                 card_url = f"https://app.pipefy.com/open-cards/{card_id}"
                 result["card_link"] = f"[{card_url}]({card_url})"
             return result
@@ -659,7 +739,13 @@ class PipeTools:
 
             Returns:
                 dict: GraphQL response containing a ``pipe`` object with ``id``, ``name``,
-                ``phases``, ``labels``, ``start_form_fields``, and related metadata from the API.
+                ``phases`` (workflow phases only; each includes ``cards_count``),
+                ``start_form_phase`` (``id``, ``name``, ``cards_count`` when
+                ``startFormPhaseId`` is set — not duplicated in ``phases``),
+                ``labels``, ``start_form_fields``, and related metadata from the API.
+
+                Start-form ``cards_count`` may be 0 while cards still exist; use
+                ``get_phase_cards`` for a full list in that phase.
             """
             await ctx.debug(f"get_pipe: pipe_id={pipe_id}")
             pipe_id_str, err = validate_tool_id(pipe_id, "pipe_id")
@@ -775,16 +861,16 @@ class PipeTools:
         ) -> dict:
             """Move a card to a target phase (Kanban column) within the same pipe.
 
-            Use this when the workflow should advance or regress a card; pair with ``get_pipe``
-            or ``get_card`` to resolve valid phase IDs. On failure, if the destination is not
-            among ``cards_can_be_moved_to_phases`` for the card's current phase, the tool may
+            Use this when the workflow should advance or regress a card. On failure, if the
+            destination is not among allowed targets for the card's current phase, the tool may
             return ``success: false`` with ``valid_destinations`` instead of only the raw API error.
 
             Args:
                 card_id: The card to move.
                     Discover via: ``find_cards`` or ``get_cards(pipe_id)``.
                 destination_phase_id: Target phase ID (must be allowed for the current phase).
-                    Discover via: ``get_pipe(pipe_id).phases[].id``.
+                    Discover via: ``get_phase_allowed_move_targets(current_phase_id)`` where
+                    ``current_phase_id`` comes from ``get_card(card_id).current_phase.id``.
 
             Returns:
                 dict: Pipefy move mutation response on success. On some validation failures,

--- a/packages/mcp/tests/tools/test_pipe_tool_helpers.py
+++ b/packages/mcp/tests/tools/test_pipe_tool_helpers.py
@@ -23,6 +23,7 @@ from pipefy_mcp.tools.pipe_tool_helpers import (
     UserCancelledError,
     _filter_editable_field_definitions,
     _filter_fields_by_definitions,
+    _merge_phase_and_start_form_field_values,
     build_add_card_comment_error_payload,
     build_add_card_comment_success_payload,
     build_delete_card_error_payload,
@@ -473,6 +474,19 @@ def test_filter_fields_by_definitions_empty_returns_empty():
     """Empty fields returns empty dict."""
     defs = [{"id": "a", "type": "short_text"}]
     assert _filter_fields_by_definitions({}, defs) == {}
+
+
+@pytest.mark.unit
+def test_merge_phase_and_start_form_field_values_keeps_both_subsets():
+    defs_sf = [{"id": "sf1", "editable": True}]
+    defs_pf = [{"id": "pf1", "editable": True}]
+    fields = {"sf1": "a", "pf1": "b", "noise": "x"}
+    result = _merge_phase_and_start_form_field_values(
+        fields,
+        phase_field_definitions=defs_pf,
+        start_form_field_definitions=defs_sf,
+    )
+    assert result == {"sf1": "a", "pf1": "b"}
 
 
 def test_filter_fields_by_definitions_keeps_only_editable_ids():

--- a/packages/mcp/tests/tools/test_pipe_tools.py
+++ b/packages/mcp/tests/tools/test_pipe_tools.py
@@ -322,21 +322,18 @@ class TestCreateCardTool:
             )
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
-    async def test_title_sets_card_title_after_creation(
+    async def test_title_passed_to_create_card_on_create_card_input(
         self,
         client_session,
         mock_pipefy_client,
         pipe_id,
     ):
-        """When title is provided, create_card calls update_card to set the title."""
+        """When title is provided, create_card passes title on CreateCardInput."""
         mock_pipefy_client.get_start_form_fields.return_value = {
             "start_form_fields": []
         }
         mock_pipefy_client.create_card.return_value = {
-            "createCard": {"card": {"id": "789"}}
-        }
-        mock_pipefy_client.update_card.return_value = {
-            "updateCard": {"card": {"id": "789", "title": "Copa América"}}
+            "createCard": {"card": {"id": "789", "title": "Copa América"}}
         }
 
         async with client_session as session:
@@ -345,30 +342,28 @@ class TestCreateCardTool:
                 {"pipe_id": pipe_id, "title": "Copa América"},
             )
             assert result.isError is False
-            mock_pipefy_client.create_card.assert_called_once_with(str(pipe_id), {})
-            mock_pipefy_client.update_card.assert_called_once_with(
-                "789", title="Copa América"
+            mock_pipefy_client.create_card.assert_called_once_with(
+                str(pipe_id), {}, title="Copa América"
             )
+            mock_pipefy_client.update_card.assert_not_called()
             response = json.loads(result.content[0].text)
             assert response["createCard"]["card"]["title"] == "Copa América"
             assert "card_link" in response
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
-    async def test_title_update_failure_returns_warning(
+    async def test_title_warning_when_response_title_mismatches(
         self,
         client_session,
         mock_pipefy_client,
         pipe_id,
     ):
-        """When update_card raises after a successful create_card, the card result
-        is still returned with a title_warning and no title set."""
+        """When API stores a different title than requested, return title_warning."""
         mock_pipefy_client.get_start_form_fields.return_value = {
             "start_form_fields": []
         }
         mock_pipefy_client.create_card.return_value = {
-            "createCard": {"card": {"id": "789"}}
+            "createCard": {"card": {"id": "789", "title": "Derived from field"}}
         }
-        mock_pipefy_client.update_card.side_effect = RuntimeError("API timeout")
 
         async with client_session as session:
             result = await session.call_tool(
@@ -376,15 +371,40 @@ class TestCreateCardTool:
                 {"pipe_id": pipe_id, "title": "My Title"},
             )
             assert result.isError is False
-            mock_pipefy_client.create_card.assert_called_once_with(str(pipe_id), {})
-            mock_pipefy_client.update_card.assert_called_once_with(
-                "789", title="My Title"
+            mock_pipefy_client.create_card.assert_called_once_with(
+                str(pipe_id), {}, title="My Title"
             )
+            mock_pipefy_client.update_card.assert_not_called()
             response = json.loads(result.content[0].text)
-            assert "title" not in response.get("createCard", {}).get("card", {})
+            assert response["createCard"]["card"]["title"] == "Derived from field"
             assert "title_warning" in response
-            assert "API timeout" in response["title_warning"]
+            assert "not applied as expected" in response["title_warning"]
             assert "card_link" in response
+
+    @pytest.mark.parametrize("client_session", [None], indirect=True)
+    async def test_no_title_warning_when_response_matches(
+        self,
+        client_session,
+        mock_pipefy_client,
+        pipe_id,
+    ):
+        """Titled create with matching API title must not emit title_warning."""
+        mock_pipefy_client.get_start_form_fields.return_value = {
+            "start_form_fields": []
+        }
+        mock_pipefy_client.create_card.return_value = {
+            "createCard": {"card": {"id": "789", "title": "My Title"}}
+        }
+
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_card",
+                {"pipe_id": pipe_id, "title": "My Title"},
+            )
+            assert result.isError is False
+            response = json.loads(result.content[0].text)
+            assert response["createCard"]["card"]["title"] == "My Title"
+            assert "title_warning" not in response
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
     async def test_no_title_skips_update_card(
@@ -441,6 +461,190 @@ class TestCreateCardTool:
         payload = extract_payload(result)
         assert payload["success"] is False
         assert "invite_members" in tool_error_message(payload)
+
+    @pytest.mark.parametrize("client_session", [None], indirect=True)
+    @pytest.mark.parametrize("invalid_phase_id", [0, -1])
+    async def test_create_card_rejects_invalid_phase_id(
+        self,
+        client_session,
+        mock_pipefy_client,
+        pipe_id,
+        invalid_phase_id,
+        extract_payload,
+    ):
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_card",
+                {
+                    "pipe_id": pipe_id,
+                    "phase_id": invalid_phase_id,
+                    "skip_elicitation": True,
+                },
+            )
+        mock_pipefy_client.create_card.assert_not_called()
+        payload = extract_payload(result)
+        assert payload["success"] is False
+
+    @pytest.mark.parametrize("client_session", [None], indirect=True)
+    async def test_create_card_forwards_phase_id_with_skip_elicitation(
+        self,
+        client_session,
+        mock_pipefy_client,
+        pipe_id,
+    ):
+        """create_card with phase_id and skip_elicitation forwards phase_id to SDK."""
+        phase_id = 987654321
+        mock_pipefy_client.get_start_form_fields.return_value = {
+            "start_form_fields": []
+        }
+        mock_pipefy_client.create_card.return_value = {
+            "createCard": {"card": {"id": "42"}}
+        }
+
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_card",
+                {
+                    "pipe_id": pipe_id,
+                    "phase_id": phase_id,
+                    "skip_elicitation": True,
+                },
+            )
+
+        assert result.isError is False
+        mock_pipefy_client.create_card.assert_called_once_with(
+            str(pipe_id), {}, phase_id=str(phase_id)
+        )
+
+    @pytest.mark.parametrize("client_session", [None], indirect=True)
+    async def test_create_card_with_phase_id_filters_fields_via_get_phase_fields(
+        self,
+        client_session,
+        mock_pipefy_client,
+        pipe_id,
+    ):
+        """When phase_id is set, field keys are filtered via phase and start-form defs."""
+        phase_id = 555666777
+        mock_pipefy_client.get_start_form_fields.return_value = {
+            "start_form_fields": [
+                {
+                    "id": "sf1",
+                    "label": "SF1",
+                    "type": "short_text",
+                    "editable": True,
+                },
+                {
+                    "id": "sf_readonly",
+                    "label": "SF RO",
+                    "type": "short_text",
+                    "editable": False,
+                },
+            ]
+        }
+        mock_pipefy_client.get_phase_fields = AsyncMock(
+            return_value={
+                "phase_id": str(phase_id),
+                "phase_name": "Orphan",
+                "fields": [
+                    {
+                        "id": "pf1",
+                        "label": "PF1",
+                        "type": "short_text",
+                        "editable": True,
+                    },
+                    {
+                        "id": "pf2",
+                        "label": "PF2",
+                        "type": "short_text",
+                        "editable": False,
+                    },
+                ],
+            }
+        )
+        mock_pipefy_client.create_card.return_value = {
+            "createCard": {"card": {"id": "99"}}
+        }
+
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_card",
+                {
+                    "pipe_id": pipe_id,
+                    "phase_id": phase_id,
+                    "fields": {"pf1": "ok", "pf2": "ignored"},
+                    "skip_elicitation": True,
+                },
+            )
+
+        assert result.isError is False
+        mock_pipefy_client.get_start_form_fields.assert_called_once_with(
+            str(pipe_id), False
+        )
+        mock_pipefy_client.get_phase_fields.assert_called_once_with(
+            str(phase_id), False
+        )
+        mock_pipefy_client.create_card.assert_called_once_with(
+            str(pipe_id), {"pf1": "ok"}, phase_id=str(phase_id)
+        )
+
+    @pytest.mark.parametrize("client_session", [None], indirect=True)
+    async def test_create_card_with_phase_id_keeps_start_form_and_phase_fields(
+        self,
+        client_session,
+        mock_pipefy_client,
+        pipe_id,
+    ):
+        """phase_id path must not drop start-form keys required by CreateCardInput."""
+        phase_id = 555666778
+        mock_pipefy_client.get_start_form_fields.return_value = {
+            "start_form_fields": [
+                {
+                    "id": "objetivo",
+                    "label": "Objetivo",
+                    "type": "long_text",
+                    "editable": True,
+                },
+            ]
+        }
+        mock_pipefy_client.get_phase_fields = AsyncMock(
+            return_value={
+                "phase_id": str(phase_id),
+                "phase_name": "Zona MCP",
+                "fields": [
+                    {
+                        "id": "flag_de_teste",
+                        "label": "Flag",
+                        "type": "checklist_vertical",
+                        "editable": True,
+                    },
+                ],
+            }
+        )
+        mock_pipefy_client.create_card.return_value = {
+            "createCard": {"card": {"id": "100"}}
+        }
+
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_card",
+                {
+                    "pipe_id": pipe_id,
+                    "phase_id": phase_id,
+                    "fields": {
+                        "objetivo": "Smoke",
+                        "flag_de_teste": "A",
+                        "unknown": "drop",
+                    },
+                    "skip_elicitation": True,
+                },
+            )
+
+        assert result.isError is False
+        mock_pipefy_client.create_card.assert_called_once_with(
+            str(pipe_id),
+            {"objetivo": "Smoke", "flag_de_teste": "A"},
+            phase_id=str(phase_id),
+        )
 
 
 @pytest.mark.anyio
@@ -592,6 +796,44 @@ class TestDirectToolCalls:
         mock_pipefy_client.get_pipe.assert_called_once_with(str(pipe_id))
         payload = extract_payload(result)
         assert payload["pipe"]["name"] == "My Pipe"
+
+    @pytest.mark.parametrize("client_session", [None], indirect=True)
+    async def test_get_pipe_returns_enriched_inventory_fields(
+        self, client_session, mock_pipefy_client, extract_payload
+    ):
+        """get_pipe surfaces SDK start_form_phase and per-phase cards_count."""
+        pipe_id = "306996634"
+        mock_pipefy_client.get_pipe = AsyncMock(
+            return_value={
+                "pipe": {
+                    "id": pipe_id,
+                    "name": "Inventory Pipe",
+                    "startFormPhaseId": "100",
+                    "start_form_phase": {
+                        "id": "100",
+                        "name": "Start form",
+                        "cards_count": 0,
+                    },
+                    "phases": [
+                        {"id": "200", "name": "Doing", "cards_count": 4},
+                    ],
+                    "labels": [],
+                    "start_form_fields": [],
+                }
+            }
+        )
+        async with client_session as session:
+            result = await session.call_tool("get_pipe", {"pipe_id": pipe_id})
+        assert result.isError is False
+        payload = extract_payload(result)
+        pipe = payload["pipe"]
+        assert pipe["start_form_phase"] == {
+            "id": "100",
+            "name": "Start form",
+            "cards_count": 0,
+        }
+        assert pipe["phases"] == [{"id": "200", "name": "Doing", "cards_count": 4}]
+        assert all(p["id"] != "100" for p in pipe["phases"])
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
     async def test_move_card_to_phase_forwards_params_to_client(

--- a/packages/mcp/tests/tools/test_pipe_tools.py
+++ b/packages/mcp/tests/tools/test_pipe_tools.py
@@ -382,6 +382,30 @@ class TestCreateCardTool:
             assert "card_link" in response
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
+    async def test_title_warning_skipped_when_create_card_null(
+        self,
+        client_session,
+        mock_pipefy_client,
+        pipe_id,
+    ):
+        """GraphQL null on createCard must not raise when checking title_warning."""
+        mock_pipefy_client.get_start_form_fields.return_value = {
+            "start_form_fields": []
+        }
+        mock_pipefy_client.create_card.return_value = {"createCard": None}
+
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_card",
+                {"pipe_id": pipe_id, "title": "My Title"},
+            )
+            assert result.isError is False
+            response = json.loads(result.content[0].text)
+            assert response == {"createCard": None}
+            assert "title_warning" not in response
+            assert "card_link" not in response
+
+    @pytest.mark.parametrize("client_session", [None], indirect=True)
     async def test_no_title_warning_when_response_matches(
         self,
         client_session,

--- a/packages/mcp/tests/tools/test_pipe_tools.py
+++ b/packages/mcp/tests/tools/test_pipe_tools.py
@@ -497,6 +497,13 @@ class TestCreateCardTool:
         mock_pipefy_client.get_start_form_fields.return_value = {
             "start_form_fields": []
         }
+        mock_pipefy_client.get_phase_fields = AsyncMock(
+            return_value={
+                "phase_id": str(phase_id),
+                "phase_name": "Target",
+                "fields": [],
+            }
+        )
         mock_pipefy_client.create_card.return_value = {
             "createCard": {"card": {"id": "42"}}
         }
@@ -798,33 +805,28 @@ class TestDirectToolCalls:
         assert payload["pipe"]["name"] == "My Pipe"
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
-    async def test_get_pipe_returns_phase_cards_count(
+    async def test_get_pipe_forwards_sdk_payload(
         self, client_session, mock_pipefy_client, extract_payload
     ):
-        """get_pipe forwards workflow phases with cards_count from the SDK."""
+        """get_pipe validates pipe_id and forwards the SDK response unchanged."""
         pipe_id = "306996634"
-        mock_pipefy_client.get_pipe = AsyncMock(
-            return_value={
-                "pipe": {
-                    "id": pipe_id,
-                    "name": "Inventory Pipe",
-                    "startFormPhaseId": "100",
-                    "phases": [
-                        {"id": "200", "name": "Doing", "cards_count": 4},
-                    ],
-                    "labels": [],
-                    "start_form_fields": [],
-                }
+        sdk_payload = {
+            "pipe": {
+                "id": pipe_id,
+                "name": "Inventory Pipe",
+                "phases": [
+                    {"id": "200", "name": "Doing", "cards_count": 4},
+                ],
+                "labels": [],
+                "start_form_fields": [],
             }
-        )
+        }
+        mock_pipefy_client.get_pipe = AsyncMock(return_value=sdk_payload)
         async with client_session as session:
             result = await session.call_tool("get_pipe", {"pipe_id": pipe_id})
         assert result.isError is False
         payload = extract_payload(result)
-        pipe = payload["pipe"]
-        assert pipe["startFormPhaseId"] == "100"
-        assert pipe["phases"] == [{"id": "200", "name": "Doing", "cards_count": 4}]
-        assert all(p["id"] != "100" for p in pipe["phases"])
+        assert payload == sdk_payload
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
     async def test_move_card_to_phase_forwards_params_to_client(

--- a/packages/mcp/tests/tools/test_pipe_tools.py
+++ b/packages/mcp/tests/tools/test_pipe_tools.py
@@ -798,10 +798,10 @@ class TestDirectToolCalls:
         assert payload["pipe"]["name"] == "My Pipe"
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
-    async def test_get_pipe_returns_enriched_inventory_fields(
+    async def test_get_pipe_returns_phase_cards_count(
         self, client_session, mock_pipefy_client, extract_payload
     ):
-        """get_pipe surfaces SDK start_form_phase and per-phase cards_count."""
+        """get_pipe forwards workflow phases with cards_count from the SDK."""
         pipe_id = "306996634"
         mock_pipefy_client.get_pipe = AsyncMock(
             return_value={
@@ -809,11 +809,6 @@ class TestDirectToolCalls:
                     "id": pipe_id,
                     "name": "Inventory Pipe",
                     "startFormPhaseId": "100",
-                    "start_form_phase": {
-                        "id": "100",
-                        "name": "Start form",
-                        "cards_count": 0,
-                    },
                     "phases": [
                         {"id": "200", "name": "Doing", "cards_count": 4},
                     ],
@@ -827,11 +822,7 @@ class TestDirectToolCalls:
         assert result.isError is False
         payload = extract_payload(result)
         pipe = payload["pipe"]
-        assert pipe["start_form_phase"] == {
-            "id": "100",
-            "name": "Start form",
-            "cards_count": 0,
-        }
+        assert pipe["startFormPhaseId"] == "100"
         assert pipe["phases"] == [{"id": "200", "name": "Doing", "cards_count": 4}]
         assert all(p["id"] != "100" for p in pipe["phases"])
 


### PR DESCRIPTION
Analytics pipe seeding (`306996636`) required **`execute_graphql`** for phase inventory and phase-local creates. **Spec:** `.cursor/dev-planning/specs/archive/card-phase-ergonomics/` — **Stack** after [#277](https://github.com/pipefy/ai-toolkit/pull/277) (closed).

**Depends on:** https://github.com/pipefy/ai-toolkit/pull/282

---

## Objective

**#1 chaos-pipe pain:** cards in orphan/non–start-form phases via `createCard` + `introspect_type("CreateCardInput")`.

- MCP `create_card(phase_id=…)` with `validate_tool_id`, merged start-form + phase field filtering
- Pass `title` on `CreateCardInput`; `title_warning` only on real API mismatch (F1)
- CLI `card create --phase-id` (F3)
- Docstrings: `start_form_phase.id` discovery (F4)

## Improvements

- Seed 12 cards in a Limbo phase with tools only (success metric from PRD).
