### PR TITLE
chore(sdk): enforce explicit TLS verification on GraphQL transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Releases are versioned in lockstep across workspace members (`pipefy-sdk`, `pipe
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Changed
+
+- **SDK**: GraphQL `HTTPXAsyncTransport` now sets `verify=True` explicitly so TLS certificate verification cannot be disabled by implicit defaults.
+
 ## [0.2.0-beta.3] - 2026-06-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- **SDK**: GraphQL `HTTPXAsyncTransport` now sets `verify=True` explicitly so TLS certificate verification cannot be disabled by implicit defaults.
+- **SDK**: GraphQL `HTTPXAsyncTransport` now sets `verify=True` explicitly to pin TLS verification on, independent of httpx's default.
 
 ## [0.2.0-beta.3] - 2026-06-03
 

--- a/packages/sdk/src/pipefy_sdk/base_client.py
+++ b/packages/sdk/src/pipefy_sdk/base_client.py
@@ -80,6 +80,7 @@ class BasePipefyClient:
             url=self._graphql_url,
             auth=self._auth,
             timeout=Timeout(timeout=self.GRAPHQL_REQUEST_TIMEOUT_SECONDS),
+            verify=True,
         )
         try:
             if self.settings.gql_reuse_fetched_graphql_schema:

--- a/packages/sdk/tests/services/test_pipefy_base_client.py
+++ b/packages/sdk/tests/services/test_pipefy_base_client.py
@@ -18,6 +18,29 @@ def _bearer() -> StaticBearerAuth:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_execute_query_builds_transport_with_tls_verification(valid_settings):
+    """HTTPXAsyncTransport must explicitly enable TLS certificate verification."""
+    query = object()
+    variables: dict = {}
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock(return_value={"ok": True})
+
+    with (
+        patch("pipefy_sdk.base_client.HTTPXAsyncTransport") as mock_transport_cls,
+        patch("pipefy_sdk.base_client.Client") as mock_client_cls,
+    ):
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        base = BasePipefyClient(settings=valid_settings, auth=_bearer())
+        await base.execute_query(query, variables)
+
+    mock_transport_cls.assert_called_once()
+    assert mock_transport_cls.call_args.kwargs["verify"] is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_execute_query_passes_variables_to_session(valid_settings):
     """Test execute_query creates a session and passes variable_values unchanged."""
     query = object()


### PR DESCRIPTION
## Summary

- Add `verify=True` explicitly when constructing `HTTPXAsyncTransport` in `BasePipefyClient.execute_query`.
- Add a unit test asserting TLS verification is enabled on every transport build.
- Document the change under `[Unreleased]` in `CHANGELOG.md`.

`validate_https_url` on settings is intentionally deferred to a follow-up PR.

## Test plan

- [x] `uv run pytest packages/sdk/tests -m "not integration"` — 874 passed
- [x] `uv run ruff check .`