### PR TITLE
chore(deps): upgrade gql to 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **SDK**: GraphQL `HTTPXAsyncTransport` now sets `verify=True` explicitly to pin TLS verification on, independent of httpx's default.
 - **Deps**: upgraded `pydantic` to 2.13.4 (`pydantic-core` 2.46.4, `pydantic-settings` 2.14.1) across workspace packages.
+- **Deps**: upgraded `gql[httpx]` to 4.0.0; `gql()` constants are `GraphQLRequest` objects (use `.document` for AST introspection in tests).
 
 ## [0.2.0-beta.3] - 2026-06-03
 

--- a/packages/sdk/pyproject.toml
+++ b/packages/sdk/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "email-validator>=2.2.0",
-    "gql[httpx]>=3.5.2",
+    "gql[httpx]>=4.0.0,<5",
     "httpx>=0.27.0",
     "openpyxl>=3.1.5",
     "pipefy-infra",

--- a/packages/sdk/src/pipefy_sdk/base_client.py
+++ b/packages/sdk/src/pipefy_sdk/base_client.py
@@ -34,8 +34,11 @@ def unwrap_relay_connection_nodes(connection: Any) -> list[dict[str, Any]]:
 def _graphql_request_with_variables(
     query: Any, variables: dict[str, Any]
 ) -> GraphQLRequest:
-    """Bind variables on a fresh request so shared ``gql()`` constants stay immutable."""
-    return GraphQLRequest(query, variable_values=variables or None)
+    """Bind variables on a fresh request so shared ``gql()`` constants stay immutable.
+
+    An empty ``variables`` dict omits ``variable_values`` (``None``) on the request.
+    """
+    return GraphQLRequest(query, variable_values=variables if variables else None)
 
 
 class BasePipefyClient:

--- a/packages/sdk/src/pipefy_sdk/base_client.py
+++ b/packages/sdk/src/pipefy_sdk/base_client.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from typing import Any, ClassVar
 
 from gql import Client
+from gql.graphql_request import GraphQLRequest
 from gql.transport.exceptions import TransportQueryError
 from gql.transport.httpx import HTTPXAsyncTransport
 from graphql import GraphQLSchema
@@ -28,6 +29,13 @@ def unwrap_relay_connection_nodes(connection: Any) -> list[dict[str, Any]]:
         if isinstance(node, dict):
             nodes.append(node)
     return nodes
+
+
+def _graphql_request_with_variables(
+    query: Any, variables: dict[str, Any]
+) -> GraphQLRequest:
+    """Bind variables on a fresh request so shared ``gql()`` constants stay immutable."""
+    return GraphQLRequest(query, variable_values=variables or None)
 
 
 class BasePipefyClient:
@@ -93,7 +101,7 @@ class BasePipefyClient:
                             )
                             async with client as session:
                                 result = await session.execute(
-                                    query, variable_values=variables
+                                    _graphql_request_with_variables(query, variables)
                                 )
                             if client.schema is not None:
                                 self._fetched_gql_schema = client.schema
@@ -104,12 +112,16 @@ class BasePipefyClient:
                     fetch_schema_from_transport=False,
                 )
                 async with reuse_client as session:
-                    return await session.execute(query, variable_values=variables)
+                    return await session.execute(
+                        _graphql_request_with_variables(query, variables)
+                    )
 
             async with Client(
                 transport=transport, fetch_schema_from_transport=False
             ) as session:
-                return await session.execute(query, variable_values=variables)
+                return await session.execute(
+                    _graphql_request_with_variables(query, variables)
+                )
         except TransportQueryError as exc:
             if self._on_graphql_error is None:
                 raise

--- a/packages/sdk/src/pipefy_sdk/queries/card_queries.py
+++ b/packages/sdk/src/pipefy_sdk/queries/card_queries.py
@@ -271,7 +271,7 @@ UPDATE_FIELDS_VALUES_MUTATION = gql(
 # (core_api / internal_v1), not the public API. These are plain strings because
 # ``InternalApiClient.execute_query`` takes a raw string and parses it with
 # ``gql()`` itself before sending, unlike the public client which expects an
-# already-parsed ``DocumentNode``. Same pattern as ``portal_internal_queries.py``.
+# already-parsed ``GraphQLRequest`` from ``gql()``. Same pattern as ``portal_internal_queries.py``.
 # ---------------------------------------------------------------------------
 
 INTERNAL_DELETE_CARD_RELATION_MUTATION = """

--- a/packages/sdk/src/pipefy_sdk/queries/portal_internal_queries.py
+++ b/packages/sdk/src/pipefy_sdk/queries/portal_internal_queries.py
@@ -3,7 +3,7 @@
 Mutations are plain strings (not ``gql()``) because
 ``InternalApiClient.execute_query`` takes a raw string and parses it with
 ``gql()`` itself before sending, unlike the public client which expects an
-already-parsed ``DocumentNode``.
+already-parsed ``GraphQLRequest`` from ``gql()``.
 """
 
 from __future__ import annotations

--- a/packages/sdk/tests/services/pipefy/test_pipe_config_service.py
+++ b/packages/sdk/tests/services/pipefy/test_pipe_config_service.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 from gql.transport.exceptions import TransportQueryError
+from graphql import print_ast
 from pipefy_auth import StaticBearerAuth
 
 from pipefy_sdk.queries.pipe_config_queries import (
@@ -934,7 +935,7 @@ async def test_get_field_conditions_success(mock_settings):
 
     query, variables = service.execute_query.call_args[0]
     assert query is GET_FIELD_CONDITIONS_QUERY
-    assert "actionId" in GET_FIELD_CONDITIONS_QUERY.loc.source.body
+    assert "actionId" in print_ast(GET_FIELD_CONDITIONS_QUERY.document)
     assert variables == {"phaseId": "404"}
     assert result == api_payload
 
@@ -956,7 +957,7 @@ async def test_get_field_condition_success(mock_settings):
 
     query, variables = service.execute_query.call_args[0]
     assert query is GET_FIELD_CONDITION_QUERY
-    assert "actionId" in GET_FIELD_CONDITION_QUERY.loc.source.body
+    assert "actionId" in print_ast(GET_FIELD_CONDITION_QUERY.document)
     assert variables == {"id": "fc-2"}
     assert result == api_payload
 

--- a/packages/sdk/tests/services/test_ai_agent_service.py
+++ b/packages/sdk/tests/services/test_ai_agent_service.py
@@ -33,14 +33,14 @@ UUID_PATTERN = re.compile(r"%\{action:([a-f0-9-]{36})\}")
 
 @pytest.mark.unit
 def test_get_ai_agent_query_includes_email_template_metadata_fields():
-    printed = print_ast(GET_AI_AGENT_QUERY)
+    printed = print_ast(GET_AI_AGENT_QUERY.document)
     assert "emailTemplateId" in printed
     assert "allowTemplateModifications" in printed
 
 
 @pytest.mark.unit
 def test_update_ai_agent_mutation_includes_email_template_metadata_fields():
-    printed = print_ast(UPDATE_AI_AGENT_MUTATION)
+    printed = print_ast(UPDATE_AI_AGENT_MUTATION.document)
     assert "emailTemplateId" in printed
     assert "allowTemplateModifications" in printed
 

--- a/packages/sdk/tests/services/test_attachment_service.py
+++ b/packages/sdk/tests/services/test_attachment_service.py
@@ -92,7 +92,7 @@ def _build_attachment(tmp_path: Path, *, name: str = "report.pdf") -> Attachment
 
 @pytest.mark.unit
 def test_create_presigned_url_mutation_document_shape():
-    doc = print_ast(CREATE_PRESIGNED_URL_MUTATION)
+    doc = print_ast(CREATE_PRESIGNED_URL_MUTATION.document)
     lowered = doc.lower()
     stripped_lines = {ln.strip() for ln in doc.splitlines()}
     assert "createpresignedurl" in lowered

--- a/packages/sdk/tests/services/test_internal_api_client.py
+++ b/packages/sdk/tests/services/test_internal_api_client.py
@@ -11,7 +11,7 @@ import json
 import httpx
 import pytest
 import respx
-from gql.transport.exceptions import TransportServerError
+from gql.transport.exceptions import TransportConnectionFailed, TransportServerError
 from pipefy_auth import StaticBearerAuth
 
 from pipefy_sdk.services.internal_api_client import InternalApiClient
@@ -216,7 +216,7 @@ async def test_execute_query_raises_on_timeout(respx_mock):
         side_effect=httpx.TimeoutException("Request timed out")
     )
 
-    with pytest.raises(httpx.TimeoutException):
+    with pytest.raises(TransportConnectionFailed, match="timed out"):
         await _build_client().execute_query("query { x }", {})
 
 

--- a/packages/sdk/tests/services/test_pipe_service.py
+++ b/packages/sdk/tests/services/test_pipe_service.py
@@ -488,20 +488,20 @@ async def test_search_pipes_truncates_per_org_when_api_returns_fewer_than_pipes_
 
 @pytest.mark.unit
 def test_search_pipes_query_selects_pipes_count():
-    printed = print_ast(SEARCH_PIPES_QUERY)
+    printed = print_ast(SEARCH_PIPES_QUERY.document)
     assert "pipesCount" in printed
 
 
 @pytest.mark.unit
 def test_get_phase_fields_query_selects_internal_id_and_uuid():
-    printed = print_ast(GET_PHASE_FIELDS_QUERY)
+    printed = print_ast(GET_PHASE_FIELDS_QUERY.document)
     assert "internal_id" in printed
     assert "uuid" in printed
 
 
 @pytest.mark.unit
 def test_get_phase_allowed_moves_query_requests_transition_field():
-    printed = print_ast(GET_PHASE_ALLOWED_MOVES_QUERY)
+    printed = print_ast(GET_PHASE_ALLOWED_MOVES_QUERY.document)
     assert "cards_can_be_moved_to_phases" in printed
 
 
@@ -550,7 +550,7 @@ async def test_get_phase_cards_count_raises_when_missing(mock_settings):
 
 
 def test_get_phase_cards_count_query_selects_native_scalar():
-    query_text = print_ast(GET_PHASE_CARDS_COUNT_QUERY)
+    query_text = print_ast(GET_PHASE_CARDS_COUNT_QUERY.document)
     assert "cards_count" in query_text
     # No card enumeration — must not touch the CardConnection edges/nodes.
     assert "edges" not in query_text

--- a/packages/sdk/tests/services/test_pipefy_base_client.py
+++ b/packages/sdk/tests/services/test_pipefy_base_client.py
@@ -1,6 +1,8 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from gql import gql
+from gql.graphql_request import GraphQLRequest
 from pipefy_auth import StaticBearerAuth
 
 from pipefy_sdk.base_client import BasePipefyClient
@@ -16,11 +18,15 @@ def _bearer() -> StaticBearerAuth:
     return StaticBearerAuth("test-token")
 
 
+def _sample_query() -> GraphQLRequest:
+    return gql("{ __typename }")
+
+
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_execute_query_builds_transport_with_tls_verification(valid_settings):
     """HTTPXAsyncTransport must explicitly enable TLS certificate verification."""
-    query = object()
+    query = _sample_query()
     variables: dict = {}
     mock_session = AsyncMock()
     mock_session.execute = AsyncMock(return_value={"ok": True})
@@ -43,7 +49,7 @@ async def test_execute_query_builds_transport_with_tls_verification(valid_settin
 @pytest.mark.asyncio
 async def test_execute_query_passes_variables_to_session(valid_settings):
     """Test execute_query creates a session and passes variable_values unchanged."""
-    query = object()
+    query = _sample_query()
     variables = {"a": 1, "nested": {"b": 2}}
 
     mock_session = AsyncMock()
@@ -56,7 +62,10 @@ async def test_execute_query_passes_variables_to_session(valid_settings):
         base = BasePipefyClient(settings=valid_settings, auth=_bearer())
         result = await base.execute_query(query, variables)
 
-    mock_session.execute.assert_called_once_with(query, variable_values=variables)
+    mock_session.execute.assert_called_once()
+    request = mock_session.execute.call_args[0][0]
+    assert isinstance(request, GraphQLRequest)
+    assert request.variable_values == variables
     assert result == {"ok": True}
     assert mock_client_cls.call_args.kwargs["fetch_schema_from_transport"] is False
     assert "schema" not in mock_client_cls.call_args.kwargs
@@ -71,7 +80,7 @@ async def test_execute_query_reuse_fetches_once_then_passes_cached_schema(
     settings = valid_settings.model_copy(
         update={"gql_reuse_fetched_graphql_schema": True}
     )
-    query = object()
+    query = _sample_query()
     variables: dict = {}
     cached_schema = object()
     mock_session = AsyncMock()
@@ -107,7 +116,7 @@ async def test_execute_query_reuse_fetches_once_then_passes_cached_schema(
 @pytest.mark.asyncio
 async def test_execute_query_bubbles_up_execute_errors_unchanged(valid_settings):
     """Test execute_query does not wrap exceptions raised by the GraphQL session."""
-    query = object()
+    query = _sample_query()
     variables = {"x": 1}
     expected_error = RuntimeError("boom")
 

--- a/packages/sdk/tests/services/test_pipefy_base_client.py
+++ b/packages/sdk/tests/services/test_pipefy_base_client.py
@@ -73,6 +73,28 @@ async def test_execute_query_passes_variables_to_session(valid_settings):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_execute_query_omits_variable_values_for_empty_dict(valid_settings):
+    """Empty variables omits variable_values on the bound GraphQLRequest."""
+    query = _sample_query()
+    variables: dict = {}
+
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock(return_value={"ok": True})
+
+    with patch("pipefy_sdk.base_client.Client") as mock_client_cls:
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        base = BasePipefyClient(settings=valid_settings, auth=_bearer())
+        await base.execute_query(query, variables)
+
+    request = mock_session.execute.call_args[0][0]
+    assert isinstance(request, GraphQLRequest)
+    assert request.variable_values is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_execute_query_reuse_fetches_once_then_passes_cached_schema(
     valid_settings,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -456,7 +456,7 @@ wheels = [
 
 [[package]]
 name = "gql"
-version = "3.5.2"
+version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -464,9 +464,9 @@ dependencies = [
     { name = "graphql-core" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/ef/5298d9d628b6a54b3b810052cb5a935d324fe28d9bfdeb741733d5c2446b/gql-3.5.2.tar.gz", hash = "sha256:07e1325b820c8ba9478e95de27ce9f23250486e7e79113dbb7659a442dc13e74", size = 180502, upload-time = "2025-03-06T10:41:09.255Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/9f/cf224a88ed71eb223b7aa0b9ff0aa10d7ecc9a4acdca2279eb046c26d5dc/gql-4.0.0.tar.gz", hash = "sha256:f22980844eb6a7c0266ffc70f111b9c7e7c7c13da38c3b439afc7eab3d7c9c8e", size = 215644, upload-time = "2025-08-17T14:32:35.397Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/71/b028b937992056e721bbf0371e13819fcca0dacde7b3c821f775ed903917/gql-3.5.2-py2.py3-none-any.whl", hash = "sha256:c830ffc38b3997b2a146317b27758305ab3d0da3bde607b49f34e32affb23ba2", size = 74346, upload-time = "2025-03-06T10:41:07.99Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/94/30bbd09e8d45339fa77a48f5778d74d47e9242c11b3cd1093b3d994770a5/gql-4.0.0-py3-none-any.whl", hash = "sha256:f3beed7c531218eb24d97cb7df031b4a84fdb462f4a2beb86e2633d395937479", size = 89900, upload-time = "2025-08-17T14:32:34.029Z" },
 ]
 
 [package.optional-dependencies]
@@ -996,7 +996,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "email-validator", specifier = ">=2.2.0" },
-    { name = "gql", extras = ["httpx"], specifier = ">=3.5.2" },
+    { name = "gql", extras = ["httpx"], specifier = ">=4.0.0,<5" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "pipefy-infra", editable = "packages/infra" },


### PR DESCRIPTION
## Summary

- Bump `gql[httpx]>=4.0.0,<5` in `packages/sdk` and refresh `uv.lock`.
- Adapt SDK tests for gql 4: `gql()` constants are `GraphQLRequest` objects (use `.document` for AST introspection); HTTP timeouts surface as `TransportConnectionFailed` (subclass of `TransportError`, so existing CLI catches remain valid).
- `session.execute(query, variable_values=...)` preserved; `verify=True` unchanged from PR1.
- CHANGELOG entry under `[Unreleased]`.

Stacked on pydantic upgrade branch — merge after `chore/upgrade-pydantic-2.13`.

## Test plan

- [x] `uv run pytest -m "not integration"` — 2947 passed
- [x] `uv run ruff check .`
- [x] `uv run pytest -m integration` — 46 skipped (no `PIPEFY_*` creds in CI agent env)

## Manual smoke (post-merge)

- Cursor MCP: invoke a read-only tool (e.g. `get_me`) against a configured server.
- Optional: `npx @modelcontextprotocol/inspector uv --directory . run pipefy-mcp-server` for transport debugging.