### PR TITLE
feat(mcp,cli): report filter preflight and CLI label hex

### DIFF
--- a/packages/cli/src/pipefy_cli/commands/_common.py
+++ b/packages/cli/src/pipefy_cli/commands/_common.py
@@ -13,7 +13,11 @@ import typer
 from gql.transport.exceptions import TransportError, TransportQueryError
 from pipefy_sdk import PipefyClient, PipefySettings, stream_bytes
 from pipefy_sdk.exceptions import PipefyError
-from pipefy_sdk.report_filter_preflight import validate_report_cards_filter
+from pipefy_sdk.label_color import normalize_label_color
+from pipefy_sdk.report_filter_preflight import (
+    normalize_report_cards_filter,
+    validate_report_cards_filter,
+)
 
 from pipefy_cli.auth import (
     AuthContext,
@@ -80,10 +84,30 @@ def validate_cards_page_size(first: int | None) -> int | None:
     return first
 
 
-def validate_report_filter_cli(filter_obj: dict[str, Any] | None) -> None:
-    message = validate_report_cards_filter(filter_obj)
+def validate_report_filter_cli(filter_obj: dict[str, Any] | None) -> dict[str, Any] | None:
+    if filter_obj is None:
+        return None
+    normalized = normalize_report_cards_filter(filter_obj)
+    message = validate_report_cards_filter(normalized)
     if message is not None:
         raise typer.BadParameter(message)
+    return normalized
+
+
+def validate_label_name_cli(name: str) -> str:
+    nm = name.strip()
+    if not nm:
+        typer.echo("--name must be non-empty.", err=True)
+        raise typer.Exit(2)
+    return nm
+
+
+def validate_label_color_cli(color: str) -> str:
+    try:
+        return normalize_label_color(color)
+    except ValueError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(2) from exc
 
 
 def export_poll_max_rounds(

--- a/packages/cli/src/pipefy_cli/commands/_common.py
+++ b/packages/cli/src/pipefy_cli/commands/_common.py
@@ -99,8 +99,7 @@ def validate_report_filter_cli(
 def validate_label_name_cli(name: str) -> str:
     nm = name.strip()
     if not nm:
-        typer.echo("--name must be non-empty.", err=True)
-        raise typer.Exit(2)
+        raise typer.BadParameter("--name must be non-empty.")
     return nm
 
 
@@ -108,8 +107,7 @@ def validate_label_color_cli(color: str) -> str:
     try:
         return normalize_label_color(color)
     except ValueError as exc:
-        typer.echo(str(exc), err=True)
-        raise typer.Exit(2) from exc
+        raise typer.BadParameter(str(exc)) from exc
 
 
 def export_poll_max_rounds(

--- a/packages/cli/src/pipefy_cli/commands/_common.py
+++ b/packages/cli/src/pipefy_cli/commands/_common.py
@@ -84,7 +84,9 @@ def validate_cards_page_size(first: int | None) -> int | None:
     return first
 
 
-def validate_report_filter_cli(filter_obj: dict[str, Any] | None) -> dict[str, Any] | None:
+def validate_report_filter_cli(
+    filter_obj: dict[str, Any] | None,
+) -> dict[str, Any] | None:
     if filter_obj is None:
         return None
     normalized = normalize_report_cards_filter(filter_obj)

--- a/packages/cli/src/pipefy_cli/commands/label.py
+++ b/packages/cli/src/pipefy_cli/commands/label.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import typer
 from pipefy_sdk import PipefyClient
-from pipefy_sdk.label_color import normalize_label_color
 
 from pipefy_cli.commands._common import (
     ID_POSITIONAL_CONTEXT_SETTINGS,
     confirm_destructive,
     resource_id_argument,
     run_cli_command,
+    validate_label_color_cli,
+    validate_label_name_cli,
 )
 
 label_app = typer.Typer(help="Pipe label operations.", no_args_is_help=True)
@@ -56,18 +57,8 @@ def label_create(
 ) -> None:
     """Create a label on a pipe."""
 
-    nm = name.strip()
-    if not nm:
-        typer.echo("--name must be non-empty.", err=True)
-        raise typer.Exit(2)
-    if not color.strip():
-        typer.echo("--color must be non-empty.", err=True)
-        raise typer.Exit(2)
-    try:
-        col = normalize_label_color(color)
-    except ValueError as exc:
-        typer.echo(str(exc), err=True)
-        raise typer.Exit(2) from exc
+    nm = validate_label_name_cli(name)
+    col = validate_label_color_cli(color)
 
     async def factory(client: PipefyClient):
         return await client.create_label(pipe_id, nm, col)
@@ -92,18 +83,8 @@ def label_update(
 ) -> None:
     """Update a label (name and color are both required by Pipefy)."""
 
-    nm = name.strip()
-    if not nm:
-        typer.echo("--name must be non-empty.", err=True)
-        raise typer.Exit(2)
-    if not color.strip():
-        typer.echo("--color must be non-empty.", err=True)
-        raise typer.Exit(2)
-    try:
-        col = normalize_label_color(color)
-    except ValueError as exc:
-        typer.echo(str(exc), err=True)
-        raise typer.Exit(2) from exc
+    nm = validate_label_name_cli(name)
+    col = validate_label_color_cli(color)
 
     async def factory(client: PipefyClient):
         return await client.update_label(label_id, name=nm, color=col)

--- a/packages/cli/src/pipefy_cli/commands/label.py
+++ b/packages/cli/src/pipefy_cli/commands/label.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import typer
 from pipefy_sdk import PipefyClient
+from pipefy_sdk.label_color import normalize_label_color
 
 from pipefy_cli.commands._common import (
     ID_POSITIONAL_CONTEXT_SETTINGS,
@@ -46,17 +47,27 @@ def label_create(
     pipe_id: str = typer.Option(..., "--pipe", help="Pipe id."),
     name: str = typer.Option(..., "--name", "-n", help="Label name."),
     color: str = typer.Option(
-        ..., "--color", "-c", help="Label color (per Pipefy API)."
+        ...,
+        "--color",
+        "-c",
+        help="Label color as hex #RRGGBB (e.g. #E50000, #FF0000).",
     ),
     json_out: bool = typer.Option(False, "--json", "-j"),
 ) -> None:
     """Create a label on a pipe."""
 
     nm = name.strip()
-    col = color.strip()
-    if not nm or not col:
-        typer.echo("--name and --color must be non-empty.", err=True)
+    if not nm:
+        typer.echo("--name must be non-empty.", err=True)
         raise typer.Exit(2)
+    if not color.strip():
+        typer.echo("--color must be non-empty.", err=True)
+        raise typer.Exit(2)
+    try:
+        col = normalize_label_color(color)
+    except ValueError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(2) from exc
 
     async def factory(client: PipefyClient):
         return await client.create_label(pipe_id, nm, col)
@@ -72,17 +83,27 @@ def label_update(
         ..., "--name", "-n", help="New label name (required by API)."
     ),
     color: str = typer.Option(
-        ..., "--color", "-c", help="New label color (required by API)."
+        ...,
+        "--color",
+        "-c",
+        help="New label color as hex #RRGGBB (required by API).",
     ),
     json_out: bool = typer.Option(False, "--json", "-j"),
 ) -> None:
     """Update a label (name and color are both required by Pipefy)."""
 
     nm = name.strip()
-    col = color.strip()
-    if not nm or not col:
-        typer.echo("--name and --color must be non-empty.", err=True)
+    if not nm:
+        typer.echo("--name must be non-empty.", err=True)
         raise typer.Exit(2)
+    if not color.strip():
+        typer.echo("--color must be non-empty.", err=True)
+        raise typer.Exit(2)
+    try:
+        col = normalize_label_color(color)
+    except ValueError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(2) from exc
 
     async def factory(client: PipefyClient):
         return await client.update_label(label_id, name=nm, color=col)

--- a/packages/cli/src/pipefy_cli/commands/report_org.py
+++ b/packages/cli/src/pipefy_cli/commands/report_org.py
@@ -78,8 +78,7 @@ def report_org_create(
     fields_list = parse_json_value(fields, "--fields") if fields else None
     if fields_list is not None and not isinstance(fields_list, list):
         raise typer.BadParameter("--fields must be a JSON array")
-    filt = parse_json_object(filter_json, "--filter")
-    validate_report_filter_cli(filt)
+    filt = validate_report_filter_cli(parse_json_object(filter_json, "--filter"))
 
     async def factory(client: PipefyClient):
         return await client.create_organization_report(
@@ -112,8 +111,7 @@ def report_org_update(
     fields_list = parse_json_value(fields, "--fields") if fields else None
     if fields_list is not None and not isinstance(fields_list, list):
         raise typer.BadParameter("--fields must be a JSON array")
-    filt = parse_json_object(filter_json, "--filter")
-    validate_report_filter_cli(filt)
+    filt = validate_report_filter_cli(parse_json_object(filter_json, "--filter"))
     pids = parse_json_value(pipe_ids, "--pipe-ids") if pipe_ids else None
     if pids is not None:
         if not isinstance(pids, list):
@@ -189,8 +187,7 @@ def report_org_export(
             "--json is mutually exclusive with --format csv (CSV is written as raw bytes to stdout)."
         )
     sort_obj = parse_json_object(sort_by, "--sort-by")
-    filt = parse_json_object(filter_json, "--filter")
-    validate_report_filter_cli(filt)
+    filt = validate_report_filter_cli(parse_json_object(filter_json, "--filter"))
     cols = parse_json_value(columns, "--columns") if columns else None
     if cols is not None and not isinstance(cols, list):
         raise typer.BadParameter("--columns must be a JSON array")

--- a/packages/cli/src/pipefy_cli/commands/report_org.py
+++ b/packages/cli/src/pipefy_cli/commands/report_org.py
@@ -13,6 +13,7 @@ from pipefy_cli.commands._common import (
     resource_id_argument,
     run_cli_command,
     run_pipefy_client_coroutine,
+    validate_report_filter_cli,
     write_export_csv_to_stdout,
 )
 
@@ -78,6 +79,7 @@ def report_org_create(
     if fields_list is not None and not isinstance(fields_list, list):
         raise typer.BadParameter("--fields must be a JSON array")
     filt = parse_json_object(filter_json, "--filter")
+    validate_report_filter_cli(filt)
 
     async def factory(client: PipefyClient):
         return await client.create_organization_report(
@@ -111,6 +113,7 @@ def report_org_update(
     if fields_list is not None and not isinstance(fields_list, list):
         raise typer.BadParameter("--fields must be a JSON array")
     filt = parse_json_object(filter_json, "--filter")
+    validate_report_filter_cli(filt)
     pids = parse_json_value(pipe_ids, "--pipe-ids") if pipe_ids else None
     if pids is not None:
         if not isinstance(pids, list):
@@ -187,6 +190,7 @@ def report_org_export(
         )
     sort_obj = parse_json_object(sort_by, "--sort-by")
     filt = parse_json_object(filter_json, "--filter")
+    validate_report_filter_cli(filt)
     cols = parse_json_value(columns, "--columns") if columns else None
     if cols is not None and not isinstance(cols, list):
         raise typer.BadParameter("--columns must be a JSON array")

--- a/packages/cli/src/pipefy_cli/commands/report_pipe.py
+++ b/packages/cli/src/pipefy_cli/commands/report_pipe.py
@@ -139,8 +139,7 @@ def report_pipe_create(
     fields_list = parse_json_value(fields, "--fields") if fields else None
     if fields_list is not None and not isinstance(fields_list, list):
         raise typer.BadParameter("--fields must be a JSON array")
-    filt = parse_json_object(filter_json, "--filter")
-    validate_report_filter_cli(filt)
+    filt = validate_report_filter_cli(parse_json_object(filter_json, "--filter"))
     formulas_val = parse_json_value(formulas, "--formulas") if formulas else None
     if formulas_val is not None and not isinstance(formulas_val, list):
         raise typer.BadParameter("--formulas must be a JSON array")
@@ -175,8 +174,7 @@ def report_pipe_update(
     fields_list = parse_json_value(fields, "--fields") if fields else None
     if fields_list is not None and not isinstance(fields_list, list):
         raise typer.BadParameter("--fields must be a JSON array")
-    filt = parse_json_object(filter_json, "--filter")
-    validate_report_filter_cli(filt)
+    filt = validate_report_filter_cli(parse_json_object(filter_json, "--filter"))
     formulas_val = parse_json_value(formulas, "--formulas") if formulas else None
     if formulas_val is not None and not isinstance(formulas_val, list):
         raise typer.BadParameter("--formulas must be a JSON array")
@@ -248,8 +246,7 @@ def report_pipe_export(
             "--json is mutually exclusive with --format csv (CSV is written as raw bytes to stdout)."
         )
     sort_obj = parse_json_object(sort_by, "--sort-by")
-    filt = parse_json_object(filter_json, "--filter")
-    validate_report_filter_cli(filt)
+    filt = validate_report_filter_cli(parse_json_object(filter_json, "--filter"))
     cols = parse_json_value(columns, "--columns") if columns else None
     if cols is not None and not isinstance(cols, list):
         raise typer.BadParameter("--columns must be a JSON array")

--- a/packages/cli/src/pipefy_cli/commands/report_pipe.py
+++ b/packages/cli/src/pipefy_cli/commands/report_pipe.py
@@ -15,6 +15,7 @@ from pipefy_cli.commands._common import (
     resource_id_argument,
     run_cli_command,
     run_pipefy_client_coroutine,
+    validate_report_filter_cli,
     write_export_csv_to_stdout,
 )
 
@@ -139,6 +140,7 @@ def report_pipe_create(
     if fields_list is not None and not isinstance(fields_list, list):
         raise typer.BadParameter("--fields must be a JSON array")
     filt = parse_json_object(filter_json, "--filter")
+    validate_report_filter_cli(filt)
     formulas_val = parse_json_value(formulas, "--formulas") if formulas else None
     if formulas_val is not None and not isinstance(formulas_val, list):
         raise typer.BadParameter("--formulas must be a JSON array")
@@ -174,6 +176,7 @@ def report_pipe_update(
     if fields_list is not None and not isinstance(fields_list, list):
         raise typer.BadParameter("--fields must be a JSON array")
     filt = parse_json_object(filter_json, "--filter")
+    validate_report_filter_cli(filt)
     formulas_val = parse_json_value(formulas, "--formulas") if formulas else None
     if formulas_val is not None and not isinstance(formulas_val, list):
         raise typer.BadParameter("--formulas must be a JSON array")
@@ -246,6 +249,7 @@ def report_pipe_export(
         )
     sort_obj = parse_json_object(sort_by, "--sort-by")
     filt = parse_json_object(filter_json, "--filter")
+    validate_report_filter_cli(filt)
     cols = parse_json_value(columns, "--columns") if columns else None
     if cols is not None and not isinstance(cols, list):
         raise typer.BadParameter("--columns must be a JSON array")

--- a/packages/cli/tests/test_label_webhook_commands.py
+++ b/packages/cli/tests/test_label_webhook_commands.py
@@ -26,6 +26,87 @@ def test_label_list_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
     assert out["labels"] == [{"id": "1", "name": "Bug"}]
 
 
+def test_label_create_rejects_color_name_before_api(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("lbl-create-hex")
+    mock_client = MagicMock()
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "label",
+                "create",
+                "--pipe",
+                "8",
+                "--name",
+                "Bug",
+                "--color",
+                "red",
+            ],
+        )
+    assert result.exit_code == 2
+    assert "expected #RGB or #RRGGBB hex color, received 'red'" in result.stderr
+    mock_client.create_label.assert_not_called()
+
+
+def test_label_create_passes_normalized_hex(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("lbl-create-ok")
+    mock_client = MagicMock()
+    mock_client.create_label = AsyncMock(return_value={"createLabel": {}})
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "label",
+                "create",
+                "--pipe",
+                "8",
+                "--name",
+                "Bug",
+                "--color",
+                "#ff0000",
+                "--json",
+            ],
+        )
+    assert result.exit_code == 0
+    mock_client.create_label.assert_awaited_once_with("8", "Bug", "#FF0000")
+
+
+def test_label_update_rejects_color_name_before_api(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("lbl-update-hex")
+    mock_client = MagicMock()
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "label",
+                "update",
+                "3",
+                "--name",
+                "Story",
+                "--color",
+                "blue",
+            ],
+        )
+    assert result.exit_code == 2
+    assert "expected #RGB or #RRGGBB hex color, received 'blue'" in result.stderr
+    mock_client.update_label.assert_not_called()
+
+
 def test_label_list_pipe_denied_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
     oauth_env("lbl-denied")
     mock_client = MagicMock()

--- a/packages/cli/tests/test_report_pipe_filter_commands.py
+++ b/packages/cli/tests/test_report_pipe_filter_commands.py
@@ -1,0 +1,100 @@
+"""CLI tests for report-pipe filter preflight."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pipefy_sdk.report_filter_preflight import EXAMPLE_PHASE_FILTER
+
+from pipefy_cli.main import app
+
+
+def test_report_pipe_create_rejects_naive_current_phase_filter(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("report-filter-bad")
+    mock_client = MagicMock()
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "report-pipe",
+                "create",
+                "--pipe",
+                "123",
+                "--name",
+                "R",
+                "--filter",
+                json.dumps({"current_phase": ["1"]}),
+            ],
+        )
+    assert result.exit_code == 2
+    mock_client.create_pipe_report.assert_not_called()
+    assert "top-level" in result.stderr
+
+
+def test_report_pipe_create_forwards_valid_filter(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("report-filter-ok")
+    filt = {
+        **EXAMPLE_PHASE_FILTER,
+        "queries": [{**EXAMPLE_PHASE_FILTER["queries"][0], "value": "99"}],
+    }
+    mock_client = MagicMock()
+    mock_client.create_pipe_report = AsyncMock(
+        return_value={"createPipeReport": {"pipeReport": {"id": "r1"}}}
+    )
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "report-pipe",
+                "create",
+                "--pipe",
+                "123",
+                "--name",
+                "R",
+                "--filter",
+                json.dumps(filt),
+                "--json",
+            ],
+        )
+    assert result.exit_code == 0, result.stderr
+    mock_client.create_pipe_report.assert_awaited_once_with(
+        "123",
+        "R",
+        fields=None,
+        filter=filt,
+        formulas=None,
+    )
+
+
+def test_report_pipe_update_rejects_invalid_filter_operator(
+    runner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("report-filter-update-bad")
+    mock_client = MagicMock()
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "report-pipe",
+                "update",
+                "10",
+                "--filter",
+                json.dumps({"operator": "xor", "queries": []}),
+            ],
+        )
+    assert result.exit_code == 2
+    mock_client.update_pipe_report.assert_not_called()

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,6 +1,6 @@
 # pipefy-mcp-server
 
-MCP server for Pipefy — **149 tools** for AI agents (Cursor, Claude Desktop, Claude Code, Codex, and any MCP-compatible client). Depends on [`pipefy-sdk`](../sdk/README.md) for all GraphQL and API logic.
+MCP server for Pipefy — **152 tools** for AI agents (Cursor, Claude Desktop, Claude Code, Codex, and any MCP-compatible client). Depends on [`pipefy-sdk`](../sdk/README.md) for all GraphQL and API logic.
 
 ## Install (pre-launch, v0.1 → v0.5)
 
@@ -112,7 +112,7 @@ This form also works as a per-project `.mcp.json` if your team shares a clone. C
 
 ## Tools
 
-**149 tools** across ten domains (including **Portals**) — see the root [`README.md`](../../README.md#mcp-server) for the full table with per-area links. Deep reference: [`docs/mcp/tools/`](../../docs/mcp/tools/cross-cutting.md) (start with [`cross-cutting.md`](../../docs/mcp/tools/cross-cutting.md)); portals: [`portal.md`](../../docs/mcp/tools/portal.md).
+**152 tools** across ten domains (including **Portals**) — see the root [`README.md`](../../README.md#mcp-server) for the full table with per-area links. Deep reference: [`docs/mcp/tools/`](../../docs/mcp/tools/cross-cutting.md) (start with [`cross-cutting.md`](../../docs/mcp/tools/cross-cutting.md)); portals: [`portal.md`](../../docs/mcp/tools/portal.md).
 
 ## Development
 

--- a/packages/mcp/src/pipefy_mcp/tools/report_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/report_tools.py
@@ -30,12 +30,6 @@ from pipefy_mcp.tools.tool_error_envelope import (
 )
 from pipefy_mcp.tools.validation_helpers import validate_tool_id
 
-_REPORT_FILTER_SHAPE_DOC = (
-    "``filter`` must use ReportCardsFilter shape (``operator`` + ``queries``), not a "
-    "top-level ``current_phase`` key; discover field names via "
-    "``get_pipe_report_filterable_fields``."
-)
-
 
 def _blank_field_error(value: str, field: str) -> dict[str, Any] | None:
     """Return an error payload when ``value`` is blank."""
@@ -556,9 +550,11 @@ class ReportTools:
             filter: dict | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
-            f"""Create an org-wide report spanning multiple pipes.
+            """Create an org-wide report spanning multiple pipes.
 
-            {_REPORT_FILTER_SHAPE_DOC}
+            ``filter`` must use ReportCardsFilter shape (``operator`` + ``queries``),
+            not a top-level ``current_phase`` key; discover field names via
+            ``get_pipe_report_filterable_fields``.
 
             Args:
                 organization_id: Organization ID.
@@ -610,9 +606,11 @@ class ReportTools:
             pipe_ids: list[str] | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
-            f"""Update an organization report; omitted parameters are unchanged.
+            """Update an organization report; omitted parameters are unchanged.
 
-            {_REPORT_FILTER_SHAPE_DOC}
+            ``filter`` must use ReportCardsFilter shape (``operator`` + ``queries``),
+            not a top-level ``current_phase`` key; discover field names via
+            ``get_pipe_report_filterable_fields``.
 
             Args:
                 report_id: Organization report ID.
@@ -712,9 +710,11 @@ class ReportTools:
             columns: list[str] | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
-            f"""Trigger an async pipe report export. Returns an export ID with state 'processing'. Poll `get_pipe_report_export(export_id)` to check when state becomes 'done' -- the response will include a `fileURL` to download the file.
+            """Trigger an async pipe report export. Returns an export ID with state 'processing'. Poll `get_pipe_report_export(export_id)` to check when state becomes 'done' -- the response will include a `fileURL` to download the file.
 
-            {_REPORT_FILTER_SHAPE_DOC}
+            ``filter`` must use ReportCardsFilter shape (``operator`` + ``queries``),
+            not a top-level ``current_phase`` key; discover field names via
+            ``get_pipe_report_filterable_fields``.
 
             Args:
                 pipe_id: Pipe ID (numeric string).
@@ -766,9 +766,11 @@ class ReportTools:
             columns: list[str] | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
-            f"""Trigger an async organization report export. Poll `get_organization_report_export(export_id)` for completion.
+            """Trigger an async organization report export. Poll `get_organization_report_export(export_id)` for completion.
 
-            {_REPORT_FILTER_SHAPE_DOC}
+            ``filter`` must use ReportCardsFilter shape (``operator`` + ``queries``),
+            not a top-level ``current_phase`` key; discover field names via
+            ``get_pipe_report_filterable_fields``.
 
             Args:
                 organization_id: Organization numeric ID (must be coercible to int — Pipefy's

--- a/packages/mcp/src/pipefy_mcp/tools/report_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/report_tools.py
@@ -8,7 +8,10 @@ from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
 from mcp.types import ToolAnnotations
 from pipefy_sdk import PipefyClient, PipefyId
-from pipefy_sdk.report_filter_preflight import validate_report_cards_filter
+from pipefy_sdk.report_filter_preflight import (
+    normalize_report_cards_filter,
+    validate_report_cards_filter,
+)
 
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.pagination_helpers import (
@@ -27,6 +30,12 @@ from pipefy_mcp.tools.tool_error_envelope import (
 )
 from pipefy_mcp.tools.validation_helpers import validate_tool_id
 
+_REPORT_FILTER_SHAPE_DOC = (
+    "``filter`` must use ReportCardsFilter shape (``operator`` + ``queries``), not a "
+    "top-level ``current_phase`` key; discover field names via "
+    "``get_pipe_report_filterable_fields``."
+)
+
 
 def _blank_field_error(value: str, field: str) -> dict[str, Any] | None:
     """Return an error payload when ``value`` is blank."""
@@ -35,13 +44,16 @@ def _blank_field_error(value: str, field: str) -> dict[str, Any] | None:
     return None
 
 
-def _report_filter_preflight_error(
+def _prepare_report_cards_filter(
     filter_obj: dict[str, Any] | None,
-) -> dict[str, Any] | None:
-    message = validate_report_cards_filter(filter_obj)
-    if message is None:
-        return None
-    return build_report_error_payload(message=message)
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    if filter_obj is None:
+        return None, None
+    normalized = normalize_report_cards_filter(filter_obj)
+    message = validate_report_cards_filter(normalized)
+    if message is not None:
+        return None, build_report_error_payload(message=message)
+    return normalized, None
 
 
 class ReportTools:
@@ -406,7 +418,7 @@ class ReportTools:
             err = _blank_field_error(name, "name")
             if err is not None:
                 return err
-            err = _report_filter_preflight_error(filter)
+            filter, err = _prepare_report_cards_filter(filter)
             if err is not None:
                 return err
             try:
@@ -457,7 +469,7 @@ class ReportTools:
             err = _blank_field_error(report_id, "report_id")
             if err is not None:
                 return err
-            err = _report_filter_preflight_error(filter)
+            filter, err = _prepare_report_cards_filter(filter)
             if err is not None:
                 return err
             try:
@@ -544,7 +556,9 @@ class ReportTools:
             filter: dict | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
-            """Create an org-wide report spanning multiple pipes.
+            f"""Create an org-wide report spanning multiple pipes.
+
+            {_REPORT_FILTER_SHAPE_DOC}
 
             Args:
                 organization_id: Organization ID.
@@ -560,7 +574,7 @@ class ReportTools:
             err = _blank_field_error(name, "name")
             if err is not None:
                 return err
-            err = _report_filter_preflight_error(filter)
+            filter, err = _prepare_report_cards_filter(filter)
             if err is not None:
                 return err
             if not pipe_ids or not isinstance(pipe_ids, list):
@@ -596,7 +610,9 @@ class ReportTools:
             pipe_ids: list[str] | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
-            """Update an organization report; omitted parameters are unchanged.
+            f"""Update an organization report; omitted parameters are unchanged.
+
+            {_REPORT_FILTER_SHAPE_DOC}
 
             Args:
                 report_id: Organization report ID.
@@ -610,7 +626,7 @@ class ReportTools:
             err = _blank_field_error(report_id, "report_id")
             if err is not None:
                 return err
-            err = _report_filter_preflight_error(filter)
+            filter, err = _prepare_report_cards_filter(filter)
             if err is not None:
                 return err
             try:
@@ -696,7 +712,9 @@ class ReportTools:
             columns: list[str] | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
-            """Trigger an async pipe report export. Returns an export ID with state 'processing'. Poll `get_pipe_report_export(export_id)` to check when state becomes 'done' -- the response will include a `fileURL` to download the file.
+            f"""Trigger an async pipe report export. Returns an export ID with state 'processing'. Poll `get_pipe_report_export(export_id)` to check when state becomes 'done' -- the response will include a `fileURL` to download the file.
+
+            {_REPORT_FILTER_SHAPE_DOC}
 
             Args:
                 pipe_id: Pipe ID (numeric string).
@@ -712,7 +730,7 @@ class ReportTools:
             err = _blank_field_error(pipe_report_id, "pipe_report_id")
             if err is not None:
                 return err
-            err = _report_filter_preflight_error(filter)
+            filter, err = _prepare_report_cards_filter(filter)
             if err is not None:
                 return err
             try:
@@ -748,7 +766,9 @@ class ReportTools:
             columns: list[str] | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
-            """Trigger an async organization report export. Poll `get_organization_report_export(export_id)` for completion.
+            f"""Trigger an async organization report export. Poll `get_organization_report_export(export_id)` for completion.
+
+            {_REPORT_FILTER_SHAPE_DOC}
 
             Args:
                 organization_id: Organization numeric ID (must be coercible to int — Pipefy's
@@ -763,7 +783,7 @@ class ReportTools:
             organization_id, err = validate_tool_id(organization_id, "organization_id")
             if err is not None:
                 return err
-            err = _report_filter_preflight_error(filter)
+            filter, err = _prepare_report_cards_filter(filter)
             if err is not None:
                 return err
             try:

--- a/packages/mcp/src/pipefy_mcp/tools/report_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/report_tools.py
@@ -8,6 +8,7 @@ from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
 from mcp.types import ToolAnnotations
 from pipefy_sdk import PipefyClient, PipefyId
+from pipefy_sdk.report_filter_preflight import validate_report_cards_filter
 
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.pagination_helpers import (
@@ -32,6 +33,15 @@ def _blank_field_error(value: str, field: str) -> dict[str, Any] | None:
     if not value.strip():
         return build_report_error_payload(message=f"'{field}' must be non-empty.")
     return None
+
+
+def _report_filter_preflight_error(
+    filter_obj: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    message = validate_report_cards_filter(filter_obj)
+    if message is None:
+        return None
+    return build_report_error_payload(message=message)
 
 
 class ReportTools:
@@ -378,6 +388,10 @@ class ReportTools:
         ) -> dict[str, Any]:
             """Create a pipe report. Use column `name` in `fields`; filter field names from `get_pipe_report_filterable_fields`.
 
+            ``filter`` must use ReportCardsFilter shape (``operator`` + ``queries``), not a
+            top-level ``current_phase`` key; discover field names via
+            ``get_pipe_report_filterable_fields``.
+
             Args:
                 pipe_id: Pipe ID (numeric string).
                 name: Report name.
@@ -390,6 +404,9 @@ class ReportTools:
             if err is not None:
                 return err
             err = _blank_field_error(name, "name")
+            if err is not None:
+                return err
+            err = _report_filter_preflight_error(filter)
             if err is not None:
                 return err
             try:
@@ -424,6 +441,9 @@ class ReportTools:
         ) -> dict[str, Any]:
             """Update a pipe report; omitted parameters are unchanged.
 
+            ``filter`` uses the same ReportCardsFilter nested shape as ``create_pipe_report``
+            (``operator`` + ``queries``; no top-level ``current_phase`` list).
+
             Args:
                 report_id: Pipe report ID.
                 name: New report name.
@@ -435,6 +455,9 @@ class ReportTools:
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             err = _blank_field_error(report_id, "report_id")
+            if err is not None:
+                return err
+            err = _report_filter_preflight_error(filter)
             if err is not None:
                 return err
             try:
@@ -537,6 +560,9 @@ class ReportTools:
             err = _blank_field_error(name, "name")
             if err is not None:
                 return err
+            err = _report_filter_preflight_error(filter)
+            if err is not None:
+                return err
             if not pipe_ids or not isinstance(pipe_ids, list):
                 return build_report_error_payload(
                     message="'pipe_ids' must be a non-empty list.",
@@ -582,6 +608,9 @@ class ReportTools:
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             err = _blank_field_error(report_id, "report_id")
+            if err is not None:
+                return err
+            err = _report_filter_preflight_error(filter)
             if err is not None:
                 return err
             try:
@@ -683,6 +712,9 @@ class ReportTools:
             err = _blank_field_error(pipe_report_id, "pipe_report_id")
             if err is not None:
                 return err
+            err = _report_filter_preflight_error(filter)
+            if err is not None:
+                return err
             try:
                 raw = await client.export_pipe_report(
                     pipe_id,
@@ -729,6 +761,9 @@ class ReportTools:
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             organization_id, err = validate_tool_id(organization_id, "organization_id")
+            if err is not None:
+                return err
+            err = _report_filter_preflight_error(filter)
             if err is not None:
                 return err
             try:

--- a/packages/mcp/tests/tools/test_report_tools.py
+++ b/packages/mcp/tests/tools/test_report_tools.py
@@ -1705,3 +1705,38 @@ async def test_export_organization_report_graphql_error(
     payload = extract_payload(result)
     assert payload["success"] is False
     assert "export org failed" in tool_error_message(payload)
+
+
+REPORT_FILTER_TOOL_NAMES = {
+    "create_pipe_report",
+    "update_pipe_report",
+    "create_organization_report",
+    "update_organization_report",
+    "export_pipe_report",
+    "export_organization_report",
+}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_report_tool_descriptions_are_non_empty(report_session):
+    async with report_session as session:
+        listed = await session.list_tools()
+
+    empty = [tool.name for tool in listed.tools if not (tool.description or "").strip()]
+    assert empty == []
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_filter_tools_warn_against_top_level_current_phase(report_session):
+    async with report_session as session:
+        listed = await session.list_tools()
+
+    descriptions = {tool.name: tool.description or "" for tool in listed.tools}
+    missing_guidance = [
+        name
+        for name in sorted(REPORT_FILTER_TOOL_NAMES)
+        if "current_phase" not in descriptions.get(name, "")
+    ]
+    assert missing_guidance == []

--- a/packages/mcp/tests/tools/test_report_tools.py
+++ b/packages/mcp/tests/tools/test_report_tools.py
@@ -10,10 +10,21 @@ from mcp.shared.memory import (
     create_connected_server_and_client_session as create_client_session,
 )
 from pipefy_sdk import PipefyClient
+from pipefy_sdk.report_filter_preflight import EXAMPLE_PHASE_FILTER
 
 from pipefy_mcp.tools.report_tools import ReportTools
 from pipefy_mcp.tools.tool_error_envelope import tool_error_message
 from tools.conftest import assert_invalid_arguments_envelope
+
+GOLDEN_REPORT_PHASE_FILTER = {
+    **EXAMPLE_PHASE_FILTER,
+    "queries": [
+        {
+            **EXAMPLE_PHASE_FILTER["queries"][0],
+            "value": "987654321",
+        }
+    ],
+}
 
 
 @pytest.fixture
@@ -416,6 +427,96 @@ async def test_create_pipe_report_success(
     payload = extract_payload(result)
     assert payload["success"] is True
     assert payload["result"]["createPipeReport"]["pipeReport"]["id"] == "r10"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_create_pipe_report_forwards_golden_report_filter(
+    report_session, mock_report_client, extract_payload
+):
+    mock_report_client.create_pipe_report.return_value = {
+        "createPipeReport": {"pipeReport": {"id": "r10", "name": "Filtered"}}
+    }
+
+    async with report_session as session:
+        result = await session.call_tool(
+            "create_pipe_report",
+            {
+                "pipe_id": "123",
+                "name": "Filtered",
+                "filter": GOLDEN_REPORT_PHASE_FILTER,
+            },
+        )
+
+    assert result.isError is False
+    mock_report_client.create_pipe_report.assert_awaited_once_with(
+        "123",
+        "Filtered",
+        fields=None,
+        filter=GOLDEN_REPORT_PHASE_FILTER,
+        formulas=None,
+    )
+    payload = extract_payload(result)
+    assert payload["success"] is True
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_create_pipe_report_rejects_naive_current_phase_filter(
+    report_session, mock_report_client, extract_payload
+):
+    async with report_session as session:
+        result = await session.call_tool(
+            "create_pipe_report",
+            {
+                "pipe_id": "123",
+                "name": "Bad filter",
+                "filter": {"current_phase": ["987654321"]},
+            },
+        )
+
+    mock_report_client.create_pipe_report.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "top-level" in tool_error_message(payload)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_export_pipe_report_rejects_naive_current_phase_filter(
+    report_session, mock_report_client, extract_payload
+):
+    async with report_session as session:
+        result = await session.call_tool(
+            "export_pipe_report",
+            {
+                "pipe_id": "123",
+                "pipe_report_id": "r1",
+                "filter": {"current_phase": ["987654321"]},
+            },
+        )
+
+    mock_report_client.export_pipe_report.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "top-level" in tool_error_message(payload)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("report_session", [None], indirect=True)
+async def test_update_pipe_report_rejects_invalid_report_filter(
+    report_session, mock_report_client, extract_payload
+):
+    async with report_session as session:
+        result = await session.call_tool(
+            "update_pipe_report",
+            {"report_id": "r10", "filter": {"operator": "xor", "queries": []}},
+        )
+
+    mock_report_client.update_pipe_report.assert_not_called()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "operator must be one of" in tool_error_message(payload)
 
 
 @pytest.mark.anyio

--- a/packages/sdk/src/pipefy_sdk/report_filter_preflight.py
+++ b/packages/sdk/src/pipefy_sdk/report_filter_preflight.py
@@ -35,6 +35,43 @@ EXAMPLE_PHASE_FILTER: dict[str, Any] = {
 }
 
 
+def normalize_report_cards_filter(filter_obj: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy with JSON integer ``value`` scalars coerced to strings."""
+    return _normalize_filter_group(filter_obj)
+
+
+def _normalize_filter_group(node: dict[str, Any]) -> dict[str, Any]:
+    normalized: dict[str, Any] = dict(node)
+    queries = node.get("queries")
+    if isinstance(queries, list):
+        normalized["queries"] = [
+            _normalize_filter_query(query) if isinstance(query, dict) else query
+            for query in queries
+        ]
+    groups = node.get("groups")
+    if isinstance(groups, list):
+        normalized["groups"] = [
+            _normalize_filter_group(group) if isinstance(group, dict) else group
+            for group in groups
+        ]
+    return normalized
+
+
+def _normalize_filter_query(node: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(node)
+    if "value" in normalized:
+        normalized["value"] = _coerce_filter_query_value(normalized["value"])
+    return normalized
+
+
+def _coerce_filter_query_value(value: Any) -> Any:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return str(value)
+    return value
+
+
 def validate_report_cards_filter(filter_obj: dict[str, Any] | None) -> str | None:
     if filter_obj is None:
         return None
@@ -138,5 +175,6 @@ __all__ = [
     "REPORT_CARDS_FILTER_GROUP_KEYS",
     "REPORT_CARDS_FILTER_QUERY_KEYS",
     "REPORT_CARDS_FILTER_REJECTED_ROOT_KEYS",
+    "normalize_report_cards_filter",
     "validate_report_cards_filter",
 ]

--- a/packages/sdk/tests/test_report_filter_preflight.py
+++ b/packages/sdk/tests/test_report_filter_preflight.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pipefy_sdk.report_filter_preflight import (
     EXAMPLE_PHASE_FILTER,
+    normalize_report_cards_filter,
     validate_report_cards_filter,
 )
 
@@ -150,11 +151,21 @@ def test_validate_report_cards_filter_rejects_non_string_value():
     err = validate_report_cards_filter(
         {
             "operator": "and",
-            "queries": [{"field": "current_phase", "operator": "eq", "value": 123}],
+            "queries": [{"field": "current_phase", "operator": "eq", "value": True}],
         }
     )
     assert err is not None
     assert "value must be a string" in err
+
+
+def test_normalize_report_cards_filter_coerces_integer_value():
+    filt = {
+        "operator": "and",
+        "queries": [{"field": "current_phase", "operator": "eq", "value": 987654321}],
+    }
+    normalized = normalize_report_cards_filter(filt)
+    assert normalized["queries"][0]["value"] == "987654321"
+    assert validate_report_cards_filter(normalized) is None
 
 
 def test_validate_report_cards_filter_allows_omitted_value():


### PR DESCRIPTION
Analytics pipe seeding (`306996636`) required **`execute_graphql`** for phase inventory and phase-local creates. **Spec:** `.cursor/dev-planning/specs/archive/card-phase-ergonomics/` — **Stack** after [#277](https://github.com/pipefy/ai-toolkit/pull/277) (closed).

**Depends on:** https://github.com/pipefy/ai-toolkit/pull/283

---

## Objective

Close remaining **boundary** gaps from chaos-pipe:

- Run `validate_report_cards_filter` on **all** MCP/CLI paths that accept `filter` (create/update/export pipe + org reports) — F6
- CLI `label create/update` uses `normalize_label_color` (F7)

## Improvements

- Top-level `current_phase` mistake caught before GraphQL with a clear message.
- `#F00` works like the live API; `red` rejected locally.
