### PR TITLE
chore: release v0.2.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Releases are versioned in lockstep across workspace members (`pipefy-sdk`, `pipe
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.2.0-beta.3] - 2026-06-03
+
+### Fixed
+
+- **SDK / MCP / CLI**: AI automation create and update no longer require service-account credentials. `generate_with_ai` create/update were routed through the `/internal_api` endpoint and gated behind a service-account check, so a normal user session (stored session from `pipefy auth login`, or a `--token` bearer) could not create or update an AI automation, which broke install flows that provision an AI triage automation. Both now go through the public `createAutomation` / `updateAutomation` mutations under the caller's normal auth, matching the read, list, and delete paths. Closes #272.
+
+### Changed
+
+- **SDK**: the AI automation surface moved from `AiAutomationService` to `AutomationService.create_ai_automation` / `update_ai_automation`, mirroring the existing `create_send_task_automation` pattern. `AiAutomationService`, `ai_automation_queries.py`, the `ai_automation_available` property, and `set_ai_automation_service` are removed; `PipefyClient` delegates to `AutomationService`. `InternalApiClient` stays (still used by `delete_card_relation`).
+
 ## [0.2.0-beta.2] - 2026-06-02
 
 ### Added

--- a/packages/auth/src/pipefy_auth/__init__.py
+++ b/packages/auth/src/pipefy_auth/__init__.py
@@ -9,7 +9,7 @@ artifacts surfaced here to the SDK.
 
 from __future__ import annotations
 
-__version__ = "0.2.0-beta.2"
+__version__ = "0.2.0-beta.3"
 
 from pipefy_auth.bearer import (
     CallableBearerAuth,

--- a/packages/cli/src/pipefy_cli/__init__.py
+++ b/packages/cli/src/pipefy_cli/__init__.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-__version__ = "0.2.0-beta.2"
+__version__ = "0.2.0-beta.3"
 
 __all__ = ["__version__"]

--- a/packages/infra/src/pipefy_infra/__init__.py
+++ b/packages/infra/src/pipefy_infra/__init__.py
@@ -13,6 +13,6 @@ package sits at the bottom of the workspace dependency graph: stdlib +
 
 from __future__ import annotations
 
-__version__ = "0.2.0-beta.2"
+__version__ = "0.2.0-beta.3"
 
 __all__ = ["__version__"]

--- a/packages/mcp/src/pipefy_mcp/__init__.py
+++ b/packages/mcp/src/pipefy_mcp/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 
-__version__ = "0.2.0-beta.2"
+__version__ = "0.2.0-beta.3"
 version = __version__
 
 m = re.match(r"^(\d+)\.(\d+)\.(\d+)", __version__)

--- a/packages/sdk/src/pipefy_sdk/__init__.py
+++ b/packages/sdk/src/pipefy_sdk/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "0.2.0-beta.2"
+__version__ = "0.2.0-beta.3"
 
 from pipefy_sdk.client import PipefyClient
 from pipefy_sdk.exceptions import PipefyAPIError, PipefyError

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipefy-workspace"
-version = "0.2.0-beta.2"
+version = "0.2.0-beta.3"
 description = "Development workspace for Pipefy MCP server, SDK, and CLI (not published as a single distribution)."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1017,7 +1017,7 @@ dev = [
 
 [[package]]
 name = "pipefy-workspace"
-version = "0.2.0b2"
+version = "0.2.0b3"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Release prep for `v0.2.0-beta.3`.

## Changes
- Bump the shared lockstep version `0.2.0-beta.2` → `0.2.0-beta.3` across the five workspace `__init__.py` files, root `pyproject.toml`, and `uv.lock` (via `scripts/bump_version.py`).
- Add the `[0.2.0-beta.3]` CHANGELOG section. The release ships one user-facing fix (#272: AI automation create/update no longer require service-account credentials, now routed through the public `createAutomation`/`updateAutomation`) and the accompanying SDK surface move (`AiAutomationService` → `AutomationService`).

## Release flow
After this merges to `dev`, a `dev` → `main` PR promotes the release, and the `v0.2.0-beta.3` + `latest` tags are placed on the resulting merge commit on `main` (mirroring how `v0.2.0-beta.2` was cut). The Release workflow then builds and attaches the wheels.

Content since `v0.2.0-beta.2`: #274 (fix #272) and #279 (chore #140, plugin manifest ownership; repo metadata, not changelogged).