### PR TITLE
refactor(sdk,mcp,cli): enforce report filter and label color validation at SDK boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - **MCP / CLI (label color)**: `create_label` and `update_label` validate `color` as hex `#RGB` or `#RRGGBB` before GraphQL (e.g. `red` is rejected with `expected #RGB or #RRGGBB hex color, received 'red'`).
+- **SDK**: report `filter` preflight and label `color` normalization now run at the SDK boundary — `ReportService` create/update/export methods and `create_label`/`update_label` normalize input and raise `ValueError` when invalid (one decision point replacing per-surface guards). MCP tools and CLI commands only map the error; messages and exit codes are unchanged.
 - **Docs / install**: canonical GitHub repository is [`pipefy/ai-toolkit`](https://github.com/pipefy/ai-toolkit). Install snippets, `install.sh`, MCP setup links, Claude plugin metadata, and `.mcp.json` now point at `github.com/pipefy/ai-toolkit` (GitHub may still redirect older URLs).
 
 ## [0.2.0-beta.2] - 2026-06-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **MCP / CLI**: `get_phase_allowed_move_targets` lists valid destination phases for `move_card_to_phase` (GraphQL `phase.cards_can_be_moved_to_phases`). MCP returns normalized `{phase_id, phase_name, allowed_phases}`; CLI: `pipefy phase targets <phase_id>`.
 - **SDK / MCP / CLI**: `get_phase_cards_count` reads native `Phase.cards_count` (MCP/CLI return `{phase_id, phase_name, cards_count}` via `get_phase`). `get_phase_cards` lists cards in a phase via `Phase.cards` pagination (`first` default 50, `after`, optional fields). CLI: `pipefy phase count <phase_id>`, `pipefy phase cards <phase_id> --first --after`.
 - **SDK / MCP / CLI**: `get_pipe` selects `cards_count` on each workflow phase in `phases[]` (start-form intake stays on `start_form_fields`).
-- **SDK / MCP / CLI**: report create/update/export paths preflight `filter` as nested `ReportCardsFilter` (`operator` + `queries`); reject naive top-level keys such as `current_phase` before GraphQL; coerce integer `value` scalars to strings.
+- **SDK / MCP / CLI**: report create/update/export paths preflight `filter` as nested `ReportCardsFilter` (`operator` + `queries`) in the SDK before GraphQL; reject naive top-level keys such as `current_phase`; coerce integer `value` scalars to strings. MCP and CLI surface the same error; CLI rejects invalid filters before auth.
 
 ### Changed
 
-- **MCP / CLI (label color)**: `create_label` and `update_label` validate `color` as hex `#RGB` or `#RRGGBB` before GraphQL (e.g. `red` is rejected with `expected #RGB or #RRGGBB hex color, received 'red'`).
-- **SDK**: report `filter` preflight and label `color` normalization now run at the SDK boundary — `ReportService` create/update/export methods and `create_label`/`update_label` normalize input and raise `ValueError` when invalid (one decision point replacing per-surface guards). MCP tools and CLI commands only map the error; messages and exit codes are unchanged.
+- **SDK / MCP / CLI (label color)**: `create_label` and `update_label` validate `color` as hex `#RGB` or `#RRGGBB` in the SDK before GraphQL (e.g. `red` is rejected with `expected #RGB or #RRGGBB hex color, received 'red'`). CLI rejects invalid color before auth.
 - **Docs / install**: canonical GitHub repository is [`pipefy/ai-toolkit`](https://github.com/pipefy/ai-toolkit). Install snippets, `install.sh`, MCP setup links, Claude plugin metadata, and `.mcp.json` now point at `github.com/pipefy/ai-toolkit` (GitHub may still redirect older URLs).
 
 ## [0.2.0-beta.2] - 2026-06-02

--- a/docs/mcp/tools/reports.md
+++ b/docs/mcp/tools/reports.md
@@ -5,7 +5,7 @@ Pipe reports and organization reports: discovery, CRUD, single pipe report fetch
 ## Cross-cutting patterns
 
 - Build `ReportCardsFilter` using `get_pipe_report_columns` and `get_pipe_report_filterable_fields`; use `introspect_type` for uncommon inputs.
-- **Filter shape:** nested `operator` (`and` | `or`) plus `queries` (and optional `groups`). Do **not** pass a top-level `current_phase` array — that is not valid GraphQL input. Filter structure is validated in the SDK before calling the API; MCP and CLI surface the same error.
+- **Filter shape:** nested `operator` (`and` | `or`) plus `queries` (and optional `groups`). Do **not** pass a top-level `current_phase` array — that is not valid GraphQL input. The SDK validates filter structure before calling the API; MCP and CLI surface the same error.
 
 ### Example phase filter (`create_pipe_report` / `update_pipe_report`)
 

--- a/docs/mcp/tools/reports.md
+++ b/docs/mcp/tools/reports.md
@@ -5,7 +5,7 @@ Pipe reports and organization reports: discovery, CRUD, single pipe report fetch
 ## Cross-cutting patterns
 
 - Build `ReportCardsFilter` using `get_pipe_report_columns` and `get_pipe_report_filterable_fields`; use `introspect_type` for uncommon inputs.
-- **Filter shape:** nested `operator` (`and` | `or`) plus `queries` (and optional `groups`). Do **not** pass a top-level `current_phase` array — that is not valid GraphQL input. `create_pipe_report` / `update_pipe_report` (MCP and CLI) validate structure before calling the API.
+- **Filter shape:** nested `operator` (`and` | `or`) plus `queries` (and optional `groups`). Do **not** pass a top-level `current_phase` array — that is not valid GraphQL input. Filter structure is validated in the SDK before calling the API; MCP and CLI surface the same error.
 
 ### Example phase filter (`create_pipe_report` / `update_pipe_report`)
 

--- a/packages/cli/src/pipefy_cli/commands/_common.py
+++ b/packages/cli/src/pipefy_cli/commands/_common.py
@@ -13,6 +13,8 @@ import typer
 from gql.transport.exceptions import TransportError, TransportQueryError
 from pipefy_sdk import PipefyClient, PipefySettings, stream_bytes
 from pipefy_sdk.exceptions import PipefyError
+from pipefy_sdk.label_color import normalize_label_color
+from pipefy_sdk.report_filter_preflight import prepare_report_cards_filter
 
 from pipefy_cli.auth import (
     AuthContext,
@@ -86,10 +88,20 @@ def validate_label_name_cli(name: str) -> str:
     return nm
 
 
-async def bad_parameter_on_value_error(call: Awaitable[_T]) -> _T:
-    """Await an SDK call, mapping its input-validation ``ValueError`` to ``typer.BadParameter``."""
+def prepare_report_cards_filter_cli(
+    filter_obj: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Normalize and validate ``ReportCardsFilter`` before auth or network I/O."""
     try:
-        return await call
+        return prepare_report_cards_filter(filter_obj)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+
+
+def normalize_label_color_cli(color: str) -> str:
+    """Normalize label ``color`` before auth or network I/O."""
+    try:
+        return normalize_label_color(color)
     except ValueError as exc:
         raise typer.BadParameter(str(exc)) from exc
 

--- a/packages/cli/src/pipefy_cli/commands/_common.py
+++ b/packages/cli/src/pipefy_cli/commands/_common.py
@@ -13,11 +13,6 @@ import typer
 from gql.transport.exceptions import TransportError, TransportQueryError
 from pipefy_sdk import PipefyClient, PipefySettings, stream_bytes
 from pipefy_sdk.exceptions import PipefyError
-from pipefy_sdk.label_color import normalize_label_color
-from pipefy_sdk.report_filter_preflight import (
-    normalize_report_cards_filter,
-    validate_report_cards_filter,
-)
 
 from pipefy_cli.auth import (
     AuthContext,
@@ -84,18 +79,6 @@ def validate_cards_page_size(first: int | None) -> int | None:
     return first
 
 
-def validate_report_filter_cli(
-    filter_obj: dict[str, Any] | None,
-) -> dict[str, Any] | None:
-    if filter_obj is None:
-        return None
-    normalized = normalize_report_cards_filter(filter_obj)
-    message = validate_report_cards_filter(normalized)
-    if message is not None:
-        raise typer.BadParameter(message)
-    return normalized
-
-
 def validate_label_name_cli(name: str) -> str:
     nm = name.strip()
     if not nm:
@@ -103,9 +86,10 @@ def validate_label_name_cli(name: str) -> str:
     return nm
 
 
-def validate_label_color_cli(color: str) -> str:
+async def bad_parameter_on_value_error(call: Awaitable[_T]) -> _T:
+    """Await an SDK call, mapping its input-validation ``ValueError`` to ``typer.BadParameter``."""
     try:
-        return normalize_label_color(color)
+        return await call
     except ValueError as exc:
         raise typer.BadParameter(str(exc)) from exc
 

--- a/packages/cli/src/pipefy_cli/commands/label.py
+++ b/packages/cli/src/pipefy_cli/commands/label.py
@@ -8,6 +8,7 @@ from pipefy_sdk import PipefyClient
 from pipefy_cli.commands._common import (
     ID_POSITIONAL_CONTEXT_SETTINGS,
     confirm_destructive,
+    normalize_label_color_cli,
     resource_id_argument,
     run_cli_command,
     validate_label_name_cli,
@@ -57,9 +58,10 @@ def label_create(
     """Create a label on a pipe."""
 
     nm = validate_label_name_cli(name)
+    clr = normalize_label_color_cli(color)
 
     async def factory(client: PipefyClient):
-        return await client.create_label(pipe_id, nm, color)
+        return await client.create_label(pipe_id, nm, clr)
 
     run_cli_command(ctx, json_out, factory)
 
@@ -82,9 +84,10 @@ def label_update(
     """Update a label (name and color are both required by Pipefy)."""
 
     nm = validate_label_name_cli(name)
+    clr = normalize_label_color_cli(color)
 
     async def factory(client: PipefyClient):
-        return await client.update_label(label_id, name=nm, color=color)
+        return await client.update_label(label_id, name=nm, color=clr)
 
     run_cli_command(ctx, json_out, factory)
 

--- a/packages/cli/src/pipefy_cli/commands/label.py
+++ b/packages/cli/src/pipefy_cli/commands/label.py
@@ -10,7 +10,6 @@ from pipefy_cli.commands._common import (
     confirm_destructive,
     resource_id_argument,
     run_cli_command,
-    validate_label_color_cli,
     validate_label_name_cli,
 )
 
@@ -58,10 +57,9 @@ def label_create(
     """Create a label on a pipe."""
 
     nm = validate_label_name_cli(name)
-    col = validate_label_color_cli(color)
 
     async def factory(client: PipefyClient):
-        return await client.create_label(pipe_id, nm, col)
+        return await client.create_label(pipe_id, nm, color)
 
     run_cli_command(ctx, json_out, factory)
 
@@ -84,10 +82,9 @@ def label_update(
     """Update a label (name and color are both required by Pipefy)."""
 
     nm = validate_label_name_cli(name)
-    col = validate_label_color_cli(color)
 
     async def factory(client: PipefyClient):
-        return await client.update_label(label_id, name=nm, color=col)
+        return await client.update_label(label_id, name=nm, color=color)
 
     run_cli_command(ctx, json_out, factory)
 

--- a/packages/cli/src/pipefy_cli/commands/report_org.py
+++ b/packages/cli/src/pipefy_cli/commands/report_org.py
@@ -7,13 +7,13 @@ from pipefy_sdk import PipefyClient
 
 from pipefy_cli.commands._common import (
     ID_POSITIONAL_CONTEXT_SETTINGS,
+    bad_parameter_on_value_error,
     confirm_destructive,
     parse_json_object,
     parse_json_value,
     resource_id_argument,
     run_cli_command,
     run_pipefy_client_coroutine,
-    validate_report_filter_cli,
     write_export_csv_to_stdout,
 )
 
@@ -78,15 +78,17 @@ def report_org_create(
     fields_list = parse_json_value(fields, "--fields") if fields else None
     if fields_list is not None and not isinstance(fields_list, list):
         raise typer.BadParameter("--fields must be a JSON array")
-    filt = validate_report_filter_cli(parse_json_object(filter_json, "--filter"))
+    filt = parse_json_object(filter_json, "--filter")
 
     async def factory(client: PipefyClient):
-        return await client.create_organization_report(
-            organization,
-            name.strip(),
-            pipe_list,
-            fields=fields_list,
-            filter=filt,
+        return await bad_parameter_on_value_error(
+            client.create_organization_report(
+                organization,
+                name.strip(),
+                pipe_list,
+                fields=fields_list,
+                filter=filt,
+            )
         )
 
     run_cli_command(ctx, json_out, factory)
@@ -111,7 +113,7 @@ def report_org_update(
     fields_list = parse_json_value(fields, "--fields") if fields else None
     if fields_list is not None and not isinstance(fields_list, list):
         raise typer.BadParameter("--fields must be a JSON array")
-    filt = validate_report_filter_cli(parse_json_object(filter_json, "--filter"))
+    filt = parse_json_object(filter_json, "--filter")
     pids = parse_json_value(pipe_ids, "--pipe-ids") if pipe_ids else None
     if pids is not None:
         if not isinstance(pids, list):
@@ -119,13 +121,15 @@ def report_org_update(
         pids = [str(x) for x in pids]
 
     async def factory(client: PipefyClient):
-        return await client.update_organization_report(
-            report_id,
-            name=name.strip() if name else None,
-            color=color,
-            fields=fields_list,
-            filter=filt,
-            pipe_ids=pids,
+        return await bad_parameter_on_value_error(
+            client.update_organization_report(
+                report_id,
+                name=name.strip() if name else None,
+                color=color,
+                fields=fields_list,
+                filter=filt,
+                pipe_ids=pids,
+            )
         )
 
     run_cli_command(ctx, json_out, factory)
@@ -187,7 +191,7 @@ def report_org_export(
             "--json is mutually exclusive with --format csv (CSV is written as raw bytes to stdout)."
         )
     sort_obj = parse_json_object(sort_by, "--sort-by")
-    filt = validate_report_filter_cli(parse_json_object(filter_json, "--filter"))
+    filt = parse_json_object(filter_json, "--filter")
     cols = parse_json_value(columns, "--columns") if columns else None
     if cols is not None and not isinstance(cols, list):
         raise typer.BadParameter("--columns must be a JSON array")
@@ -200,7 +204,23 @@ def report_org_export(
     if fmt == "json":
 
         async def factory(client: PipefyClient):
-            return await client.export_organization_report(
+            return await bad_parameter_on_value_error(
+                client.export_organization_report(
+                    organization,
+                    organization_report_id=organization_report_id,
+                    pipe_ids=pids,
+                    sort_by=sort_obj,
+                    filter=filt,
+                    columns=cols,
+                )
+            )
+
+        run_cli_command(ctx, json_out, factory)
+        return
+
+    async def csv_factory(client: PipefyClient) -> None:
+        start = await bad_parameter_on_value_error(
+            client.export_organization_report(
                 organization,
                 organization_report_id=organization_report_id,
                 pipe_ids=pids,
@@ -208,18 +228,6 @@ def report_org_export(
                 filter=filt,
                 columns=cols,
             )
-
-        run_cli_command(ctx, json_out, factory)
-        return
-
-    async def csv_factory(client: PipefyClient) -> None:
-        start = await client.export_organization_report(
-            organization,
-            organization_report_id=organization_report_id,
-            pipe_ids=pids,
-            sort_by=sort_obj,
-            filter=filt,
-            columns=cols,
         )
         exp = (start.get("exportOrganizationReport") or {}).get(
             "organizationReportExport"

--- a/packages/cli/src/pipefy_cli/commands/report_org.py
+++ b/packages/cli/src/pipefy_cli/commands/report_org.py
@@ -7,10 +7,10 @@ from pipefy_sdk import PipefyClient
 
 from pipefy_cli.commands._common import (
     ID_POSITIONAL_CONTEXT_SETTINGS,
-    bad_parameter_on_value_error,
     confirm_destructive,
     parse_json_object,
     parse_json_value,
+    prepare_report_cards_filter_cli,
     resource_id_argument,
     run_cli_command,
     run_pipefy_client_coroutine,
@@ -78,17 +78,15 @@ def report_org_create(
     fields_list = parse_json_value(fields, "--fields") if fields else None
     if fields_list is not None and not isinstance(fields_list, list):
         raise typer.BadParameter("--fields must be a JSON array")
-    filt = parse_json_object(filter_json, "--filter")
+    filt = prepare_report_cards_filter_cli(parse_json_object(filter_json, "--filter"))
 
     async def factory(client: PipefyClient):
-        return await bad_parameter_on_value_error(
-            client.create_organization_report(
-                organization,
-                name.strip(),
-                pipe_list,
-                fields=fields_list,
-                filter=filt,
-            )
+        return await client.create_organization_report(
+            organization,
+            name.strip(),
+            pipe_list,
+            fields=fields_list,
+            filter=filt,
         )
 
     run_cli_command(ctx, json_out, factory)
@@ -113,7 +111,7 @@ def report_org_update(
     fields_list = parse_json_value(fields, "--fields") if fields else None
     if fields_list is not None and not isinstance(fields_list, list):
         raise typer.BadParameter("--fields must be a JSON array")
-    filt = parse_json_object(filter_json, "--filter")
+    filt = prepare_report_cards_filter_cli(parse_json_object(filter_json, "--filter"))
     pids = parse_json_value(pipe_ids, "--pipe-ids") if pipe_ids else None
     if pids is not None:
         if not isinstance(pids, list):
@@ -121,15 +119,13 @@ def report_org_update(
         pids = [str(x) for x in pids]
 
     async def factory(client: PipefyClient):
-        return await bad_parameter_on_value_error(
-            client.update_organization_report(
-                report_id,
-                name=name.strip() if name else None,
-                color=color,
-                fields=fields_list,
-                filter=filt,
-                pipe_ids=pids,
-            )
+        return await client.update_organization_report(
+            report_id,
+            name=name.strip() if name else None,
+            color=color,
+            fields=fields_list,
+            filter=filt,
+            pipe_ids=pids,
         )
 
     run_cli_command(ctx, json_out, factory)
@@ -191,7 +187,7 @@ def report_org_export(
             "--json is mutually exclusive with --format csv (CSV is written as raw bytes to stdout)."
         )
     sort_obj = parse_json_object(sort_by, "--sort-by")
-    filt = parse_json_object(filter_json, "--filter")
+    filt = prepare_report_cards_filter_cli(parse_json_object(filter_json, "--filter"))
     cols = parse_json_value(columns, "--columns") if columns else None
     if cols is not None and not isinstance(cols, list):
         raise typer.BadParameter("--columns must be a JSON array")
@@ -204,23 +200,7 @@ def report_org_export(
     if fmt == "json":
 
         async def factory(client: PipefyClient):
-            return await bad_parameter_on_value_error(
-                client.export_organization_report(
-                    organization,
-                    organization_report_id=organization_report_id,
-                    pipe_ids=pids,
-                    sort_by=sort_obj,
-                    filter=filt,
-                    columns=cols,
-                )
-            )
-
-        run_cli_command(ctx, json_out, factory)
-        return
-
-    async def csv_factory(client: PipefyClient) -> None:
-        start = await bad_parameter_on_value_error(
-            client.export_organization_report(
+            return await client.export_organization_report(
                 organization,
                 organization_report_id=organization_report_id,
                 pipe_ids=pids,
@@ -228,6 +208,18 @@ def report_org_export(
                 filter=filt,
                 columns=cols,
             )
+
+        run_cli_command(ctx, json_out, factory)
+        return
+
+    async def csv_factory(client: PipefyClient) -> None:
+        start = await client.export_organization_report(
+            organization,
+            organization_report_id=organization_report_id,
+            pipe_ids=pids,
+            sort_by=sort_obj,
+            filter=filt,
+            columns=cols,
         )
         exp = (start.get("exportOrganizationReport") or {}).get(
             "organizationReportExport"

--- a/packages/cli/src/pipefy_cli/commands/report_pipe.py
+++ b/packages/cli/src/pipefy_cli/commands/report_pipe.py
@@ -9,13 +9,13 @@ from pipefy_sdk import PipefyClient
 
 from pipefy_cli.commands._common import (
     ID_POSITIONAL_CONTEXT_SETTINGS,
+    bad_parameter_on_value_error,
     confirm_destructive,
     parse_json_object,
     parse_json_value,
     resource_id_argument,
     run_cli_command,
     run_pipefy_client_coroutine,
-    validate_report_filter_cli,
     write_export_csv_to_stdout,
 )
 
@@ -139,18 +139,20 @@ def report_pipe_create(
     fields_list = parse_json_value(fields, "--fields") if fields else None
     if fields_list is not None and not isinstance(fields_list, list):
         raise typer.BadParameter("--fields must be a JSON array")
-    filt = validate_report_filter_cli(parse_json_object(filter_json, "--filter"))
+    filt = parse_json_object(filter_json, "--filter")
     formulas_val = parse_json_value(formulas, "--formulas") if formulas else None
     if formulas_val is not None and not isinstance(formulas_val, list):
         raise typer.BadParameter("--formulas must be a JSON array")
 
     async def factory(client: PipefyClient):
-        return await client.create_pipe_report(
-            pipe,
-            name.strip(),
-            fields=fields_list,
-            filter=filt,
-            formulas=formulas_val,
+        return await bad_parameter_on_value_error(
+            client.create_pipe_report(
+                pipe,
+                name.strip(),
+                fields=fields_list,
+                filter=filt,
+                formulas=formulas_val,
+            )
         )
 
     run_cli_command(ctx, json_out, factory)
@@ -174,20 +176,22 @@ def report_pipe_update(
     fields_list = parse_json_value(fields, "--fields") if fields else None
     if fields_list is not None and not isinstance(fields_list, list):
         raise typer.BadParameter("--fields must be a JSON array")
-    filt = validate_report_filter_cli(parse_json_object(filter_json, "--filter"))
+    filt = parse_json_object(filter_json, "--filter")
     formulas_val = parse_json_value(formulas, "--formulas") if formulas else None
     if formulas_val is not None and not isinstance(formulas_val, list):
         raise typer.BadParameter("--formulas must be a JSON array")
 
     async def factory(client: PipefyClient):
-        return await client.update_pipe_report(
-            report_id,
-            name=name.strip() if name else None,
-            color=color,
-            fields=fields_list,
-            filter=filt,
-            formulas=formulas_val,
-            featured_field=featured_field,
+        return await bad_parameter_on_value_error(
+            client.update_pipe_report(
+                report_id,
+                name=name.strip() if name else None,
+                color=color,
+                fields=fields_list,
+                filter=filt,
+                formulas=formulas_val,
+                featured_field=featured_field,
+            )
         )
 
     run_cli_command(ctx, json_out, factory)
@@ -246,7 +250,7 @@ def report_pipe_export(
             "--json is mutually exclusive with --format csv (CSV is written as raw bytes to stdout)."
         )
     sort_obj = parse_json_object(sort_by, "--sort-by")
-    filt = validate_report_filter_cli(parse_json_object(filter_json, "--filter"))
+    filt = parse_json_object(filter_json, "--filter")
     cols = parse_json_value(columns, "--columns") if columns else None
     if cols is not None and not isinstance(cols, list):
         raise typer.BadParameter("--columns must be a JSON array")
@@ -254,24 +258,28 @@ def report_pipe_export(
     if fmt == "json":
 
         async def factory(client: PipefyClient):
-            return await client.export_pipe_report(
-                pipe,
-                report_id,
-                sort_by=sort_obj,
-                filter=filt,
-                columns=cols,
+            return await bad_parameter_on_value_error(
+                client.export_pipe_report(
+                    pipe,
+                    report_id,
+                    sort_by=sort_obj,
+                    filter=filt,
+                    columns=cols,
+                )
             )
 
         run_cli_command(ctx, json_out, factory)
         return
 
     async def csv_factory(client: PipefyClient) -> None:
-        start = await client.export_pipe_report(
-            pipe,
-            report_id,
-            sort_by=sort_obj,
-            filter=filt,
-            columns=cols,
+        start = await bad_parameter_on_value_error(
+            client.export_pipe_report(
+                pipe,
+                report_id,
+                sort_by=sort_obj,
+                filter=filt,
+                columns=cols,
+            )
         )
         exp = (start.get("exportPipeReport") or {}).get("pipeReportExport") or {}
         export_id = exp.get("id")

--- a/packages/cli/src/pipefy_cli/commands/report_pipe.py
+++ b/packages/cli/src/pipefy_cli/commands/report_pipe.py
@@ -9,10 +9,10 @@ from pipefy_sdk import PipefyClient
 
 from pipefy_cli.commands._common import (
     ID_POSITIONAL_CONTEXT_SETTINGS,
-    bad_parameter_on_value_error,
     confirm_destructive,
     parse_json_object,
     parse_json_value,
+    prepare_report_cards_filter_cli,
     resource_id_argument,
     run_cli_command,
     run_pipefy_client_coroutine,
@@ -139,20 +139,18 @@ def report_pipe_create(
     fields_list = parse_json_value(fields, "--fields") if fields else None
     if fields_list is not None and not isinstance(fields_list, list):
         raise typer.BadParameter("--fields must be a JSON array")
-    filt = parse_json_object(filter_json, "--filter")
+    filt = prepare_report_cards_filter_cli(parse_json_object(filter_json, "--filter"))
     formulas_val = parse_json_value(formulas, "--formulas") if formulas else None
     if formulas_val is not None and not isinstance(formulas_val, list):
         raise typer.BadParameter("--formulas must be a JSON array")
 
     async def factory(client: PipefyClient):
-        return await bad_parameter_on_value_error(
-            client.create_pipe_report(
-                pipe,
-                name.strip(),
-                fields=fields_list,
-                filter=filt,
-                formulas=formulas_val,
-            )
+        return await client.create_pipe_report(
+            pipe,
+            name.strip(),
+            fields=fields_list,
+            filter=filt,
+            formulas=formulas_val,
         )
 
     run_cli_command(ctx, json_out, factory)
@@ -176,22 +174,20 @@ def report_pipe_update(
     fields_list = parse_json_value(fields, "--fields") if fields else None
     if fields_list is not None and not isinstance(fields_list, list):
         raise typer.BadParameter("--fields must be a JSON array")
-    filt = parse_json_object(filter_json, "--filter")
+    filt = prepare_report_cards_filter_cli(parse_json_object(filter_json, "--filter"))
     formulas_val = parse_json_value(formulas, "--formulas") if formulas else None
     if formulas_val is not None and not isinstance(formulas_val, list):
         raise typer.BadParameter("--formulas must be a JSON array")
 
     async def factory(client: PipefyClient):
-        return await bad_parameter_on_value_error(
-            client.update_pipe_report(
-                report_id,
-                name=name.strip() if name else None,
-                color=color,
-                fields=fields_list,
-                filter=filt,
-                formulas=formulas_val,
-                featured_field=featured_field,
-            )
+        return await client.update_pipe_report(
+            report_id,
+            name=name.strip() if name else None,
+            color=color,
+            fields=fields_list,
+            filter=filt,
+            formulas=formulas_val,
+            featured_field=featured_field,
         )
 
     run_cli_command(ctx, json_out, factory)
@@ -250,7 +246,7 @@ def report_pipe_export(
             "--json is mutually exclusive with --format csv (CSV is written as raw bytes to stdout)."
         )
     sort_obj = parse_json_object(sort_by, "--sort-by")
-    filt = parse_json_object(filter_json, "--filter")
+    filt = prepare_report_cards_filter_cli(parse_json_object(filter_json, "--filter"))
     cols = parse_json_value(columns, "--columns") if columns else None
     if cols is not None and not isinstance(cols, list):
         raise typer.BadParameter("--columns must be a JSON array")
@@ -258,28 +254,24 @@ def report_pipe_export(
     if fmt == "json":
 
         async def factory(client: PipefyClient):
-            return await bad_parameter_on_value_error(
-                client.export_pipe_report(
-                    pipe,
-                    report_id,
-                    sort_by=sort_obj,
-                    filter=filt,
-                    columns=cols,
-                )
-            )
-
-        run_cli_command(ctx, json_out, factory)
-        return
-
-    async def csv_factory(client: PipefyClient) -> None:
-        start = await bad_parameter_on_value_error(
-            client.export_pipe_report(
+            return await client.export_pipe_report(
                 pipe,
                 report_id,
                 sort_by=sort_obj,
                 filter=filt,
                 columns=cols,
             )
+
+        run_cli_command(ctx, json_out, factory)
+        return
+
+    async def csv_factory(client: PipefyClient) -> None:
+        start = await client.export_pipe_report(
+            pipe,
+            report_id,
+            sort_by=sort_obj,
+            filter=filt,
+            columns=cols,
         )
         exp = (start.get("exportPipeReport") or {}).get("pipeReportExport") or {}
         export_id = exp.get("id")

--- a/packages/cli/tests/test_label_webhook_commands.py
+++ b/packages/cli/tests/test_label_webhook_commands.py
@@ -26,14 +26,39 @@ def test_label_list_json(runner, clean_pipefy_env, saved_cwd, oauth_env):
     assert out["labels"] == [{"id": "1", "name": "Bug"}]
 
 
-def test_label_create_rejects_color_name_before_api(
+def test_label_create_rejects_non_hex_color_without_auth(
+    runner, clean_pipefy_env, saved_cwd
+):
+    mock_client = MagicMock()
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "label",
+                "create",
+                "--pipe",
+                "8",
+                "--name",
+                "Bug",
+                "--color",
+                "red",
+            ],
+        )
+    assert result.exit_code == 2
+    mock_client.create_label.assert_not_called()
+    assert "expected #RGB or #RRGGBB hex color, received 'red'" in result.stderr
+    assert "auth" not in result.stderr.lower()
+
+
+def test_label_create_rejects_non_hex_color(
     runner, clean_pipefy_env, saved_cwd, oauth_env
 ):
     oauth_env("lbl-create-hex")
     mock_client = MagicMock()
-    mock_client.create_label = AsyncMock(
-        side_effect=ValueError("expected #RGB or #RRGGBB hex color, received 'red'")
-    )
+    mock_client.create_label = AsyncMock()
     with patch(
         "pipefy_cli.commands._common.get_authenticated_client",
         return_value=mock_client,
@@ -53,10 +78,10 @@ def test_label_create_rejects_color_name_before_api(
         )
     assert result.exit_code == 2
     assert "expected #RGB or #RRGGBB hex color, received 'red'" in result.stderr
-    mock_client.create_label.assert_awaited_once()
+    mock_client.create_label.assert_not_called()
 
 
-def test_label_create_passes_normalized_hex(
+def test_label_create_forwards_normalized_color_to_sdk(
     runner, clean_pipefy_env, saved_cwd, oauth_env
 ):
     oauth_env("lbl-create-ok")
@@ -81,17 +106,15 @@ def test_label_create_passes_normalized_hex(
             ],
         )
     assert result.exit_code == 0
-    mock_client.create_label.assert_awaited_once_with("8", "Bug", "#ff0000")
+    mock_client.create_label.assert_awaited_once_with("8", "Bug", "#FF0000")
 
 
-def test_label_update_rejects_color_name_before_api(
+def test_label_update_rejects_non_hex_color(
     runner, clean_pipefy_env, saved_cwd, oauth_env
 ):
     oauth_env("lbl-update-hex")
     mock_client = MagicMock()
-    mock_client.update_label = AsyncMock(
-        side_effect=ValueError("expected #RGB or #RRGGBB hex color, received 'blue'")
-    )
+    mock_client.update_label = AsyncMock()
     with patch(
         "pipefy_cli.commands._common.get_authenticated_client",
         return_value=mock_client,
@@ -110,7 +133,7 @@ def test_label_update_rejects_color_name_before_api(
         )
     assert result.exit_code == 2
     assert "expected #RGB or #RRGGBB hex color, received 'blue'" in result.stderr
-    mock_client.update_label.assert_awaited_once()
+    mock_client.update_label.assert_not_called()
 
 
 def test_label_list_pipe_denied_json(runner, clean_pipefy_env, saved_cwd, oauth_env):

--- a/packages/cli/tests/test_label_webhook_commands.py
+++ b/packages/cli/tests/test_label_webhook_commands.py
@@ -31,6 +31,9 @@ def test_label_create_rejects_color_name_before_api(
 ):
     oauth_env("lbl-create-hex")
     mock_client = MagicMock()
+    mock_client.create_label = AsyncMock(
+        side_effect=ValueError("expected #RGB or #RRGGBB hex color, received 'red'")
+    )
     with patch(
         "pipefy_cli.commands._common.get_authenticated_client",
         return_value=mock_client,
@@ -50,7 +53,7 @@ def test_label_create_rejects_color_name_before_api(
         )
     assert result.exit_code == 2
     assert "expected #RGB or #RRGGBB hex color, received 'red'" in result.stderr
-    mock_client.create_label.assert_not_called()
+    mock_client.create_label.assert_awaited_once()
 
 
 def test_label_create_passes_normalized_hex(
@@ -78,7 +81,7 @@ def test_label_create_passes_normalized_hex(
             ],
         )
     assert result.exit_code == 0
-    mock_client.create_label.assert_awaited_once_with("8", "Bug", "#FF0000")
+    mock_client.create_label.assert_awaited_once_with("8", "Bug", "#ff0000")
 
 
 def test_label_update_rejects_color_name_before_api(
@@ -86,6 +89,9 @@ def test_label_update_rejects_color_name_before_api(
 ):
     oauth_env("lbl-update-hex")
     mock_client = MagicMock()
+    mock_client.update_label = AsyncMock(
+        side_effect=ValueError("expected #RGB or #RRGGBB hex color, received 'blue'")
+    )
     with patch(
         "pipefy_cli.commands._common.get_authenticated_client",
         return_value=mock_client,
@@ -104,7 +110,7 @@ def test_label_update_rejects_color_name_before_api(
         )
     assert result.exit_code == 2
     assert "expected #RGB or #RRGGBB hex color, received 'blue'" in result.stderr
-    mock_client.update_label.assert_not_called()
+    mock_client.update_label.assert_awaited_once()
 
 
 def test_label_list_pipe_denied_json(runner, clean_pipefy_env, saved_cwd, oauth_env):

--- a/packages/cli/tests/test_report_pipe_filter_commands.py
+++ b/packages/cli/tests/test_report_pipe_filter_commands.py
@@ -15,6 +15,12 @@ def test_report_pipe_create_rejects_naive_current_phase_filter(
 ):
     oauth_env("report-filter-bad")
     mock_client = MagicMock()
+    mock_client.create_pipe_report = AsyncMock(
+        side_effect=ValueError(
+            "filter must use ReportCardsFilter shape (operator + queries), "
+            "not top-level 'current_phase'."
+        )
+    )
     with patch(
         "pipefy_cli.commands._common.get_authenticated_client",
         return_value=mock_client,
@@ -33,7 +39,7 @@ def test_report_pipe_create_rejects_naive_current_phase_filter(
             ],
         )
     assert result.exit_code == 2
-    mock_client.create_pipe_report.assert_not_called()
+    mock_client.create_pipe_report.assert_awaited_once()
     assert "top-level" in result.stderr
 
 
@@ -82,6 +88,11 @@ def test_report_pipe_update_rejects_invalid_filter_operator(
 ):
     oauth_env("report-filter-update-bad")
     mock_client = MagicMock()
+    mock_client.update_pipe_report = AsyncMock(
+        side_effect=ValueError(
+            "filter.operator must be one of ['and', 'or'], received 'xor'."
+        )
+    )
     with patch(
         "pipefy_cli.commands._common.get_authenticated_client",
         return_value=mock_client,
@@ -97,4 +108,5 @@ def test_report_pipe_update_rejects_invalid_filter_operator(
             ],
         )
     assert result.exit_code == 2
-    mock_client.update_pipe_report.assert_not_called()
+    mock_client.update_pipe_report.assert_awaited_once()
+    assert "operator must be one of" in result.stderr

--- a/packages/cli/tests/test_report_pipe_filter_commands.py
+++ b/packages/cli/tests/test_report_pipe_filter_commands.py
@@ -15,12 +15,7 @@ def test_report_pipe_create_rejects_naive_current_phase_filter(
 ):
     oauth_env("report-filter-bad")
     mock_client = MagicMock()
-    mock_client.create_pipe_report = AsyncMock(
-        side_effect=ValueError(
-            "filter must use ReportCardsFilter shape (operator + queries), "
-            "not top-level 'current_phase'."
-        )
-    )
+    mock_client.create_pipe_report = AsyncMock()
     with patch(
         "pipefy_cli.commands._common.get_authenticated_client",
         return_value=mock_client,
@@ -39,8 +34,35 @@ def test_report_pipe_create_rejects_naive_current_phase_filter(
             ],
         )
     assert result.exit_code == 2
-    mock_client.create_pipe_report.assert_awaited_once()
+    mock_client.create_pipe_report.assert_not_called()
     assert "top-level" in result.stderr
+
+
+def test_report_pipe_create_rejects_invalid_filter_without_auth(
+    runner, clean_pipefy_env, saved_cwd
+):
+    mock_client = MagicMock()
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "report-pipe",
+                "create",
+                "--pipe",
+                "123",
+                "--name",
+                "R",
+                "--filter",
+                json.dumps({"current_phase": ["1"]}),
+            ],
+        )
+    assert result.exit_code == 2
+    mock_client.create_pipe_report.assert_not_called()
+    assert "top-level" in result.stderr
+    assert "auth" not in result.stderr.lower()
 
 
 def test_report_pipe_create_forwards_valid_filter(
@@ -88,11 +110,7 @@ def test_report_pipe_update_rejects_invalid_filter_operator(
 ):
     oauth_env("report-filter-update-bad")
     mock_client = MagicMock()
-    mock_client.update_pipe_report = AsyncMock(
-        side_effect=ValueError(
-            "filter.operator must be one of ['and', 'or'], received 'xor'."
-        )
-    )
+    mock_client.update_pipe_report = AsyncMock()
     with patch(
         "pipefy_cli.commands._common.get_authenticated_client",
         return_value=mock_client,
@@ -108,5 +126,5 @@ def test_report_pipe_update_rejects_invalid_filter_operator(
             ],
         )
     assert result.exit_code == 2
-    mock_client.update_pipe_report.assert_awaited_once()
+    mock_client.update_pipe_report.assert_not_called()
     assert "operator must be one of" in result.stderr

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_config_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_config_tools.py
@@ -6,7 +6,6 @@ from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
 from mcp.types import ToolAnnotations
 from pipefy_sdk import PipefyClient, PipefyId
-from pipefy_sdk.label_color import normalize_label_color
 from pipefy_sdk.phase_inventory import (
     get_phase_not_found_message,
     is_get_phase_not_found_error,
@@ -1094,17 +1093,15 @@ class PipeConfigTools:
                     code="INVALID_ARGUMENTS",
                 )
             try:
-                normalized_color = normalize_label_color(color)
+                raw = await client.create_label(
+                    pipe_id,
+                    name.strip(),
+                    color,
+                )
             except ValueError as exc:
                 return build_pipe_tool_error_payload(
                     message=str(exc),
                     code="INVALID_ARGUMENTS",
-                )
-            try:
-                raw = await client.create_label(
-                    pipe_id,
-                    name.strip(),
-                    normalized_color,
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
@@ -1159,22 +1156,20 @@ class PipeConfigTools:
                     message="Invalid 'color': provide a non-empty string.",
                     code="INVALID_ARGUMENTS",
                 )
-            try:
-                normalized_color = normalize_label_color(color)
-            except ValueError as exc:
-                return build_pipe_tool_error_payload(
-                    message=str(exc),
-                    code="INVALID_ARGUMENTS",
-                )
             update_attrs: dict[str, Any] = {
                 k: v
                 for k, v in (extra_input or {}).items()
                 if k not in _UPDATE_LABEL_EXTRA_RESERVED
             }
             update_attrs["name"] = name.strip()
-            update_attrs["color"] = normalized_color
+            update_attrs["color"] = color
             try:
                 raw = await client.update_label(label_id, **update_attrs)
+            except ValueError as exc:
+                return build_pipe_tool_error_payload(
+                    message=str(exc),
+                    code="INVALID_ARGUMENTS",
+                )
             except Exception as exc:  # noqa: BLE001
                 return handle_pipe_config_tool_graphql_error(
                     exc,

--- a/packages/mcp/src/pipefy_mcp/tools/report_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/report_tools.py
@@ -8,10 +8,6 @@ from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
 from mcp.types import ToolAnnotations
 from pipefy_sdk import PipefyClient, PipefyId
-from pipefy_sdk.report_filter_preflight import (
-    normalize_report_cards_filter,
-    validate_report_cards_filter,
-)
 
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.pagination_helpers import (
@@ -36,18 +32,6 @@ def _blank_field_error(value: str, field: str) -> dict[str, Any] | None:
     if not value.strip():
         return build_report_error_payload(message=f"'{field}' must be non-empty.")
     return None
-
-
-def _prepare_report_cards_filter(
-    filter_obj: dict[str, Any] | None,
-) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
-    if filter_obj is None:
-        return None, None
-    normalized = normalize_report_cards_filter(filter_obj)
-    message = validate_report_cards_filter(normalized)
-    if message is not None:
-        return None, build_report_error_payload(message=message)
-    return normalized, None
 
 
 class ReportTools:
@@ -412,13 +396,12 @@ class ReportTools:
             err = _blank_field_error(name, "name")
             if err is not None:
                 return err
-            filter, err = _prepare_report_cards_filter(filter)
-            if err is not None:
-                return err
             try:
                 raw = await client.create_pipe_report(
                     pipe_id, name, fields=fields, filter=filter, formulas=formulas
                 )
+            except ValueError as exc:
+                return build_report_error_payload(message=str(exc))
             except Exception as exc:  # noqa: BLE001
                 return handle_report_tool_graphql_error(
                     exc,
@@ -463,9 +446,6 @@ class ReportTools:
             err = _blank_field_error(report_id, "report_id")
             if err is not None:
                 return err
-            filter, err = _prepare_report_cards_filter(filter)
-            if err is not None:
-                return err
             try:
                 raw = await client.update_pipe_report(
                     report_id,
@@ -476,6 +456,8 @@ class ReportTools:
                     formulas=formulas,
                     featured_field=featured_field,
                 )
+            except ValueError as exc:
+                return build_report_error_payload(message=str(exc))
             except Exception as exc:  # noqa: BLE001
                 return handle_report_tool_graphql_error(
                     exc,
@@ -570,9 +552,6 @@ class ReportTools:
             err = _blank_field_error(name, "name")
             if err is not None:
                 return err
-            filter, err = _prepare_report_cards_filter(filter)
-            if err is not None:
-                return err
             if not pipe_ids or not isinstance(pipe_ids, list):
                 return build_report_error_payload(
                     message="'pipe_ids' must be a non-empty list.",
@@ -581,6 +560,8 @@ class ReportTools:
                 raw = await client.create_organization_report(
                     organization_id, name, pipe_ids, fields=fields, filter=filter
                 )
+            except ValueError as exc:
+                return build_report_error_payload(message=str(exc))
             except Exception as exc:  # noqa: BLE001
                 return handle_report_tool_graphql_error(
                     exc,
@@ -624,9 +605,6 @@ class ReportTools:
             err = _blank_field_error(report_id, "report_id")
             if err is not None:
                 return err
-            filter, err = _prepare_report_cards_filter(filter)
-            if err is not None:
-                return err
             try:
                 raw = await client.update_organization_report(
                     report_id,
@@ -636,6 +614,8 @@ class ReportTools:
                     filter=filter,
                     pipe_ids=pipe_ids,
                 )
+            except ValueError as exc:
+                return build_report_error_payload(message=str(exc))
             except Exception as exc:  # noqa: BLE001
                 return handle_report_tool_graphql_error(
                     exc,
@@ -730,9 +710,6 @@ class ReportTools:
             err = _blank_field_error(pipe_report_id, "pipe_report_id")
             if err is not None:
                 return err
-            filter, err = _prepare_report_cards_filter(filter)
-            if err is not None:
-                return err
             try:
                 raw = await client.export_pipe_report(
                     pipe_id,
@@ -741,6 +718,8 @@ class ReportTools:
                     filter=filter,
                     columns=columns,
                 )
+            except ValueError as exc:
+                return build_report_error_payload(message=str(exc))
             except Exception as exc:  # noqa: BLE001
                 return handle_report_tool_graphql_error(
                     exc,
@@ -785,9 +764,6 @@ class ReportTools:
             organization_id, err = validate_tool_id(organization_id, "organization_id")
             if err is not None:
                 return err
-            filter, err = _prepare_report_cards_filter(filter)
-            if err is not None:
-                return err
             try:
                 raw = await client.export_organization_report(
                     organization_id,
@@ -797,6 +773,8 @@ class ReportTools:
                     filter=filter,
                     columns=columns,
                 )
+            except ValueError as exc:
+                return build_report_error_payload(message=str(exc))
             except Exception as exc:  # noqa: BLE001
                 return handle_report_tool_graphql_error(
                     exc,

--- a/packages/mcp/tests/tools/test_pipe_config_tools.py
+++ b/packages/mcp/tests/tools/test_pipe_config_tools.py
@@ -1845,7 +1845,7 @@ async def test_create_label_rejects_blank_color__no_integration(
     ],
 )
 @pytest.mark.parametrize("pipe_config_session", [None], indirect=True)
-async def test_label_color_rejects_non_hex_before_graphql__no_integration(
+async def test_label_color_maps_sdk_value_error__no_integration(
     pipe_config_session,
     mock_pipe_config_client,
     extract_payload,

--- a/packages/mcp/tests/tools/test_pipe_config_tools.py
+++ b/packages/mcp/tests/tools/test_pipe_config_tools.py
@@ -1852,10 +1852,14 @@ async def test_label_color_rejects_non_hex_before_graphql__no_integration(
     tool_name: str,
     arguments: dict[str, object],
 ):
+    rejection = ValueError(
+        f"expected #RGB or #RRGGBB hex color, received {arguments['color']!r}"
+    )
+    mock_pipe_config_client.create_label.side_effect = rejection
+    mock_pipe_config_client.update_label.side_effect = rejection
     async with pipe_config_session as session:
         result = await session.call_tool(tool_name, arguments)
-    mock_pipe_config_client.create_label.assert_not_called()
-    mock_pipe_config_client.update_label.assert_not_called()
+    getattr(mock_pipe_config_client, tool_name).assert_awaited_once()
     payload = extract_payload(result)
     assert payload["success"] is False
     assert payload["error"]["code"] == "INVALID_ARGUMENTS"

--- a/packages/mcp/tests/tools/test_report_tools.py
+++ b/packages/mcp/tests/tools/test_report_tools.py
@@ -465,6 +465,10 @@ async def test_create_pipe_report_forwards_golden_report_filter(
 async def test_create_pipe_report_rejects_naive_current_phase_filter(
     report_session, mock_report_client, extract_payload
 ):
+    mock_report_client.create_pipe_report.side_effect = ValueError(
+        "filter must use ReportCardsFilter shape (operator + queries), "
+        "not top-level 'current_phase'."
+    )
     async with report_session as session:
         result = await session.call_tool(
             "create_pipe_report",
@@ -475,7 +479,7 @@ async def test_create_pipe_report_rejects_naive_current_phase_filter(
             },
         )
 
-    mock_report_client.create_pipe_report.assert_not_called()
+    mock_report_client.create_pipe_report.assert_awaited_once()
     payload = extract_payload(result)
     assert payload["success"] is False
     assert "top-level" in tool_error_message(payload)
@@ -486,6 +490,10 @@ async def test_create_pipe_report_rejects_naive_current_phase_filter(
 async def test_export_pipe_report_rejects_naive_current_phase_filter(
     report_session, mock_report_client, extract_payload
 ):
+    mock_report_client.export_pipe_report.side_effect = ValueError(
+        "filter must use ReportCardsFilter shape (operator + queries), "
+        "not top-level 'current_phase'."
+    )
     async with report_session as session:
         result = await session.call_tool(
             "export_pipe_report",
@@ -496,7 +504,7 @@ async def test_export_pipe_report_rejects_naive_current_phase_filter(
             },
         )
 
-    mock_report_client.export_pipe_report.assert_not_called()
+    mock_report_client.export_pipe_report.assert_awaited_once()
     payload = extract_payload(result)
     assert payload["success"] is False
     assert "top-level" in tool_error_message(payload)
@@ -507,13 +515,16 @@ async def test_export_pipe_report_rejects_naive_current_phase_filter(
 async def test_update_pipe_report_rejects_invalid_report_filter(
     report_session, mock_report_client, extract_payload
 ):
+    mock_report_client.update_pipe_report.side_effect = ValueError(
+        "filter.operator must be one of ['and', 'or'], received 'xor'."
+    )
     async with report_session as session:
         result = await session.call_tool(
             "update_pipe_report",
             {"report_id": "r10", "filter": {"operator": "xor", "queries": []}},
         )
 
-    mock_report_client.update_pipe_report.assert_not_called()
+    mock_report_client.update_pipe_report.assert_awaited_once()
     payload = extract_payload(result)
     assert payload["success"] is False
     assert "operator must be one of" in tool_error_message(payload)

--- a/packages/sdk/src/pipefy_sdk/report_filter_preflight.py
+++ b/packages/sdk/src/pipefy_sdk/report_filter_preflight.py
@@ -72,7 +72,8 @@ def _coerce_filter_query_value(value: Any) -> Any:
     return value
 
 
-def validate_report_cards_filter(filter_obj: dict[str, Any] | None) -> str | None:
+def report_cards_filter_error(filter_obj: dict[str, Any] | None) -> str | None:
+    """Return an error message for an invalid ``ReportCardsFilter``, or ``None`` when valid."""
     if filter_obj is None:
         return None
     if not isinstance(filter_obj, dict):
@@ -176,5 +177,5 @@ __all__ = [
     "REPORT_CARDS_FILTER_QUERY_KEYS",
     "REPORT_CARDS_FILTER_REJECTED_ROOT_KEYS",
     "normalize_report_cards_filter",
-    "validate_report_cards_filter",
+    "report_cards_filter_error",
 ]

--- a/packages/sdk/src/pipefy_sdk/report_filter_preflight.py
+++ b/packages/sdk/src/pipefy_sdk/report_filter_preflight.py
@@ -72,6 +72,19 @@ def _coerce_filter_query_value(value: Any) -> Any:
     return value
 
 
+def prepare_report_cards_filter(
+    filter_obj: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Normalize a ``ReportCardsFilter`` and raise ``ValueError`` when invalid."""
+    if filter_obj is None:
+        return None
+    normalized = normalize_report_cards_filter(filter_obj)
+    message = report_cards_filter_error(normalized)
+    if message is not None:
+        raise ValueError(message)
+    return normalized
+
+
 def report_cards_filter_error(filter_obj: dict[str, Any] | None) -> str | None:
     """Return an error message for an invalid ``ReportCardsFilter``, or ``None`` when valid."""
     if filter_obj is None:
@@ -177,5 +190,6 @@ __all__ = [
     "REPORT_CARDS_FILTER_QUERY_KEYS",
     "REPORT_CARDS_FILTER_REJECTED_ROOT_KEYS",
     "normalize_report_cards_filter",
+    "prepare_report_cards_filter",
     "report_cards_filter_error",
 ]

--- a/packages/sdk/src/pipefy_sdk/services/pipe_config_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/pipe_config_service.py
@@ -9,6 +9,7 @@ from httpx import Auth
 from pipefy_infra.coerce import optional_str
 
 from pipefy_sdk.base_client import BasePipefyClient
+from pipefy_sdk.label_color import normalize_label_color
 from pipefy_sdk.queries.pipe_config_queries import (
     CLONE_PIPE_MUTATION,
     CREATE_FIELD_CONDITION_MUTATION,
@@ -310,12 +311,13 @@ class PipeConfigService(BasePipefyClient):
         Args:
             pipe_id: Pipe that will receive the label.
             name: Label name.
-            color: Label color (per API).
+            color: Label color as hex ``#RGB`` or ``#RRGGBB`` (normalized to ``#RRGGBB``;
+                raises ``ValueError`` otherwise).
         """
         input_obj: dict[str, Any] = {
             "pipe_id": str(pipe_id),
             "name": name,
-            "color": color,
+            "color": normalize_label_color(color),
         }
         return await self.execute_query(CREATE_LABEL_MUTATION, {"input": input_obj})
 
@@ -325,7 +327,11 @@ class PipeConfigService(BasePipefyClient):
         Args:
             label_id: Label ID.
             **attrs: `UpdateLabelInput` fields to set (omit or pass None to skip).
+                ``color`` is normalized to hex ``#RRGGBB`` (raises ``ValueError``
+                on non-hex input).
         """
+        if attrs.get("color") is not None:
+            attrs["color"] = normalize_label_color(attrs["color"])
         payload: dict[str, Any] = {"id": str(label_id)}
         for key, value in attrs.items():
             if value is not None:

--- a/packages/sdk/src/pipefy_sdk/services/report_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/report_service.py
@@ -25,7 +25,24 @@ from pipefy_sdk.queries.report_queries import (
     UPDATE_ORGANIZATION_REPORT_MUTATION,
     UPDATE_PIPE_REPORT_MUTATION,
 )
+from pipefy_sdk.report_filter_preflight import (
+    normalize_report_cards_filter,
+    report_cards_filter_error,
+)
 from pipefy_sdk.settings import PipefySettings
+
+
+def _prepared_report_cards_filter(
+    filter_obj: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Normalize a ``ReportCardsFilter`` and raise ``ValueError`` when invalid."""
+    if filter_obj is None:
+        return None
+    normalized = normalize_report_cards_filter(filter_obj)
+    message = report_cards_filter_error(normalized)
+    if message is not None:
+        raise ValueError(message)
+    return normalized
 
 
 class ReportService(BasePipefyClient):
@@ -164,14 +181,15 @@ class ReportService(BasePipefyClient):
             pipe_id: Pipe ID (numeric string).
             name: Report name.
             fields: Internal field names (``name`` from ``get_pipe_report_columns``).
-            filter: Report filter (``ReportCardsFilter`` shape).
+            filter: Report filter (``ReportCardsFilter`` shape; normalized, raises ``ValueError`` when invalid).
             formulas: Formula definitions (list of [field, operator, ...] tuples).
         """
         input_obj: dict[str, Any] = {"pipeId": str(pipe_id), "name": name}
+        prepared_filter = _prepared_report_cards_filter(filter)
         if fields is not None:
             input_obj["fields"] = fields
-        if filter is not None:
-            input_obj["filter"] = filter
+        if prepared_filter is not None:
+            input_obj["filter"] = prepared_filter
         if formulas is not None:
             input_obj["formulas"] = formulas
         return await self.execute_query(
@@ -196,7 +214,7 @@ class ReportService(BasePipefyClient):
             name: New report name.
             color: Report color.
             fields: Internal field names for columns.
-            filter: Report filter (``ReportCardsFilter`` shape).
+            filter: Report filter (``ReportCardsFilter`` shape; normalized, raises ``ValueError`` when invalid).
             formulas: Formula definitions.
             featured_field: Featured field name.
         """
@@ -205,7 +223,7 @@ class ReportService(BasePipefyClient):
             "name": name,
             "color": color,
             "fields": fields,
-            "filter": filter,
+            "filter": _prepared_report_cards_filter(filter),
             "formulas": formulas,
             "featuredField": featured_field,
         }
@@ -242,17 +260,18 @@ class ReportService(BasePipefyClient):
             name: Report name.
             pipe_ids: List of pipe IDs to include.
             fields: Internal field names for columns.
-            filter: Report filter (``ReportCardsFilter`` shape).
+            filter: Report filter (``ReportCardsFilter`` shape; normalized, raises ``ValueError`` when invalid).
         """
         input_obj: dict[str, Any] = {
             "organizationId": str(organization_id),
             "name": name,
             "pipeIds": [str(pid) for pid in pipe_ids],
         }
+        prepared_filter = _prepared_report_cards_filter(filter)
         if fields is not None:
             input_obj["fields"] = fields
-        if filter is not None:
-            input_obj["filter"] = filter
+        if prepared_filter is not None:
+            input_obj["filter"] = prepared_filter
         return await self.execute_query(
             CREATE_ORGANIZATION_REPORT_MUTATION, {"input": input_obj}
         )
@@ -274,7 +293,7 @@ class ReportService(BasePipefyClient):
             name: New report name.
             color: Report color.
             fields: Internal field names for columns.
-            filter: Report filter (``ReportCardsFilter`` shape).
+            filter: Report filter (``ReportCardsFilter`` shape; normalized, raises ``ValueError`` when invalid).
             pipe_ids: Pipe IDs to include.
         """
         input_obj: dict[str, Any] = {"id": str(report_id)}
@@ -282,7 +301,7 @@ class ReportService(BasePipefyClient):
             "name": name,
             "color": color,
             "fields": fields,
-            "filter": filter,
+            "filter": _prepared_report_cards_filter(filter),
             "pipeIds": [str(pid) for pid in pipe_ids] if pipe_ids is not None else None,
         }
         for key, value in optional_fields.items():
@@ -317,17 +336,18 @@ class ReportService(BasePipefyClient):
             pipe_id: Pipe ID (GraphQL ``ID``).
             pipe_report_id: Pipe report ID to export.
             sort_by: ``ReportSortDirectionInput`` (``direction``, ``field``).
-            filter: ``ReportCardsFilter`` shape.
+            filter: ``ReportCardsFilter`` shape; normalized, raises ``ValueError`` when invalid.
             columns: Column field IDs to include in the export file.
         """
         input_obj: dict[str, Any] = {
             "pipeId": str(pipe_id),
             "pipeReportId": str(pipe_report_id),
         }
+        prepared_filter = _prepared_report_cards_filter(filter)
         if sort_by is not None:
             input_obj["sortBy"] = sort_by
-        if filter is not None:
-            input_obj["filter"] = filter
+        if prepared_filter is not None:
+            input_obj["filter"] = prepared_filter
         if columns is not None:
             input_obj["columns"] = columns
         return await self.execute_query(
@@ -351,7 +371,7 @@ class ReportService(BasePipefyClient):
             organization_report_id: Report to export; omit to export by pipes only.
             pipe_ids: Pipe IDs to scope the export.
             sort_by: ``ReportSortDirectionInput``.
-            filter: ``ReportCardsFilter`` shape.
+            filter: ``ReportCardsFilter`` shape; normalized, raises ``ValueError`` when invalid.
             columns: Column field IDs for the export file.
         """
         # int() casts: live schema uses Int (not ID) for these fields — see ADR-002.
@@ -362,7 +382,7 @@ class ReportService(BasePipefyClient):
             else None,
             "pipeIds": [int(pid) for pid in pipe_ids] if pipe_ids is not None else None,
             "sortBy": sort_by,
-            "filter": filter,
+            "filter": _prepared_report_cards_filter(filter),
             "columns": columns,
         }
         for key, value in optional_fields.items():

--- a/packages/sdk/src/pipefy_sdk/services/report_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/report_service.py
@@ -25,24 +25,8 @@ from pipefy_sdk.queries.report_queries import (
     UPDATE_ORGANIZATION_REPORT_MUTATION,
     UPDATE_PIPE_REPORT_MUTATION,
 )
-from pipefy_sdk.report_filter_preflight import (
-    normalize_report_cards_filter,
-    report_cards_filter_error,
-)
+from pipefy_sdk.report_filter_preflight import prepare_report_cards_filter
 from pipefy_sdk.settings import PipefySettings
-
-
-def _prepared_report_cards_filter(
-    filter_obj: dict[str, Any] | None,
-) -> dict[str, Any] | None:
-    """Normalize a ``ReportCardsFilter`` and raise ``ValueError`` when invalid."""
-    if filter_obj is None:
-        return None
-    normalized = normalize_report_cards_filter(filter_obj)
-    message = report_cards_filter_error(normalized)
-    if message is not None:
-        raise ValueError(message)
-    return normalized
 
 
 class ReportService(BasePipefyClient):
@@ -185,7 +169,7 @@ class ReportService(BasePipefyClient):
             formulas: Formula definitions (list of [field, operator, ...] tuples).
         """
         input_obj: dict[str, Any] = {"pipeId": str(pipe_id), "name": name}
-        prepared_filter = _prepared_report_cards_filter(filter)
+        prepared_filter = prepare_report_cards_filter(filter)
         if fields is not None:
             input_obj["fields"] = fields
         if prepared_filter is not None:
@@ -223,7 +207,7 @@ class ReportService(BasePipefyClient):
             "name": name,
             "color": color,
             "fields": fields,
-            "filter": _prepared_report_cards_filter(filter),
+            "filter": prepare_report_cards_filter(filter),
             "formulas": formulas,
             "featuredField": featured_field,
         }
@@ -267,7 +251,7 @@ class ReportService(BasePipefyClient):
             "name": name,
             "pipeIds": [str(pid) for pid in pipe_ids],
         }
-        prepared_filter = _prepared_report_cards_filter(filter)
+        prepared_filter = prepare_report_cards_filter(filter)
         if fields is not None:
             input_obj["fields"] = fields
         if prepared_filter is not None:
@@ -301,7 +285,7 @@ class ReportService(BasePipefyClient):
             "name": name,
             "color": color,
             "fields": fields,
-            "filter": _prepared_report_cards_filter(filter),
+            "filter": prepare_report_cards_filter(filter),
             "pipeIds": [str(pid) for pid in pipe_ids] if pipe_ids is not None else None,
         }
         for key, value in optional_fields.items():
@@ -343,7 +327,7 @@ class ReportService(BasePipefyClient):
             "pipeId": str(pipe_id),
             "pipeReportId": str(pipe_report_id),
         }
-        prepared_filter = _prepared_report_cards_filter(filter)
+        prepared_filter = prepare_report_cards_filter(filter)
         if sort_by is not None:
             input_obj["sortBy"] = sort_by
         if prepared_filter is not None:
@@ -382,7 +366,7 @@ class ReportService(BasePipefyClient):
             else None,
             "pipeIds": [int(pid) for pid in pipe_ids] if pipe_ids is not None else None,
             "sortBy": sort_by,
-            "filter": _prepared_report_cards_filter(filter),
+            "filter": prepare_report_cards_filter(filter),
             "columns": columns,
         }
         for key, value in optional_fields.items():

--- a/packages/sdk/tests/services/pipefy/test_pipe_config_service.py
+++ b/packages/sdk/tests/services/pipefy/test_pipe_config_service.py
@@ -638,18 +638,66 @@ async def test_delete_phase_field_includes_pipe_uuid_when_provided(mock_settings
 async def test_create_label_sends_pipe_name_color(mock_settings):
     service = _make_service(
         mock_settings,
-        {"createLabel": {"label": {"id": "1", "name": "Bug", "color": "red"}}},
+        {"createLabel": {"label": {"id": "1", "name": "Bug", "color": "#FF0000"}}},
     )
-    result = await service.create_label(20, "Bug", "red")
+    result = await service.create_label(20, "Bug", "#FF0000")
 
     query, variables = service.execute_query.call_args[0]
     assert query is CREATE_LABEL_MUTATION
     assert variables == {
-        "input": {"pipe_id": "20", "name": "Bug", "color": "red"},
+        "input": {"pipe_id": "20", "name": "Bug", "color": "#FF0000"},
     }
     assert result == {
-        "createLabel": {"label": {"id": "1", "name": "Bug", "color": "red"}},
+        "createLabel": {"label": {"id": "1", "name": "Bug", "color": "#FF0000"}},
     }
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("raw_color", "normalized_color"),
+    [("#abc", "#AABBCC"), ("#ff0000", "#FF0000")],
+)
+async def test_create_label_normalizes_color(
+    mock_settings, raw_color, normalized_color
+):
+    service = _make_service(mock_settings, {"createLabel": {"label": {"id": "1"}}})
+    await service.create_label(20, "Bug", raw_color)
+
+    variables = service.execute_query.call_args[0][1]
+    assert variables["input"]["color"] == normalized_color
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_label_rejects_non_hex_color(mock_settings):
+    service = _make_service(mock_settings, {})
+
+    with pytest.raises(ValueError, match="expected #RGB or #RRGGBB hex color"):
+        await service.create_label(20, "Bug", "red")
+
+    service.execute_query.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_update_label_normalizes_color(mock_settings):
+    service = _make_service(mock_settings, {"updateLabel": {"label": {"id": "2"}}})
+    await service.update_label(2, name="Feature", color="#abc")
+
+    variables = service.execute_query.call_args[0][1]
+    assert variables["input"]["color"] == "#AABBCC"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_update_label_rejects_non_hex_color(mock_settings):
+    service = _make_service(mock_settings, {})
+
+    with pytest.raises(ValueError, match="expected #RGB or #RRGGBB hex color"):
+        await service.update_label(2, name="Feature", color="blue")
+
+    service.execute_query.assert_not_called()
 
 
 @pytest.mark.unit

--- a/packages/sdk/tests/services/pipefy/test_report_service.py
+++ b/packages/sdk/tests/services/pipefy/test_report_service.py
@@ -24,6 +24,7 @@ from pipefy_sdk.queries.report_queries import (
     UPDATE_ORGANIZATION_REPORT_MUTATION,
     UPDATE_PIPE_REPORT_MUTATION,
 )
+from pipefy_sdk.report_filter_preflight import EXAMPLE_PHASE_FILTER
 from pipefy_sdk.services.report_service import ReportService
 from pipefy_sdk.settings import PipefySettings
 
@@ -310,8 +311,6 @@ async def test_create_pipe_report_success(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_create_pipe_report_forwards_golden_phase_filter(mock_settings):
-    from pipefy_sdk.report_filter_preflight import EXAMPLE_PHASE_FILTER
-
     golden_filter = {
         **EXAMPLE_PHASE_FILTER,
         "queries": [
@@ -538,3 +537,94 @@ async def test_update_pipe_report_transport_error(mock_settings):
     )
     with pytest.raises(TransportQueryError):
         await service.update_pipe_report("10", name="N")
+
+
+def _filter_method_invokers():
+    return [
+        (
+            "create_pipe_report",
+            lambda service, filt: service.create_pipe_report(
+                "123", "Report", filter=filt
+            ),
+        ),
+        (
+            "update_pipe_report",
+            lambda service, filt: service.update_pipe_report("10", filter=filt),
+        ),
+        (
+            "create_organization_report",
+            lambda service, filt: service.create_organization_report(
+                "100", "Report", ["200"], filter=filt
+            ),
+        ),
+        (
+            "update_organization_report",
+            lambda service, filt: service.update_organization_report("5", filter=filt),
+        ),
+        (
+            "export_pipe_report",
+            lambda service, filt: service.export_pipe_report("100", "200", filter=filt),
+        ),
+        (
+            "export_organization_report",
+            lambda service, filt: service.export_organization_report(42, filter=filt),
+        ),
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method_name", "invoke"),
+    _filter_method_invokers(),
+    ids=[name for name, _ in _filter_method_invokers()],
+)
+async def test_report_mutations_reject_invalid_filter(
+    mock_settings, method_name, invoke
+):
+    service = _make_service(mock_settings, {})
+
+    with pytest.raises(ValueError, match="top-level 'current_phase'"):
+        await invoke(service, {"current_phase": ["987654321"]})
+
+    service.execute_query.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method_name", "invoke"),
+    _filter_method_invokers(),
+    ids=[name for name, _ in _filter_method_invokers()],
+)
+async def test_report_mutations_reject_invalid_filter_operator(
+    mock_settings, method_name, invoke
+):
+    service = _make_service(mock_settings, {})
+
+    with pytest.raises(ValueError, match="operator must be one of"):
+        await invoke(service, {"operator": "xor", "queries": []})
+
+    service.execute_query.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method_name", "invoke"),
+    _filter_method_invokers(),
+    ids=[name for name, _ in _filter_method_invokers()],
+)
+async def test_report_mutations_normalize_integer_filter_values(
+    mock_settings, method_name, invoke
+):
+    int_value_filter = {
+        **EXAMPLE_PHASE_FILTER,
+        "queries": [{**EXAMPLE_PHASE_FILTER["queries"][0], "value": 99}],
+    }
+    service = _make_service(mock_settings, {})
+
+    await invoke(service, int_value_filter)
+
+    variables = service.execute_query.call_args[0][1]
+    assert variables["input"]["filter"]["queries"][0]["value"] == "99"

--- a/packages/sdk/tests/test_report_filter_preflight.py
+++ b/packages/sdk/tests/test_report_filter_preflight.py
@@ -5,19 +5,19 @@ from __future__ import annotations
 from pipefy_sdk.report_filter_preflight import (
     EXAMPLE_PHASE_FILTER,
     normalize_report_cards_filter,
-    validate_report_cards_filter,
+    report_cards_filter_error,
 )
 
 
-def test_validate_report_cards_filter_none_passes():
-    assert validate_report_cards_filter(None) is None
+def test_report_cards_filter_error_none_passes():
+    assert report_cards_filter_error(None) is None
 
 
-def test_validate_report_cards_filter_valid_phase_skeleton_passes():
-    assert validate_report_cards_filter(EXAMPLE_PHASE_FILTER) is None
+def test_report_cards_filter_error_valid_phase_skeleton_passes():
+    assert report_cards_filter_error(EXAMPLE_PHASE_FILTER) is None
 
 
-def test_validate_report_cards_filter_nested_group_passes():
+def test_report_cards_filter_error_nested_group_passes():
     filt = {
         "operator": "or",
         "groups": [
@@ -29,46 +29,46 @@ def test_validate_report_cards_filter_nested_group_passes():
             }
         ],
     }
-    assert validate_report_cards_filter(filt) is None
+    assert report_cards_filter_error(filt) is None
 
 
-def test_validate_report_cards_filter_rejects_top_level_current_phase():
-    err = validate_report_cards_filter({"current_phase": ["123"]})
+def test_report_cards_filter_error_rejects_top_level_current_phase():
+    err = report_cards_filter_error({"current_phase": ["123"]})
     assert err is not None
     assert "top-level" in err
     assert "current_phase" in err
     assert "get_pipe_report_filterable_fields" in err
 
 
-def test_validate_report_cards_filter_rejects_unknown_root_key():
-    err = validate_report_cards_filter({"operator": "and", "bogus": True})
+def test_report_cards_filter_error_rejects_unknown_root_key():
+    err = report_cards_filter_error({"operator": "and", "bogus": True})
     assert err is not None
     assert "unknown key" in err
     assert "bogus" in err
 
 
-def test_validate_report_cards_filter_requires_operator():
-    err = validate_report_cards_filter({"queries": []})
+def test_report_cards_filter_error_requires_operator():
+    err = report_cards_filter_error({"queries": []})
     assert err is not None
     assert "operator is required" in err
 
 
-def test_validate_report_cards_filter_rejects_invalid_group_operator():
-    err = validate_report_cards_filter({"operator": "xor", "queries": []})
+def test_report_cards_filter_error_rejects_invalid_group_operator():
+    err = report_cards_filter_error({"operator": "xor", "queries": []})
     assert err is not None
     assert "operator must be one of" in err
 
 
-def test_validate_report_cards_filter_query_requires_field_and_operator():
-    err = validate_report_cards_filter(
+def test_report_cards_filter_error_query_requires_field_and_operator():
+    err = report_cards_filter_error(
         {"operator": "and", "queries": [{"operator": "eq", "value": "x"}]}
     )
     assert err is not None
     assert ".field is required" in err
 
 
-def test_validate_report_cards_filter_query_rejects_unknown_keys():
-    err = validate_report_cards_filter(
+def test_report_cards_filter_error_query_rejects_unknown_keys():
+    err = report_cards_filter_error(
         {
             "operator": "and",
             "queries": [{"field": "current_phase", "operator": "eq", "phase_id": "1"}],
@@ -79,76 +79,76 @@ def test_validate_report_cards_filter_query_rejects_unknown_keys():
     assert "phase_id" in err
 
 
-def test_validate_report_cards_filter_rejects_non_object_filter():
-    err = validate_report_cards_filter([])  # type: ignore[arg-type]
+def test_report_cards_filter_error_rejects_non_object_filter():
+    err = report_cards_filter_error([])  # type: ignore[arg-type]
     assert err is not None
     assert "JSON object" in err
 
 
-def test_validate_report_cards_filter_rejects_non_string_group_operator():
-    err = validate_report_cards_filter({"operator": 123, "queries": []})
+def test_report_cards_filter_error_rejects_non_string_group_operator():
+    err = report_cards_filter_error({"operator": 123, "queries": []})
     assert err is not None
     assert "operator must be a non-empty string" in err
 
 
-def test_validate_report_cards_filter_rejects_non_list_queries():
-    err = validate_report_cards_filter({"operator": "and", "queries": "x"})
+def test_report_cards_filter_error_rejects_non_list_queries():
+    err = report_cards_filter_error({"operator": "and", "queries": "x"})
     assert err is not None
     assert "queries must be a list" in err
 
 
-def test_validate_report_cards_filter_rejects_non_list_groups():
-    err = validate_report_cards_filter({"operator": "and", "groups": "x"})
+def test_report_cards_filter_error_rejects_non_list_groups():
+    err = report_cards_filter_error({"operator": "and", "groups": "x"})
     assert err is not None
     assert "groups must be a list" in err
 
 
-def test_validate_report_cards_filter_rejects_non_object_group_entry():
-    err = validate_report_cards_filter({"operator": "and", "groups": ["x"]})
+def test_report_cards_filter_error_rejects_non_object_group_entry():
+    err = report_cards_filter_error({"operator": "and", "groups": ["x"]})
     assert err is not None
     assert "groups[0] must be an object" in err
 
 
-def test_validate_report_cards_filter_propagates_nested_group_error():
-    err = validate_report_cards_filter(
+def test_report_cards_filter_error_propagates_nested_group_error():
+    err = report_cards_filter_error(
         {"operator": "or", "groups": [{"operator": "xor", "queries": []}]}
     )
     assert err is not None
     assert "groups[0].operator must be one of" in err
 
 
-def test_validate_report_cards_filter_rejects_non_object_query():
-    err = validate_report_cards_filter({"operator": "and", "queries": ["x"]})
+def test_report_cards_filter_error_rejects_non_object_query():
+    err = report_cards_filter_error({"operator": "and", "queries": ["x"]})
     assert err is not None
     assert "queries[0] must be an object" in err
 
 
-def test_validate_report_cards_filter_rejects_blank_query_field():
-    err = validate_report_cards_filter(
+def test_report_cards_filter_error_rejects_blank_query_field():
+    err = report_cards_filter_error(
         {"operator": "and", "queries": [{"field": "  ", "operator": "eq"}]}
     )
     assert err is not None
     assert "field must be a non-empty string" in err
 
 
-def test_validate_report_cards_filter_requires_query_operator():
-    err = validate_report_cards_filter(
+def test_report_cards_filter_error_requires_query_operator():
+    err = report_cards_filter_error(
         {"operator": "and", "queries": [{"field": "current_phase"}]}
     )
     assert err is not None
     assert ".operator is required" in err
 
 
-def test_validate_report_cards_filter_rejects_blank_query_operator():
-    err = validate_report_cards_filter(
+def test_report_cards_filter_error_rejects_blank_query_operator():
+    err = report_cards_filter_error(
         {"operator": "and", "queries": [{"field": "current_phase", "operator": "  "}]}
     )
     assert err is not None
     assert "operator must be a non-empty string" in err
 
 
-def test_validate_report_cards_filter_rejects_non_string_value():
-    err = validate_report_cards_filter(
+def test_report_cards_filter_error_rejects_non_string_value():
+    err = report_cards_filter_error(
         {
             "operator": "and",
             "queries": [{"field": "current_phase", "operator": "eq", "value": True}],
@@ -165,13 +165,13 @@ def test_normalize_report_cards_filter_coerces_integer_value():
     }
     normalized = normalize_report_cards_filter(filt)
     assert normalized["queries"][0]["value"] == "987654321"
-    assert validate_report_cards_filter(normalized) is None
+    assert report_cards_filter_error(normalized) is None
 
 
-def test_validate_report_cards_filter_allows_omitted_value():
+def test_report_cards_filter_error_allows_omitted_value():
     # exists / not_exists operators carry no value; an omitted value must pass.
     assert (
-        validate_report_cards_filter(
+        report_cards_filter_error(
             {
                 "operator": "and",
                 "queries": [{"field": "due_date", "operator": "exists"}],
@@ -181,8 +181,8 @@ def test_validate_report_cards_filter_allows_omitted_value():
     )
 
 
-def test_validate_report_cards_filter_rejects_blank_query_type():
-    err = validate_report_cards_filter(
+def test_report_cards_filter_error_rejects_blank_query_type():
+    err = report_cards_filter_error(
         {
             "operator": "and",
             "queries": [{"field": "current_phase", "operator": "eq", "type": "  "}],


### PR DESCRIPTION
## Summary

- Implements the consolidated review proposal from #284 (https://github.com/pipefy/ai-toolkit/pull/284#issuecomment-4672322470): ReportCardsFilter preflight and label color normalization move from twelve effect sites (six MCP report tools + six CLI commands) into the SDK funnel they all forward through.
- `ReportService` create/update/export methods now normalize the filter and raise `ValueError` with the planner message; `PipeConfigService.create_label`/`update_label` normalize the hex color. The twelve leaf guards are deleted; MCP maps `ValueError` to the same `build_report_error_payload` envelope and the CLI maps it to exit code 2 (`typer.BadParameter` on report commands), so messages and exit codes are unchanged.
- Also lands the #280 naming finding: `validate_report_cards_filter` -> `report_cards_filter_error`, matching its `str | None` errors-as-values return.

PR 7 of the card-phase stack, stacked on #285. 

The diff exceeds the usual 10-file guideline because it is one structural move (one decision point replacing twelve guards, with relocated test coverage); it nets less code at the surfaces.
